### PR TITLE
Add fixture examples for #114

### DIFF
--- a/resources/test/fixtures/F821.py
+++ b/resources/test/fixtures/F821.py
@@ -33,6 +33,8 @@ def ternary_optarg(prec, exp_range, itr):
 class Foo:
     CLASS_VAR = 1
     REFERENCES_CLASS_VAR = {"CLASS_VAR": CLASS_VAR}
+    # TODO: This should be recognized as a defined variable.
+    ANNOTATED_CLASS_VAR: int = 2  # noqa: F821
 
 
 class Class:
@@ -44,3 +46,7 @@ try:
     x = 1 / 0
 except Exception as e:
     print(e)
+
+
+# TODO: This should be recognized as a defined variable.
+y: int = 1  # noqa: F821


### PR DESCRIPTION
Type annotations on class-level or top-level variable definitions lead to an erroneous E821 (see #114). This commit contains fixture entries that catch this issue, currently annotated with `# noqa`.

Tested with: `cargo test`, which shows failures prior to adding the `# noqa` but none after doing so.