### PR TITLE
Fix false positive for `IfTuple`

### DIFF
--- a/resources/test/fixtures/F634.py
+++ b/resources/test/fixtures/F634.py
@@ -6,3 +6,5 @@ for _ in range(5):
         pass
     elif (3, 4):
         pass
+    elif ():
+        pass

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -241,11 +241,13 @@ impl Visitor for Checker<'_> {
             }
             StmtKind::If { test, .. } => {
                 if self.settings.select.contains(CheckKind::IfTuple.code()) {
-                    if let ExprKind::Tuple { .. } = test.node {
-                        self.checks.push(Check {
-                            kind: CheckKind::IfTuple,
-                            location: stmt.location,
-                        });
+                    if let ExprKind::Tuple { elts, .. } = &test.node {
+                        if elts.len() > 0 {
+                            self.checks.push(Check {
+                                kind: CheckKind::IfTuple,
+                                location: stmt.location,
+                            });
+                        }
                     }
                 }
             }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -242,7 +242,7 @@ impl Visitor for Checker<'_> {
             StmtKind::If { test, .. } => {
                 if self.settings.select.contains(CheckKind::IfTuple.code()) {
                     if let ExprKind::Tuple { elts, .. } = &test.node {
-                        if elts.len() > 0 {
+                        if !elts.is_empty() {
                             self.checks.push(Check {
                                 kind: CheckKind::IfTuple,
                                 location: stmt.location,


### PR DESCRIPTION
This PR fixes a false positive for `IfTuple` when a tuple has no elements:

```bash
> cat resources/test/fixtures/F634.py
if (1, 2):
    pass

for _ in range(5):
    if True:
        pass
    elif (3, 4):
        pass
    elif ():
        pass


# BEFORE
> cargo run resources/test/fixtures/F634.py
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/ruff resources/test/fixtures/F634.py`
Found 3 error(s).

resources/test/fixtures/F634.py:1:1: F634 If test is a tuple, which is always `True`
resources/test/fixtures/F634.py:7:5: F634 If test is a tuple, which is always `True`
# false positive - empty tuple is falsy
resources/test/fixtures/F634.py:9:5: F634 If test is a tuple, which is always `True`

# AFTER
> cargo run resources/test/fixtures/F634.py
   Compiling ruff v0.0.25 (/home/haru/Desktop/repositories/ruff)
    Finished dev [unoptimized + debuginfo] target(s) in 2.77s
     Running `target/debug/ruff resources/test/fixtures/F634.py`
Found 2 error(s).

resources/test/fixtures/F634.py:1:1: F634 If test is a tuple, which is always `True`
resources/test/fixtures/F634.py:7:5: F634 If test is a tuple, which is always `True`
```

`IfTuple` implementation in `pyflakes`:

https://github.com/PyCQA/pyflakes/blob/7d6479e46f8f3e9607c9ef7975cc892db023d413/pyflakes/checker.py#L1912-L1915

```python
    def IF(self, node):
        if isinstance(node.test, ast.Tuple) and node.test.elts != []:
            self.report(messages.IfTuple, node)
        self.handleChildren(node)
```

Tuple emptiness is checked as well (`node.test.elts != []`).
