### PR TITLE
Remove unnecessary Option wrapper from some pyproject::Config fields

### DIFF
--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -29,10 +29,13 @@ pub fn load_config(pyproject: &Option<PathBuf>) -> Result<Config> {
 pub struct Config {
     pub line_length: Option<usize>,
     pub exclude: Option<Vec<String>>,
-    pub extend_exclude: Option<Vec<String>>,
+    #[serde(default)]
+    pub extend_exclude: Vec<String>,
     pub select: Option<Vec<CheckCode>>,
-    pub ignore: Option<Vec<CheckCode>>,
-    pub per_file_ignores: Option<Vec<StrCheckCodePair>>,
+    #[serde(default)]
+    pub ignore: Vec<CheckCode>,
+    #[serde(default)]
+    pub per_file_ignores: Vec<StrCheckCodePair>,
     pub dummy_variable_rgx: Option<String>,
 }
 
@@ -175,10 +178,10 @@ mod tests {
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
-                    extend_exclude: None,
+                    extend_exclude: vec![],
                     select: None,
-                    ignore: None,
-                    per_file_ignores: None,
+                    ignore: vec![],
+                    per_file_ignores: vec![],
                     dummy_variable_rgx: None,
                 })
             })
@@ -197,10 +200,10 @@ line-length = 79
                 ruff: Some(Config {
                     line_length: Some(79),
                     exclude: None,
-                    extend_exclude: None,
+                    extend_exclude: vec![],
                     select: None,
-                    ignore: None,
-                    per_file_ignores: None,
+                    ignore: vec![],
+                    per_file_ignores: vec![],
                     dummy_variable_rgx: None,
                 })
             })
@@ -219,10 +222,10 @@ exclude = ["foo.py"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: Some(vec!["foo.py".to_string()]),
-                    extend_exclude: None,
+                    extend_exclude: vec![],
                     select: None,
-                    ignore: None,
-                    per_file_ignores: None,
+                    ignore: vec![],
+                    per_file_ignores: vec![],
                     dummy_variable_rgx: None,
                 })
             })
@@ -241,10 +244,10 @@ select = ["E501"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
-                    extend_exclude: None,
+                    extend_exclude: vec![],
                     select: Some(vec![CheckCode::E501]),
-                    ignore: None,
-                    per_file_ignores: None,
+                    ignore: vec![],
+                    per_file_ignores: vec![],
                     dummy_variable_rgx: None,
                 })
             })
@@ -263,10 +266,10 @@ ignore = ["E501"]
                 ruff: Some(Config {
                     line_length: None,
                     exclude: None,
-                    extend_exclude: None,
+                    extend_exclude: vec![],
                     select: None,
-                    ignore: Some(vec![CheckCode::E501]),
-                    per_file_ignores: None,
+                    ignore: vec![CheckCode::E501],
+                    per_file_ignores: vec![],
                     dummy_variable_rgx: None,
                 })
             })
@@ -325,14 +328,14 @@ other-attribute = 1
             Config {
                 line_length: Some(88),
                 exclude: None,
-                extend_exclude: Some(vec![
+                extend_exclude: vec![
                     "excluded.py".to_string(),
                     "migrations".to_string(),
                     "directory/also_excluded.py".to_string(),
-                ]),
+                ],
                 select: None,
-                ignore: None,
-                per_file_ignores: None,
+                ignore: vec![],
+                per_file_ignores: vec![],
                 dummy_variable_rgx: None,
             }
         );

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -149,13 +149,9 @@ impl Settings {
                 .unwrap_or_else(|| DEFAULT_EXCLUDE.clone()),
             extend_exclude: config
                 .extend_exclude
-                .map(|paths| {
-                    paths
-                        .iter()
-                        .map(|path| FilePattern::from_user(path, &project_root))
-                        .collect()
-                })
-                .unwrap_or_default(),
+                .iter()
+                .map(|path| FilePattern::from_user(path, &project_root))
+                .collect(),
             select: if let Some(select) = config.select {
                 BTreeSet::from_iter(select)
             } else {
@@ -163,13 +159,9 @@ impl Settings {
             },
             per_file_ignores: config
                 .per_file_ignores
-                .map(|ignore_strings| {
-                    ignore_strings
-                        .into_iter()
-                        .map(|pair| PerFileIgnore::new(pair, &project_root))
-                        .collect()
-                })
-                .unwrap_or_default(),
+                .into_iter()
+                .map(|pair| PerFileIgnore::new(pair, &project_root))
+                .collect(),
             dummy_variable_rgx: match config.dummy_variable_rgx {
                 Some(pattern) => Regex::new(&pattern)
                     .map_err(|e| anyhow!("Invalid dummy-variable-rgx value: {e}"))?,
@@ -178,9 +170,7 @@ impl Settings {
             pyproject,
             project_root,
         };
-        if let Some(ignore) = &config.ignore {
-            settings.ignore(ignore);
-        }
+        settings.ignore(&config.ignore);
         Ok(settings)
     }
 


### PR DESCRIPTION
For `extend_exclude`, `ignore`, and `per_file_ignores`, `None` has the same effect as `Some(vec![])`, so there’s no need to encode it separately.

This is not the case for `exclude` and `select`, so I’ve left those alone.
