### PR TITLE
fix: Make assigns to dunder exception for E402.

### DIFF
--- a/resources/test/fixtures/E402.py
+++ b/resources/test/fixtures/E402.py
@@ -1,4 +1,8 @@
 """Top-level docstring."""
+
+__all__ = ["y"]
+__version__: str = "0.1.0"
+
 import a
 
 try:

--- a/src/snapshots/ruff__linter__tests__e402.snap
+++ b/src/snapshots/ruff__linter__tests__e402.snap
@@ -4,7 +4,7 @@ expression: checks
 ---
 - kind: ModuleImportNotAtTopOfFile
   location:
-    row: 20
+    row: 24
     column: 1
   fix: ~
 


### PR DESCRIPTION
This commit allow assignments to dunder names to be placed after a before normal imports. PEP 8 says:

> Module level "dunders" (i.e. names with two leading and two trailing
> underscores) such as __all__, __author__, __version__, etc. should be
> placed after the module docstring but before any import statements
> except from __future__ imports.

Note that the checking logic is a copy of [that of pycodestyle](https://github.com/PyCQA/pycodestyle/blob/2.9.1/pycodestyle.py#L1153).