### PR TITLE
Add initial wasm32-wasi support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "4.0.14"
+version = "4.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
 dependencies = [
  "atty",
  "bitflags",
@@ -1613,7 +1613,8 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 [[package]]
 name = "path-absolutize"
 version = "3.0.14"
-source = "git+https://github.com/konstin/path-absolutize?rev=a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161#a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1d4993b16f7325d90c18c3c6a3327db7808752db8d208cea0acee0abd52c52"
 dependencies = [
  "path-dedot",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "4.0.9"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
  "atty",
  "bitflags",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.9"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -464,6 +464,16 @@ dependencies = [
  "thiserror",
  "which",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -584,6 +594,50 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdffe87e1d521a10f9696f833fe502293ea446d7f256c06128293a4119bdf4cb"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -1017,15 +1071,26 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde6edd6cef363e9359ed3c98ba64590ba9eecba2293eb5a723ab32aee8926aa"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1111,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "joinery"
@@ -1225,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libcst"
@@ -1251,6 +1316,15 @@ source = "git+https://github.com/charliermarsh/LibCST?rev=32a044c127668df44582f8
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1538,18 +1612,17 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "path-absolutize"
-version = "3.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3de4b40bd9736640f14c438304c09538159802388febb02c8abaae0846c1f13"
+version = "3.0.14"
+source = "git+https://github.com/konstin/path-absolutize?rev=a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161#a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161"
 dependencies = [
  "path-dedot",
 ]
 
 [[package]]
 name = "path-dedot"
-version = "3.0.17"
+version = "3.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d611d5291372b3738a34ebf0d1f849e58b1dcc1101032f76a346eaa1f8ddbb5b"
+checksum = "9a81540d94551664b72b72829b12bd167c73c9d25fbac0e04fafa8023f7e4901"
 dependencies = [
  "once_cell",
 ]
@@ -2118,6 +2191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -2340,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2575,9 +2654,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -2587,6 +2666,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,8 +1008,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2054,6 +2056,7 @@ dependencies = [
  "dirs 4.0.0",
  "fern",
  "filetime",
+ "getrandom 0.2.7",
  "glob",
  "insta",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ titlecase = "2.2.1"
 cacache = { version = "10.0.1" } # uses async-std
 clearscreen = { version = "1.0.10" } # uses which
 
+# https://docs.rs/getrandom/0.2.7/getrandom/#webassembly-support
+# For (future) wasm-pack support
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2.7", features = ["js"] }
+
 [dev-dependencies]
 assert_cmd = "2.0.4"
 insta = { version = "1.19.1", features = ["yaml"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,8 @@ name = "ruff"
 [dependencies]
 anyhow = { version = "1.0.60" }
 bincode = { version = "1.3.3" }
-cacache = { version = "10.0.1" }
 chrono = { version = "0.4.21" }
 clap = { version = "4.0.1", features = ["derive"] }
-clearscreen = { version = "1.0.10" }
 colored = { version = "2.0.0" }
 common-path = { version = "1.0.0" }
 dirs = { version = "4.0.0" }
@@ -24,7 +22,8 @@ libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "32a044c127668
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }
 once_cell = { version = "1.13.1" }
-path-absolutize = { version = "3.0.13", features = ["once_cell_cache"] }
+# https://github.com/magiclen/path-absolutize/pull/12
+path-absolutize = { git = "https://github.com/konstin/path-absolutize", rev = "a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161", features = ["once_cell_cache", "use_unix_paths_on_wasm"] }
 rayon = { version = "1.5.3" }
 regex = { version = "1.6.0" }
 rustpython-ast = { features = ["unparse"], git = "https://github.com/charliermarsh/RustPython.git", rev = "778ae2aeb521d0438d2a91bd11238bb5c2bf9d4f" }
@@ -39,6 +38,10 @@ strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = "0.24.3"
 num-bigint = "0.4.3"
 titlecase = "2.2.1"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+cacache = { version = "10.0.1" } # uses async-std
+clearscreen = { version = "1.0.10" } # uses which
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "32a044c127668
 log = { version = "0.4.17" }
 notify = { version = "4.0.17" }
 once_cell = { version = "1.13.1" }
-# https://github.com/magiclen/path-absolutize/pull/12
-path-absolutize = { git = "https://github.com/konstin/path-absolutize", rev = "a7b29a5dfee4eee4e6f1c7bf5bc53011066b7161", features = ["once_cell_cache", "use_unix_paths_on_wasm"] }
+path-absolutize = { version = "3.0.14", features = ["once_cell_cache", "use_unix_paths_on_wasm"] }
 rayon = { version = "1.5.3" }
 regex = { version = "1.6.0" }
 rustpython-ast = { features = ["unparse"], git = "https://github.com/charliermarsh/RustPython.git", rev = "778ae2aeb521d0438d2a91bd11238bb5c2bf9d4f" }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::path::Path;
 
 use anyhow::Result;
+#[cfg(not(target_family = "wasm"))]
 use log::debug;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::{lexer, parser};
@@ -122,6 +123,7 @@ pub fn lint_stdin(
         .collect())
 }
 
+#[cfg_attr(target_family = "wasm", allow(unused_variables))]
 pub fn lint_path(
     path: &Path,
     settings: &Settings,
@@ -131,6 +133,7 @@ pub fn lint_path(
     let metadata = path.metadata()?;
 
     // Check the cache.
+    #[cfg(not(target_family = "wasm"))]
     if let Some(messages) = cache::get(path, &metadata, settings, autofix, mode) {
         debug!("Cache hit for: {}", path.to_string_lossy());
         return Ok(messages);
@@ -166,6 +169,7 @@ pub fn lint_path(
             filename: path.to_string_lossy().to_string(),
         })
         .collect();
+    #[cfg(not(target_family = "wasm"))]
     cache::set(path, &metadata, settings, autofix, &messages, mode);
 
     Ok(messages)

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use notify::{raw_watcher, RecursiveMode, Watcher};
 use rayon::prelude::*;
 use walkdir::DirEntry;
 
+#[cfg(not(target_family = "wasm"))]
 use ruff::cache;
 use ruff::checks::CheckCode;
 use ruff::checks::CheckKind;
@@ -313,6 +314,7 @@ fn inner_main() -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     cache::init()?;
 
     let mut printer = Printer::new(cli.format, cli.verbose);

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -104,6 +104,7 @@ impl Printer {
     }
 
     pub fn clear_screen(&mut self) -> Result<()> {
+        #[cfg(not(target_family = "wasm"))]
         clearscreen::clear()?;
         Ok(())
     }


### PR DESCRIPTION
I'm currently experimenting whether it's feasible to make wasm32-wasi wheels. This is also the groundwork needed to make a web version of ruff, which might the more interesting use case.

Debug fails in wasmtime with "too many locals: locals exceed maximum", so release only atm.

Usage:

Either

```
cargo build --target wasm32-wasi --release --no-default-features
wasmtime run --dir . ~/ruff/target/wasm32-wasi/release/ruff.wasm .
```

or with latest main maturin

```
maturin build --target wasm32-wasi --release --strip --no-default-features
pip install target/wheels/ruff-0.0.69-py3-none-any.whl
ruff . # Currenly limit to . due to wasi isolation
```

I hope that https://github.com/magiclen/path-absolutize/pull/12 lands soon so i can switch back to crates.io path-absolutize before this gets merged