### PR TITLE
fix: Use UTF-32 char count for line length (#223)

### DIFF
--- a/resources/test/fixtures/E501.py
+++ b/resources/test/fixtures/E501.py
@@ -4,3 +4,6 @@
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 """
+
+_ = "---------------------------------------------------------------------------AAAAAAA"
+_ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜"


### PR DESCRIPTION
This should make ruff compatible with flake8 (pycodestyle) on checking length of a line which contains non-single-byte characters.