### PR TITLE
Use a separate repo for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.40
     hooks:
       - id: lint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,0 @@
-- id: lint
-  name: ruff lint
-  description: Run ruff to lint Python files.
-  entry: ruff
-  language: python
-  types_or: [python]
-  pass_filenames: true

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ You can run ruff in `--watch` mode to automatically re-run on-change:
 ruff path/to/code/ --watch
 ```
 
-ruff also works with [Pre-Commit](https://pre-commit.com) (requires Cargo on system):
+ruff also works with [pre-commit](https://pre-commit.com):
 
 ```yaml
 repos:
-- repo: https://github.com/charliermarsh/ruff
-  rev: v0.0.40
-  hooks:
-    - id: lint
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.40
+    hooks:
+      - id: lint
 ```
 
 ## Configuration


### PR DESCRIPTION
Resolves #225.

By defining the pre-commit configuration in _this_ repo, users had to build ruff from source, which requires Cargo. By putting the pre-commit configuration in a standalone repo that _depends_ on ruff, we can leverage PyPI's prebuilt wheels.
