### PR TITLE
Handle filesystem errors more consistently

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -449,9 +449,7 @@ impl CheckKind {
             CheckKind::FutureFeatureNotDefined(name) => {
                 format!("future feature '{name}' is not defined")
             }
-            CheckKind::IOError(name) => {
-                format!("No such file or directory: `{name}`")
-            }
+            CheckKind::IOError(message) => message.clone(),
             CheckKind::IfTuple => "If test is a tuple, which is always `True`".to_string(),
             CheckKind::InvalidPrintSyntax => "use of >> is invalid with print function".to_string(),
             CheckKind::ImportStarNotPermitted(name) => {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -59,7 +59,7 @@ pub fn iter_python_files<'a>(
     path: &'a Path,
     exclude: &'a [FilePattern],
     extend_exclude: &'a [FilePattern],
-) -> impl Iterator<Item = DirEntry> + 'a {
+) -> impl Iterator<Item = Result<DirEntry, walkdir::Error>> + 'a {
     // Run some checks over the provided patterns, to enable optimizations below.
     let has_exclude = !exclude.is_empty();
     let has_extend_exclude = !extend_exclude.is_empty();
@@ -105,9 +105,10 @@ pub fn iter_python_files<'a>(
                 }
             }
         })
-        .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            (entry.depth() == 0 && !entry.file_type().is_dir()) || is_included(entry.path())
+            entry.as_ref().map_or(true, |entry| {
+                (entry.depth() == 0 && !entry.file_type().is_dir()) || is_included(entry.path())
+            })
         })
 }
 


### PR DESCRIPTION
Emit E902 for all filesystem errors that occur during directory walking or linting. Use the system-provided error message instead of assuming that all filesystem errors are “No such file or directory”. Remove the redundant `exists()` checks since we are no longer suppressing that error during directory walking.