### PR TITLE
Adjust line numbers when reporting rules in f-strings

### DIFF
--- a/resources/test/fixtures/F821.py
+++ b/resources/test/fixtures/F821.py
@@ -82,3 +82,10 @@ class Ticket:
 def update_tomato():
     print(TOMATO)
     TOMATO = "cherry tomato"
+
+
+A = f'{B}'
+A = (
+    f'B'
+    f'{B}'
+)

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -65,3 +65,7 @@ pub struct Binding {
     /// last used.
     pub used: Option<(usize, Location)>,
 }
+
+pub trait CheckLocator {
+    fn locate_check(&self, default: Location) -> Location;
+}

--- a/src/snapshots/ruff__linter__tests__f821.snap
+++ b/src/snapshots/ruff__linter__tests__f821.snap
@@ -38,4 +38,16 @@ expression: checks
     row: 83
     column: 11
   fix: ~
+- kind:
+    UndefinedName: B
+  location:
+    row: 87
+    column: 7
+  fix: ~
+- kind:
+    UndefinedName: B
+  location:
+    row: 89
+    column: 7
+  fix: ~
 


### PR DESCRIPTION
The best we can do until this is fixed in the parser itself: whenever reporting a rule in an f-string, just use the location of the f-string itself. This will be wrong in some cases, but at least it will be close.

Resolves #145.
