### PR TITLE
Improve default exclusions and support extend-exclude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,12 +907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,7 +1751,6 @@ dependencies = [
  "dirs 4.0.0",
  "fern",
  "filetime",
- "glob",
  "itertools",
  "log",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1757,7 @@ dependencies = [
  "dirs 4.0.0",
  "fern",
  "filetime",
+ "glob",
  "itertools",
  "log",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ common-path = { version = "1.0.0" }
 dirs = { version = "4.0.0" }
 fern = { version = "0.6.1" }
 filetime = { version = "0.2.17" }
+glob = "0.3.0"
 itertools = "0.10.3"
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ common-path = { version = "1.0.0" }
 dirs = { version = "4.0.0" }
 fern = { version = "0.6.1" }
 filetime = { version = "0.2.17" }
-glob = { version = "0.3.0" }
 itertools = "0.10.3"
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }

--- a/resources/test/fixtures/pyproject.toml
+++ b/resources/test/fixtures/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-exclude = ["excluded.py", "**/migrations"]
+extend-exclude = ["excluded\\.py", "migrations"]
 select = [
     "E402",
     "E501",

--- a/resources/test/fixtures/pyproject.toml
+++ b/resources/test/fixtures/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 88
-extend-exclude = ["excluded\\.py", "migrations"]
+extend-exclude = ["excluded.py", "migrations"]
 select = [
     "E402",
     "E501",

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -97,6 +97,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E402]),
             },
             &fixer::Mode::Generate,
@@ -122,6 +123,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E501]),
             },
             &fixer::Mode::Generate,
@@ -147,6 +149,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E711]),
             },
             &fixer::Mode::Generate,
@@ -179,6 +182,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E712]),
             },
             &fixer::Mode::Generate,
@@ -222,6 +226,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E713]),
             },
             &fixer::Mode::Generate,
@@ -247,6 +252,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E721]),
             },
             &fixer::Mode::Generate,
@@ -349,6 +355,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E722]),
             },
             &fixer::Mode::Generate,
@@ -374,6 +381,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E714]),
             },
             &fixer::Mode::Generate,
@@ -399,6 +407,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E731]),
             },
             &fixer::Mode::Generate,
@@ -432,6 +441,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E741]),
             },
             &fixer::Mode::Generate,
@@ -580,6 +590,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E742]),
             },
             &fixer::Mode::Generate,
@@ -618,6 +629,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::E743]),
             },
             &fixer::Mode::Generate,
@@ -656,6 +668,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F401]),
             },
             &fixer::Mode::Generate,
@@ -693,6 +706,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F403]),
             },
             &fixer::Mode::Generate,
@@ -725,6 +739,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F404]),
             },
             &fixer::Mode::Generate,
@@ -750,6 +765,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F406]),
             },
             &fixer::Mode::Generate,
@@ -782,6 +798,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F407]),
             },
             &fixer::Mode::Generate,
@@ -807,6 +824,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F541]),
             },
             &fixer::Mode::Generate,
@@ -844,6 +862,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F601]),
             },
             &fixer::Mode::Generate,
@@ -880,6 +899,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F602]),
             },
             &fixer::Mode::Generate,
@@ -904,6 +924,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F622]),
             },
             &fixer::Mode::Generate,
@@ -928,6 +949,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F631]),
             },
             &fixer::Mode::Generate,
@@ -960,6 +982,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F632]),
             },
             &fixer::Mode::Generate,
@@ -992,6 +1015,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F633]),
             },
             &fixer::Mode::Generate,
@@ -1017,6 +1041,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F634]),
             },
             &fixer::Mode::Generate,
@@ -1049,6 +1074,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F701]),
             },
             &fixer::Mode::Generate,
@@ -1091,6 +1117,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F702]),
             },
             &fixer::Mode::Generate,
@@ -1133,6 +1160,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F704]),
             },
             &fixer::Mode::Generate,
@@ -1170,6 +1198,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F706]),
             },
             &fixer::Mode::Generate,
@@ -1202,6 +1231,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F707]),
             },
             &fixer::Mode::Generate,
@@ -1239,6 +1269,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F722]),
             },
             &fixer::Mode::Generate,
@@ -1264,6 +1295,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F821]),
             },
             &fixer::Mode::Generate,
