### PR TITLE
Feature/per file ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ OPTIONS:
             Print help information
     -n, --no-cache
             Disable cache reads
+        --per-file-ignores <PER_FILE_IGNORES>...
+            List of mappings from file pattern to code to exclude
     -q, --quiet
             Disable all logging (but still exit with status code "1" upon detecting errors)
         --add-noqa

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -180,12 +180,11 @@ pub fn check_lines(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
-    use regex::Regex;
+    use crate::autofix::fixer;
+    use crate::checks::{Check, CheckCode};
+    use crate::settings;
 
     use super::check_lines;
-    use super::*;
 
     #[test]
     fn e501_non_ascii_char() {
@@ -193,21 +192,14 @@ mod tests {
         let noqa_line_for: Vec<usize> = vec![1];
         let check_with_max_line_length = |line_length: usize| {
             let mut checks: Vec<Check> = vec![];
-            let settings = Settings {
-                pyproject: None,
-                project_root: None,
-                line_length,
-                exclude: vec![],
-                extend_exclude: vec![],
-                select: BTreeSet::from_iter(vec![CheckCode::E501]),
-                per_file_ignores: vec![],
-                dummy_variable_rgx: Regex::new(r"^_+").unwrap(),
-            };
             check_lines(
                 &mut checks,
                 line,
                 &noqa_line_for,
-                &settings,
+                &settings::Settings {
+                    line_length,
+                    ..settings::Settings::for_rule(CheckCode::E501)
+                },
                 &fixer::Mode::Generate,
             );
             return checks;

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -198,6 +198,7 @@ mod tests {
                 exclude: vec![],
                 extend_exclude: vec![],
                 select: BTreeSet::from_iter(vec![CheckCode::E501]),
+                per_file_ignores: vec![],
             };
             check_lines(
                 &mut checks,

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -125,8 +125,14 @@ pub fn ignores_from_path<'a>(
     let (file_path, file_basename) = extract_path_names(path)?;
     Ok(pattern_code_pairs
         .iter()
-        .filter(|x| is_excluded(file_path, file_basename, [&x.pattern].into_iter()))
-        .map(|x| &x.code)
+        .filter(|pattern_code_pair| {
+            is_excluded(
+                file_path,
+                file_basename,
+                [&pattern_code_pair.pattern].into_iter(),
+            )
+        })
+        .map(|pattern_code_pair| &pattern_code_pair.code)
         .collect())
 }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -56,13 +56,14 @@ fn check_path(
     let ignores = fs::ignores_from_path(path, &settings.per_file_ignores).unwrap();
 
     // Filter checks by ignores
-    checks
-        .into_iter()
-        .filter(|check| match &ignores {
-            Some(ignores_set) => !ignores_set.contains(check.kind.code()),
-            None => true,
-        })
-        .collect()
+    if ignores.is_empty() {
+        checks
+    } else {
+        checks
+            .into_iter()
+            .filter(|check| !ignores.contains(check.kind.code()))
+            .collect()
+    }
 }
 
 pub fn lint_path(

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -52,7 +52,17 @@ fn check_path(
     // Run the lines-based checks.
     check_lines(&mut checks, contents, &noqa_line_for, settings, autofix);
 
+    // Create path ignores (panics if path cannot be parsed)
+    let ignores = fs::ignores_from_path(path, &settings.per_file_ignores).unwrap();
+
+    // Filter checks by ignores
     checks
+        .into_iter()
+        .filter(|check| match &ignores {
+            Some(ignores_set) => !ignores_set.contains(check.kind.code()),
+            None => true,
+        })
+        .collect()
 }
 
 pub fn lint_path(

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -21,7 +21,7 @@ fn check_path(
     tokens: Vec<LexResult>,
     settings: &Settings,
     autofix: &fixer::Mode,
-) -> Vec<Check> {
+) -> Result<Vec<Check>> {
     // Aggregate all checks.
     let mut checks: Vec<Check> = vec![];
 
@@ -52,18 +52,18 @@ fn check_path(
     // Run the lines-based checks.
     check_lines(&mut checks, contents, &noqa_line_for, settings, autofix);
 
-    // Create path ignores (panics if path cannot be parsed)
-    let ignores = fs::ignores_from_path(path, &settings.per_file_ignores).unwrap();
-
-    // Filter checks by ignores
-    if ignores.is_empty() {
-        checks
-    } else {
-        checks
-            .into_iter()
-            .filter(|check| !ignores.contains(check.kind.code()))
-            .collect()
+    // Create path ignores.
+    if !checks.is_empty() && !settings.per_file_ignores.is_empty() {
+        let ignores = fs::ignores_from_path(path, &settings.per_file_ignores)?;
+        if !ignores.is_empty() {
+            return Ok(checks
+                .into_iter()
+                .filter(|check| !ignores.contains(check.kind.code()))
+                .collect());
+        }
     }
+
+    Ok(checks)
 }
 
 pub fn lint_path(
@@ -87,7 +87,7 @@ pub fn lint_path(
     let tokens: Vec<LexResult> = lexer::make_tokenizer(&contents).collect();
 
     // Generate checks.
-    let mut checks = check_path(path, &contents, tokens, settings, autofix);
+    let mut checks = check_path(path, &contents, tokens, settings, autofix)?;
 
     // Apply autofix.
     if matches!(autofix, fixer::Mode::Apply) {
@@ -120,7 +120,7 @@ pub fn add_noqa_to_path(path: &Path, settings: &Settings) -> Result<usize> {
     let noqa_line_for = noqa::extract_noqa_line_for(&tokens);
 
     // Generate checks.
-    let checks = check_path(path, &contents, tokens, settings, &fixer::Mode::None);
+    let checks = check_path(path, &contents, tokens, settings, &fixer::Mode::None)?;
 
     add_noqa(&checks, &contents, &noqa_line_for, path)
 }
@@ -147,9 +147,7 @@ mod tests {
     ) -> Result<Vec<Check>> {
         let contents = fs::read_file(path)?;
         let tokens: Vec<LexResult> = lexer::make_tokenizer(&contents).collect();
-        Ok(linter::check_path(
-            path, &contents, tokens, settings, autofix,
-        ))
+        linter::check_path(path, &contents, tokens, settings, autofix)
     }
 
     #[test]

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -63,11 +63,12 @@ impl<'de> Deserialize<'de> for StrCheckCodePair {
 
 impl FromStr for StrCheckCodePair {
     type Err = anyhow::Error;
+
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         let (pattern_str, code_string) = {
             let tokens = string.split(':').collect::<Vec<_>>();
             if tokens.len() != 2 {
-                return Err(anyhow!("expected {}", Self::EXPECTED_PATTERN));
+                return Err(anyhow!("Expected {}", Self::EXPECTED_PATTERN));
             }
             (tokens[0], tokens[1])
         };

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -37,6 +37,7 @@ pub struct Config {
     pub extend_exclude: Option<Vec<String>>,
     pub select: Option<Vec<CheckCode>>,
     pub ignore: Option<Vec<CheckCode>>,
+    pub per_file_ignores: Option<Vec<String>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -137,6 +138,7 @@ mod tests {
                     extend_exclude: None,
                     select: None,
                     ignore: None,
+                    per_file_ignores: None,
                 })
             })
         );
@@ -157,6 +159,7 @@ line-length = 79
                     extend_exclude: None,
                     select: None,
                     ignore: None,
+                    per_file_ignores: None,
                 })
             })
         );
@@ -177,6 +180,7 @@ exclude = ["foo.py"]
                     extend_exclude: None,
                     select: None,
                     ignore: None,
+                    per_file_ignores: None,
                 })
             })
         );
