### PR TITLE
Implement W605 (invalid escape sequence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The 🛠 emoji indicates that a rule is automatically fixable by the `--fix` com
 | F841 | UnusedVariable | Local variable `...` is assigned to but never used |  |
 | F901 | RaiseNotImplemented | `raise NotImplemented` should be `raise NotImplementedError` |  |
 
-### pycodestyle
+### pycodestyle (error)
 
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
@@ -275,7 +275,13 @@ The 🛠 emoji indicates that a rule is automatically fixable by the `--fix` com
 | E743 | AmbiguousFunctionName | Ambiguous function name: `...` |  |
 | E902 | IOError | IOError: `...` |  |
 | E999 | SyntaxError | SyntaxError: `...` |  |
+
+### pycodestyle (warning)
+
+| Code | Name | Message | Fix |
+| ---- | ---- | ------- | --- |
 | W292 | NoNewLineAtEndOfFile | No newline at end of file |  |
+| W605 | InvalidEscapeSequence | Invalid escape sequence: '\c' |  |
 
 ### pydocstyle
 

--- a/resources/test/fixtures/W605.py
+++ b/resources/test/fixtures/W605.py
@@ -1,0 +1,35 @@
+#: W605:1:10
+regex = '\.png$'
+
+#: W605:2:1
+regex = '''
+\.png$
+'''
+
+#: W605:2:6
+f(
+    '\_'
+)
+
+#: W605:4:6
+"""
+multi-line
+literal
+with \_ somewhere
+in the middle
+"""
+
+#: Okay
+regex = r'\.png$'
+regex = '\\.png$'
+regex = r'''
+\.png$
+'''
+regex = r'''
+\\.png$
+'''
+s = '\\'
+regex = '\w'  # noqa
+regex = '''
+\w
+'''  # noqa

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -1,3 +1,5 @@
+//! Lint rules based on AST traversal.
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
 use std::path::Path;

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -1,3 +1,5 @@
+//! Lint rules based on checking raw physical lines.
+
 use std::collections::BTreeMap;
 
 use rustpython_parser::ast::Location;

--- a/src/check_tokens.rs
+++ b/src/check_tokens.rs
@@ -1,0 +1,124 @@
+//! Lint rules based on token traversal.
+
+use rustpython_ast::Location;
+use rustpython_parser::lexer::{LexResult, Tok};
+
+use crate::ast::operations::SourceCodeLocator;
+use crate::ast::types::Range;
+use crate::checks::{Check, CheckCode, CheckKind};
+use crate::Settings;
+
+// See: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+const VALID_ESCAPE_SEQUENCES: &[char; 23] = &[
+    '\n', '\\', '\'', '"', 'a', 'b', 'f', 'n', 'r', 't', 'v', '0', '1', '2', '3', '4', '5', '6',
+    '7', 'x', // Escape sequences only recognized in string literals
+    'N', 'u', 'U',
+];
+
+/// Return the quotation markers used for a String token.
+fn extract_quote(text: &str) -> &str {
+    if text.len() >= 3 {
+        let triple = &text[text.len() - 3..];
+        if triple == "'''" || triple == "\"\"\"" {
+            return triple;
+        }
+    }
+
+    if !text.is_empty() {
+        let single = &text[text.len() - 1..];
+        if single == "'" || single == "\"" {
+            return single;
+        }
+    }
+
+    panic!("Unable to find quotation mark for String token.")
+}
+
+/// W605
+fn invalid_escape_sequence(
+    locator: &SourceCodeLocator,
+    start: &Location,
+    end: &Location,
+) -> Vec<Check> {
+    let mut checks = vec![];
+
+    let text = locator.slice_source_code_range(&Range {
+        location: *start,
+        end_location: *end,
+    });
+
+    // Determine whether the string is single- or triple-quoted.
+    let quote = extract_quote(text);
+    let quote_pos = text.find(quote).unwrap();
+    let prefix = text[..quote_pos].to_lowercase();
+    let body = &text[(quote_pos + quote.len())..(text.len() - quote.len())];
+
+    if !prefix.contains('r') {
+        let mut col_offset = 0;
+        let mut row_offset = 0;
+        let mut in_escape = false;
+        let mut chars = body.chars();
+        let mut current = chars.next();
+        let mut next = chars.next();
+        while let (Some(current_char), Some(next_char)) = (current, next) {
+            // If we see an escaped backslash, avoid treating the character _after_ the
+            // escaped backslash as itself an escaped character.
+            if in_escape {
+                in_escape = false;
+            } else {
+                in_escape = current_char == '\\' && next_char == '\\';
+                if current_char == '\\' && !VALID_ESCAPE_SEQUENCES.contains(&next_char) {
+                    // Compute the location of the escape sequence by offsetting the location of the
+                    // string token by the characters we've seen thus far.
+                    let location = if row_offset == 0 {
+                        Location::new(
+                            start.row() + row_offset,
+                            start.column() + prefix.len() + quote.len() + col_offset,
+                        )
+                    } else {
+                        Location::new(start.row() + row_offset, col_offset + 1)
+                    };
+                    let end_location = Location::new(location.row(), location.column() + 1);
+                    checks.push(Check::new(
+                        CheckKind::InvalidEscapeSequence(next_char),
+                        Range {
+                            location,
+                            end_location,
+                        },
+                    ))
+                }
+            }
+
+            // Track the offset from the start position as we iterate over the body.
+            if current_char == '\n' {
+                col_offset = 0;
+                row_offset += 1;
+            } else {
+                col_offset += 1;
+            }
+
+            current = next;
+            next = chars.next();
+        }
+    }
+
+    checks
+}
+
+pub fn check_tokens(
+    checks: &mut Vec<Check>,
+    contents: &str,
+    tokens: &[LexResult],
+    settings: &Settings,
+) {
+    // TODO(charlie): Use a shared SourceCodeLocator between this site and the AST traversal.
+    let locator = SourceCodeLocator::new(contents);
+    let enforce_invalid_escape_sequence = settings.enabled.contains(&CheckCode::W605);
+    for (start, tok, end) in tokens.iter().flatten() {
+        if enforce_invalid_escape_sequence {
+            if matches!(tok, Tok::String { .. }) {
+                checks.extend(invalid_escape_sequence(&locator, start, end));
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod autofix;
 pub mod cache;
 pub mod check_ast;
 mod check_lines;
+mod check_tokens;
 pub mod checks;
 pub mod cli;
 pub mod code_gen;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -160,7 +160,7 @@ impl RawSettings {
                     .filter(|code| {
                         matches!(
                             code.category(),
-                            CheckCategory::Pycodestyle | CheckCategory::Pyflakes
+                            CheckCategory::PycodestyleError | CheckCategory::Pyflakes
                         )
                     })
                     .collect()

--- a/src/snapshots/ruff__linter__tests__W605_W605.py.snap
+++ b/src/snapshots/ruff__linter__tests__W605_W605.py.snap
@@ -1,0 +1,41 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind:
+    InvalidEscapeSequence: "."
+  location:
+    row: 2
+    column: 10
+  end_location:
+    row: 2
+    column: 11
+  fix: ~
+- kind:
+    InvalidEscapeSequence: "."
+  location:
+    row: 6
+    column: 1
+  end_location:
+    row: 6
+    column: 2
+  fix: ~
+- kind:
+    InvalidEscapeSequence: _
+  location:
+    row: 11
+    column: 6
+  end_location:
+    row: 11
+    column: 7
+  fix: ~
+- kind:
+    InvalidEscapeSequence: _
+  location:
+    row: 18
+    column: 6
+  end_location:
+    row: 18
+    column: 7
+  fix: ~
+


### PR DESCRIPTION
This PR implements W605 (the "invalid escape sequence" check). To do so, I've introduced a new check runner, `check_tokens.rs`, which iterates over the token stream, similar to `pycodestyle`.

I've disabled these pycodestyle warnings by default for now, since I want to do some performance optimizations around the number of traversals we're doing for the token stream and source code.

Resolves #474.
