### PR TITLE
Suppress “Found 0 error(s)” message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,7 @@ fn inner_main() -> Result<ExitCode> {
 
     cache::init()?;
 
-    let mut printer = Printer::new(cli.format);
+    let mut printer = Printer::new(cli.format, cli.verbose);
     if cli.watch {
         if cli.fix {
             println!("Warning: --fix is not enabled in watch mode.");

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -13,11 +13,12 @@ pub enum SerializationFormat {
 
 pub struct Printer {
     format: SerializationFormat,
+    verbose: bool,
 }
 
 impl Printer {
-    pub fn new(format: SerializationFormat) -> Self {
-        Self { format }
+    pub fn new(format: SerializationFormat, verbose: bool) -> Self {
+        Self { format, verbose }
     }
 
     pub fn write_once(&mut self, messages: &[Message]) -> Result<()> {
@@ -39,7 +40,7 @@ impl Printer {
                         outstanding.len(),
                         fixed.len()
                     )
-                } else {
+                } else if !outstanding.is_empty() || self.verbose {
                     println!("Found {} error(s).", outstanding.len())
                 }
 


### PR DESCRIPTION
When ruff is run from a script alongside many other linters, the noisy default messages from each one saying that no errors were found can easily drown out a real error. Only print the error count if it’s nonzero or `--verbose` was specified.

(I’m open to making this opt-out rather than opt-in if you prefer, although I’m not sure what I’d call the option. `--quiet` already means something else, suppressing all output including errors.)