@@ -197,6 +201,7 @@ select = ["E501"]
                     extend_exclude: None,
                     select: Some(vec![CheckCode::E501]),
                     ignore: None,
+                    per_file_ignores: None,
                 })
             })
         );
@@ -217,6 +222,7 @@ ignore = ["E501"]
                     extend_exclude: None,
                     select: None,
                     ignore: Some(vec![CheckCode::E501]),
+                    per_file_ignores: None,
                 })
             })
         );
@@ -281,6 +287,7 @@ other-attribute = 1
                 ]),
                 select: None,
                 ignore: None,
+                per_file_ignores: None,
             }
         );
 

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -1,9 +1,11 @@
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use common_path::common_path_all;
 use path_absolutize::Absolutize;
-use serde::Deserialize;
+use serde::de;
+use serde::{Deserialize, Deserializer};
 
 use crate::checks::CheckCode;
 use crate::fs;
@@ -37,7 +39,48 @@ pub struct Config {
     pub extend_exclude: Option<Vec<String>>,
     pub select: Option<Vec<CheckCode>>,
     pub ignore: Option<Vec<CheckCode>>,
-    pub per_file_ignores: Option<Vec<String>>,
+    pub per_file_ignores: Option<Vec<StrCheckCodePair>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct StrCheckCodePair {
+    pub pattern: String,
+    pub code: CheckCode,
+}
+
+impl StrCheckCodePair {
+    const EXPECTED_PATTERN: &str = "<FilePattern>:<CheckCode> pattern";
+}
+
+impl<'de> Deserialize<'de> for StrCheckCodePair {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let str_result = String::deserialize(deserializer)?;
+        Self::from_str(str_result.as_str()).map_err(|_| {
+            de::Error::invalid_value(
+                de::Unexpected::Str(str_result.as_str()),
+                &Self::EXPECTED_PATTERN,
+            )
+        })
+    }
+}
+
+impl FromStr for StrCheckCodePair {
+    type Err = anyhow::Error;
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        let (pattern_str, code_string) = {
+            let tokens = string.split(':').collect::<Vec<_>>();
+            if tokens.len() != 2 {
+                return Err(anyhow!("expected {}", Self::EXPECTED_PATTERN));
+            }
+            (tokens[0], tokens[1])
+        };
+        let code = CheckCode::from_str(code_string)?;
+        let pattern = pattern_str.into();
+        Ok(Self { pattern, code })
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -103,9 +146,11 @@ pub fn find_project_root(sources: &[PathBuf]) -> Option<PathBuf> {
 mod tests {
     use std::env::current_dir;
     use std::path::PathBuf;
+    use std::str::FromStr;
 
     use anyhow::Result;
 
+    use super::StrCheckCodePair;
     use crate::checks::CheckCode;
     use crate::pyproject::{
         find_project_root, find_pyproject_toml, parse_pyproject_toml, Config, PyProject, Tools,
@@ -292,5 +337,23 @@ other-attribute = 1
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn str_check_code_pair_strings() {
+        let result = StrCheckCodePair::from_str("foo:E501");
+        assert!(result.is_ok());
+        let result = StrCheckCodePair::from_str("E501:foo");
+        assert!(result.is_err());
+        let result = StrCheckCodePair::from_str("E501");
+        assert!(result.is_err());
+        let result = StrCheckCodePair::from_str("foo");
+        assert!(result.is_err());
+        let result = StrCheckCodePair::from_str("foo:E501:E402");
+        assert!(result.is_err());
+        let result = StrCheckCodePair::from_str("**/bar:E501");
+        assert!(result.is_ok());
+        let result = StrCheckCodePair::from_str("bar:E502");
+        assert!(result.is_err());
     }
 }

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -43,7 +43,7 @@ pub struct StrCheckCodePair {
 }
 
 impl StrCheckCodePair {
-    const EXPECTED_PATTERN: &str = "<FilePattern>:<CheckCode> pattern";
+    const EXPECTED_PATTERN: &'static str = "<FilePattern>:<CheckCode> pattern";
 }
 
 impl<'de> Deserialize<'de> for StrCheckCodePair {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -161,13 +161,15 @@ impl Settings {
             } else {
                 BTreeSet::from_iter(DEFAULT_CHECK_CODES)
             },
-            per_file_ignores: match config.per_file_ignores {
-                Some(ignore_strings) => ignore_strings
-                    .into_iter()
-                    .map(|pair| PerFileIgnore::new(pair, &project_root))
-                    .collect(),
-                None => vec![],
-            },
+            per_file_ignores: config
+                .per_file_ignores
+                .map(|ignore_strings| {
+                    ignore_strings
+                        .into_iter()
+                        .map(|pair| PerFileIgnore::new(pair, &project_root))
+                        .collect()
+                })
+                .unwrap_or_default(),
             dummy_variable_rgx: match config.dummy_variable_rgx {
                 Some(pattern) => Regex::new(&pattern)
                     .map_err(|e| anyhow!("Invalid dummy-variable-rgx value: {e}"))?,


### PR DESCRIPTION
resolves #241

This PR implements per-file-ignores as a per-path built filter for the output of `crate::linter::check_path`.
The goal is feature parity.

## Caveats

There is definitely room for optimisation here. Currently filtering the output by removing checks to ignore, after they've been checked leaves the obvious improvement of not executing the check in the first place. This is fairly intrusive on the current approach to the Checker as `settings.selected` is used ubiquitously as the source for code checking.

Additionally, all pairs are matched against each entry to generate the set of ignores to filter against. It's possible to use a better representation of these patterns such that iterating over the each match is possible (although this still has a worst case of O(n)).

Errors for incorrect `pattern:code` pairs currently fail silently in config, and fail with the corresponding anyhow message dumped to stdout. This behaviour is potentially debatable and feedback would be appreciated.

## Description

Per file ignores is available from both the cli via `--per-file-ignores=<stuff>` and in the pyproject.toml under `tool.ruff.per-file-ignores`. Additionally the cache-key is generated using per-file-ignores, as changes to the setting leads to a different output that  couldn't be represented by the previous cache-key generation
