### PR TITLE
Enable F404 by default

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -94,6 +94,7 @@ impl Settings {
                     CheckCode::E999,
                     CheckCode::F401,
                     CheckCode::F403,
+                    CheckCode::F404,
                     CheckCode::F406,
                     CheckCode::F407,
                     CheckCode::F541,


### PR DESCRIPTION
This seems to have been forgotten in #159.