### PR TITLE
Fix multi-segment import removal

### DIFF
--- a/resources/test/fixtures/F401_0.py
+++ b/resources/test/fixtures/F401_0.py
@@ -86,5 +86,3 @@ else:
 
 
 CustomInt: TypeAlias = "np.int8 | np.int16"
-
-from foo.bar import baz

--- a/resources/test/fixtures/F401_5.py
+++ b/resources/test/fixtures/F401_5.py
@@ -1,0 +1,5 @@
+"""Test: removal of multi-segment and aliases imports."""
+from a.b import c
+from d.e import f as g
+import h.i
+import j.k as l

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -330,6 +330,7 @@ mod tests {
     #[test_case(CheckCode::F401, Path::new("F401_2.py"); "F401_2")]
     #[test_case(CheckCode::F401, Path::new("F401_3.py"); "F401_3")]
     #[test_case(CheckCode::F401, Path::new("F401_4.py"); "F401_4")]
+    #[test_case(CheckCode::F401, Path::new("F401_5.py"); "F401_5")]
     #[test_case(CheckCode::F402, Path::new("F402.py"); "F402")]
     #[test_case(CheckCode::F403, Path::new("F403.py"); "F403")]
     #[test_case(CheckCode::F404, Path::new("F404.py"); "F404")]

--- a/src/pyflakes/fixes.rs
+++ b/src/pyflakes/fixes.rs
@@ -40,13 +40,11 @@ pub fn remove_unused_imports(
     // Preserve the trailing comma (or not) from the last entry.
     let trailing_comma = aliases.last().and_then(|alias| alias.comma.clone());
 
-    // Identify unused imports from within the `import from`.
+    // Identify unused imports from within the `import`.
     let mut removable = vec![];
     for (index, alias) in aliases.iter().enumerate() {
-        if let NameOrAttribute::N(import_name) = &alias.name {
-            if full_names.contains(&import_name.value) {
-                removable.push(index);
-            }
+        if full_names.contains(&compose_module_path(&alias.name).as_str()) {
+            removable.push(index);
         }
     }
     // TODO(charlie): This is quadratic.

--- a/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
@@ -51,13 +51,13 @@ expression: checks
     column: 24
   fix:
     patch:
-      content: import logging.handlers
+      content: ""
       location:
         row: 12
         column: 1
       end_location:
-        row: 12
-        column: 24
+        row: 13
+        column: 1
     applied: false
 - kind:
     UnusedImport:
@@ -134,24 +134,5 @@ expression: checks
       end_location:
         row: 53
         column: 22
-    applied: false
-- kind:
-    UnusedImport:
-      - foo.bar.baz
-  location:
-    row: 90
-    column: 1
-  end_location:
-    row: 90
-    column: 24
-  fix:
-    patch:
-      content: ""
-      location:
-        row: 90
-        column: 1
-      end_location:
-        row: 91
-        column: 1
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
@@ -1,0 +1,81 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind:
+    UnusedImport:
+      - a.b.c
+  location:
+    row: 2
+    column: 1
+  end_location:
+    row: 2
+    column: 18
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 2
+        column: 1
+      end_location:
+        row: 3
+        column: 1
+    applied: false
+- kind:
+    UnusedImport:
+      - d.e.f
+  location:
+    row: 3
+    column: 1
+  end_location:
+    row: 3
+    column: 23
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 3
+        column: 1
+      end_location:
+        row: 4
+        column: 1
+    applied: false
+- kind:
+    UnusedImport:
+      - h.i
+  location:
+    row: 4
+    column: 1
+  end_location:
+    row: 4
+    column: 11
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 4
+        column: 1
+      end_location:
+        row: 5
+        column: 1
+    applied: false
+- kind:
+    UnusedImport:
+      - j.k
+  location:
+    row: 5
+    column: 1
+  end_location:
+    row: 5
+    column: 16
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 5
+        column: 1
+      end_location:
+        row: 6
+        column: 1
+    applied: false
+


### PR DESCRIPTION
Same as #479, but for standard imports (as opposed to `import from` statements).