### PR TITLE
Fix collapsed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ The 🛠 emoji indicates that a rule is automatically fixable by the `--fix` com
 | U004 | UselessObjectInheritance | Class `...` inherits from object |  | 🛠 |
 | U005 | NoAssertEquals | `assertEquals` is deprecated, use `assertEqual` instead |  | 🛠 |
 | U006 | UsePEP585Annotation | Use `list` instead of `List` for type annotations |  | 🛠 |
-| U007 | UsePEP604Annotation | Use `X | Y` for type annotations |  | 🛠 |
+| U007 | UsePEP604Annotation | Use `X \| Y` for type annotations |  | 🛠 |
 | M001 | UnusedNOQA | Unused `noqa` directive |  | 🛠 |
 
 ## Integrations

--- a/examples/generate_rules_table.rs
+++ b/examples/generate_rules_table.rs
@@ -18,7 +18,7 @@ fn main() {
             "| {} | {} | {} | {} | {} |",
             check_kind.code().as_ref(),
             check_kind.as_ref(),
-            check_kind.body(),
+            check_kind.body().replace("|", r"\|"),
             default_token,
             fix_token
         );


### PR DESCRIPTION
Fix the collapsed message by escaping `|`.

Before

<img width="781" alt="image" src="https://user-images.githubusercontent.com/17039389/194769347-c6c4596d-791d-4e76-bd51-a171d0814f38.png">

After

<img width="935" alt="image" src="https://user-images.githubusercontent.com/17039389/194769438-501b9547-a56e-44e9-9d7f-dc97a691db1b.png">

