### PR TITLE
chore: Avoid `collect` in `inner_main`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::mpsc::channel;
 use std::time::Instant;
@@ -183,9 +183,7 @@ fn inner_main() -> Result<ExitCode> {
 
     set_up_logging(cli.verbose)?;
 
-    // TODO(charlie): Can we avoid this cast?
-    let paths: Vec<&Path> = cli.files.iter().map(PathBuf::as_path).collect();
-    let mut settings = Settings::from_paths(paths)?;
+    let mut settings = Settings::from_paths(&cli.files)?;
     if !cli.select.is_empty() {
         settings.select(cli.select);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn inner_main() -> Result<ExitCode> {
 
     set_up_logging(cli.verbose)?;
 
-    let mut settings = Settings::from_paths(&cli.files)?;
+    let mut settings = Settings::from_paths(&cli.files);
     if !cli.select.is_empty() {
         settings.select(cli.select);
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
-use anyhow::Result;
 use glob::Pattern;
 
 use crate::checks::CheckCode;
@@ -25,7 +24,7 @@ impl Hash for Settings {
 }
 
 impl Settings {
-    pub fn from_paths(paths: &[PathBuf]) -> Result<Self> {
+    pub fn from_paths(paths: &[PathBuf]) -> Self {
         let (project_root, config) = load_config(paths);
         let mut settings = Settings {
             line_length: config.line_length.unwrap_or(88),
@@ -89,7 +88,7 @@ impl Settings {
         if let Some(ignore) = &config.ignore {
             settings.ignore(ignore);
         }
-        Ok(settings)
+        settings
     }
 
     pub fn select(&mut self, codes: Vec<CheckCode>) {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
-use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use glob::Pattern;
@@ -25,8 +25,8 @@ impl Hash for Settings {
 }
 
 impl Settings {
-    pub fn from_paths<'a>(paths: impl IntoIterator<Item = &'a Path>) -> Result<Self> {
-        let (project_root, config) = load_config(paths)?;
+    pub fn from_paths(paths: &[PathBuf]) -> Result<Self> {
+        let (project_root, config) = load_config(paths);
         let mut settings = Settings {
             line_length: config.line_length.unwrap_or(88),
             exclude: config


### PR DESCRIPTION
I tried to guess if it was what you meant by the `todo` entry. With this change, there is a bit less monomorphization & no vector allocation. Additionally `load_config` has a simpler signature without `Result` (as one of the `clippy` lints suggests) + similarly `Settings::from_paths`. Let me know what you think :)