### PR TITLE
Include specified files, even if they lack a .py[i] extension

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -107,8 +107,7 @@ pub fn iter_python_files<'a>(
         })
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            let path = entry.path();
-            is_included(path)
+            (entry.depth() == 0 && !entry.file_type().is_dir()) || is_included(entry.path())
         })
 }
 


### PR DESCRIPTION
Some Python scripts don’t have a `.py` extension (especially executables with `#!` lines).  We should only filter the extension of files found within a specified directory (`ruff .`), not of specified files (`ruff my-script`).