### PR TITLE
Show user configuration file path in --help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,17 +24,30 @@ use ::ruff::linter::lint_path;
 use ::ruff::logging::set_up_logging;
 use ::ruff::message::Message;
 use ::ruff::printer::{Printer, SerializationFormat};
-use ::ruff::pyproject::{self, StrCheckCodePair};
+use ::ruff::pyproject::{self, user_pyproject_toml_path, StrCheckCodePair};
 use ::ruff::settings::{FilePattern, PerFileIgnore, Settings};
 use ::ruff::tell_user;
 
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+fn after_help() -> String {
+    if let Some(path) = user_pyproject_toml_path() {
+        format!(
+            "User configuration file: {} ({})\n",
+            path.to_string_lossy(),
+            if path.is_file() { "present" } else { "absent" }
+        )
+    } else {
+        "".to_string()
+    }
+}
+
 #[derive(Debug, Parser)]
 #[clap(name = CARGO_PKG_NAME)]
 #[clap(about = "An extremely fast Python linter.", long_about = None)]
 #[clap(version)]
+#[clap(after_help = after_help())]
 struct Cli {
     #[arg(value_hint = ValueHint::AnyPath, required = true)]
     files: Vec<PathBuf>,

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -101,18 +101,20 @@ pub fn find_pyproject_toml(path: &Option<PathBuf>) -> Option<PathBuf> {
         }
     }
 
-    find_user_pyproject_toml()
+    if let Some(path_pyproject_toml) = user_pyproject_toml_path() {
+        if path_pyproject_toml.is_file() {
+            return Some(path_pyproject_toml);
+        }
+    }
+
+    None
 }
 
-fn find_user_pyproject_toml() -> Option<PathBuf> {
+pub fn user_pyproject_toml_path() -> Option<PathBuf> {
     let mut path = dirs::config_dir()?;
     path.push("ruff");
     path.push("pyproject.toml");
-    if path.is_file() {
-        Some(path)
-    } else {
-        None
-    }
+    Some(path)
 }
 
 pub fn find_project_root(sources: &[PathBuf]) -> Option<PathBuf> {


### PR DESCRIPTION
Refs https://github.com/charliermarsh/ruff/pull/215#discussion_r973620904, #248.

Note that the `after_help()` computation runs on every invocation of `ruff`, not just `ruff --help`, which is less than ideal but probably fine. I’ll let you decide whether it’s worthwhile.