### PR TITLE
Fix C401 and C402

### DIFF
--- a/src/ast/checkers.rs
+++ b/src/ast/checkers.rs
@@ -757,7 +757,7 @@ pub fn unnecessary_generator_set(expr: &Expr, func: &Expr, args: &Vec<Expr>) -> 
             if id == "set" {
                 if let ExprKind::GeneratorExp { .. } = &args[0].node {
                     return Some(Check::new(
-                        CheckKind::UnnecessaryGeneratorList,
+                        CheckKind::UnnecessaryGeneratorSet,
                         Range::from_located(expr),
                     ));
                 }
@@ -776,7 +776,7 @@ pub fn unnecessary_generator_dict(expr: &Expr, func: &Expr, args: &Vec<Expr>) ->
                     match &elt.node {
                         ExprKind::Tuple { elts, .. } if elts.len() == 2 => {
                             return Some(Check::new(
-                                CheckKind::UnnecessaryListComprehensionDict,
+                                CheckKind::UnnecessaryGeneratorDict,
                                 Range::from_located(expr),
                             ));
                         }

--- a/src/snapshots/ruff__linter__tests__C401_C401.py.snap
+++ b/src/snapshots/ruff__linter__tests__C401_C401.py.snap
@@ -2,7 +2,7 @@
 source: src/linter.rs
 expression: checks
 ---
-- kind: UnnecessaryGeneratorList
+- kind: UnnecessaryGeneratorSet
   location:
     row: 1
     column: 5

--- a/src/snapshots/ruff__linter__tests__C402_C402.py.snap
+++ b/src/snapshots/ruff__linter__tests__C402_C402.py.snap
@@ -2,7 +2,7 @@
 source: src/linter.rs
 expression: checks
 ---
-- kind: UnnecessaryListComprehensionDict
+- kind: UnnecessaryGeneratorDict
   location:
     row: 1
     column: 5


### PR DESCRIPTION
Before:

```
> cargo run -- --select C401,C402 --no-cache resources/test/fixtures/C401.py resources/test/fixtures/C402.py
resources/test/fixtures/C401.py:1:5: C400 Unnecessary generator - rewrite as a list comprehension
resources/test/fixtures/C402.py:1:5: C404 Unnecessary list comprehension - rewrite as a dict comprehension
```

After:

```
> cargo run -- --select C401,C402 --no-cache resources/test/fixtures/C401.py resources/test/fixtures/C402.py
resources/test/fixtures/C401.py:1:5: C401 Unnecessary generator - rewrite as a set comprehension
resources/test/fixtures/C402.py:1:5: C402 Unnecessary generator - rewrite as a dict comprehension
```