### PR TITLE
perf: Avoid `Vec<&str>` allocation during line length checking

### DIFF
--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -3,6 +3,22 @@ use rustpython_parser::ast::Location;
 use crate::checks::{Check, CheckKind};
 use crate::settings::Settings;
 
+/// Whether the given line is too long and should be reported.
+fn should_enforce_line_length(line: &str, limit: usize) -> bool {
+    if line.len() > limit {
+        let mut chunks = line.split_whitespace();
+        if let (Some(first), Some(_)) = (chunks.next(), chunks.next()) {
+            // Do not enforce the line length for commented lines with a single word
+            !(first == "#" && chunks.next().is_none())
+        } else {
+            // Single word / no printable chars - no way to make the line shorter
+            false
+        }
+    } else {
+        false
+    }
+}
+
 pub fn check_lines(checks: &mut Vec<Check>, contents: &str, settings: &Settings) {
     let enforce_line_too_ling = settings.select.contains(CheckKind::LineTooLong.code());
 
@@ -18,16 +34,13 @@ pub fn check_lines(checks: &mut Vec<Check>, contents: &str, settings: &Settings)
         }
 
         // Enforce line length.
-        if enforce_line_too_ling && line.len() > settings.line_length {
-            let chunks: Vec<&str> = line.split_whitespace().collect();
-            if !(chunks.len() == 1 || (chunks.len() == 2 && chunks[0] == "#")) {
-                let check = Check {
-                    kind: CheckKind::LineTooLong,
-                    location: Location::new(row + 1, settings.line_length + 1),
-                };
-                if !check.is_inline_ignored(line) {
-                    line_checks.push(check);
-                }
+        if enforce_line_too_ling && should_enforce_line_length(line, settings.line_length) {
+            let check = Check {
+                kind: CheckKind::LineTooLong,
+                location: Location::new(row + 1, settings.line_length + 1),
+            };
+            if !check.is_inline_ignored(line) {
+                line_checks.push(check);
             }
         }
     }


### PR DESCRIPTION
I noticed that for each line a new vector is allocated, however it could be avoided. Generally, this allocation doesn't hurt much, but it could be visible on lines with a lot of short words and is invoked on **every** line `ruff` processes. For example, the [\_\_init\_\_.py](https://github.com/psf/black/blob/main/src/black/__init__.py) (1388 lines) file from `black` gains ~35% improvement:
- before: `236.92 µs`
- after: `152.35 µs`

Here is the data for the example used to test E501 (~45% improvement):

- before: `781.69 ns`
- after: `430.58 ns`

NOTE: I measured only `check_lines` performance with a single check enabled.

P.S. Sorry if I am nitpicking too much about performance (as it is likely not the most impactful thing at this stage).