### PR TITLE
Fix “not a char boundary” error with Unicode in extract_quote

### DIFF
--- a/src/pycodestyle/checks.rs
+++ b/src/pycodestyle/checks.rs
@@ -248,17 +248,9 @@ const VALID_ESCAPE_SEQUENCES: &[char; 23] = &[
 
 /// Return the quotation markers used for a String token.
 fn extract_quote(text: &str) -> &str {
-    if text.len() >= 3 {
-        let triple = &text[text.len() - 3..];
-        if triple == "'''" || triple == "\"\"\"" {
-            return triple;
-        }
-    }
-
-    if !text.is_empty() {
-        let single = &text[text.len() - 1..];
-        if single == "'" || single == "\"" {
-            return single;
+    for quote in ["'''", "\"\"\"", "'", "\""] {
+        if text.ends_with(quote) {
+            return quote;
         }
     }
 


### PR DESCRIPTION
Fixes this error:

```console
$ echo 's = "Δx"' | ruff --select=W605 -
thread 'main' panicked at 'byte index 2 is not a char boundary; it is inside 'Δ' (bytes 1..3) of `"Δx"`', src/pycodestyle/checks.rs:252:23
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```