### PR TITLE
change url to comply with pep 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,11 @@ classifiers = [
 ]
 author = "Charlie Marsh"
 author_email = "charlie.r.marsh@gmail.com"
-url = "https://github.com/charliermarsh/ruff"
 description = "An extremely fast Python linter, written in Rust."
 requires-python = ">=3.7"
+
+[project.urls]
+repository = "https://github.com/charliermarsh/ruff"
 
 [build-system]
 requires = ["maturin>=0.13,<0.14"]


### PR DESCRIPTION
I was surprised when looking at the repository wasn't listed on PyPI:
https://pypi.org/project/ruff/

I think this might be because the url listed in pyproject.toml doesn't comply with [PEP 621](https://peps.python.org/pep-0621/#example)

It's a small change. I chose "repository", but "home" or "github" would work too.
