### PR TITLE
Avoid auto-fixing unused imports in __init__.py

### DIFF
--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2115,15 +2115,27 @@ impl<'a> Checker<'a> {
                         None
                     };
 
-                    let mut check = Check::new(
-                        CheckKind::UnusedImport(full_names.into_iter().map(String::from).collect()),
-                        self.locate_check(Range::from_located(child)),
-                    );
-                    if let Some(fix) = fix {
-                        check.amend(fix);
+                    if self.path.ends_with("__init__.py") {
+                        self.checks.push(Check::new(
+                            CheckKind::UnusedImport(
+                                full_names.into_iter().map(String::from).collect(),
+                                true,
+                            ),
+                            self.locate_check(Range::from_located(child)),
+                        ));
+                    } else {
+                        let mut check = Check::new(
+                            CheckKind::UnusedImport(
+                                full_names.into_iter().map(String::from).collect(),
+                                false,
+                            ),
+                            self.locate_check(Range::from_located(child)),
+                        );
+                        if let Some(fix) = fix {
+                            check.amend(fix);
+                        }
+                        self.checks.push(check);
                     }
-
-                    self.checks.push(check);
                 }
             }
         }

--- a/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
@@ -4,7 +4,8 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - functools
+      - - functools
+      - false
   location:
     row: 2
     column: 1
@@ -23,7 +24,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - collections.OrderedDict
+      - - collections.OrderedDict
+      - false
   location:
     row: 4
     column: 1
@@ -42,7 +44,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - logging.handlers
+      - - logging.handlers
+      - false
   location:
     row: 12
     column: 1
@@ -61,7 +64,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - shelve
+      - - shelve
+      - false
   location:
     row: 33
     column: 5
@@ -80,7 +84,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - importlib
+      - - importlib
+      - false
   location:
     row: 34
     column: 5
@@ -99,7 +104,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - pathlib
+      - - pathlib
+      - false
   location:
     row: 38
     column: 5
@@ -118,7 +124,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - pickle
+      - - pickle
+      - false
   location:
     row: 53
     column: 9

--- a/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
@@ -4,7 +4,8 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - a.b.c
+      - - a.b.c
+      - false
   location:
     row: 2
     column: 1
@@ -23,7 +24,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - d.e.f
+      - - d.e.f
+      - false
   location:
     row: 3
     column: 1
@@ -42,7 +44,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - h.i
+      - - h.i
+      - false
   location:
     row: 4
     column: 1
@@ -61,7 +64,8 @@ expression: checks
     applied: false
 - kind:
     UnusedImport:
-      - j.k
+      - - j.k
+      - false
   location:
     row: 5
     column: 1

--- a/src/snapshots/ruff__linter__tests__future_annotations.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations.snap
@@ -4,7 +4,8 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - models.Nut
+      - - models.Nut
+      - false
   location:
     row: 5
     column: 1


### PR DESCRIPTION
Resolves #484:

```
∴ cargo run resources/test/fixtures/__init__.py -n
   Compiling ruff v0.0.85 (/Users/crmarsh/workspace/ruff)
    Finished dev [unoptimized + debuginfo] target(s) in 3.61s
     Running `target/debug/ruff resources/test/fixtures/__init__.py -n`
Found 1 error(s).
resources/test/fixtures/__init__.py:1:1: F401 `os` imported but unused and missing from `__all__`
```