### PR TITLE
Print warning and error messages in stderr

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,7 @@ fn inner_main() -> Result<ExitCode> {
     }
 
     if cli.show_settings && cli.show_files {
-        println!("Error: specify --show-settings or show-files (not both).");
+        eprintln!("Error: specify --show-settings or show-files (not both).");
         return Ok(ExitCode::FAILURE);
     }
     if cli.show_settings {
@@ -284,15 +284,15 @@ fn inner_main() -> Result<ExitCode> {
     let mut printer = Printer::new(cli.format, cli.verbose);
     if cli.watch {
         if cli.fix {
-            println!("Warning: --fix is not enabled in watch mode.");
+            eprintln!("Warning: --fix is not enabled in watch mode.");
         }
 
         if cli.add_noqa {
-            println!("Warning: --no-qa is not enabled in watch mode.");
+            eprintln!("Warning: --no-qa is not enabled in watch mode.");
         }
 
         if cli.format != SerializationFormat::Text {
-            println!("Warning: --format 'text' is used in watch mode.");
+            eprintln!("Warning: --format 'text' is used in watch mode.");
         }
 
         // Perform an initial run instantly.

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,7 +355,7 @@ fn main() -> ExitCode {
     match inner_main() {
         Ok(code) => code,
         Err(err) => {
-            println!("{} {:?}", "error".red().bold(), err);
+            eprintln!("{} {:?}", "error".red().bold(), err);
             ExitCode::FAILURE
         }
     }

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -15,8 +15,8 @@ pub fn load_config(pyproject: &Option<PathBuf>) -> Result<Config> {
             .and_then(|tool| tool.ruff)
             .unwrap_or_default()),
         None => {
-            println!("No pyproject.toml found.");
-            println!("Falling back to default configuration...");
+            eprintln!("No pyproject.toml found.");
+            eprintln!("Falling back to default configuration...");
             Ok(Default::default())
         }
     }


### PR DESCRIPTION
I found this issue when I was parsing the JSON output. Warning messages should be written in stderr, not stdout:

Actual:

```
> ruff --format json code.py 2> /dev/null
No pyproject.toml found. <-
Falling back to default configuration... <-
[
  {
    "kind": "IfTuple",
    "fixed": false,
    "location": {
      "row": 1,
      "column": 1
    },
    "filename": "/home/haru/Desktop/repositories/ruff-extension-test/code.py"
  }
]
```

Expected:

```
> ruff --format json code.py 2> /dev/null
[
  {
    "kind": "IfTuple",
    "fixed": false,
    "location": {
      "row": 1,
      "column": 1
    },
    "filename": "/home/haru/Desktop/repositories/ruff-extension-test/code.py"
  }
]
```