### PR TITLE
Add `--version` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ OPTIONS:
             List of error codes to enable
     -v, --verbose
             Enable verbose logging
+    -V, --version
+            Print version information
     -w, --watch
             Run in watch mode by re-running whenever files change
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 #[derive(Debug, Parser)]
 #[clap(name = format!("{CARGO_PKG_NAME} (v{CARGO_PKG_VERSION})"))]
 #[clap(about = "An extremely fast Python linter.", long_about = None)]
+#[clap(version)]
 struct Cli {
     #[clap(parse(from_os_str), value_hint = ValueHint::AnyPath, required = true)]
     files: Vec<PathBuf>,


### PR DESCRIPTION
```
> ruff -V
ruff (v0.0.40) 0.0.40

> ruff --version
ruff (v0.0.40) 0.0.40

> ruff --help
ruff (v0.0.40) 0.0.40
An extremely fast Python linter.

USAGE:
    ruff [OPTIONS] <FILES>...

ARGS:
    <FILES>...    

OPTIONS:
    -e, --exit-zero
            Exit with status code "0", even upon detecting errors

        --exclude <EXCLUDE>...
            List of paths, used to exclude files and/or directories from checks

        --extend-exclude <EXTEND_EXCLUDE>...
            Like --exclude, but adds additional files and directories on top of the excluded ones

    -f, --fix
            Attempt to automatically fix lint errors

        --format <FORMAT>
            Output serialization format for error messages [default: text] [possible values: text,
            json]

    -h, --help
            Print help information

        --ignore <IGNORE>...
            List of error codes to ignore

    -n, --no-cache
            Disable cache reads

    -q, --quiet
            Disable all logging (but still exit with status code "1" upon detecting errors)

        --select <SELECT>...
            List of error codes to enable

    -v, --verbose
            Enable verbose logging

    -V, --version
            Print version information

    -w, --watch
            Run in watch mode by re-running whenever files change
```