@@ -1311,6 +1343,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F822]),
             },
             &fixer::Mode::Generate,
@@ -1336,6 +1369,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F823]),
             },
             &fixer::Mode::Generate,
@@ -1361,6 +1395,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F831]),
             },
             &fixer::Mode::Generate,
@@ -1398,6 +1433,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F841]),
             },
             &fixer::Mode::Generate,
@@ -1445,6 +1481,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F901]),
             },
             &fixer::Mode::Generate,
@@ -1477,6 +1514,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::R001]),
             },
             &fixer::Mode::Generate,
@@ -1699,6 +1737,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::R002]),
             },
             &fixer::Mode::Generate,
@@ -1741,6 +1780,7 @@ mod tests {
             &settings::Settings {
                 line_length: 88,
                 exclude: vec![],
+                extend_exclude: vec![],
                 select: BTreeSet::from([CheckCode::F401, CheckCode::F821]),
             },
             &fixer::Mode::Generate,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@ use std::time::Instant;
 use anyhow::Result;
 use clap::{Parser, ValueHint};
 use colored::Colorize;
-use glob::Pattern;
 use log::{debug, error};
 use notify::{raw_watcher, RecursiveMode, Watcher};
 use rayon::prelude::*;
+use regex::Regex;
 use walkdir::DirEntry;
 
 use ::ruff::checks::CheckCode;
@@ -54,9 +54,12 @@ struct Cli {
     /// List of error codes to ignore.
     #[clap(long, multiple = true)]
     ignore: Vec<CheckCode>,
-    /// List of file and/or directory patterns to exclude from checks.
+    /// List of regular expressions, used to exclude files and/or directories from checks.
     #[clap(long, multiple = true)]
-    exclude: Vec<Pattern>,
+    exclude: Vec<Regex>,
+    /// Like --exclude, but adds additional files and directories on top of the excluded ones.
+    #[clap(long, multiple = true)]
+    extend_exclude: Vec<Regex>,
 }
 
 #[cfg(feature = "update-informer")]
@@ -192,6 +195,9 @@ fn inner_main() -> Result<ExitCode> {
     }
     if !cli.exclude.is_empty() {
         settings.exclude(cli.exclude);
+    }
+    if !cli.extend_exclude.is_empty() {
+        settings.extend_exclude(cli.extend_exclude);
     }
 
     if cli.watch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,10 @@ use std::time::Instant;
 use anyhow::Result;
 use clap::{Parser, ValueHint};
 use colored::Colorize;
+use glob::Pattern;
 use log::{debug, error};
 use notify::{raw_watcher, RecursiveMode, Watcher};
 use rayon::prelude::*;
-use regex::Regex;
 use walkdir::DirEntry;
 
 use ::ruff::checks::CheckCode;
@@ -54,12 +54,12 @@ struct Cli {
     /// List of error codes to ignore.
     #[clap(long, multiple = true)]
     ignore: Vec<CheckCode>,
-    /// List of regular expressions, used to exclude files and/or directories from checks.
+    /// List of paths, used to exclude files and/or directories from checks.
     #[clap(long, multiple = true)]
-    exclude: Vec<Regex>,
+    exclude: Vec<Pattern>,
     /// Like --exclude, but adds additional files and directories on top of the excluded ones.
     #[clap(long, multiple = true)]
-    extend_exclude: Vec<Regex>,
+    extend_exclude: Vec<Pattern>,
 }
 
 #[cfg(feature = "update-informer")]
@@ -96,7 +96,7 @@ fn run_once(
     let start = Instant::now();
     let paths: Vec<DirEntry> = files
         .iter()
-        .flat_map(|path| iter_python_files(path, &settings.exclude))
+        .flat_map(|path| iter_python_files(path, &settings.exclude, &settings.extend_exclude))
         .collect();
     let duration = start.elapsed();
     debug!("Identified files to lint in: {:?}", duration);
@@ -194,10 +194,10 @@ fn inner_main() -> Result<ExitCode> {
         settings.ignore(&cli.ignore);
     }
     if !cli.exclude.is_empty() {
-        settings.exclude(cli.exclude);
+        settings.exclude = cli.exclude;
     }
     if !cli.extend_exclude.is_empty() {
-        settings.extend_exclude(cli.extend_exclude);
+        settings.extend_exclude = cli.extend_exclude;
     }
 
     if cli.watch {

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -12,7 +12,7 @@ pub fn load_config(paths: &[PathBuf]) -> Config {
     match find_project_root(paths) {
         Some(project_root) => match find_pyproject_toml(&project_root) {
             Some(path) => {
-                debug!("Found pyproject.toml at: {}", path.to_string_lossy());
+                debug!("Found pyproject.toml at: {:?}", path);
                 match parse_pyproject_toml(&path) {
                     Ok(pyproject) => pyproject
                         .tool
@@ -260,7 +260,7 @@ other-attribute = 1
                 line_length: Some(88),
                 exclude: None,
                 extend_exclude: Some(vec![
-                    Path::new("excluded\\.py").to_path_buf(),
+                    Path::new("excluded.py").to_path_buf(),
                     Path::new("migrations").to_path_buf()
                 ]),
                 select: Some(vec![

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -8,19 +8,16 @@ use serde::Deserialize;
 use crate::checks::CheckCode;
 use crate::fs;
 
-pub fn load_config(paths: &[PathBuf]) -> (PathBuf, Config) {
+pub fn load_config(paths: &[PathBuf]) -> Config {
     match find_project_root(paths) {
         Some(project_root) => match find_pyproject_toml(&project_root) {
             Some(path) => {
                 debug!("Found pyproject.toml at: {}", path.to_string_lossy());
                 match parse_pyproject_toml(&path) {
-                    Ok(pyproject) => {
-                        let config = pyproject
-                            .tool
-                            .and_then(|tool| tool.ruff)
-                            .unwrap_or_default();
-                        (project_root, config)
-                    }
+                    Ok(pyproject) => pyproject
+                        .tool
+                        .and_then(|tool| tool.ruff)
+                        .unwrap_or_default(),
                     Err(e) => {
                         println!("Failed to load pyproject.toml: {:?}", e);
                         println!("Falling back to default configuration...");
@@ -39,6 +36,7 @@ pub fn load_config(paths: &[PathBuf]) -> (PathBuf, Config) {
 pub struct Config {
     pub line_length: Option<usize>,
     pub exclude: Option<Vec<PathBuf>>,
+    pub extend_exclude: Option<Vec<PathBuf>>,
     pub select: Option<Vec<CheckCode>>,
     pub ignore: Option<Vec<CheckCode>>,
 }
@@ -123,6 +121,7 @@ mod tests {
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
+                    extend_exclude: None,
                     select: None,
                     ignore: None,
                 })
@@ -142,6 +141,7 @@ line-length = 79
                 ruff: Some(Config {
                     line_length: Some(79),
                     exclude: None,
+                    extend_exclude: None,
                     select: None,
                     ignore: None,
                 })
@@ -161,6 +161,7 @@ exclude = ["foo.py"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: Some(vec![Path::new("foo.py").to_path_buf()]),
+                    extend_exclude: None,
                     select: None,
                     ignore: None,
                 })
@@ -180,6 +181,7 @@ select = ["E501"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
+                    extend_exclude: None,
                     select: Some(vec![CheckCode::E501]),
                     ignore: None,
                 })
@@ -199,6 +201,7 @@ ignore = ["E501"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
+                    extend_exclude: None,
                     select: None,
                     ignore: Some(vec![CheckCode::E501]),
                 })
@@ -255,9 +258,10 @@ other-attribute = 1
             config,
             Config {
                 line_length: Some(88),
-                exclude: Some(vec![
-                    Path::new("excluded.py").to_path_buf(),
-                    Path::new("**/migrations").to_path_buf()
+                exclude: None,
+                extend_exclude: Some(vec![
+                    Path::new("excluded\\.py").to_path_buf(),
+                    Path::new("migrations").to_path_buf()
                 ]),
                 select: Some(vec![
                     CheckCode::E402,


### PR DESCRIPTION
This PR changes `--exclude` to use regular expressions rather than globs, which matches Black's behavior. We also now match Black's default list of exclusions, and support a `--extend-exclude` command-line argument and `pyproject.toml` field.

Resolves #176.
