### PR TITLE
Suppress “No pyproject.toml found” message with --quiet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub mod settings;
 pub mod visibility;
 
 /// Run ruff over Python source code directly.
-pub fn check(path: &Path, contents: &str) -> Result<Vec<Message>> {
+pub fn check(path: &Path, contents: &str, quiet: bool) -> Result<Vec<Message>> {
     // Find the project root and pyproject.toml.
     let project_root = pyproject::find_project_root(&[path.to_path_buf()]);
     match &project_root {
@@ -54,7 +54,11 @@ pub fn check(path: &Path, contents: &str) -> Result<Vec<Message>> {
         None => debug!("Unable to find pyproject.toml; using default settings..."),
     };
 
-    let settings = Settings::from_raw(RawSettings::from_pyproject(&pyproject, &project_root)?);
+    let settings = Settings::from_raw(RawSettings::from_pyproject(
+        &pyproject,
+        &project_root,
+        quiet,
+    )?);
 
     // Tokenize once.
     let tokens: Vec<LexResult> = tokenize(contents);

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,7 @@ fn inner_main() -> Result<ExitCode> {
         .map(|pair| PerFileIgnore::new(pair, &project_root))
         .collect();
 
-    let mut settings = RawSettings::from_pyproject(&pyproject, &project_root)?;
+    let mut settings = RawSettings::from_pyproject(&pyproject, &project_root, cli.quiet)?;
     if !exclude.is_empty() {
         settings.exclude = exclude;
     }

--- a/src/pyproject.rs
+++ b/src/pyproject.rs
@@ -11,15 +11,17 @@ use crate::checks::CheckCode;
 use crate::fs;
 use crate::settings::PythonVersion;
 
-pub fn load_config(pyproject: &Option<PathBuf>) -> Result<Config> {
+pub fn load_config(pyproject: &Option<PathBuf>, quiet: bool) -> Result<Config> {
     match pyproject {
         Some(pyproject) => Ok(parse_pyproject_toml(pyproject)?
             .tool
             .and_then(|tool| tool.ruff)
             .unwrap_or_default()),
         None => {
-            eprintln!("No pyproject.toml found.");
-            eprintln!("Falling back to default configuration...");
+            if !quiet {
+                eprintln!("No pyproject.toml found.");
+                eprintln!("Falling back to default configuration...");
+            }
             Ok(Default::default())
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -130,8 +130,9 @@ impl RawSettings {
     pub fn from_pyproject(
         pyproject: &Option<PathBuf>,
         project_root: &Option<PathBuf>,
+        quiet: bool,
     ) -> Result<Self> {
-        let config = load_config(pyproject)?;
+        let config = load_config(pyproject, quiet)?;
         Ok(RawSettings {
             dummy_variable_rgx: match config.dummy_variable_rgx {
                 Some(pattern) => Regex::new(&pattern)


### PR DESCRIPTION
Fixes part of #476.