### PR TITLE
Fix ruff's pyproject.toml section name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ git clone --branch 3.10 https://github.com/python/cpython.git resources/test/cpy
 Add this `pyproject.toml` to the CPython directory:
 
 ```toml
-[tool.linter]
+[tool.ruff]
 line-length = 88
 exclude = [
     "Lib/lib2to3/tests/data/bom.py",


### PR DESCRIPTION
That took me a bit to figure out why ruff isn't applying any of the settings I put in pyproject.toml :)

Side suggestion: make `-v` tell you more about settings loading - it currently just tells you that it found `pyproject.toml` but not whether, for example, it found ruff section *or* what settings it picked up.