### PR TITLE
Fix `Message.cmp`

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -20,7 +20,7 @@ impl Ord for Message {
         (&self.filename, self.location.row(), self.location.column()).cmp(&(
             &other.filename,
             other.location.row(),
-            self.location.column(),
+            other.location.column(),
         ))
     }
 }


### PR DESCRIPTION
Fix `Message.cmp`, which currently compares `self.location.column()` and `self.location.column()`.