### PR TITLE
chore: Use `once_cell` instead of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,7 +1759,6 @@ dependencies = [
  "filetime",
  "glob",
  "itertools",
- "lazy_static",
  "log",
  "notify",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ fern = { version = "0.6.1" }
 filetime = { version = "0.2.17" }
 glob = { version = "0.3.0" }
 itertools = "0.10.3"
-lazy_static = "1.4.0"
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }
 once_cell = { version = "1.13.1" }

--- a/src/python/typing.rs
+++ b/src/python/typing.rs
@@ -1,8 +1,8 @@
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::collections::BTreeSet;
 
-lazy_static! {
-    static ref ANNOTATED_SUBSCRIPTS: BTreeSet<&'static str> = BTreeSet::from([
+static ANNOTATED_SUBSCRIPTS: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
+    BTreeSet::from([
         "AbstractAsyncContextManager",
         "AbstractContextManager",
         "AbstractSet",
@@ -80,8 +80,8 @@ lazy_static! {
         "set",
         "tuple",
         "type",
-    ]);
-}
+    ])
+});
 
 pub fn is_annotated_subscript(name: &str) -> bool {
     ANNOTATED_SUBSCRIPTS.contains(name)


### PR DESCRIPTION
`once_cell` crate matches the currently unstable `once_cell` feature & is a bit faster as far as I remember.