### PR TITLE
Detect multi-target assignment as unpacking if *any* target is unpacking

### DIFF
--- a/resources/test/fixtures/F841.py
+++ b/resources/test/fixtures/F841.py
@@ -22,3 +22,6 @@ def g():
 
     bar = (1, 2)
     (c, d) = bar
+
+    (x, y) = baz = bar
+    print(baz)

--- a/resources/test/fixtures/F841.py
+++ b/resources/test/fixtures/F841.py
@@ -24,4 +24,3 @@ def g():
     (c, d) = bar
 
     (x, y) = baz = bar
-    print(baz)

--- a/src/ast/operations.rs
+++ b/src/ast/operations.rs
@@ -101,11 +101,13 @@ pub fn in_nested_block(parent_stack: &[usize], parents: &[&Stmt]) -> bool {
 /// Check if a node represents an unpacking assignment.
 pub fn is_unpacking_assignment(stmt: &Stmt) -> bool {
     if let StmtKind::Assign { targets, value, .. } = &stmt.node {
-        for child in targets {
-            match &child.node {
-                ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. } => {}
-                _ => return false,
-            }
+        if !targets.iter().any(|child| {
+            matches!(
+                child.node,
+                ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. }
+            )
+        }) {
+            return false;
         }
         match &value.node {
             ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. } => return false,


### PR DESCRIPTION
Improves the fix for #161.