### PR TITLE
perf: Compile `Regex` once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "opaque-debug"
@@ -1657,6 +1657,7 @@ dependencies = [
  "glob",
  "log",
  "notify",
+ "once_cell",
  "rayon",
  "regex",
  "rustpython-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ filetime = { version = "0.2.17" }
 glob = { version = "0.3.0"}
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }
+once_cell = { version = "1.13.1" }
 rayon = { version = "1.5.3" }
 regex = { version = "1.6.0" }
 rustpython-parser = { features = ["lalrpop"], git = "https://github.com/charliermarsh/RustPython.git", rev = "1613f6c6990011a4bc559e79aaf28d715f9f729b" }


### PR DESCRIPTION
This PR moves `Regex::new` behind `Lazy`, so each regex effectively only compiles once. Right now it only affects line checks, and this change improves the performance a lot (253.89 ms -> 22.895 ms for a ~1000 lines Python file with many long lines)