### PR TITLE
Remove RustPython fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/charliermarsh/RustPython.git?rev=1b253a12705f84972cd76e8dc1cdaaccb233e5a5#1b253a12705f84972cd76e8dc1cdaaccb233e5a5"
+source = "git+https://github.com/RustPython/RustPython.git?rev=77b821a1941019fe34f73ce17cea013ae1b98fd0#77b821a1941019fe34f73ce17cea013ae1b98fd0"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2258,7 +2258,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/charliermarsh/RustPython.git?rev=1b253a12705f84972cd76e8dc1cdaaccb233e5a5#1b253a12705f84972cd76e8dc1cdaaccb233e5a5"
+source = "git+https://github.com/RustPython/RustPython.git?rev=77b821a1941019fe34f73ce17cea013ae1b98fd0#77b821a1941019fe34f73ce17cea013ae1b98fd0"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -2281,7 +2281,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/charliermarsh/RustPython.git?rev=1b253a12705f84972cd76e8dc1cdaaccb233e5a5#1b253a12705f84972cd76e8dc1cdaaccb233e5a5"
+source = "git+https://github.com/RustPython/RustPython.git?rev=77b821a1941019fe34f73ce17cea013ae1b98fd0#77b821a1941019fe34f73ce17cea013ae1b98fd0"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2298,7 +2298,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/charliermarsh/RustPython.git?rev=1b253a12705f84972cd76e8dc1cdaaccb233e5a5#1b253a12705f84972cd76e8dc1cdaaccb233e5a5"
+source = "git+https://github.com/RustPython/RustPython.git?rev=77b821a1941019fe34f73ce17cea013ae1b98fd0#77b821a1941019fe34f73ce17cea013ae1b98fd0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ once_cell = { version = "1.13.1" }
 path-absolutize = { version = "3.0.14", features = ["once_cell_cache", "use_unix_paths_on_wasm"] }
 rayon = { version = "1.5.3" }
 regex = { version = "1.6.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/charliermarsh/RustPython.git", rev = "1b253a12705f84972cd76e8dc1cdaaccb233e5a5" }
-rustpython-common = { git = "https://github.com/charliermarsh/RustPython.git", rev = "1b253a12705f84972cd76e8dc1cdaaccb233e5a5" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/charliermarsh/RustPython.git", rev = "1b253a12705f84972cd76e8dc1cdaaccb233e5a5" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "77b821a1941019fe34f73ce17cea013ae1b98fd0" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "77b821a1941019fe34f73ce17cea013ae1b98fd0" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "77b821a1941019fe34f73ce17cea013ae1b98fd0" }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = { version = "1.0.83" }
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/foo.py
+++ b/foo.py
@@ -1,0 +1,5 @@
+def function_with_nesting():
+    """Foo bar documentation."""
+    @overload
+    def nested_overloaded_func(a: int) -> str:
+        ...

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -137,7 +137,7 @@ pub fn to_absolute(relative: &Location, base: &Location) -> Location {
     if relative.row() == 1 {
         Location::new(
             relative.row() + base.row() - 1,
-            relative.column() + base.column() - 1,
+            relative.column() + base.column(),
         )
     } else {
         Location::new(relative.row() + base.row() - 1, relative.column())

--- a/src/autofix/fixer.rs
+++ b/src/autofix/fixer.rs
@@ -69,19 +69,18 @@ fn apply_fixes<'a>(fixes: impl Iterator<Item = &'a mut Fix>, contents: &str) -> 
 
         if fix.patch.location.row() > last_pos.row() {
             if last_pos.row() > 0 || last_pos.column() > 0 {
-                output.push_str(&lines[last_pos.row() - 1][last_pos.column() - 1..]);
+                output.push_str(&lines[last_pos.row() - 1][last_pos.column()..]);
                 output.push('\n');
             }
             for line in &lines[last_pos.row()..fix.patch.location.row() - 1] {
                 output.push_str(line);
                 output.push('\n');
             }
-            output
-                .push_str(&lines[fix.patch.location.row() - 1][..fix.patch.location.column() - 1]);
+            output.push_str(&lines[fix.patch.location.row() - 1][..fix.patch.location.column()]);
             output.push_str(&fix.patch.content);
         } else {
             output.push_str(
-                &lines[last_pos.row() - 1][last_pos.column() - 1..fix.patch.location.column() - 1],
+                &lines[last_pos.row() - 1][last_pos.column()..fix.patch.location.column()],
             );
             output.push_str(&fix.patch.content);
         }
@@ -95,7 +94,7 @@ fn apply_fixes<'a>(fixes: impl Iterator<Item = &'a mut Fix>, contents: &str) -> 
         && (last_pos.row() - 1) < lines.len()
         && (last_pos.row() > 0 || last_pos.column() > 0)
     {
-        output.push_str(&lines[last_pos.row() - 1][last_pos.column() - 1..]);
+        output.push_str(&lines[last_pos.row() - 1][last_pos.column()..]);
         output.push('\n');
     }
     if last_pos.row() < lines.len() {
@@ -133,8 +132,8 @@ mod tests {
         let mut fixes = vec![Fix {
             patch: Patch {
                 content: "Bar".to_string(),
-                location: Location::new(1, 9),
-                end_location: Location::new(1, 15),
+                location: Location::new(1, 8),
+                end_location: Location::new(1, 14),
             },
             applied: false,
         }];
@@ -159,8 +158,8 @@ mod tests {
         let mut fixes = vec![Fix {
             patch: Patch {
                 content: "".to_string(),
-                location: Location::new(1, 8),
-                end_location: Location::new(1, 16),
+                location: Location::new(1, 7),
+                end_location: Location::new(1, 15),
             },
             applied: false,
         }];
@@ -186,16 +185,16 @@ mod tests {
             Fix {
                 patch: Patch {
                     content: "".to_string(),
-                    location: Location::new(1, 8),
-                    end_location: Location::new(1, 17),
+                    location: Location::new(1, 7),
+                    end_location: Location::new(1, 16),
                 },
                 applied: false,
             },
             Fix {
                 patch: Patch {
                     content: "".to_string(),
-                    location: Location::new(1, 17),
-                    end_location: Location::new(1, 24),
+                    location: Location::new(1, 16),
+                    end_location: Location::new(1, 23),
                 },
                 applied: false,
             },
@@ -222,16 +221,16 @@ mod tests {
             Fix {
                 patch: Patch {
                     content: "".to_string(),
-                    location: Location::new(1, 8),
-                    end_location: Location::new(1, 16),
+                    location: Location::new(1, 7),
+                    end_location: Location::new(1, 15),
                 },
                 applied: false,
             },
             Fix {
                 patch: Patch {
                     content: "ignored".to_string(),
-                    location: Location::new(1, 10),
-                    end_location: Location::new(1, 12),
+                    location: Location::new(1, 9),
+                    end_location: Location::new(1, 11),
                 },
                 applied: false,
             },

--- a/src/autofix/helpers.rs
+++ b/src/autofix/helpers.rs
@@ -82,8 +82,8 @@ pub fn remove_stmt(stmt: &Stmt, parent: Option<&Stmt>, deleted: &[&Stmt]) -> Res
         // Otherwise, nuke the entire line.
         // TODO(charlie): This logic assumes that there are no multi-statement physical lines.
         Ok(Fix::deletion(
-            Location::new(stmt.location.row(), 1),
-            Location::new(stmt.end_location.unwrap().row() + 1, 1),
+            Location::new(stmt.location.row(), 0),
+            Location::new(stmt.end_location.unwrap().row() + 1, 0),
         ))
     }
 }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -387,7 +387,7 @@ where
             }
             StmtKind::Import { names } => {
                 if self.settings.enabled.contains(&CheckCode::E402) {
-                    if self.seen_import_boundary && stmt.location.column() == 1 {
+                    if self.seen_import_boundary && stmt.location.column() == 0 {
                         self.checks.push(Check::new(
                             CheckKind::ModuleImportNotAtTopOfFile,
                             self.locate_check(Range::from_located(stmt)),
@@ -493,7 +493,7 @@ where
                 level,
             } => {
                 if self.settings.enabled.contains(&CheckCode::E402) {
-                    if self.seen_import_boundary && stmt.location.column() == 1 {
+                    if self.seen_import_boundary && stmt.location.column() == 0 {
                         self.checks.push(Check::new(
                             CheckKind::ModuleImportNotAtTopOfFile,
                             self.locate_check(Range::from_located(stmt)),

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -94,8 +94,8 @@ pub fn check_lines(
                 let check = Check::new(
                     CheckKind::LineTooLong(line_length, settings.line_length),
                     Range {
-                        location: Location::new(lineno + 1, 1),
-                        end_location: Location::new(lineno + 1, line_length + 1),
+                        location: Location::new(lineno + 1, 0),
+                        end_location: Location::new(lineno + 1, line_length),
                     },
                 );
 
@@ -164,14 +164,14 @@ pub fn check_lines(
                         let mut check = Check::new(
                             CheckKind::UnusedNOQA(None),
                             Range {
-                                location: Location::new(row + 1, start + 1),
-                                end_location: Location::new(row + 1, end + 1),
+                                location: Location::new(row + 1, start),
+                                end_location: Location::new(row + 1, end),
                             },
                         );
                         if autofix.patch() {
                             check.amend(Fix::deletion(
-                                Location::new(row + 1, start + 1),
-                                Location::new(row + 1, lines[row].chars().count() + 1),
+                                Location::new(row + 1, start),
+                                Location::new(row + 1, lines[row].chars().count()),
                             ));
                         }
                         line_checks.push(check);
@@ -192,21 +192,21 @@ pub fn check_lines(
                         let mut check = Check::new(
                             CheckKind::UnusedNOQA(Some(invalid_codes)),
                             Range {
-                                location: Location::new(row + 1, start + 1),
-                                end_location: Location::new(row + 1, end + 1),
+                                location: Location::new(row + 1, start),
+                                end_location: Location::new(row + 1, end),
                             },
                         );
                         if autofix.patch() {
                             if valid_codes.is_empty() {
                                 check.amend(Fix::deletion(
-                                    Location::new(row + 1, start + 1),
-                                    Location::new(row + 1, lines[row].chars().count() + 1),
+                                    Location::new(row + 1, start),
+                                    Location::new(row + 1, lines[row].chars().count()),
                                 ));
                             } else {
                                 check.amend(Fix::replacement(
                                     format!("  # noqa: {}", valid_codes.join(", ")),
-                                    Location::new(row + 1, start + 1),
-                                    Location::new(row + 1, lines[row].chars().count() + 1),
+                                    Location::new(row + 1, start),
+                                    Location::new(row + 1, lines[row].chars().count()),
                                 ));
                             }
                         }

--- a/src/docstrings/helpers.rs
+++ b/src/docstrings/helpers.rs
@@ -28,7 +28,7 @@ pub fn leading_space(line: &str) -> String {
 pub fn indentation<'a>(checker: &'a Checker, docstring: &Expr) -> &'a str {
     let range = Range::from_located(docstring);
     checker.locator.slice_source_code_range(&Range {
-        location: Location::new(range.location.row(), 1),
+        location: Location::new(range.location.row(), 0),
         end_location: Location::new(range.location.row(), range.location.column()),
     })
 }

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles.py.snap
@@ -6,45 +6,45 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 18
-    column: 8
+    column: 7
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 21
-    column: 21
+    column: 20
   end_location:
     row: 22
-    column: 38
+    column: 37
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 30
-    column: 9
+    column: 8
   end_location:
     row: 32
-    column: 12
+    column: 11
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 35
-    column: 13
+    column: 12
   end_location:
     row: 37
-    column: 16
+    column: 15
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_class.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_class.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 28
+    column: 27
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 5
-    column: 23
+    column: 22
   end_location:
     row: 5
-    column: 44
+    column: 43
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_function.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_function.py.snap
@@ -6,45 +6,45 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 27
+    column: 26
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 11
-    column: 5
+    column: 4
   end_location:
     row: 11
-    column: 27
+    column: 26
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 15
-    column: 39
+    column: 38
   end_location:
+    row: 17
+    column: 3
+  fix: ~
+- kind:
+    BadQuotesMultilineString: single
+  location:
     row: 17
     column: 4
-  fix: ~
-- kind:
-    BadQuotesMultilineString: single
-  location:
-    row: 17
-    column: 5
   end_location:
     row: 17
-    column: 20
+    column: 19
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 21
-    column: 5
+    column: 4
   end_location:
     row: 21
-    column: 28
+    column: 27
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_module_multiline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_module_multiline.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 11
-    column: 4
+    column: 3
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_module_singleline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_doubles_module_singleline.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 32
+    column: 31
   fix: ~
 - kind:
     BadQuotesMultilineString: single
   location:
     row: 6
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 32
+    column: 31
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles.py.snap
@@ -6,27 +6,27 @@ expression: checks
     BadQuotesDocstring: double
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesDocstring: double
   location:
     row: 14
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 8
+    column: 7
   fix: ~
 - kind:
     BadQuotesDocstring: double
   location:
     row: 26
-    column: 9
+    column: 8
   end_location:
     row: 28
-    column: 12
+    column: 11
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_class.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_class.py.snap
@@ -6,27 +6,27 @@ expression: checks
     BadQuotesDocstring: double
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 54
-  fix: ~
-- kind:
-    BadQuotesDocstring: double
-  location:
-    row: 6
-    column: 9
-  end_location:
-    row: 6
-    column: 58
-  fix: ~
-- kind:
-    BadQuotesDocstring: double
-  location:
-    row: 9
-    column: 29
-  end_location:
-    row: 9
     column: 53
+  fix: ~
+- kind:
+    BadQuotesDocstring: double
+  location:
+    row: 6
+    column: 8
+  end_location:
+    row: 6
+    column: 57
+  fix: ~
+- kind:
+    BadQuotesDocstring: double
+  location:
+    row: 9
+    column: 28
+  end_location:
+    row: 9
+    column: 52
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_function.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_function.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesDocstring: double
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 57
+    column: 56
   fix: ~
 - kind:
     BadQuotesDocstring: double
   location:
     row: 8
-    column: 5
+    column: 4
   end_location:
     row: 10
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_module_multiline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_module_multiline.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesDocstring: double
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 4
+    column: 3
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_module_singleline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__double_docstring_docstring_singles_module_singleline.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesDocstring: double
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 50
+    column: 49
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesInlineString: single
   location:
     row: 1
-    column: 25
+    column: 24
   end_location:
     row: 1
-    column: 46
+    column: 45
   fix: ~
 - kind:
     BadQuotesInlineString: single
   location:
     row: 2
-    column: 25
+    column: 24
   end_location:
     row: 2
-    column: 47
+    column: 46
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles_escaped.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles_escaped.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: AvoidQuoteEscape
   location:
     row: 1
-    column: 26
+    column: 25
   end_location:
     row: 1
-    column: 48
+    column: 47
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles_multiline_string.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__doubles_doubles_multiline_string.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesMultilineString: single
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 13
+    column: 12
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles.py.snap
@@ -6,27 +6,27 @@ expression: checks
     BadQuotesDocstring: single
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesDocstring: single
   location:
     row: 12
-    column: 5
+    column: 4
   end_location:
     row: 14
-    column: 8
+    column: 7
   fix: ~
 - kind:
     BadQuotesDocstring: single
   location:
     row: 24
-    column: 9
+    column: 8
   end_location:
     row: 26
-    column: 12
+    column: 11
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_class.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_class.py.snap
@@ -6,27 +6,27 @@ expression: checks
     BadQuotesDocstring: single
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 54
-  fix: ~
-- kind:
-    BadQuotesDocstring: single
-  location:
-    row: 6
-    column: 9
-  end_location:
-    row: 6
-    column: 58
-  fix: ~
-- kind:
-    BadQuotesDocstring: single
-  location:
-    row: 9
-    column: 29
-  end_location:
-    row: 9
     column: 53
+  fix: ~
+- kind:
+    BadQuotesDocstring: single
+  location:
+    row: 6
+    column: 8
+  end_location:
+    row: 6
+    column: 57
+  fix: ~
+- kind:
+    BadQuotesDocstring: single
+  location:
+    row: 9
+    column: 28
+  end_location:
+    row: 9
+    column: 52
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_function.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_function.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesDocstring: single
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 57
+    column: 56
   fix: ~
 - kind:
     BadQuotesDocstring: single
   location:
     row: 8
-    column: 5
+    column: 4
   end_location:
     row: 10
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_module_multiline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_module_multiline.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesDocstring: single
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 4
+    column: 3
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_module_singleline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_doubles_module_singleline.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesDocstring: single
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 50
+    column: 49
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles.py.snap
@@ -6,54 +6,54 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 11
-    column: 21
+    column: 20
   end_location:
     row: 13
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 18
-    column: 5
+    column: 4
   end_location:
     row: 20
-    column: 8
+    column: 7
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 23
-    column: 21
+    column: 20
   end_location:
     row: 24
-    column: 38
+    column: 37
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 32
-    column: 9
+    column: 8
   end_location:
     row: 34
-    column: 12
+    column: 11
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 37
-    column: 13
+    column: 12
   end_location:
     row: 39
-    column: 16
+    column: 15
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_class.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_class.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 28
+    column: 27
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 5
-    column: 23
+    column: 22
   end_location:
     row: 5
-    column: 44
+    column: 43
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_function.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_function.py.snap
@@ -6,45 +6,45 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 27
+    column: 26
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 11
-    column: 5
+    column: 4
   end_location:
     row: 11
-    column: 27
+    column: 26
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 15
-    column: 39
+    column: 38
   end_location:
+    row: 17
+    column: 3
+  fix: ~
+- kind:
+    BadQuotesMultilineString: double
+  location:
     row: 17
     column: 4
-  fix: ~
-- kind:
-    BadQuotesMultilineString: double
-  location:
-    row: 17
-    column: 5
   end_location:
     row: 17
-    column: 20
+    column: 19
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 21
-    column: 5
+    column: 4
   end_location:
     row: 21
-    column: 28
+    column: 27
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_module_multiline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_module_multiline.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 11
-    column: 4
+    column: 3
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_module_singleline.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__single_docstring_docstring_singles_module_singleline.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 32
+    column: 31
   fix: ~
 - kind:
     BadQuotesMultilineString: double
   location:
     row: 6
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 32
+    column: 31
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BadQuotesInlineString: double
   location:
     row: 1
-    column: 25
+    column: 24
   end_location:
     row: 1
-    column: 46
+    column: 45
   fix: ~
 - kind:
     BadQuotesInlineString: double
   location:
     row: 2
-    column: 25
+    column: 24
   end_location:
     row: 2
-    column: 47
+    column: 46
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles_escaped.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles_escaped.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: AvoidQuoteEscape
   location:
     row: 1
-    column: 26
+    column: 25
   end_location:
     row: 1
-    column: 48
+    column: 47
   fix: ~
 

--- a/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles_multiline_string.py.snap
+++ b/src/flake8_quotes/snapshots/ruff__flake8_quotes__checks__tests__singles_singles_multiline_string.py.snap
@@ -6,9 +6,9 @@ expression: checks
     BadQuotesMultilineString: double
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 13
+    column: 12
   fix: ~
 

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -246,8 +246,8 @@ ghi
         let checks = vec![Check::new(
             CheckKind::UnusedVariable("x".to_string()),
             Range {
-                location: Location::new(1, 1),
-                end_location: Location::new(1, 1),
+                location: Location::new(1, 0),
+                end_location: Location::new(1, 0),
             },
         )];
         let contents = "x = 1";
@@ -260,15 +260,15 @@ ghi
             Check::new(
                 CheckKind::AmbiguousVariableName("x".to_string()),
                 Range {
-                    location: Location::new(1, 1),
-                    end_location: Location::new(1, 1),
+                    location: Location::new(1, 0),
+                    end_location: Location::new(1, 0),
                 },
             ),
             Check::new(
                 CheckKind::UnusedVariable("x".to_string()),
                 Range {
-                    location: Location::new(1, 1),
-                    end_location: Location::new(1, 1),
+                    location: Location::new(1, 0),
+                    end_location: Location::new(1, 0),
                 },
             ),
         ];
@@ -282,15 +282,15 @@ ghi
             Check::new(
                 CheckKind::AmbiguousVariableName("x".to_string()),
                 Range {
-                    location: Location::new(1, 1),
-                    end_location: Location::new(1, 1),
+                    location: Location::new(1, 0),
+                    end_location: Location::new(1, 0),
                 },
             ),
             Check::new(
                 CheckKind::UnusedVariable("x".to_string()),
                 Range {
-                    location: Location::new(1, 1),
-                    end_location: Location::new(1, 1),
+                    location: Location::new(1, 0),
+                    end_location: Location::new(1, 0),
                 },
             ),
         ];

--- a/src/pydocstyle/plugins.rs
+++ b/src/pydocstyle/plugins.rs
@@ -35,8 +35,8 @@ pub fn not_missing(
                 checker.add_check(Check::new(
                     CheckKind::PublicModule,
                     Range {
-                        location: Location::new(1, 1),
-                        end_location: Location::new(1, 1),
+                        location: Location::new(1, 0),
+                        end_location: Location::new(1, 0),
                     },
                 ));
             }
@@ -47,8 +47,8 @@ pub fn not_missing(
                 checker.add_check(Check::new(
                     CheckKind::PublicPackage,
                     Range {
-                        location: Location::new(1, 1),
-                        end_location: Location::new(1, 1),
+                        location: Location::new(1, 0),
+                        end_location: Location::new(1, 0),
                     },
                 ));
             }
@@ -181,8 +181,8 @@ pub fn blank_before_after_function(checker: &mut Checker, definition: &Definitio
                         if checker.patch() {
                             // Delete the blank line before the docstring.
                             check.amend(Fix::deletion(
-                                Location::new(docstring.location.row() - blank_lines_before, 1),
-                                Location::new(docstring.location.row(), 1),
+                                Location::new(docstring.location.row() - blank_lines_before, 0),
+                                Location::new(docstring.location.row(), 0),
                             ));
                         }
                         checker.add_check(check);
@@ -222,8 +222,8 @@ pub fn blank_before_after_function(checker: &mut Checker, definition: &Definitio
                         if checker.patch() {
                             // Delete the blank line after the docstring.
                             check.amend(Fix::deletion(
-                                Location::new(docstring.location.row() + 1, 1),
-                                Location::new(docstring.location.row() + 1 + blank_lines_after, 1),
+                                Location::new(docstring.location.row() + 1, 0),
+                                Location::new(docstring.location.row() + 1 + blank_lines_after, 0),
                             ));
                         }
                         checker.add_check(check);
@@ -268,8 +268,8 @@ pub fn blank_before_after_class(checker: &mut Checker, definition: &Definition) 
                             if checker.patch() {
                                 // Delete the blank line before the class.
                                 check.amend(Fix::deletion(
-                                    Location::new(docstring.location.row() - blank_lines_before, 1),
-                                    Location::new(docstring.location.row(), 1),
+                                    Location::new(docstring.location.row() - blank_lines_before, 0),
+                                    Location::new(docstring.location.row(), 0),
                                 ));
                             }
                             checker.add_check(check);
@@ -285,8 +285,8 @@ pub fn blank_before_after_class(checker: &mut Checker, definition: &Definition) 
                                 // Insert one blank line before the class.
                                 check.amend(Fix::replacement(
                                     "\n".to_string(),
-                                    Location::new(docstring.location.row() - blank_lines_before, 1),
-                                    Location::new(docstring.location.row(), 1),
+                                    Location::new(docstring.location.row() - blank_lines_before, 0),
+                                    Location::new(docstring.location.row(), 0),
                                 ));
                             }
                             checker.add_check(check);
@@ -322,10 +322,10 @@ pub fn blank_before_after_class(checker: &mut Checker, definition: &Definition) 
                             // Insert a blank line before the class (replacing any existing lines).
                             check.amend(Fix::replacement(
                                 "\n".to_string(),
-                                Location::new(docstring.end_location.unwrap().row() + 1, 1),
+                                Location::new(docstring.end_location.unwrap().row() + 1, 0),
                                 Location::new(
                                     docstring.end_location.unwrap().row() + 1 + blank_lines_after,
-                                    1,
+                                    0,
                                 ),
                             ));
                         }
@@ -364,8 +364,8 @@ pub fn blank_after_summary(checker: &mut Checker, definition: &Definition) {
                     // Insert one blank line after the summary (replacing any existing lines).
                     check.amend(Fix::replacement(
                         "\n".to_string(),
-                        Location::new(docstring.location.row() + 1, 1),
-                        Location::new(docstring.location.row() + 1 + blanks_count, 1),
+                        Location::new(docstring.location.row() + 1, 0),
+                        Location::new(docstring.location.row() + 1 + blanks_count, 0),
                     ));
                 }
                 checker.add_check(check);
@@ -416,15 +416,15 @@ pub fn indent(checker: &mut Checker, definition: &Definition) {
                         let mut check = Check::new(
                             CheckKind::NoUnderIndentation,
                             Range {
-                                location: Location::new(docstring.location.row() + i, 1),
-                                end_location: Location::new(docstring.location.row() + i, 1),
+                                location: Location::new(docstring.location.row() + i, 0),
+                                end_location: Location::new(docstring.location.row() + i, 0),
                             },
                         );
                         if checker.patch() {
                             check.amend(Fix::replacement(
                                 helpers::clean(&docstring_indent),
-                                Location::new(docstring.location.row() + i, 1),
-                                Location::new(docstring.location.row() + i, 1 + line_indent.len()),
+                                Location::new(docstring.location.row() + i, 0),
+                                Location::new(docstring.location.row() + i, line_indent.len()),
                             ));
                         }
                         checker.add_check(check);
@@ -465,18 +465,15 @@ pub fn indent(checker: &mut Checker, definition: &Definition) {
                             let mut check = Check::new(
                                 CheckKind::NoOverIndentation,
                                 Range {
-                                    location: Location::new(docstring.location.row() + i, 1),
-                                    end_location: Location::new(docstring.location.row() + i, 1),
+                                    location: Location::new(docstring.location.row() + i, 0),
+                                    end_location: Location::new(docstring.location.row() + i, 0),
                                 },
                             );
                             if checker.patch() {
                                 check.amend(Fix::replacement(
                                     helpers::clean(&docstring_indent),
-                                    Location::new(docstring.location.row() + i, 1),
-                                    Location::new(
-                                        docstring.location.row() + i,
-                                        1 + line_indent.len(),
-                                    ),
+                                    Location::new(docstring.location.row() + i, 0),
+                                    Location::new(docstring.location.row() + i, line_indent.len()),
                                 ));
                             }
                             checker.add_check(check);
@@ -492,15 +489,15 @@ pub fn indent(checker: &mut Checker, definition: &Definition) {
                         let mut check = Check::new(
                             CheckKind::NoOverIndentation,
                             Range {
-                                location: Location::new(docstring.location.row() + i, 1),
-                                end_location: Location::new(docstring.location.row() + i, 1),
+                                location: Location::new(docstring.location.row() + i, 0),
+                                end_location: Location::new(docstring.location.row() + i, 0),
                             },
                         );
                         if checker.patch() {
                             check.amend(Fix::replacement(
                                 helpers::clean(&docstring_indent),
-                                Location::new(docstring.location.row() + i, 1),
-                                Location::new(docstring.location.row() + i, 1 + line_indent.len()),
+                                Location::new(docstring.location.row() + i, 0),
+                                Location::new(docstring.location.row() + i, line_indent.len()),
                             ));
                         }
                         checker.add_check(check);
@@ -921,7 +918,7 @@ fn blanks_and_section_underline(
                 );
                 check.amend(Fix::insertion(
                     content,
-                    Location::new(docstring.location.row() + context.original_index + 1, 1),
+                    Location::new(docstring.location.row() + context.original_index + 1, 0),
                 ));
             }
             checker.add_check(check);
@@ -955,7 +952,7 @@ fn blanks_and_section_underline(
                 );
                 check.amend(Fix::insertion(
                     content,
-                    Location::new(docstring.location.row() + context.original_index + 1, 1),
+                    Location::new(docstring.location.row() + context.original_index + 1, 0),
                 ));
             }
             checker.add_check(check);
@@ -971,13 +968,13 @@ fn blanks_and_section_underline(
                 if checker.patch() {
                     // Delete any blank lines between the header and content.
                     check.amend(Fix::deletion(
-                        Location::new(docstring.location.row() + context.original_index + 1, 1),
+                        Location::new(docstring.location.row() + context.original_index + 1, 0),
                         Location::new(
                             docstring.location.row()
                                 + context.original_index
                                 + 1
                                 + blank_lines_after_header,
-                            1,
+                            0,
                         ),
                     ));
                 }
@@ -994,13 +991,13 @@ fn blanks_and_section_underline(
                 if checker.patch() {
                     // Delete any blank lines between the header and the underline.
                     check.amend(Fix::deletion(
-                        Location::new(docstring.location.row() + context.original_index + 1, 1),
+                        Location::new(docstring.location.row() + context.original_index + 1, 0),
                         Location::new(
                             docstring.location.row()
                                 + context.original_index
                                 + 1
                                 + blank_lines_after_header,
-                            1,
+                            0,
                         ),
                     ));
                 }
@@ -1036,7 +1033,7 @@ fn blanks_and_section_underline(
                                 + context.original_index
                                 + 1
                                 + blank_lines_after_header,
-                            1,
+                            0,
                         ),
                         Location::new(
                             docstring.location.row()
@@ -1044,7 +1041,7 @@ fn blanks_and_section_underline(
                                 + 1
                                 + blank_lines_after_header
                                 + 1,
-                            1,
+                            0,
                         ),
                     ));
                 };
@@ -1069,7 +1066,7 @@ fn blanks_and_section_underline(
                                 + context.original_index
                                 + 1
                                 + blank_lines_after_header,
-                            1,
+                            0,
                         ),
                         Location::new(
                             docstring.location.row()
@@ -1117,7 +1114,7 @@ fn blanks_and_section_underline(
                                         + context.original_index
                                         + 1
                                         + line_after_dashes_index,
-                                    1,
+                                    0,
                                 ),
                                 Location::new(
                                     docstring.location.row()
@@ -1125,7 +1122,7 @@ fn blanks_and_section_underline(
                                         + 1
                                         + line_after_dashes_index
                                         + blank_lines_after_dashes,
-                                    1,
+                                    0,
                                 ),
                             ));
                         }
@@ -1179,11 +1176,11 @@ fn common_section(
                             capitalized_section_name,
                             Location::new(
                                 docstring.location.row() + context.original_index,
-                                1 + section_name_start,
+                                *section_name_start,
                             ),
                             Location::new(
                                 docstring.location.row() + context.original_index,
-                                1 + section_name_start + section_name_length,
+                                section_name_start + section_name_length,
                             ),
                         ))
                     }
@@ -1205,10 +1202,10 @@ fn common_section(
                 // Replace the existing indentation with whitespace of the appropriate length.
                 check.amend(Fix::replacement(
                     helpers::clean(&indentation),
-                    Location::new(docstring.location.row() + context.original_index, 1),
+                    Location::new(docstring.location.row() + context.original_index, 0),
                     Location::new(
                         docstring.location.row() + context.original_index,
-                        1 + leading_space.len(),
+                        leading_space.len(),
                     ),
                 ));
             };
@@ -1237,7 +1234,7 @@ fn common_section(
                                 + context.original_index
                                 + 1
                                 + context.following_lines.len(),
-                            1,
+                            0,
                         ),
                     ));
                 }
@@ -1258,7 +1255,7 @@ fn common_section(
                                 + context.original_index
                                 + 1
                                 + context.following_lines.len(),
-                            1,
+                            0,
                         ),
                     ));
                 }
@@ -1277,7 +1274,7 @@ fn common_section(
                 // Add a blank line before the section.
                 check.amend(Fix::insertion(
                     "\n".to_string(),
-                    Location::new(docstring.location.row() + context.original_index, 1),
+                    Location::new(docstring.location.row() + context.original_index, 0),
                 ));
             }
             checker.add_check(check)
@@ -1444,11 +1441,11 @@ fn numpy_section(checker: &mut Checker, definition: &Definition, context: &Secti
                     check.amend(Fix::deletion(
                         Location::new(
                             docstring.location.row() + context.original_index,
-                            1 + suffix_start,
+                            *suffix_start,
                         ),
                         Location::new(
                             docstring.location.row() + context.original_index,
-                            1 + suffix_start + suffix_length,
+                            suffix_start + suffix_length,
                         ),
                     ));
                 }
@@ -1494,11 +1491,11 @@ fn google_section(checker: &mut Checker, definition: &Definition, context: &Sect
                         ":".to_string(),
                         Location::new(
                             docstring.location.row() + context.original_index,
-                            1 + suffix_start,
+                            *suffix_start,
                         ),
                         Location::new(
                             docstring.location.row() + context.original_index,
-                            1 + suffix_start + suffix_length,
+                            suffix_start + suffix_length,
                         ),
                     ));
                 }

--- a/src/snapshots/ruff__linter__tests__A001_A001.py.snap
+++ b/src/snapshots/ruff__linter__tests__A001_A001.py.snap
@@ -6,162 +6,162 @@ expression: checks
     BuiltinVariableShadowing: sum
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 19
+    column: 18
   fix: ~
 - kind:
     BuiltinVariableShadowing: int
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 30
+    column: 29
   fix: ~
 - kind:
     BuiltinVariableShadowing: print
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 6
+    column: 5
   fix: ~
 - kind:
     BuiltinVariableShadowing: copyright
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 10
+    column: 9
   fix: ~
 - kind:
     BuiltinVariableShadowing: complex
   location:
     row: 6
-    column: 2
+    column: 1
   end_location:
     row: 6
-    column: 14
+    column: 13
   fix: ~
 - kind:
     BuiltinVariableShadowing: float
   location:
     row: 7
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 6
+    column: 5
   fix: ~
 - kind:
     BuiltinVariableShadowing: object
   location:
     row: 7
-    column: 9
+    column: 8
   end_location:
     row: 7
-    column: 15
+    column: 14
   fix: ~
 - kind:
     BuiltinVariableShadowing: min
   location:
     row: 8
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 4
+    column: 3
   fix: ~
 - kind:
     BuiltinVariableShadowing: max
   location:
     row: 8
-    column: 6
+    column: 5
   end_location:
     row: 8
-    column: 9
+    column: 8
   fix: ~
 - kind:
     BuiltinVariableShadowing: bytes
   location:
     row: 10
-    column: 1
+    column: 0
   end_location:
     row: 13
-    column: 1
+    column: 0
   fix: ~
 - kind:
     BuiltinVariableShadowing: slice
   location:
     row: 13
-    column: 1
+    column: 0
   end_location:
     row: 16
-    column: 1
+    column: 0
   fix: ~
 - kind:
     BuiltinVariableShadowing: ValueError
   location:
     row: 18
-    column: 1
+    column: 0
   end_location:
     row: 21
-    column: 1
+    column: 0
   fix: ~
 - kind:
     BuiltinVariableShadowing: memoryview
   location:
     row: 21
-    column: 5
+    column: 4
   end_location:
     row: 21
-    column: 15
+    column: 14
   fix: ~
 - kind:
     BuiltinVariableShadowing: bytearray
   location:
     row: 21
-    column: 18
+    column: 17
   end_location:
     row: 21
-    column: 27
+    column: 26
   fix: ~
 - kind:
     BuiltinVariableShadowing: str
   location:
     row: 24
-    column: 22
+    column: 21
   end_location:
     row: 24
-    column: 25
+    column: 24
   fix: ~
 - kind:
     BuiltinVariableShadowing: all
   location:
     row: 24
-    column: 45
+    column: 44
   end_location:
     row: 24
-    column: 48
+    column: 47
   fix: ~
 - kind:
     BuiltinVariableShadowing: any
   location:
     row: 24
-    column: 50
+    column: 49
   end_location:
     row: 24
-    column: 53
+    column: 52
   fix: ~
 - kind:
     BuiltinVariableShadowing: sum
   location:
     row: 27
-    column: 8
+    column: 7
   end_location:
     row: 27
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__A002_A002.py.snap
+++ b/src/snapshots/ruff__linter__tests__A002_A002.py.snap
@@ -6,63 +6,63 @@ expression: checks
     BuiltinArgumentShadowing: str
   location:
     row: 1
-    column: 11
+    column: 10
   end_location:
     row: 1
-    column: 14
+    column: 13
   fix: ~
 - kind:
     BuiltinArgumentShadowing: type
   location:
     row: 1
-    column: 19
+    column: 18
   end_location:
     row: 1
-    column: 23
+    column: 22
   fix: ~
 - kind:
     BuiltinArgumentShadowing: complex
   location:
     row: 1
-    column: 26
+    column: 25
   end_location:
     row: 1
-    column: 33
+    column: 32
   fix: ~
 - kind:
     BuiltinArgumentShadowing: Exception
   location:
     row: 1
-    column: 35
+    column: 34
   end_location:
     row: 1
-    column: 44
+    column: 43
   fix: ~
 - kind:
     BuiltinArgumentShadowing: getattr
   location:
     row: 1
-    column: 48
+    column: 47
   end_location:
     row: 1
-    column: 55
+    column: 54
   fix: ~
 - kind:
     BuiltinArgumentShadowing: bytes
   location:
     row: 5
-    column: 17
+    column: 16
   end_location:
     row: 5
-    column: 22
+    column: 21
   fix: ~
 - kind:
     BuiltinArgumentShadowing: float
   location:
     row: 9
-    column: 16
+    column: 15
   end_location:
     row: 9
-    column: 21
+    column: 20
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__A003_A003.py.snap
+++ b/src/snapshots/ruff__linter__tests__A003_A003.py.snap
@@ -6,18 +6,18 @@ expression: checks
     BuiltinAttributeShadowing: ImportError
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 16
+    column: 15
   fix: ~
 - kind:
     BuiltinAttributeShadowing: str
   location:
     row: 7
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B002_B002.py.snap
+++ b/src/snapshots/ruff__linter__tests__B002_B002.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: UnaryPrefixIncrement
   location:
     row: 15
-    column: 9
+    column: 8
   end_location:
     row: 15
-    column: 12
+    column: 11
   fix: ~
 - kind: UnaryPrefixIncrement
   location:
     row: 20
-    column: 12
+    column: 11
   end_location:
     row: 20
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B006_B006_B008.py.snap
+++ b/src/snapshots/ruff__linter__tests__B006_B006_B008.py.snap
@@ -5,89 +5,89 @@ expression: checks
 - kind: MutableArgumentDefault
   location:
     row: 60
-    column: 25
+    column: 24
   end_location:
     row: 60
-    column: 34
+    column: 33
   fix: ~
 - kind: MutableArgumentDefault
   location:
     row: 64
-    column: 30
+    column: 29
   end_location:
     row: 64
-    column: 32
+    column: 31
   fix: ~
 - kind: MutableArgumentDefault
   location:
     row: 68
-    column: 20
+    column: 19
   end_location:
     row: 68
+    column: 24
+  fix: ~
+- kind: MutableArgumentDefault
+  location:
+    row: 72
+    column: 19
+  end_location:
+    row: 72
+    column: 44
+  fix: ~
+- kind: MutableArgumentDefault
+  location:
+    row: 76
+    column: 31
+  end_location:
+    row: 76
+    column: 56
+  fix: ~
+- kind: MutableArgumentDefault
+  location:
+    row: 80
     column: 25
-  fix: ~
-- kind: MutableArgumentDefault
-  location:
-    row: 72
-    column: 20
-  end_location:
-    row: 72
-    column: 45
-  fix: ~
-- kind: MutableArgumentDefault
-  location:
-    row: 76
-    column: 32
-  end_location:
-    row: 76
-    column: 57
-  fix: ~
-- kind: MutableArgumentDefault
-  location:
-    row: 80
-    column: 26
   end_location:
     row: 80
-    column: 45
+    column: 44
   fix: ~
 - kind: MutableArgumentDefault
   location:
     row: 85
-    column: 46
-  end_location:
-    row: 85
-    column: 70
-  fix: ~
-- kind: MutableArgumentDefault
-  location:
-    row: 89
-    column: 46
-  end_location:
-    row: 89
-    column: 73
-  fix: ~
-- kind: MutableArgumentDefault
-  location:
-    row: 93
     column: 45
   end_location:
-    row: 93
+    row: 85
     column: 69
   fix: ~
 - kind: MutableArgumentDefault
   location:
+    row: 89
+    column: 45
+  end_location:
+    row: 89
+    column: 72
+  fix: ~
+- kind: MutableArgumentDefault
+  location:
+    row: 93
+    column: 44
+  end_location:
+    row: 93
+    column: 68
+  fix: ~
+- kind: MutableArgumentDefault
+  location:
     row: 97
-    column: 33
+    column: 32
   end_location:
     row: 97
-    column: 35
+    column: 34
   fix: ~
 - kind: MutableArgumentDefault
   location:
     row: 170
-    column: 20
+    column: 19
   end_location:
     row: 170
-    column: 49
+    column: 48
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B007_B007.py.snap
+++ b/src/snapshots/ruff__linter__tests__B007_B007.py.snap
@@ -6,72 +6,72 @@ expression: checks
     UnusedLoopControlVariable: i
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
-    column: 6
+    column: 5
   fix:
     patch:
       content: _i
       location:
         row: 6
-        column: 5
+        column: 4
       end_location:
         row: 6
-        column: 6
+        column: 5
     applied: false
 - kind:
     UnusedLoopControlVariable: k
   location:
     row: 18
-    column: 13
+    column: 12
   end_location:
     row: 18
-    column: 14
+    column: 13
   fix:
     patch:
       content: _k
       location:
         row: 18
-        column: 13
+        column: 12
       end_location:
         row: 18
-        column: 14
+        column: 13
     applied: false
 - kind:
     UnusedLoopControlVariable: i
   location:
     row: 30
-    column: 5
+    column: 4
   end_location:
     row: 30
-    column: 6
+    column: 5
   fix:
     patch:
       content: _i
       location:
         row: 30
-        column: 5
+        column: 4
       end_location:
         row: 30
-        column: 6
+        column: 5
     applied: false
 - kind:
     UnusedLoopControlVariable: k
   location:
     row: 30
-    column: 13
+    column: 12
   end_location:
     row: 30
-    column: 14
+    column: 13
   fix:
     patch:
       content: _k
       location:
         row: 30
-        column: 13
+        column: 12
       end_location:
         row: 30
-        column: 14
+        column: 13
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__B011_B011.py.snap
+++ b/src/snapshots/ruff__linter__tests__B011_B011.py.snap
@@ -5,35 +5,35 @@ expression: checks
 - kind: DoNotAssertFalse
   location:
     row: 8
-    column: 8
+    column: 7
   end_location:
     row: 8
-    column: 13
+    column: 12
   fix:
     patch:
       content: raise AssertionError()
       location:
         row: 8
-        column: 1
+        column: 0
       end_location:
         row: 8
-        column: 13
+        column: 12
     applied: false
 - kind: DoNotAssertFalse
   location:
     row: 10
-    column: 8
+    column: 7
   end_location:
     row: 10
-    column: 13
+    column: 12
   fix:
     patch:
       content: "raise AssertionError('message')"
       location:
         row: 10
-        column: 1
+        column: 0
       end_location:
         row: 10
-        column: 24
+        column: 23
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__B013_B013.py.snap
+++ b/src/snapshots/ruff__linter__tests__B013_B013.py.snap
@@ -6,9 +6,9 @@ expression: checks
     RedundantTupleInExceptionHandler: ValueError
   location:
     row: 3
-    column: 9
+    column: 8
   end_location:
     row: 3
-    column: 20
+    column: 19
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B014_B014.py.snap
+++ b/src/snapshots/ruff__linter__tests__B014_B014.py.snap
@@ -7,56 +7,56 @@ expression: checks
       - OSError
   location:
     row: 17
-    column: 9
+    column: 8
   end_location:
     row: 17
-    column: 25
+    column: 24
   fix:
     patch:
       content: "OSError,"
       location:
         row: 17
-        column: 9
+        column: 8
       end_location:
         row: 17
-        column: 25
+        column: 24
     applied: false
 - kind:
     DuplicateHandlerException:
       - MyError
   location:
     row: 28
-    column: 9
+    column: 8
   end_location:
     row: 28
-    column: 25
+    column: 24
   fix:
     patch:
       content: "MyError,"
       location:
         row: 28
-        column: 9
+        column: 8
       end_location:
         row: 28
-        column: 25
+        column: 24
     applied: false
 - kind:
     DuplicateHandlerException:
       - re.error
   location:
     row: 49
-    column: 9
+    column: 8
   end_location:
     row: 49
-    column: 27
+    column: 26
   fix:
     patch:
       content: "re.error,"
       location:
         row: 49
-        column: 9
+        column: 8
       end_location:
         row: 49
-        column: 27
+        column: 26
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__B017_B017.py.snap
+++ b/src/snapshots/ruff__linter__tests__B017_B017.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: NoAssertRaisesException
   location:
     row: 22
-    column: 9
+    column: 8
   end_location:
     row: 25
-    column: 5
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B025_B025.py.snap
+++ b/src/snapshots/ruff__linter__tests__B025_B025.py.snap
@@ -6,36 +6,36 @@ expression: checks
     DuplicateTryBlockException: ValueError
   location:
     row: 15
-    column: 1
+    column: 0
   end_location:
     row: 22
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DuplicateTryBlockException: pickle.PickleError
   location:
     row: 22
-    column: 1
+    column: 0
   end_location:
     row: 31
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DuplicateTryBlockException: TypeError
   location:
     row: 31
-    column: 1
+    column: 0
   end_location:
     row: 39
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DuplicateTryBlockException: ValueError
   location:
     row: 31
-    column: 1
+    column: 0
   end_location:
     row: 39
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C400_C400.py.snap
+++ b/src/snapshots/ruff__linter__tests__C400_C400.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryGeneratorList
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 1
-    column: 30
+    column: 29
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C401_C401.py.snap
+++ b/src/snapshots/ruff__linter__tests__C401_C401.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryGeneratorSet
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 1
-    column: 29
+    column: 28
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C402_C402.py.snap
+++ b/src/snapshots/ruff__linter__tests__C402_C402.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryGeneratorDict
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 31
+    column: 30
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C403_C403.py.snap
+++ b/src/snapshots/ruff__linter__tests__C403_C403.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryListComprehensionSet
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 1
-    column: 31
+    column: 30
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C404_C404.py.snap
+++ b/src/snapshots/ruff__linter__tests__C404_C404.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryListComprehensionDict
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 33
+    column: 32
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C405_C405.py.snap
+++ b/src/snapshots/ruff__linter__tests__C405_C405.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UnnecessaryLiteralSet: list
   location:
     row: 1
-    column: 6
+    column: 5
   end_location:
     row: 1
-    column: 17
+    column: 16
   fix: ~
 - kind:
     UnnecessaryLiteralSet: tuple
   location:
     row: 2
-    column: 6
+    column: 5
   end_location:
     row: 2
-    column: 17
+    column: 16
   fix: ~
 - kind:
     UnnecessaryLiteralSet: list
   location:
     row: 3
-    column: 6
+    column: 5
   end_location:
     row: 3
-    column: 13
+    column: 12
   fix: ~
 - kind:
     UnnecessaryLiteralSet: tuple
   location:
     row: 4
-    column: 6
+    column: 5
   end_location:
     row: 4
-    column: 13
+    column: 12
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C406_C406.py.snap
+++ b/src/snapshots/ruff__linter__tests__C406_C406.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UnnecessaryLiteralDict: list
   location:
     row: 1
-    column: 6
+    column: 5
   end_location:
     row: 1
-    column: 20
+    column: 19
   fix: ~
 - kind:
     UnnecessaryLiteralDict: tuple
   location:
     row: 2
-    column: 6
+    column: 5
   end_location:
     row: 2
-    column: 21
+    column: 20
   fix: ~
 - kind:
     UnnecessaryLiteralDict: list
   location:
     row: 3
-    column: 6
+    column: 5
   end_location:
     row: 3
-    column: 14
+    column: 13
   fix: ~
 - kind:
     UnnecessaryLiteralDict: tuple
   location:
     row: 4
-    column: 6
+    column: 5
   end_location:
     row: 4
-    column: 14
+    column: 13
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C408_C408.py.snap
+++ b/src/snapshots/ruff__linter__tests__C408_C408.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UnnecessaryCollectionCall: tuple
   location:
     row: 1
-    column: 5
+    column: 4
   end_location:
     row: 1
-    column: 12
+    column: 11
   fix: ~
 - kind:
     UnnecessaryCollectionCall: list
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
+    column: 10
+  fix: ~
+- kind:
+    UnnecessaryCollectionCall: dict
+  location:
+    row: 3
+    column: 5
+  end_location:
+    row: 3
     column: 11
   fix: ~
 - kind:
     UnnecessaryCollectionCall: dict
   location:
-    row: 3
-    column: 6
-  end_location:
-    row: 3
-    column: 12
-  fix: ~
-- kind:
-    UnnecessaryCollectionCall: dict
-  location:
     row: 4
-    column: 6
+    column: 5
   end_location:
     row: 4
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C409_C409.py.snap
+++ b/src/snapshots/ruff__linter__tests__C409_C409.py.snap
@@ -6,27 +6,27 @@ expression: checks
     UnnecessaryLiteralWithinTupleCall: list
   location:
     row: 1
-    column: 6
+    column: 5
   end_location:
     row: 1
-    column: 19
+    column: 18
   fix: ~
 - kind:
     UnnecessaryLiteralWithinTupleCall: tuple
   location:
     row: 2
-    column: 6
+    column: 5
   end_location:
     row: 2
-    column: 19
+    column: 18
   fix: ~
 - kind:
     UnnecessaryLiteralWithinTupleCall: list
   location:
     row: 3
-    column: 6
+    column: 5
   end_location:
     row: 3
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C410_C410.py.snap
+++ b/src/snapshots/ruff__linter__tests__C410_C410.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UnnecessaryLiteralWithinListCall: list
   location:
     row: 1
-    column: 6
+    column: 5
   end_location:
     row: 1
-    column: 18
+    column: 17
   fix: ~
 - kind:
     UnnecessaryLiteralWithinListCall: tuple
   location:
     row: 2
-    column: 6
+    column: 5
   end_location:
     row: 2
-    column: 18
+    column: 17
   fix: ~
 - kind:
     UnnecessaryLiteralWithinListCall: list
   location:
     row: 3
-    column: 6
+    column: 5
   end_location:
     row: 3
-    column: 14
+    column: 13
   fix: ~
 - kind:
     UnnecessaryLiteralWithinListCall: tuple
   location:
     row: 4
-    column: 6
+    column: 5
   end_location:
     row: 4
-    column: 14
+    column: 13
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C411_C411.py.snap
+++ b/src/snapshots/ruff__linter__tests__C411_C411.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: UnnecessaryListCall
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 21
+    column: 20
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C413_C413.py.snap
+++ b/src/snapshots/ruff__linter__tests__C413_C413.py.snap
@@ -6,27 +6,27 @@ expression: checks
     UnnecessaryCallAroundSorted: list
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 16
+    column: 15
   fix: ~
 - kind:
     UnnecessaryCallAroundSorted: reversed
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 20
+    column: 19
   fix: ~
 - kind:
     UnnecessaryCallAroundSorted: reversed
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 34
+    column: 33
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C414_C414.py.snap
+++ b/src/snapshots/ruff__linter__tests__C414_C414.py.snap
@@ -8,76 +8,76 @@ expression: checks
       - list
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 14
-  fix: ~
-- kind:
-    UnnecessaryDoubleCastOrProcess:
-      - tuple
-      - list
-  location:
-    row: 3
-    column: 1
-  end_location:
-    row: 3
-    column: 15
-  fix: ~
-- kind:
-    UnnecessaryDoubleCastOrProcess:
-      - list
-      - tuple
-  location:
-    row: 4
-    column: 1
-  end_location:
-    row: 4
-    column: 15
-  fix: ~
-- kind:
-    UnnecessaryDoubleCastOrProcess:
-      - tuple
-      - tuple
-  location:
-    row: 5
-    column: 1
-  end_location:
-    row: 5
-    column: 16
-  fix: ~
-- kind:
-    UnnecessaryDoubleCastOrProcess:
-      - set
-      - set
-  location:
-    row: 6
-    column: 1
-  end_location:
-    row: 6
-    column: 12
-  fix: ~
-- kind:
-    UnnecessaryDoubleCastOrProcess:
-      - list
-      - set
-  location:
-    row: 7
-    column: 1
-  end_location:
-    row: 7
     column: 13
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
       - tuple
+      - list
+  location:
+    row: 3
+    column: 0
+  end_location:
+    row: 3
+    column: 14
+  fix: ~
+- kind:
+    UnnecessaryDoubleCastOrProcess:
+      - list
+      - tuple
+  location:
+    row: 4
+    column: 0
+  end_location:
+    row: 4
+    column: 14
+  fix: ~
+- kind:
+    UnnecessaryDoubleCastOrProcess:
+      - tuple
+      - tuple
+  location:
+    row: 5
+    column: 0
+  end_location:
+    row: 5
+    column: 15
+  fix: ~
+- kind:
+    UnnecessaryDoubleCastOrProcess:
+      - set
+      - set
+  location:
+    row: 6
+    column: 0
+  end_location:
+    row: 6
+    column: 11
+  fix: ~
+- kind:
+    UnnecessaryDoubleCastOrProcess:
+      - list
+      - set
+  location:
+    row: 7
+    column: 0
+  end_location:
+    row: 7
+    column: 12
+  fix: ~
+- kind:
+    UnnecessaryDoubleCastOrProcess:
+      - tuple
       - set
   location:
     row: 8
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 14
+    column: 13
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -85,10 +85,10 @@ expression: checks
       - set
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 9
-    column: 15
+    column: 14
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -96,10 +96,10 @@ expression: checks
       - set
   location:
     row: 10
-    column: 1
+    column: 0
   end_location:
     row: 10
-    column: 17
+    column: 16
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -107,10 +107,10 @@ expression: checks
       - sorted
   location:
     row: 11
-    column: 1
+    column: 0
   end_location:
     row: 11
-    column: 16
+    column: 15
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -118,10 +118,10 @@ expression: checks
       - sorted
   location:
     row: 12
-    column: 1
+    column: 0
   end_location:
     row: 12
-    column: 17
+    column: 16
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -129,10 +129,10 @@ expression: checks
       - sorted
   location:
     row: 13
-    column: 1
+    column: 0
   end_location:
     row: 13
-    column: 18
+    column: 17
   fix: ~
 - kind:
     UnnecessaryDoubleCastOrProcess:
@@ -140,9 +140,9 @@ expression: checks
       - sorted
   location:
     row: 14
-    column: 1
+    column: 0
   end_location:
     row: 14
-    column: 20
+    column: 19
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C415_C415.py.snap
+++ b/src/snapshots/ruff__linter__tests__C415_C415.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UnnecessarySubscriptReversal: set
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 19
+    column: 18
   fix: ~
 - kind:
     UnnecessarySubscriptReversal: reversed
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 24
+    column: 23
   fix: ~
 - kind:
     UnnecessarySubscriptReversal: sorted
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 22
+    column: 21
   fix: ~
 - kind:
     UnnecessarySubscriptReversal: sorted
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 36
+    column: 35
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C416_C416.py.snap
+++ b/src/snapshots/ruff__linter__tests__C416_C416.py.snap
@@ -6,18 +6,18 @@ expression: checks
     UnnecessaryComprehension: list
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 15
+    column: 14
   fix: ~
 - kind:
     UnnecessaryComprehension: set
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__C417_C417.py.snap
+++ b/src/snapshots/ruff__linter__tests__C417_C417.py.snap
@@ -6,72 +6,72 @@ expression: checks
     UnnecessaryMap: generator
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 27
+    column: 26
   fix: ~
 - kind:
     UnnecessaryMap: generator
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 28
+    column: 27
   fix: ~
 - kind:
     UnnecessaryMap: list
   location:
     row: 4
-    column: 1
-  end_location:
-    row: 4
-    column: 33
-  fix: ~
-- kind:
-    UnnecessaryMap: generator
-  location:
-    row: 4
-    column: 6
+    column: 0
   end_location:
     row: 4
     column: 32
   fix: ~
 - kind:
+    UnnecessaryMap: generator
+  location:
+    row: 4
+    column: 5
+  end_location:
+    row: 4
+    column: 31
+  fix: ~
+- kind:
     UnnecessaryMap: set
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 37
+    column: 36
   fix: ~
 - kind:
     UnnecessaryMap: generator
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 36
+    column: 35
   fix: ~
 - kind:
     UnnecessaryMap: dict
   location:
     row: 6
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 37
+    column: 36
   fix: ~
 - kind:
     UnnecessaryMap: generator
   location:
     row: 6
-    column: 6
+    column: 5
   end_location:
     row: 6
-    column: 36
+    column: 35
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D100_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D100_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: PublicModule
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D101_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D101_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: PublicClass
   location:
     row: 14
-    column: 1
+    column: 0
   end_location:
     row: 67
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D102_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D102_D.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: PublicMethod
   location:
     row: 22
-    column: 5
+    column: 4
   end_location:
     row: 25
-    column: 5
+    column: 4
   fix: ~
 - kind: PublicMethod
   location:
     row: 51
-    column: 5
+    column: 4
   end_location:
     row: 54
-    column: 5
+    column: 4
   fix: ~
 - kind: PublicMethod
   location:
     row: 63
-    column: 5
+    column: 4
   end_location:
     row: 67
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D103_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D103_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: PublicFunction
   location:
     row: 395
-    column: 1
+    column: 0
   end_location:
     row: 396
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D105_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D105_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: MagicMethod
   location:
     row: 59
-    column: 5
+    column: 4
   end_location:
     row: 62
-    column: 5
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D107_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D107_D.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: PublicInit
   location:
     row: 55
-    column: 5
+    column: 4
   end_location:
     row: 58
-    column: 5
+    column: 4
   fix: ~
 - kind: PublicInit
   location:
     row: 529
-    column: 5
+    column: 4
   end_location:
     row: 533
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D201_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D201_D.py.snap
@@ -6,36 +6,36 @@ expression: checks
     NoBlankLineBeforeFunction: 1
   location:
     row: 132
-    column: 5
+    column: 4
   end_location:
     row: 132
-    column: 25
+    column: 24
   fix:
     patch:
       content: ""
       location:
         row: 131
-        column: 1
+        column: 0
       end_location:
         row: 132
-        column: 1
+        column: 0
     applied: false
 - kind:
     NoBlankLineBeforeFunction: 1
   location:
     row: 146
-    column: 5
+    column: 4
   end_location:
     row: 146
-    column: 38
+    column: 37
   fix:
     patch:
       content: ""
       location:
         row: 145
-        column: 1
+        column: 0
       end_location:
         row: 146
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D202_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D202_D.py.snap
@@ -6,36 +6,36 @@ expression: checks
     NoBlankLineAfterFunction: 1
   location:
     row: 137
-    column: 5
+    column: 4
   end_location:
     row: 137
-    column: 25
+    column: 24
   fix:
     patch:
       content: ""
       location:
         row: 138
-        column: 1
+        column: 0
       end_location:
         row: 139
-        column: 1
+        column: 0
     applied: false
 - kind:
     NoBlankLineAfterFunction: 1
   location:
     row: 146
-    column: 5
+    column: 4
   end_location:
     row: 146
-    column: 38
+    column: 37
   fix:
     patch:
       content: ""
       location:
         row: 147
-        column: 1
+        column: 0
       end_location:
         row: 148
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D203_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D203_D.py.snap
@@ -6,54 +6,54 @@ expression: checks
     OneBlankLineBeforeClass: 0
   location:
     row: 156
-    column: 5
+    column: 4
   end_location:
     row: 156
-    column: 33
+    column: 32
   fix:
     patch:
       content: "\n"
       location:
         row: 156
-        column: 1
+        column: 0
       end_location:
         row: 156
-        column: 1
+        column: 0
     applied: false
 - kind:
     OneBlankLineBeforeClass: 0
   location:
     row: 187
-    column: 5
+    column: 4
   end_location:
     row: 187
-    column: 46
+    column: 45
   fix:
     patch:
       content: "\n"
       location:
         row: 187
-        column: 1
+        column: 0
       end_location:
         row: 187
-        column: 1
+        column: 0
     applied: false
 - kind:
     OneBlankLineBeforeClass: 0
   location:
     row: 521
-    column: 5
+    column: 4
   end_location:
     row: 527
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 521
-        column: 1
+        column: 0
       end_location:
         row: 521
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D204_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D204_D.py.snap
@@ -6,36 +6,36 @@ expression: checks
     OneBlankLineAfterClass: 0
   location:
     row: 176
-    column: 5
+    column: 4
   end_location:
     row: 176
-    column: 25
+    column: 24
   fix:
     patch:
       content: "\n"
       location:
         row: 177
-        column: 1
+        column: 0
       end_location:
         row: 177
-        column: 1
+        column: 0
     applied: false
 - kind:
     OneBlankLineAfterClass: 0
   location:
     row: 187
-    column: 5
+    column: 4
   end_location:
     row: 187
-    column: 46
+    column: 45
   fix:
     patch:
       content: "\n"
       location:
         row: 188
-        column: 1
+        column: 0
       end_location:
         row: 188
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D205_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D205_D.py.snap
@@ -5,35 +5,35 @@ expression: checks
 - kind: BlankLineAfterSummary
   location:
     row: 195
-    column: 5
+    column: 4
   end_location:
     row: 198
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 196
-        column: 1
+        column: 0
       end_location:
         row: 196
-        column: 1
+        column: 0
     applied: false
 - kind: BlankLineAfterSummary
   location:
     row: 205
-    column: 5
+    column: 4
   end_location:
     row: 210
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 206
-        column: 1
+        column: 0
       end_location:
         row: 208
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D207_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D207_D.py.snap
@@ -5,35 +5,35 @@ expression: checks
 - kind: NoUnderIndentation
   location:
     row: 227
-    column: 1
+    column: 0
   end_location:
     row: 227
-    column: 1
+    column: 0
   fix:
     patch:
       content: "    "
       location:
         row: 227
-        column: 1
+        column: 0
       end_location:
         row: 227
-        column: 1
+        column: 0
     applied: false
 - kind: NoUnderIndentation
   location:
     row: 435
-    column: 1
+    column: 0
   end_location:
     row: 435
-    column: 1
+    column: 0
   fix:
     patch:
       content: "                                    "
       location:
         row: 435
-        column: 1
+        column: 0
       end_location:
         row: 435
-        column: 5
+        column: 4
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D208_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D208_D.py.snap
@@ -5,52 +5,52 @@ expression: checks
 - kind: NoOverIndentation
   location:
     row: 247
-    column: 1
+    column: 0
   end_location:
     row: 247
-    column: 1
+    column: 0
   fix:
     patch:
       content: "    "
       location:
         row: 247
-        column: 1
+        column: 0
       end_location:
         row: 247
+        column: 7
+    applied: false
+- kind: NoOverIndentation
+  location:
+    row: 259
+    column: 0
+  end_location:
+    row: 259
+    column: 0
+  fix:
+    patch:
+      content: "    "
+      location:
+        row: 259
+        column: 0
+      end_location:
+        row: 259
         column: 8
     applied: false
 - kind: NoOverIndentation
   location:
-    row: 259
-    column: 1
-  end_location:
-    row: 259
-    column: 1
-  fix:
-    patch:
-      content: "    "
-      location:
-        row: 259
-        column: 1
-      end_location:
-        row: 259
-        column: 9
-    applied: false
-- kind: NoOverIndentation
-  location:
     row: 267
-    column: 1
+    column: 0
   end_location:
     row: 267
-    column: 1
+    column: 0
   fix:
     patch:
       content: "    "
       location:
         row: 267
-        column: 1
+        column: 0
       end_location:
         row: 267
-        column: 9
+        column: 8
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D209_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D209_D.py.snap
@@ -5,18 +5,18 @@ expression: checks
 - kind: NewLineAfterLastParagraph
   location:
     row: 276
-    column: 5
+    column: 4
   end_location:
     row: 278
-    column: 20
+    column: 19
   fix:
     patch:
       content: "\n    "
       location:
         row: 278
-        column: 17
+        column: 16
       end_location:
         row: 278
-        column: 17
+        column: 16
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D210_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D210_D.py.snap
@@ -5,52 +5,52 @@ expression: checks
 - kind: NoSurroundingWhitespace
   location:
     row: 283
-    column: 5
+    column: 4
   end_location:
     row: 283
-    column: 34
+    column: 33
   fix:
     patch:
       content: Whitespace at the end.
       location:
         row: 283
-        column: 8
+        column: 7
       end_location:
         row: 283
-        column: 31
+        column: 30
     applied: false
 - kind: NoSurroundingWhitespace
   location:
     row: 288
-    column: 5
+    column: 4
   end_location:
     row: 288
-    column: 38
+    column: 37
   fix:
     patch:
       content: Whitespace at everywhere.
       location:
         row: 288
-        column: 8
+        column: 7
       end_location:
         row: 288
-        column: 35
+        column: 34
     applied: false
 - kind: NoSurroundingWhitespace
   location:
     row: 294
-    column: 5
+    column: 4
   end_location:
     row: 297
-    column: 8
+    column: 7
   fix:
     patch:
       content: Whitespace at the beginning.
       location:
         row: 294
-        column: 8
+        column: 7
       end_location:
         row: 294
-        column: 37
+        column: 36
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D211_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D211_D.py.snap
@@ -6,36 +6,36 @@ expression: checks
     NoBlankLineBeforeClass: 1
   location:
     row: 165
-    column: 5
+    column: 4
   end_location:
     row: 165
-    column: 30
+    column: 29
   fix:
     patch:
       content: ""
       location:
         row: 164
-        column: 1
+        column: 0
       end_location:
         row: 165
-        column: 1
+        column: 0
     applied: false
 - kind:
     NoBlankLineBeforeClass: 1
   location:
     row: 176
-    column: 5
+    column: 4
   end_location:
     row: 176
-    column: 25
+    column: 24
   fix:
     patch:
       content: ""
       location:
         row: 175
-        column: 1
+        column: 0
       end_location:
         row: 176
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D212_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D212_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: MultiLineSummaryFirstLine
   location:
     row: 124
-    column: 5
+    column: 4
   end_location:
     row: 126
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D213_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D213_D.py.snap
@@ -5,129 +5,129 @@ expression: checks
 - kind: MultiLineSummarySecondLine
   location:
     row: 195
-    column: 5
+    column: 4
   end_location:
     row: 198
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 205
-    column: 5
+    column: 4
   end_location:
     row: 210
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 215
-    column: 5
+    column: 4
   end_location:
     row: 219
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 225
-    column: 5
+    column: 4
   end_location:
     row: 229
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 235
-    column: 5
+    column: 4
   end_location:
     row: 239
-    column: 4
+    column: 3
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 245
-    column: 5
+    column: 4
   end_location:
     row: 249
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 255
-    column: 5
+    column: 4
   end_location:
     row: 259
-    column: 12
+    column: 11
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 265
-    column: 5
+    column: 4
   end_location:
     row: 269
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 276
-    column: 5
+    column: 4
   end_location:
     row: 278
-    column: 20
+    column: 19
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 294
-    column: 5
+    column: 4
   end_location:
     row: 297
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 338
-    column: 5
+    column: 4
   end_location:
     row: 343
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 378
-    column: 5
+    column: 4
   end_location:
     row: 381
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 387
-    column: 5
+    column: 4
   end_location:
     row: 391
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 433
-    column: 37
+    column: 36
   end_location:
     row: 436
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 445
-    column: 5
+    column: 4
   end_location:
     row: 449
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiLineSummarySecondLine
   location:
     row: 521
-    column: 5
+    column: 4
   end_location:
     row: 527
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D214_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D214_sections.py.snap
@@ -6,18 +6,18 @@ expression: checks
     SectionNotOverIndented: Returns
   location:
     row: 135
-    column: 5
+    column: 4
   end_location:
     row: 141
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    "
       location:
         row: 137
-        column: 1
+        column: 0
       end_location:
         row: 137
-        column: 9
+        column: 8
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D215_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D215_sections.py.snap
@@ -6,16 +6,16 @@ expression: checks
     SectionUnderlineNotOverIndented: Returns
   location:
     row: 147
-    column: 5
+    column: 4
   end_location:
     row: 153
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    "
       location:
         row: 150
-        column: 1
+        column: 0
       end_location:
         row: 150
         column: 9
@@ -24,16 +24,16 @@ expression: checks
     SectionUnderlineNotOverIndented: Returns
   location:
     row: 161
-    column: 5
+    column: 4
   end_location:
     row: 165
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    "
       location:
         row: 164
-        column: 1
+        column: 0
       end_location:
         row: 164
         column: 9

--- a/src/snapshots/ruff__linter__tests__D300_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D300_D.py.snap
@@ -5,41 +5,41 @@ expression: checks
 - kind: UsesTripleQuotes
   location:
     row: 302
-    column: 5
+    column: 4
   end_location:
     row: 302
-    column: 20
+    column: 19
   fix: ~
 - kind: UsesTripleQuotes
   location:
     row: 307
-    column: 5
+    column: 4
   end_location:
     row: 307
-    column: 20
+    column: 19
   fix: ~
 - kind: UsesTripleQuotes
   location:
     row: 312
-    column: 5
+    column: 4
   end_location:
     row: 312
-    column: 16
+    column: 15
   fix: ~
 - kind: UsesTripleQuotes
   location:
     row: 317
-    column: 5
+    column: 4
   end_location:
     row: 317
-    column: 16
+    column: 15
   fix: ~
 - kind: UsesTripleQuotes
   location:
     row: 323
-    column: 5
+    column: 4
   end_location:
     row: 323
-    column: 17
+    column: 16
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D400_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D400_D.py.snap
@@ -5,129 +5,129 @@ expression: checks
 - kind: EndsInPeriod
   location:
     row: 124
-    column: 5
+    column: 4
   end_location:
     row: 126
-    column: 8
+    column: 7
   fix: ~
 - kind: EndsInPeriod
   location:
     row: 283
-    column: 5
+    column: 4
   end_location:
     row: 283
-    column: 34
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 288
-    column: 5
-  end_location:
-    row: 288
-    column: 38
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 350
-    column: 5
-  end_location:
-    row: 350
-    column: 18
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 401
-    column: 25
-  end_location:
-    row: 401
-    column: 40
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 405
-    column: 5
-  end_location:
-    row: 405
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 411
-    column: 5
-  end_location:
-    row: 411
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 417
-    column: 35
-  end_location:
-    row: 417
-    column: 50
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 424
-    column: 49
-  end_location:
-    row: 424
-    column: 64
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 465
-    column: 5
-  end_location:
-    row: 465
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 470
-    column: 5
-  end_location:
-    row: 470
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 475
-    column: 5
-  end_location:
-    row: 475
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 482
-    column: 5
-  end_location:
-    row: 482
-    column: 25
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 504
-    column: 5
-  end_location:
-    row: 504
-    column: 35
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 509
-    column: 5
-  end_location:
-    row: 509
-    column: 34
-  fix: ~
-- kind: EndsInPeriod
-  location:
-    row: 515
-    column: 5
-  end_location:
-    row: 515
     column: 33
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 288
+    column: 4
+  end_location:
+    row: 288
+    column: 37
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 350
+    column: 4
+  end_location:
+    row: 350
+    column: 17
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 401
+    column: 24
+  end_location:
+    row: 401
+    column: 39
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 405
+    column: 4
+  end_location:
+    row: 405
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 411
+    column: 4
+  end_location:
+    row: 411
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 417
+    column: 34
+  end_location:
+    row: 417
+    column: 49
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 424
+    column: 48
+  end_location:
+    row: 424
+    column: 63
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 465
+    column: 4
+  end_location:
+    row: 465
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 470
+    column: 4
+  end_location:
+    row: 470
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 475
+    column: 4
+  end_location:
+    row: 475
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 482
+    column: 4
+  end_location:
+    row: 482
+    column: 24
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 504
+    column: 4
+  end_location:
+    row: 504
+    column: 34
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 509
+    column: 4
+  end_location:
+    row: 509
+    column: 33
+  fix: ~
+- kind: EndsInPeriod
+  location:
+    row: 515
+    column: 4
+  end_location:
+    row: 515
+    column: 32
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D402_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D402_D.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: NoSignature
   location:
     row: 373
-    column: 5
+    column: 4
   end_location:
     row: 373
-    column: 31
+    column: 30
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D405_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D405_sections.py.snap
@@ -6,36 +6,36 @@ expression: checks
     CapitalizeSectionName: returns
   location:
     row: 17
-    column: 5
+    column: 4
   end_location:
     row: 23
-    column: 8
+    column: 7
   fix:
     patch:
       content: Returns
       location:
         row: 19
-        column: 5
+        column: 4
       end_location:
         row: 19
-        column: 12
+        column: 11
     applied: false
 - kind:
     CapitalizeSectionName: Short summary
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: Short Summary
       location:
         row: 209
-        column: 5
+        column: 4
       end_location:
         row: 209
-        column: 18
+        column: 17
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D406_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D406_sections.py.snap
@@ -6,72 +6,72 @@ expression: checks
     NewLineAfterSectionName: Returns
   location:
     row: 30
-    column: 5
+    column: 4
   end_location:
     row: 36
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 32
-        column: 12
+        column: 11
       end_location:
         row: 32
-        column: 13
+        column: 12
     applied: false
 - kind:
     NewLineAfterSectionName: Raises
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 218
-        column: 11
+        column: 10
       end_location:
         row: 218
-        column: 12
+        column: 11
     applied: false
 - kind:
     NewLineAfterSectionName: Returns
   location:
     row: 252
-    column: 5
+    column: 4
   end_location:
     row: 262
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 257
-        column: 12
+        column: 11
       end_location:
         row: 257
-        column: 13
+        column: 12
     applied: false
 - kind:
     NewLineAfterSectionName: Raises
   location:
     row: 252
-    column: 5
+    column: 4
   end_location:
     row: 262
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 259
-        column: 11
+        column: 10
       end_location:
         row: 259
-        column: 12
+        column: 11
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D407_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D407_sections.py.snap
@@ -6,270 +6,270 @@ expression: checks
     DashedUnderlineAfterSection: Returns
   location:
     row: 42
-    column: 5
+    column: 4
   end_location:
     row: 47
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    -------\n"
       location:
         row: 45
-        column: 1
+        column: 0
       end_location:
         row: 45
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Returns
   location:
     row: 54
-    column: 5
+    column: 4
   end_location:
     row: 58
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    -------\n"
       location:
         row: 57
-        column: 1
+        column: 0
       end_location:
         row: 57
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Raises
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    ------\n"
       location:
         row: 219
-        column: 1
+        column: 0
       end_location:
         row: 219
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Returns
   location:
     row: 252
-    column: 5
+    column: 4
   end_location:
     row: 262
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    -------\n"
       location:
         row: 258
-        column: 1
+        column: 0
       end_location:
         row: 258
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Raises
   location:
     row: 252
-    column: 5
+    column: 4
   end_location:
     row: 262
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    ------\n"
       location:
         row: 260
-        column: 1
+        column: 0
       end_location:
         row: 260
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 269
-    column: 5
+    column: 4
   end_location:
     row: 274
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    ----\n"
       location:
         row: 272
-        column: 1
+        column: 0
       end_location:
         row: 272
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 284
-    column: 9
+    column: 8
   end_location:
     row: 292
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 289
-        column: 1
+        column: 0
       end_location:
         row: 289
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 301
-    column: 5
+    column: 4
   end_location:
     row: 306
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    ----\n"
       location:
         row: 304
-        column: 1
+        column: 0
       end_location:
         row: 304
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 313
-    column: 9
+    column: 8
   end_location:
     row: 319
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 316
-        column: 1
+        column: 0
       end_location:
         row: 316
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 325
-    column: 9
+    column: 8
   end_location:
     row: 330
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 328
-        column: 1
+        column: 0
       end_location:
         row: 328
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 337
-    column: 9
+    column: 8
   end_location:
     row: 343
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 340
-        column: 1
+        column: 0
       end_location:
         row: 340
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 350
-    column: 9
+    column: 8
   end_location:
     row: 355
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 353
-        column: 1
+        column: 0
       end_location:
         row: 353
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 362
-    column: 9
+    column: 8
   end_location:
     row: 367
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 365
-        column: 1
+        column: 0
       end_location:
         row: 365
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 371
-    column: 9
+    column: 8
   end_location:
     row: 382
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 374
-        column: 1
+        column: 0
       end_location:
         row: 374
-        column: 1
+        column: 0
     applied: false
 - kind:
     DashedUnderlineAfterSection: Args
   location:
     row: 490
-    column: 9
+    column: 8
   end_location:
     row: 497
-    column: 12
+    column: 11
   fix:
     patch:
       content: "        ----\n"
       location:
         row: 495
-        column: 1
+        column: 0
       end_location:
         row: 495
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D408_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D408_sections.py.snap
@@ -6,18 +6,18 @@ expression: checks
     SectionUnderlineAfterName: Returns
   location:
     row: 85
-    column: 5
+    column: 4
   end_location:
     row: 92
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 88
-        column: 1
+        column: 0
       end_location:
         row: 89
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D409_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D409_sections.py.snap
@@ -6,36 +6,36 @@ expression: checks
     SectionUnderlineMatchesSectionLength: Returns
   location:
     row: 99
-    column: 5
+    column: 4
   end_location:
     row: 105
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    -------\n"
       location:
         row: 102
-        column: 1
+        column: 0
       end_location:
         row: 103
-        column: 1
+        column: 0
     applied: false
 - kind:
     SectionUnderlineMatchesSectionLength: Returns
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: "    -------\n"
       location:
         row: 216
-        column: 1
+        column: 0
       end_location:
         row: 217
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D410_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D410_sections.py.snap
@@ -6,36 +6,36 @@ expression: checks
     BlankLineAfterSection: Returns
   location:
     row: 67
-    column: 5
+    column: 4
   end_location:
     row: 78
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 71
-        column: 1
+        column: 0
       end_location:
         row: 71
-        column: 1
+        column: 0
     applied: false
 - kind:
     BlankLineAfterSection: Returns
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 218
-        column: 1
+        column: 0
       end_location:
         row: 218
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D411_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D411_sections.py.snap
@@ -6,54 +6,54 @@ expression: checks
     BlankLineBeforeSection: Yields
   location:
     row: 67
-    column: 5
+    column: 4
   end_location:
     row: 78
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 71
-        column: 1
+        column: 0
       end_location:
         row: 71
-        column: 1
+        column: 0
     applied: false
 - kind:
     BlankLineBeforeSection: Returns
   location:
     row: 122
-    column: 5
+    column: 4
   end_location:
     row: 129
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 125
-        column: 1
+        column: 0
       end_location:
         row: 125
-        column: 1
+        column: 0
     applied: false
 - kind:
     BlankLineBeforeSection: Raises
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: "\n"
       location:
         row: 218
-        column: 1
+        column: 0
       end_location:
         row: 218
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D412_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D412_sections.py.snap
@@ -6,18 +6,18 @@ expression: checks
     NoBlankLinesBetweenHeaderAndContent: Short summary
   location:
     row: 207
-    column: 5
+    column: 4
   end_location:
     row: 221
-    column: 8
+    column: 7
   fix:
     patch:
       content: ""
       location:
         row: 211
-        column: 1
+        column: 0
       end_location:
         row: 212
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__D414_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D414_sections.py.snap
@@ -6,45 +6,45 @@ expression: checks
     NonEmptySection: Returns
   location:
     row: 54
-    column: 5
+    column: 4
   end_location:
     row: 58
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NonEmptySection: Returns
   location:
     row: 67
-    column: 5
+    column: 4
   end_location:
     row: 78
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NonEmptySection: Yields
   location:
     row: 67
-    column: 5
+    column: 4
   end_location:
     row: 78
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NonEmptySection: Returns
   location:
     row: 161
-    column: 5
+    column: 4
   end_location:
     row: 165
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NonEmptySection: Returns
   location:
     row: 252
-    column: 5
+    column: 4
   end_location:
     row: 262
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D415_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D415_D.py.snap
@@ -5,121 +5,121 @@ expression: checks
 - kind: EndsInPunctuation
   location:
     row: 124
-    column: 5
+    column: 4
   end_location:
     row: 126
-    column: 8
+    column: 7
   fix: ~
 - kind: EndsInPunctuation
   location:
     row: 283
-    column: 5
+    column: 4
   end_location:
     row: 283
+    column: 33
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 288
+    column: 4
+  end_location:
+    row: 288
+    column: 37
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 350
+    column: 4
+  end_location:
+    row: 350
+    column: 17
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 401
+    column: 24
+  end_location:
+    row: 401
+    column: 39
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 405
+    column: 4
+  end_location:
+    row: 405
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 411
+    column: 4
+  end_location:
+    row: 411
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 417
+    column: 34
+  end_location:
+    row: 417
+    column: 49
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 424
+    column: 48
+  end_location:
+    row: 424
+    column: 63
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 465
+    column: 4
+  end_location:
+    row: 465
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 470
+    column: 4
+  end_location:
+    row: 470
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 475
+    column: 4
+  end_location:
+    row: 475
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 482
+    column: 4
+  end_location:
+    row: 482
+    column: 24
+  fix: ~
+- kind: EndsInPunctuation
+  location:
+    row: 504
+    column: 4
+  end_location:
+    row: 504
     column: 34
   fix: ~
 - kind: EndsInPunctuation
   location:
-    row: 288
-    column: 5
-  end_location:
-    row: 288
-    column: 38
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 350
-    column: 5
-  end_location:
-    row: 350
-    column: 18
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 401
-    column: 25
-  end_location:
-    row: 401
-    column: 40
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 405
-    column: 5
-  end_location:
-    row: 405
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 411
-    column: 5
-  end_location:
-    row: 411
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 417
-    column: 35
-  end_location:
-    row: 417
-    column: 50
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 424
-    column: 49
-  end_location:
-    row: 424
-    column: 64
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 465
-    column: 5
-  end_location:
-    row: 465
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 470
-    column: 5
-  end_location:
-    row: 470
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 475
-    column: 5
-  end_location:
-    row: 475
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 482
-    column: 5
-  end_location:
-    row: 482
-    column: 25
-  fix: ~
-- kind: EndsInPunctuation
-  location:
-    row: 504
-    column: 5
-  end_location:
-    row: 504
-    column: 35
-  fix: ~
-- kind: EndsInPunctuation
-  location:
     row: 515
-    column: 5
+    column: 4
   end_location:
     row: 515
-    column: 33
+    column: 32
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D417_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D417_sections.py.snap
@@ -7,20 +7,20 @@ expression: checks
       - y
   location:
     row: 283
-    column: 5
+    column: 4
   end_location:
     row: 296
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DocumentAllArguments:
       - y
   location:
     row: 300
-    column: 1
+    column: 0
   end_location:
     row: 309
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -29,10 +29,10 @@ expression: checks
       - z
   location:
     row: 324
-    column: 5
+    column: 4
   end_location:
     row: 332
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -41,10 +41,10 @@ expression: checks
       - z
   location:
     row: 336
-    column: 5
+    column: 4
   end_location:
     row: 345
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -53,10 +53,10 @@ expression: checks
       - z
   location:
     row: 349
-    column: 5
+    column: 4
   end_location:
     row: 357
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -64,20 +64,20 @@ expression: checks
       - b
   location:
     row: 361
-    column: 5
+    column: 4
   end_location:
     row: 369
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
       - y
   location:
     row: 389
-    column: 1
+    column: 0
   end_location:
     row: 401
-    column: 1
+    column: 0
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -86,10 +86,10 @@ expression: checks
       - z
   location:
     row: 425
-    column: 5
+    column: 4
   end_location:
     row: 436
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -98,10 +98,10 @@ expression: checks
       - z
   location:
     row: 440
-    column: 5
+    column: 4
   end_location:
     row: 455
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -109,19 +109,19 @@ expression: checks
       - z
   location:
     row: 459
-    column: 5
+    column: 4
   end_location:
     row: 471
-    column: 5
+    column: 4
   fix: ~
 - kind:
     DocumentAllArguments:
       - y
   location:
     row: 489
-    column: 5
+    column: 4
   end_location:
     row: 498
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D418_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D418_D.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: SkipDocstring
   location:
     row: 33
-    column: 5
+    column: 4
   end_location:
     row: 37
-    column: 5
+    column: 4
   fix: ~
 - kind: SkipDocstring
   location:
     row: 85
-    column: 5
+    column: 4
   end_location:
     row: 89
-    column: 5
+    column: 4
   fix: ~
 - kind: SkipDocstring
   location:
     row: 105
-    column: 1
+    column: 0
   end_location:
     row: 110
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D419_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D419_D.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: NonEmpty
   location:
     row: 19
-    column: 9
+    column: 8
   end_location:
     row: 19
-    column: 15
+    column: 14
   fix: ~
 - kind: NonEmpty
   location:
     row: 69
-    column: 5
+    column: 4
   end_location:
     row: 69
-    column: 12
-  fix: ~
-- kind: NonEmpty
-  location:
-    row: 75
-    column: 9
-  end_location:
-    row: 75
     column: 11
+  fix: ~
+- kind: NonEmpty
+  location:
+    row: 75
+    column: 8
+  end_location:
+    row: 75
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E402_E402.py.snap
+++ b/src/snapshots/ruff__linter__tests__E402_E402.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: ModuleImportNotAtTopOfFile
   location:
     row: 24
-    column: 1
+    column: 0
   end_location:
     row: 24
-    column: 9
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E501_E501.py.snap
+++ b/src/snapshots/ruff__linter__tests__E501_E501.py.snap
@@ -8,9 +8,9 @@ expression: checks
       - 88
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 124
+    column: 123
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E711_E711.py.snap
+++ b/src/snapshots/ruff__linter__tests__E711_E711.py.snap
@@ -6,72 +6,72 @@ expression: checks
     NoneComparison: Eq
   location:
     row: 2
-    column: 11
+    column: 10
   end_location:
     row: 2
-    column: 15
+    column: 14
   fix: ~
 - kind:
     NoneComparison: NotEq
   location:
     row: 5
-    column: 11
+    column: 10
   end_location:
     row: 5
-    column: 15
+    column: 14
   fix: ~
 - kind:
     NoneComparison: Eq
   location:
     row: 8
-    column: 4
+    column: 3
   end_location:
     row: 8
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NoneComparison: NotEq
   location:
     row: 11
-    column: 4
+    column: 3
   end_location:
     row: 11
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NoneComparison: Eq
   location:
     row: 14
-    column: 14
+    column: 13
   end_location:
     row: 14
-    column: 18
+    column: 17
   fix: ~
 - kind:
     NoneComparison: NotEq
   location:
     row: 17
-    column: 14
+    column: 13
   end_location:
     row: 17
-    column: 18
+    column: 17
   fix: ~
 - kind:
     NoneComparison: NotEq
   location:
     row: 20
-    column: 4
+    column: 3
   end_location:
     row: 20
-    column: 8
+    column: 7
   fix: ~
 - kind:
     NoneComparison: Eq
   location:
     row: 23
-    column: 4
+    column: 3
   end_location:
     row: 23
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E712_E712.py.snap
+++ b/src/snapshots/ruff__linter__tests__E712_E712.py.snap
@@ -8,54 +8,54 @@ expression: checks
       - Eq
   location:
     row: 2
-    column: 11
+    column: 10
   end_location:
     row: 2
+    column: 14
+  fix: ~
+- kind:
+    TrueFalseComparison:
+      - false
+      - NotEq
+  location:
+    row: 5
+    column: 10
+  end_location:
+    row: 5
     column: 15
   fix: ~
 - kind:
     TrueFalseComparison:
-      - false
-      - NotEq
-  location:
-    row: 5
-    column: 11
-  end_location:
-    row: 5
-    column: 16
-  fix: ~
-- kind:
-    TrueFalseComparison:
       - true
       - NotEq
   location:
     row: 8
-    column: 4
+    column: 3
   end_location:
     row: 8
+    column: 7
+  fix: ~
+- kind:
+    TrueFalseComparison:
+      - false
+      - Eq
+  location:
+    row: 11
+    column: 3
+  end_location:
+    row: 11
     column: 8
   fix: ~
 - kind:
     TrueFalseComparison:
-      - false
-      - Eq
-  location:
-    row: 11
-    column: 4
-  end_location:
-    row: 11
-    column: 9
-  fix: ~
-- kind:
-    TrueFalseComparison:
       - true
       - Eq
   location:
     row: 14
-    column: 14
+    column: 13
   end_location:
     row: 14
-    column: 18
+    column: 17
   fix: ~
 - kind:
     TrueFalseComparison:
@@ -63,10 +63,10 @@ expression: checks
       - NotEq
   location:
     row: 17
-    column: 14
+    column: 13
   end_location:
     row: 17
-    column: 19
+    column: 18
   fix: ~
 - kind:
     TrueFalseComparison:
@@ -74,10 +74,10 @@ expression: checks
       - Eq
   location:
     row: 20
-    column: 20
+    column: 19
   end_location:
     row: 20
-    column: 24
+    column: 23
   fix: ~
 - kind:
     TrueFalseComparison:
@@ -85,10 +85,10 @@ expression: checks
       - Eq
   location:
     row: 20
-    column: 44
+    column: 43
   end_location:
     row: 20
-    column: 49
+    column: 48
   fix: ~
 - kind:
     TrueFalseComparison:
@@ -96,9 +96,9 @@ expression: checks
       - Eq
   location:
     row: 22
-    column: 5
+    column: 4
   end_location:
     row: 22
-    column: 9
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E713_E713.py.snap
+++ b/src/snapshots/ruff__linter__tests__E713_E713.py.snap
@@ -5,41 +5,41 @@ expression: checks
 - kind: NotInTest
   location:
     row: 2
-    column: 10
+    column: 9
   end_location:
     row: 2
-    column: 14
+    column: 13
   fix: ~
 - kind: NotInTest
   location:
     row: 5
-    column: 12
-  end_location:
-    row: 5
-    column: 16
-  fix: ~
-- kind: NotInTest
-  location:
-    row: 8
-    column: 10
-  end_location:
-    row: 8
-    column: 14
-  fix: ~
-- kind: NotInTest
-  location:
-    row: 11
-    column: 25
-  end_location:
-    row: 11
-    column: 29
-  fix: ~
-- kind: NotInTest
-  location:
-    row: 14
     column: 11
   end_location:
-    row: 14
+    row: 5
     column: 15
+  fix: ~
+- kind: NotInTest
+  location:
+    row: 8
+    column: 9
+  end_location:
+    row: 8
+    column: 13
+  fix: ~
+- kind: NotInTest
+  location:
+    row: 11
+    column: 24
+  end_location:
+    row: 11
+    column: 28
+  fix: ~
+- kind: NotInTest
+  location:
+    row: 14
+    column: 10
+  end_location:
+    row: 14
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E714_E714.py.snap
+++ b/src/snapshots/ruff__linter__tests__E714_E714.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: NotIsTest
   location:
     row: 2
-    column: 10
+    column: 9
   end_location:
     row: 2
-    column: 14
+    column: 13
   fix: ~
 - kind: NotIsTest
   location:
     row: 5
-    column: 12
+    column: 11
   end_location:
     row: 5
-    column: 16
+    column: 15
   fix: ~
 - kind: NotIsTest
   location:
     row: 8
-    column: 10
+    column: 9
   end_location:
     row: 8
-    column: 23
+    column: 22
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E721_E721.py.snap
+++ b/src/snapshots/ruff__linter__tests__E721_E721.py.snap
@@ -5,129 +5,129 @@ expression: checks
 - kind: TypeComparison
   location:
     row: 2
-    column: 14
+    column: 13
   end_location:
     row: 2
-    column: 25
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 5
-    column: 14
-  end_location:
-    row: 5
-    column: 25
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 10
-    column: 8
-  end_location:
-    row: 10
     column: 24
   fix: ~
 - kind: TypeComparison
   location:
+    row: 5
+    column: 13
+  end_location:
+    row: 5
+    column: 24
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 10
+    column: 7
+  end_location:
+    row: 10
+    column: 23
+  fix: ~
+- kind: TypeComparison
+  location:
     row: 15
-    column: 14
+    column: 13
   end_location:
     row: 15
-    column: 35
+    column: 34
   fix: ~
 - kind: TypeComparison
   location:
     row: 18
-    column: 18
+    column: 17
   end_location:
     row: 18
-    column: 32
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 18
-    column: 46
-  end_location:
-    row: 18
-    column: 59
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 20
-    column: 18
-  end_location:
-    row: 20
-    column: 29
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 22
-    column: 18
-  end_location:
-    row: 22
-    column: 29
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 24
-    column: 18
-  end_location:
-    row: 24
     column: 31
   fix: ~
 - kind: TypeComparison
   location:
-    row: 26
-    column: 18
+    row: 18
+    column: 45
   end_location:
-    row: 26
+    row: 18
+    column: 58
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 20
+    column: 17
+  end_location:
+    row: 20
+    column: 28
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 22
+    column: 17
+  end_location:
+    row: 22
+    column: 28
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 24
+    column: 17
+  end_location:
+    row: 24
     column: 30
   fix: ~
 - kind: TypeComparison
   location:
-    row: 28
-    column: 18
+    row: 26
+    column: 17
   end_location:
-    row: 28
-    column: 31
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 30
-    column: 18
-  end_location:
-    row: 30
-    column: 31
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 32
-    column: 18
-  end_location:
-    row: 32
-    column: 35
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 34
-    column: 18
-  end_location:
-    row: 38
-    column: 2
-  fix: ~
-- kind: TypeComparison
-  location:
-    row: 40
-    column: 18
-  end_location:
-    row: 40
+    row: 26
     column: 29
   fix: ~
 - kind: TypeComparison
   location:
+    row: 28
+    column: 17
+  end_location:
+    row: 28
+    column: 30
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 30
+    column: 17
+  end_location:
+    row: 30
+    column: 30
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 32
+    column: 17
+  end_location:
+    row: 32
+    column: 34
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 34
+    column: 17
+  end_location:
+    row: 38
+    column: 1
+  fix: ~
+- kind: TypeComparison
+  location:
+    row: 40
+    column: 17
+  end_location:
+    row: 40
+    column: 28
+  fix: ~
+- kind: TypeComparison
+  location:
     row: 42
-    column: 18
+    column: 17
   end_location:
     row: 42
-    column: 31
+    column: 30
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E722_E722.py.snap
+++ b/src/snapshots/ruff__linter__tests__E722_E722.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: DoNotUseBareExcept
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 1
+    column: 0
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 11
-    column: 1
+    column: 0
   end_location:
     row: 14
-    column: 1
+    column: 0
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 16
-    column: 1
+    column: 0
   end_location:
     row: 19
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E731_E731.py.snap
+++ b/src/snapshots/ruff__linter__tests__E731_E731.py.snap
@@ -5,41 +5,41 @@ expression: checks
 - kind: DoNotAssignLambda
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 20
+    column: 19
   fix: ~
 - kind: DoNotAssignLambda
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 20
+    column: 19
   fix: ~
 - kind: DoNotAssignLambda
   location:
     row: 7
-    column: 5
+    column: 4
   end_location:
     row: 7
-    column: 30
+    column: 29
   fix: ~
 - kind: DoNotAssignLambda
   location:
     row: 12
-    column: 1
+    column: 0
   end_location:
     row: 12
-    column: 28
+    column: 27
   fix: ~
 - kind: DoNotAssignLambda
   location:
     row: 16
-    column: 1
+    column: 0
   end_location:
     row: 16
-    column: 26
+    column: 25
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E741_E741.py.snap
+++ b/src/snapshots/ruff__linter__tests__E741_E741.py.snap
@@ -6,225 +6,225 @@ expression: checks
     AmbiguousVariableName: l
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 2
+    column: 1
   fix: ~
 - kind:
     AmbiguousVariableName: I
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 2
+    column: 1
   fix: ~
 - kind:
     AmbiguousVariableName: O
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 2
+    column: 1
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
+    row: 6
+    column: 0
+  end_location:
     row: 6
     column: 1
-  end_location:
-    row: 6
-    column: 2
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
+    row: 8
+    column: 3
+  end_location:
     row: 8
     column: 4
-  end_location:
-    row: 8
-    column: 5
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 9
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 6
+    column: 5
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 10
-    column: 5
+    column: 4
   end_location:
     row: 10
-    column: 6
+    column: 5
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 11
-    column: 5
+    column: 4
   end_location:
     row: 11
-    column: 6
+    column: 5
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 6
+    column: 5
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
+    row: 20
+    column: 7
+  end_location:
     row: 20
     column: 8
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 25
+    column: 4
   end_location:
-    row: 20
+    row: 25
+    column: 12
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 26
+    column: 4
+  end_location:
+    row: 26
+    column: 5
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 30
+    column: 4
+  end_location:
+    row: 30
+    column: 5
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 33
+    column: 8
+  end_location:
+    row: 33
+    column: 18
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 34
+    column: 8
+  end_location:
+    row: 34
     column: 9
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
-    row: 25
-    column: 5
+    row: 40
+    column: 7
   end_location:
-    row: 25
+    row: 40
+    column: 8
+  fix: ~
+- kind:
+    AmbiguousVariableName: I
+  location:
+    row: 40
     column: 13
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 26
-    column: 5
   end_location:
-    row: 26
-    column: 6
+    row: 40
+    column: 14
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
-    row: 30
-    column: 5
+    row: 44
+    column: 7
   end_location:
-    row: 30
-    column: 6
+    row: 44
+    column: 8
+  fix: ~
+- kind:
+    AmbiguousVariableName: I
+  location:
+    row: 44
+    column: 15
+  end_location:
+    row: 44
+    column: 16
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
-    row: 33
+    row: 48
+    column: 8
+  end_location:
+    row: 48
     column: 9
+  fix: ~
+- kind:
+    AmbiguousVariableName: I
+  location:
+    row: 48
+    column: 13
   end_location:
-    row: 33
+    row: 48
+    column: 14
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 57
+    column: 15
+  end_location:
+    row: 57
+    column: 16
+  fix: ~
+- kind:
+    AmbiguousVariableName: l
+  location:
+    row: 66
     column: 19
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 34
-    column: 9
   end_location:
-    row: 34
-    column: 10
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 40
-    column: 8
-  end_location:
-    row: 40
-    column: 9
-  fix: ~
-- kind:
-    AmbiguousVariableName: I
-  location:
-    row: 40
-    column: 14
-  end_location:
-    row: 40
-    column: 15
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 44
-    column: 8
-  end_location:
-    row: 44
-    column: 9
-  fix: ~
-- kind:
-    AmbiguousVariableName: I
-  location:
-    row: 44
-    column: 16
-  end_location:
-    row: 44
-    column: 17
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 48
-    column: 9
-  end_location:
-    row: 48
-    column: 10
-  fix: ~
-- kind:
-    AmbiguousVariableName: I
-  location:
-    row: 48
-    column: 14
-  end_location:
-    row: 48
-    column: 15
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
-    row: 57
-    column: 16
-  end_location:
-    row: 57
-    column: 17
-  fix: ~
-- kind:
-    AmbiguousVariableName: l
-  location:
     row: 66
     column: 20
-  end_location:
-    row: 66
-    column: 21
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 71
-    column: 1
+    column: 0
   end_location:
     row: 74
-    column: 1
+    column: 0
   fix: ~
 - kind:
     AmbiguousVariableName: l
   location:
     row: 74
-    column: 5
+    column: 4
   end_location:
     row: 74
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E742_E742.py.snap
+++ b/src/snapshots/ruff__linter__tests__E742_E742.py.snap
@@ -6,27 +6,27 @@ expression: checks
     AmbiguousClassName: l
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 1
+    column: 0
   fix: ~
 - kind:
     AmbiguousClassName: I
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 9
-    column: 1
+    column: 0
   fix: ~
 - kind:
     AmbiguousClassName: O
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 13
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E743_E743.py.snap
+++ b/src/snapshots/ruff__linter__tests__E743_E743.py.snap
@@ -6,27 +6,27 @@ expression: checks
     AmbiguousFunctionName: l
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 1
+    column: 0
   fix: ~
 - kind:
     AmbiguousFunctionName: I
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 9
-    column: 1
+    column: 0
   fix: ~
 - kind:
     AmbiguousFunctionName: O
   location:
     row: 10
-    column: 5
+    column: 4
   end_location:
     row: 14
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E999_E999.py.snap
+++ b/src/snapshots/ruff__linter__tests__E999_E999.py.snap
@@ -6,9 +6,9 @@ expression: checks
     SyntaxError: Got unexpected EOF
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
@@ -8,19 +8,19 @@ expression: checks
       - false
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 21
+    column: 20
   fix:
     patch:
       content: import os
       location:
         row: 2
-        column: 1
+        column: 0
       end_location:
         row: 2
-        column: 21
+        column: 20
     applied: false
 - kind:
     UnusedImport:
@@ -28,19 +28,19 @@ expression: checks
       - false
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 2
+    column: 1
   fix:
     patch:
       content: "from collections import (\n    Counter,\n    namedtuple,\n)"
       location:
         row: 4
-        column: 1
+        column: 0
       end_location:
         row: 8
-        column: 2
+        column: 1
     applied: false
 - kind:
     UnusedImport:
@@ -48,19 +48,19 @@ expression: checks
       - false
   location:
     row: 12
-    column: 1
+    column: 0
   end_location:
     row: 12
-    column: 24
+    column: 23
   fix:
     patch:
       content: ""
       location:
         row: 12
-        column: 1
+        column: 0
       end_location:
         row: 13
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -68,19 +68,19 @@ expression: checks
       - false
   location:
     row: 33
-    column: 5
+    column: 4
   end_location:
     row: 33
-    column: 18
+    column: 17
   fix:
     patch:
       content: ""
       location:
         row: 33
-        column: 1
+        column: 0
       end_location:
         row: 34
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -88,19 +88,19 @@ expression: checks
       - false
   location:
     row: 34
-    column: 5
+    column: 4
   end_location:
     row: 34
-    column: 21
+    column: 20
   fix:
     patch:
       content: ""
       location:
         row: 34
-        column: 1
+        column: 0
       end_location:
         row: 35
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -108,19 +108,19 @@ expression: checks
       - false
   location:
     row: 38
-    column: 5
+    column: 4
   end_location:
     row: 38
-    column: 19
+    column: 18
   fix:
     patch:
       content: ""
       location:
         row: 38
-        column: 1
+        column: 0
       end_location:
         row: 39
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -128,18 +128,18 @@ expression: checks
       - false
   location:
     row: 53
-    column: 9
+    column: 8
   end_location:
     row: 53
-    column: 22
+    column: 21
   fix:
     patch:
       content: pass
       location:
         row: 53
-        column: 9
+        column: 8
       end_location:
         row: 53
-        column: 22
+        column: 21
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
@@ -8,19 +8,19 @@ expression: checks
       - false
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 18
+    column: 17
   fix:
     patch:
       content: ""
       location:
         row: 2
-        column: 1
+        column: 0
       end_location:
         row: 3
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -28,19 +28,19 @@ expression: checks
       - false
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 23
+    column: 22
   fix:
     patch:
       content: ""
       location:
         row: 3
-        column: 1
+        column: 0
       end_location:
         row: 4
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -48,19 +48,19 @@ expression: checks
       - false
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 4
-        column: 1
+        column: 0
       end_location:
         row: 5
-        column: 1
+        column: 0
     applied: false
 - kind:
     UnusedImport:
@@ -68,18 +68,18 @@ expression: checks
       - false
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 16
+    column: 15
   fix:
     patch:
       content: ""
       location:
         row: 5
-        column: 1
+        column: 0
       end_location:
         row: 6
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__F402_F402.py.snap
+++ b/src/snapshots/ruff__linter__tests__F402_F402.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - 1
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 7
+    column: 6
   fix: ~
 - kind:
     ImportShadowedByLoopVar:
@@ -19,9 +19,9 @@ expression: checks
       - 2
   location:
     row: 8
-    column: 5
+    column: 4
   end_location:
     row: 8
-    column: 9
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F403_F403.py.snap
+++ b/src/snapshots/ruff__linter__tests__F403_F403.py.snap
@@ -6,18 +6,18 @@ expression: checks
     ImportStarUsed: F634
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 19
+    column: 18
   fix: ~
 - kind:
     ImportStarUsed: F634
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 19
+    column: 18
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F404_F404.py.snap
+++ b/src/snapshots/ruff__linter__tests__F404_F404.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: LateFutureImport
   location:
     row: 6
-    column: 1
+    column: 0
   end_location:
     row: 6
-    column: 38
+    column: 37
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F405_F405.py.snap
+++ b/src/snapshots/ruff__linter__tests__F405_F405.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - - mymodule
   location:
     row: 5
-    column: 11
+    column: 10
   end_location:
     row: 5
-    column: 15
+    column: 14
   fix: ~
 - kind:
     ImportStarUsage:
@@ -19,9 +19,9 @@ expression: checks
       - - mymodule
   location:
     row: 11
-    column: 1
+    column: 0
   end_location:
     row: 11
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F406_F406.py.snap
+++ b/src/snapshots/ruff__linter__tests__F406_F406.py.snap
@@ -6,18 +6,18 @@ expression: checks
     ImportStarNotPermitted: F634
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 23
+    column: 22
   fix: ~
 - kind:
     ImportStarNotPermitted: F634
   location:
     row: 9
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 23
+    column: 22
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F407_F407.py.snap
+++ b/src/snapshots/ruff__linter__tests__F407_F407.py.snap
@@ -6,9 +6,9 @@ expression: checks
     FutureFeatureNotDefined: non_existent_feature
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 44
+    column: 43
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F541_F541.py.snap
+++ b/src/snapshots/ruff__linter__tests__F541_F541.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: FStringMissingPlaceholders
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 11
+    column: 10
   fix: ~
 - kind: FStringMissingPlaceholders
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 11
+    column: 10
   fix: ~
 - kind: FStringMissingPlaceholders
   location:
     row: 7
-    column: 5
+    column: 4
   end_location:
     row: 7
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F601_F601.py.snap
+++ b/src/snapshots/ruff__linter__tests__F601_F601.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: MultiValueRepeatedKeyLiteral
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 8
+    column: 7
   fix: ~
 - kind: MultiValueRepeatedKeyLiteral
   location:
     row: 9
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 6
+    column: 5
   fix: ~
 - kind: MultiValueRepeatedKeyLiteral
   location:
     row: 11
-    column: 5
+    column: 4
   end_location:
     row: 11
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F602_F602.py.snap
+++ b/src/snapshots/ruff__linter__tests__F602_F602.py.snap
@@ -6,9 +6,9 @@ expression: checks
     MultiValueRepeatedKeyVariable: a
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 6
+    column: 5
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F622_F622.py.snap
+++ b/src/snapshots/ruff__linter__tests__F622_F622.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: TwoStarredExpressions
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 10
+    column: 9
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F631_F631.py.snap
+++ b/src/snapshots/ruff__linter__tests__F631_F631.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: AssertTuple
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 20
+    column: 19
   fix: ~
 - kind: AssertTuple
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 16
+    column: 15
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F632_F632.py.snap
+++ b/src/snapshots/ruff__linter__tests__F632_F632.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: IsLiteral
   location:
     row: 1
-    column: 6
+    column: 5
   end_location:
     row: 1
-    column: 14
+    column: 13
   fix: ~
 - kind: IsLiteral
   location:
     row: 4
-    column: 8
+    column: 7
   end_location:
     row: 4
-    column: 16
+    column: 15
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F633_F633.py.snap
+++ b/src/snapshots/ruff__linter__tests__F633_F633.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: InvalidPrintSyntax
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 6
+    column: 5
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F634_F634.py.snap
+++ b/src/snapshots/ruff__linter__tests__F634_F634.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: IfTuple
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 1
+    column: 0
   fix: ~
 - kind: IfTuple
   location:
     row: 7
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 5
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F701_F701.py.snap
+++ b/src/snapshots/ruff__linter__tests__F701_F701.py.snap
@@ -5,33 +5,33 @@ expression: checks
 - kind: BreakOutsideLoop
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 10
+    column: 9
   fix: ~
 - kind: BreakOutsideLoop
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 10
+    column: 9
   fix: ~
 - kind: BreakOutsideLoop
   location:
     row: 20
+    column: 4
+  end_location:
+    row: 20
+    column: 9
+  fix: ~
+- kind: BreakOutsideLoop
+  location:
+    row: 23
+    column: 0
+  end_location:
+    row: 23
     column: 5
-  end_location:
-    row: 20
-    column: 10
-  fix: ~
-- kind: BreakOutsideLoop
-  location:
-    row: 23
-    column: 1
-  end_location:
-    row: 23
-    column: 6
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F702_F702.py.snap
+++ b/src/snapshots/ruff__linter__tests__F702_F702.py.snap
@@ -5,33 +5,33 @@ expression: checks
 - kind: ContinueOutsideLoop
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 13
+    column: 12
   fix: ~
 - kind: ContinueOutsideLoop
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 13
+    column: 12
   fix: ~
 - kind: ContinueOutsideLoop
   location:
     row: 20
-    column: 5
+    column: 4
   end_location:
     row: 20
-    column: 13
+    column: 12
   fix: ~
 - kind: ContinueOutsideLoop
   location:
     row: 23
-    column: 1
+    column: 0
   end_location:
     row: 23
-    column: 9
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F704_F704.py.snap
+++ b/src/snapshots/ruff__linter__tests__F704_F704.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: YieldOutsideFunction
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
+    column: 11
+  fix: ~
+- kind: YieldOutsideFunction
+  location:
+    row: 9
+    column: 0
+  end_location:
+    row: 9
+    column: 7
+  fix: ~
+- kind: YieldOutsideFunction
+  location:
+    row: 10
+    column: 0
+  end_location:
+    row: 10
     column: 12
-  fix: ~
-- kind: YieldOutsideFunction
-  location:
-    row: 9
-    column: 1
-  end_location:
-    row: 9
-    column: 8
-  fix: ~
-- kind: YieldOutsideFunction
-  location:
-    row: 10
-    column: 1
-  end_location:
-    row: 10
-    column: 13
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F706_F706.py.snap
+++ b/src/snapshots/ruff__linter__tests__F706_F706.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: ReturnOutsideFunction
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
-    column: 13
+    column: 12
   fix: ~
 - kind: ReturnOutsideFunction
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 9
-    column: 9
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F707_F707.py.snap
+++ b/src/snapshots/ruff__linter__tests__F707_F707.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: DefaultExceptNotLast
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 1
+    column: 0
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 10
-    column: 1
+    column: 0
   end_location:
     row: 12
-    column: 1
+    column: 0
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 19
-    column: 1
+    column: 0
   end_location:
     row: 21
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F722_F722.py.snap
+++ b/src/snapshots/ruff__linter__tests__F722_F722.py.snap
@@ -6,9 +6,9 @@ expression: checks
     ForwardAnnotationSyntaxError: ///
   location:
     row: 9
-    column: 12
+    column: 11
   end_location:
     row: 9
-    column: 17
+    column: 16
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F821_F821.py.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821.py.snap
@@ -6,99 +6,99 @@ expression: checks
     UndefinedName: self
   location:
     row: 2
-    column: 12
+    column: 11
   end_location:
     row: 2
+    column: 15
+  fix: ~
+- kind:
+    UndefinedName: self
+  location:
+    row: 6
+    column: 12
+  end_location:
+    row: 6
     column: 16
   fix: ~
 - kind:
     UndefinedName: self
   location:
-    row: 6
-    column: 13
-  end_location:
-    row: 6
-    column: 17
-  fix: ~
-- kind:
-    UndefinedName: self
-  location:
     row: 10
-    column: 9
+    column: 8
   end_location:
     row: 10
-    column: 13
+    column: 12
   fix: ~
 - kind:
     UndefinedName: numeric_string
   location:
     row: 21
-    column: 12
+    column: 11
   end_location:
     row: 21
-    column: 26
+    column: 25
   fix: ~
 - kind:
     UndefinedName: Bar
   location:
     row: 58
-    column: 4
+    column: 3
   end_location:
     row: 58
-    column: 9
+    column: 8
   fix: ~
 - kind:
     UndefinedName: TOMATO
   location:
     row: 83
-    column: 11
+    column: 10
   end_location:
     row: 83
-    column: 17
+    column: 16
   fix: ~
 - kind:
     UndefinedName: B
   location:
     row: 87
-    column: 5
+    column: 4
   end_location:
     row: 87
-    column: 11
+    column: 10
   fix: ~
 - kind:
     UndefinedName: B
   location:
     row: 89
-    column: 5
+    column: 4
   end_location:
     row: 89
-    column: 9
+    column: 8
   fix: ~
 - kind:
     UndefinedName: PEP593Test123
   location:
     row: 114
-    column: 9
+    column: 8
   end_location:
     row: 114
-    column: 24
+    column: 23
   fix: ~
 - kind:
     UndefinedName: foo
   location:
     row: 122
-    column: 14
+    column: 13
   end_location:
     row: 122
-    column: 19
+    column: 18
   fix: ~
 - kind:
     UndefinedName: bar
   location:
     row: 122
-    column: 21
+    column: 20
   end_location:
     row: 122
-    column: 26
+    column: 25
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F822_F822.py.snap
+++ b/src/snapshots/ruff__linter__tests__F822_F822.py.snap
@@ -6,9 +6,9 @@ expression: checks
     UndefinedExport: b
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 8
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F823_F823.py.snap
+++ b/src/snapshots/ruff__linter__tests__F823_F823.py.snap
@@ -6,9 +6,9 @@ expression: checks
     UndefinedLocal: my_var
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F831_F831.py.snap
+++ b/src/snapshots/ruff__linter__tests__F831_F831.py.snap
@@ -5,25 +5,25 @@ expression: checks
 - kind: DuplicateArgumentName
   location:
     row: 1
-    column: 25
+    column: 24
   end_location:
     row: 1
-    column: 31
+    column: 30
   fix: ~
 - kind: DuplicateArgumentName
   location:
     row: 5
-    column: 28
-  end_location:
-    row: 5
-    column: 34
-  fix: ~
-- kind: DuplicateArgumentName
-  location:
-    row: 9
     column: 27
   end_location:
-    row: 9
+    row: 5
     column: 33
+  fix: ~
+- kind: DuplicateArgumentName
+  location:
+    row: 9
+    column: 26
+  end_location:
+    row: 9
+    column: 32
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F841_F841.py.snap
+++ b/src/snapshots/ruff__linter__tests__F841_F841.py.snap
@@ -6,45 +6,45 @@ expression: checks
     UnusedVariable: e
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 1
+    column: 0
   fix: ~
 - kind:
     UnusedVariable: z
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 6
+    column: 5
   fix: ~
 - kind:
     UnusedVariable: foo
   location:
     row: 20
-    column: 5
+    column: 4
   end_location:
     row: 20
-    column: 8
+    column: 7
   fix: ~
 - kind:
     UnusedVariable: a
   location:
     row: 21
-    column: 6
+    column: 5
   end_location:
     row: 21
-    column: 7
+    column: 6
   fix: ~
 - kind:
     UnusedVariable: b
   location:
     row: 21
-    column: 9
+    column: 8
   end_location:
     row: 21
-    column: 10
+    column: 9
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F901_F901.py.snap
+++ b/src/snapshots/ruff__linter__tests__F901_F901.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: RaiseNotImplemented
   location:
     row: 2
-    column: 11
+    column: 10
   end_location:
     row: 2
-    column: 27
+    column: 26
   fix: ~
 - kind: RaiseNotImplemented
   location:
     row: 6
-    column: 11
+    column: 10
   end_location:
     row: 6
-    column: 25
+    column: 24
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N801_N801.py.snap
+++ b/src/snapshots/ruff__linter__tests__N801_N801.py.snap
@@ -6,45 +6,45 @@ expression: checks
     InvalidClassName: bad
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidClassName: _bad
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 9
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidClassName: bad_class
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 13
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidClassName: Bad_Class
   location:
     row: 13
-    column: 1
+    column: 0
   end_location:
     row: 17
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidClassName: BAD_CLASS
   location:
     row: 17
-    column: 1
+    column: 0
   end_location:
     row: 21
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N802_N802.py.snap
+++ b/src/snapshots/ruff__linter__tests__N802_N802.py.snap
@@ -6,45 +6,45 @@ expression: checks
     InvalidFunctionName: Bad
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidFunctionName: _Bad
   location:
     row: 8
-    column: 1
+    column: 0
   end_location:
     row: 12
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidFunctionName: BAD
   location:
     row: 12
-    column: 1
+    column: 0
   end_location:
     row: 16
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidFunctionName: BAD_FUNC
   location:
     row: 16
-    column: 1
+    column: 0
   end_location:
     row: 20
-    column: 1
+    column: 0
   fix: ~
 - kind:
     InvalidFunctionName: testTest
   location:
     row: 40
-    column: 5
+    column: 4
   end_location:
     row: 42
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N803_N803.py.snap
+++ b/src/snapshots/ruff__linter__tests__N803_N803.py.snap
@@ -6,18 +6,18 @@ expression: checks
     InvalidArgumentName: A
   location:
     row: 1
-    column: 13
+    column: 12
   end_location:
     row: 1
-    column: 14
+    column: 13
   fix: ~
 - kind:
     InvalidArgumentName: A
   location:
     row: 6
-    column: 25
+    column: 24
   end_location:
     row: 6
-    column: 26
+    column: 25
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N804_N804.py.snap
+++ b/src/snapshots/ruff__linter__tests__N804_N804.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: InvalidFirstArgumentNameForClassMethod
   location:
     row: 3
-    column: 26
+    column: 25
   end_location:
     row: 3
-    column: 30
+    column: 29
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N805_N805.py.snap
+++ b/src/snapshots/ruff__linter__tests__N805_N805.py.snap
@@ -5,17 +5,17 @@ expression: checks
 - kind: InvalidFirstArgumentNameForMethod
   location:
     row: 5
-    column: 20
+    column: 19
   end_location:
     row: 5
-    column: 24
+    column: 23
   fix: ~
 - kind: InvalidFirstArgumentNameForMethod
   location:
     row: 10
-    column: 30
+    column: 29
   end_location:
     row: 10
-    column: 34
+    column: 33
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N806_N806.py.snap
+++ b/src/snapshots/ruff__linter__tests__N806_N806.py.snap
@@ -6,18 +6,18 @@ expression: checks
     NonLowercaseVariableInFunction: Camel
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 10
+    column: 9
   fix: ~
 - kind:
     NonLowercaseVariableInFunction: CONSTANT
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 13
+    column: 12
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N807_N807.py.snap
+++ b/src/snapshots/ruff__linter__tests__N807_N807.py.snap
@@ -5,9 +5,9 @@ expression: checks
 - kind: DunderFunctionName
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N811_N811.py.snap
+++ b/src/snapshots/ruff__linter__tests__N811_N811.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - const
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 26
+    column: 25
   fix: ~
 - kind:
     ConstantImportedAsNonConstant:
@@ -19,10 +19,10 @@ expression: checks
       - constant
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 37
+    column: 36
   fix: ~
 - kind:
     ConstantImportedAsNonConstant:
@@ -30,9 +30,9 @@ expression: checks
       - another_constant
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 53
+    column: 52
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N812_N812.py.snap
+++ b/src/snapshots/ruff__linter__tests__N812_N812.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - Lower
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 31
+    column: 30
   fix: ~
 - kind:
     LowercaseImportedAsNonLowercase:
@@ -19,10 +19,10 @@ expression: checks
       - Lowercase
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 39
+    column: 38
   fix: ~
 - kind:
     LowercaseImportedAsNonLowercase:
@@ -30,9 +30,9 @@ expression: checks
       - AnotherLowercase
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 54
+    column: 53
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N813_N813.py.snap
+++ b/src/snapshots/ruff__linter__tests__N813_N813.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - camel
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 26
+    column: 25
   fix: ~
 - kind:
     CamelcaseImportedAsLowercase:
@@ -19,10 +19,10 @@ expression: checks
       - camelcase
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 39
+    column: 38
   fix: ~
 - kind:
     CamelcaseImportedAsLowercase:
@@ -30,9 +30,9 @@ expression: checks
       - another_camelcase
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 54
+    column: 53
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N814_N814.py.snap
+++ b/src/snapshots/ruff__linter__tests__N814_N814.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - CAMEL
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 26
+    column: 25
   fix: ~
 - kind:
     CamelcaseImportedAsConstant:
@@ -19,10 +19,10 @@ expression: checks
       - CAMELCASE
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 39
+    column: 38
   fix: ~
 - kind:
     CamelcaseImportedAsConstant:
@@ -30,9 +30,9 @@ expression: checks
       - ANOTHER_CAMELCASE
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 54
+    column: 53
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N815_N815.py.snap
+++ b/src/snapshots/ruff__linter__tests__N815_N815.py.snap
@@ -6,27 +6,27 @@ expression: checks
     MixedCaseVariableInClassScope: mixedCase
   location:
     row: 4
-    column: 5
+    column: 4
   end_location:
     row: 4
-    column: 14
+    column: 13
   fix: ~
 - kind:
     MixedCaseVariableInClassScope: _mixedCase
   location:
     row: 5
-    column: 5
+    column: 4
   end_location:
     row: 5
-    column: 15
+    column: 14
   fix: ~
 - kind:
     MixedCaseVariableInClassScope: mixed_Case
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N816_N816.py.snap
+++ b/src/snapshots/ruff__linter__tests__N816_N816.py.snap
@@ -6,27 +6,27 @@ expression: checks
     MixedCaseVariableInGlobalScope: mixedCase
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 10
+    column: 9
   fix: ~
 - kind:
     MixedCaseVariableInGlobalScope: _mixedCase
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 11
+    column: 10
   fix: ~
 - kind:
     MixedCaseVariableInGlobalScope: mixed_Case
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 11
+    column: 10
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N817_N817.py.snap
+++ b/src/snapshots/ruff__linter__tests__N817_N817.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - CM
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 23
+    column: 22
   fix: ~
 - kind:
     CamelcaseImportedAsAcronym:
@@ -19,9 +19,9 @@ expression: checks
       - CC
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 32
+    column: 31
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N818_N818.py.snap
+++ b/src/snapshots/ruff__linter__tests__N818_N818.py.snap
@@ -6,9 +6,9 @@ expression: checks
     ErrorSuffixOnExceptionName: C
   location:
     row: 9
-    column: 1
+    column: 0
   end_location:
     row: 11
-    column: 1
+    column: 0
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__T201_T201.py.snap
+++ b/src/snapshots/ruff__linter__tests__T201_T201.py.snap
@@ -5,18 +5,18 @@ expression: checks
 - kind: PrintFound
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 23
+    column: 22
   fix:
     patch:
       content: ""
       location:
         row: 1
-        column: 1
+        column: 0
       end_location:
         row: 2
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__T203_T203.py.snap
+++ b/src/snapshots/ruff__linter__tests__T203_T203.py.snap
@@ -5,35 +5,35 @@ expression: checks
 - kind: PPrintFound
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 24
+    column: 23
   fix:
     patch:
       content: ""
       location:
         row: 3
-        column: 1
+        column: 0
       end_location:
         row: 4
-        column: 1
+        column: 0
     applied: false
 - kind: PPrintFound
   location:
     row: 8
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 31
+    column: 30
   fix:
     patch:
       content: ""
       location:
         row: 8
-        column: 1
+        column: 0
       end_location:
         row: 9
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U001_U001.py.snap
+++ b/src/snapshots/ruff__linter__tests__U001_U001.py.snap
@@ -5,35 +5,35 @@ expression: checks
 - kind: UselessMetaclassType
   location:
     row: 2
-    column: 5
+    column: 4
   end_location:
     row: 2
-    column: 25
+    column: 24
   fix:
     patch:
       content: pass
       location:
         row: 2
-        column: 5
+        column: 4
       end_location:
         row: 2
-        column: 25
+        column: 24
     applied: false
 - kind: UselessMetaclassType
   location:
     row: 6
-    column: 5
+    column: 4
   end_location:
     row: 6
-    column: 25
+    column: 24
   fix:
     patch:
       content: ""
       location:
         row: 6
-        column: 1
+        column: 0
       end_location:
         row: 7
-        column: 1
+        column: 0
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U002_U002.py.snap
+++ b/src/snapshots/ruff__linter__tests__U002_U002.py.snap
@@ -5,52 +5,52 @@ expression: checks
 - kind: UnnecessaryAbspath
   location:
     row: 3
-    column: 5
+    column: 4
   end_location:
     row: 3
-    column: 22
+    column: 21
   fix:
     patch:
       content: __file__
       location:
         row: 3
-        column: 5
+        column: 4
       end_location:
         row: 3
-        column: 22
+        column: 21
     applied: false
 - kind: UnnecessaryAbspath
   location:
     row: 9
-    column: 5
+    column: 4
   end_location:
     row: 9
-    column: 30
+    column: 29
   fix:
     patch:
       content: __file__
       location:
         row: 9
-        column: 5
+        column: 4
       end_location:
         row: 9
-        column: 30
+        column: 29
     applied: false
 - kind: UnnecessaryAbspath
   location:
     row: 15
-    column: 5
+    column: 4
   end_location:
     row: 15
-    column: 27
+    column: 26
   fix:
     patch:
       content: __file__
       location:
         row: 15
-        column: 5
+        column: 4
       end_location:
         row: 15
-        column: 27
+        column: 26
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U003_U003.py.snap
+++ b/src/snapshots/ruff__linter__tests__U003_U003.py.snap
@@ -6,90 +6,90 @@ expression: checks
     TypeOfPrimitive: Str
   location:
     row: 1
-    column: 1
+    column: 0
   end_location:
     row: 1
-    column: 9
+    column: 8
   fix:
     patch:
       content: str
       location:
         row: 1
-        column: 1
+        column: 0
       end_location:
         row: 1
-        column: 9
+        column: 8
     applied: false
 - kind:
     TypeOfPrimitive: Bytes
   location:
     row: 2
-    column: 1
+    column: 0
   end_location:
     row: 2
-    column: 10
+    column: 9
   fix:
     patch:
       content: bytes
       location:
         row: 2
-        column: 1
+        column: 0
       end_location:
         row: 2
-        column: 10
+        column: 9
     applied: false
 - kind:
     TypeOfPrimitive: Int
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 3
-    column: 8
+    column: 7
   fix:
     patch:
       content: int
       location:
         row: 3
-        column: 1
+        column: 0
       end_location:
         row: 3
-        column: 8
+        column: 7
     applied: false
 - kind:
     TypeOfPrimitive: Float
   location:
     row: 4
-    column: 1
+    column: 0
   end_location:
     row: 4
-    column: 9
+    column: 8
   fix:
     patch:
       content: float
       location:
         row: 4
-        column: 1
+        column: 0
       end_location:
         row: 4
-        column: 9
+        column: 8
     applied: false
 - kind:
     TypeOfPrimitive: Complex
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 5
-    column: 9
+    column: 8
   fix:
     patch:
       content: complex
       location:
         row: 5
-        column: 1
+        column: 0
       end_location:
         row: 5
-        column: 9
+        column: 8
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U004_U004.py.snap
+++ b/src/snapshots/ruff__linter__tests__U004_U004.py.snap
@@ -6,360 +6,360 @@ expression: checks
     UselessObjectInheritance: A
   location:
     row: 5
-    column: 9
+    column: 8
   end_location:
     row: 5
-    column: 15
+    column: 14
   fix:
     patch:
       content: ""
       location:
         row: 5
-        column: 8
+        column: 7
       end_location:
         row: 5
-        column: 16
+        column: 15
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 10
-    column: 5
+    column: 4
   end_location:
     row: 10
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 9
-        column: 8
+        column: 7
       end_location:
         row: 11
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 16
-    column: 5
+    column: 4
   end_location:
     row: 16
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 15
-        column: 8
+        column: 7
       end_location:
         row: 18
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 24
-    column: 5
+    column: 4
   end_location:
     row: 24
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 22
-        column: 8
+        column: 7
       end_location:
         row: 25
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 31
-    column: 5
+    column: 4
   end_location:
     row: 31
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 29
-        column: 8
+        column: 7
       end_location:
         row: 32
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 37
-    column: 5
+    column: 4
   end_location:
     row: 37
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 36
-        column: 8
+        column: 7
       end_location:
         row: 39
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 45
-    column: 5
+    column: 4
   end_location:
     row: 45
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 43
-        column: 8
+        column: 7
       end_location:
         row: 47
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 53
-    column: 5
+    column: 4
   end_location:
     row: 53
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 51
-        column: 8
+        column: 7
       end_location:
         row: 55
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 61
-    column: 5
+    column: 4
   end_location:
     row: 61
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 59
-        column: 8
+        column: 7
       end_location:
         row: 63
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 69
-    column: 5
+    column: 4
   end_location:
     row: 69
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 67
-        column: 8
+        column: 7
       end_location:
         row: 71
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: B
   location:
     row: 75
-    column: 12
+    column: 11
   end_location:
     row: 75
-    column: 18
+    column: 17
   fix:
     patch:
       content: ""
       location:
         row: 75
-        column: 10
-      end_location:
-        row: 75
-        column: 18
-    applied: false
-- kind:
-    UselessObjectInheritance: B
-  location:
-    row: 79
-    column: 9
-  end_location:
-    row: 79
-    column: 15
-  fix:
-    patch:
-      content: ""
-      location:
-        row: 79
         column: 9
       end_location:
-        row: 79
+        row: 75
         column: 17
     applied: false
 - kind:
     UselessObjectInheritance: B
   location:
+    row: 79
+    column: 8
+  end_location:
+    row: 79
+    column: 14
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 79
+        column: 8
+      end_location:
+        row: 79
+        column: 16
+    applied: false
+- kind:
+    UselessObjectInheritance: B
+  location:
     row: 84
-    column: 5
+    column: 4
   end_location:
     row: 84
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 84
-        column: 5
+        column: 4
       end_location:
         row: 85
-        column: 5
+        column: 4
     applied: false
 - kind:
     UselessObjectInheritance: B
   location:
     row: 92
-    column: 5
+    column: 4
   end_location:
     row: 92
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 91
-        column: 6
+        column: 5
       end_location:
         row: 92
-        column: 11
+        column: 10
     applied: false
 - kind:
     UselessObjectInheritance: B
   location:
     row: 98
-    column: 5
+    column: 4
   end_location:
     row: 98
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 98
-        column: 5
+        column: 4
       end_location:
         row: 100
-        column: 5
+        column: 4
     applied: false
 - kind:
     UselessObjectInheritance: B
   location:
     row: 108
-    column: 5
+    column: 4
   end_location:
     row: 108
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 107
-        column: 6
+        column: 5
       end_location:
         row: 108
-        column: 11
+        column: 10
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 114
-    column: 13
+    column: 12
   end_location:
     row: 114
-    column: 19
+    column: 18
   fix:
     patch:
       content: ""
       location:
         row: 114
-        column: 12
+        column: 11
       end_location:
         row: 114
-        column: 20
+        column: 19
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 119
-    column: 5
+    column: 4
   end_location:
     row: 119
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 118
-        column: 8
+        column: 7
       end_location:
         row: 120
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 125
-    column: 5
+    column: 4
   end_location:
     row: 125
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 124
-        column: 8
+        column: 7
       end_location:
         row: 126
-        column: 2
+        column: 1
     applied: false
 - kind:
     UselessObjectInheritance: A
   location:
     row: 131
-    column: 5
+    column: 4
   end_location:
     row: 131
-    column: 11
+    column: 10
   fix:
     patch:
       content: ""
       location:
         row: 130
-        column: 8
+        column: 7
       end_location:
         row: 133
-        column: 2
+        column: 1
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U005_U005.py.snap
+++ b/src/snapshots/ruff__linter__tests__U005_U005.py.snap
@@ -8,19 +8,19 @@ expression: checks
       - assertEqual
   location:
     row: 6
-    column: 9
+    column: 8
   end_location:
     row: 6
-    column: 26
+    column: 25
   fix:
     patch:
       content: self.assertEqual
       location:
         row: 6
-        column: 9
+        column: 8
       end_location:
         row: 6
-        column: 26
+        column: 25
     applied: false
 - kind:
     DeprecatedUnittestAlias:
@@ -28,19 +28,19 @@ expression: checks
       - assertEqual
   location:
     row: 7
-    column: 9
+    column: 8
   end_location:
     row: 7
-    column: 26
+    column: 25
   fix:
     patch:
       content: self.assertEqual
       location:
         row: 7
-        column: 9
+        column: 8
       end_location:
         row: 7
-        column: 26
+        column: 25
     applied: false
 - kind:
     DeprecatedUnittestAlias:
@@ -48,19 +48,19 @@ expression: checks
       - assertAlmostEqual
   location:
     row: 9
-    column: 9
+    column: 8
   end_location:
     row: 9
-    column: 35
+    column: 34
   fix:
     patch:
       content: self.assertAlmostEqual
       location:
         row: 9
-        column: 9
+        column: 8
       end_location:
         row: 9
-        column: 35
+        column: 34
     applied: false
 - kind:
     DeprecatedUnittestAlias:
@@ -68,18 +68,18 @@ expression: checks
       - assertNotRegex
   location:
     row: 10
-    column: 9
+    column: 8
   end_location:
     row: 10
-    column: 36
+    column: 35
   fix:
     patch:
       content: self.assertNotRegex
       location:
         row: 10
-        column: 9
+        column: 8
       end_location:
         row: 10
-        column: 36
+        column: 35
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U006_U006.py.snap
+++ b/src/snapshots/ruff__linter__tests__U006_U006.py.snap
@@ -6,36 +6,36 @@ expression: checks
     UsePEP585Annotation: List
   location:
     row: 4
-    column: 10
+    column: 9
   end_location:
     row: 4
-    column: 14
+    column: 13
   fix:
     patch:
       content: list
       location:
         row: 4
-        column: 10
+        column: 9
       end_location:
         row: 4
-        column: 14
+        column: 13
     applied: false
 - kind:
     UsePEP585Annotation: List
   location:
     row: 11
-    column: 10
+    column: 9
   end_location:
     row: 11
-    column: 21
+    column: 20
   fix:
     patch:
       content: list
       location:
         row: 11
-        column: 10
+        column: 9
       end_location:
         row: 11
-        column: 21
+        column: 20
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U007_U007.py.snap
+++ b/src/snapshots/ruff__linter__tests__U007_U007.py.snap
@@ -5,137 +5,137 @@ expression: checks
 - kind: UsePEP604Annotation
   location:
     row: 4
-    column: 10
+    column: 9
   end_location:
     row: 4
-    column: 23
+    column: 22
   fix:
     patch:
       content: str | None
       location:
         row: 4
-        column: 10
+        column: 9
       end_location:
         row: 4
-        column: 23
+        column: 22
     applied: false
 - kind: UsePEP604Annotation
   location:
     row: 11
-    column: 10
+    column: 9
   end_location:
     row: 11
-    column: 30
+    column: 29
   fix:
     patch:
       content: str | None
       location:
         row: 11
-        column: 10
+        column: 9
       end_location:
         row: 11
-        column: 30
+        column: 29
     applied: false
 - kind: UsePEP604Annotation
   location:
     row: 18
-    column: 10
-  end_location:
-    row: 18
-    column: 46
-  fix:
-    patch:
-      content: "str | int | Union[float, bytes]"
-      location:
-        row: 18
-        column: 10
-      end_location:
-        row: 18
-        column: 46
-    applied: false
-- kind: UsePEP604Annotation
-  location:
-    row: 18
-    column: 26
+    column: 9
   end_location:
     row: 18
     column: 45
   fix:
     patch:
-      content: float | bytes
+      content: "str | int | Union[float, bytes]"
       location:
         row: 18
-        column: 26
+        column: 9
       end_location:
         row: 18
         column: 45
     applied: false
 - kind: UsePEP604Annotation
   location:
+    row: 18
+    column: 25
+  end_location:
+    row: 18
+    column: 44
+  fix:
+    patch:
+      content: float | bytes
+      location:
+        row: 18
+        column: 25
+      end_location:
+        row: 18
+        column: 44
+    applied: false
+- kind: UsePEP604Annotation
+  location:
     row: 25
-    column: 10
+    column: 9
   end_location:
     row: 25
-    column: 32
+    column: 31
   fix:
     patch:
       content: str | int
       location:
         row: 25
-        column: 10
+        column: 9
       end_location:
         row: 25
-        column: 32
+        column: 31
     applied: false
 - kind: UsePEP604Annotation
   location:
     row: 32
-    column: 10
+    column: 9
   end_location:
     row: 32
-    column: 48
+    column: 47
   fix:
     patch:
       content: "str | int | Union[float, bytes]"
       location:
         row: 32
-        column: 10
+        column: 9
       end_location:
         row: 32
-        column: 48
+        column: 47
     applied: false
 - kind: UsePEP604Annotation
   location:
     row: 32
-    column: 10
+    column: 9
   end_location:
     row: 32
-    column: 48
+    column: 47
   fix:
     patch:
       content: float | bytes
       location:
         row: 32
-        column: 10
+        column: 9
       end_location:
         row: 32
-        column: 48
+        column: 47
     applied: false
 - kind: UsePEP604Annotation
   location:
     row: 39
-    column: 10
+    column: 9
   end_location:
     row: 39
-    column: 34
+    column: 33
   fix:
     patch:
       content: str | int
       location:
         row: 39
-        column: 10
+        column: 9
       end_location:
         row: 39
-        column: 34
+        column: 33
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__U008_U008.py.snap
+++ b/src/snapshots/ruff__linter__tests__U008_U008.py.snap
@@ -5,86 +5,86 @@ expression: checks
 - kind: SuperCallWithParameters
   location:
     row: 17
-    column: 18
+    column: 17
   end_location:
     row: 17
-    column: 36
+    column: 35
   fix:
     patch:
       content: super()
       location:
         row: 17
-        column: 18
+        column: 17
       end_location:
         row: 17
-        column: 36
+        column: 35
     applied: false
 - kind: SuperCallWithParameters
   location:
     row: 18
-    column: 9
+    column: 8
   end_location:
     row: 18
-    column: 27
+    column: 26
   fix:
     patch:
       content: super()
       location:
         row: 18
-        column: 9
+        column: 8
       end_location:
         row: 18
-        column: 27
+        column: 26
     applied: false
 - kind: SuperCallWithParameters
   location:
     row: 19
-    column: 9
+    column: 8
   end_location:
     row: 22
-    column: 10
+    column: 9
   fix:
     patch:
       content: super()
       location:
         row: 19
-        column: 9
+        column: 8
       end_location:
         row: 22
-        column: 10
-    applied: false
-- kind: SuperCallWithParameters
-  location:
-    row: 36
-    column: 9
-  end_location:
-    row: 36
-    column: 29
-  fix:
-    patch:
-      content: super()
-      location:
-        row: 36
         column: 9
+    applied: false
+- kind: SuperCallWithParameters
+  location:
+    row: 36
+    column: 8
+  end_location:
+    row: 36
+    column: 28
+  fix:
+    patch:
+      content: super()
+      location:
+        row: 36
+        column: 8
       end_location:
         row: 36
-        column: 29
+        column: 28
     applied: false
 - kind: SuperCallWithParameters
   location:
     row: 50
-    column: 13
+    column: 12
   end_location:
     row: 50
-    column: 33
+    column: 32
   fix:
     patch:
       content: super()
       location:
         row: 50
-        column: 13
+        column: 12
       end_location:
         row: 50
-        column: 33
+        column: 32
     applied: false
 

--- a/src/snapshots/ruff__linter__tests__W605_W605.py.snap
+++ b/src/snapshots/ruff__linter__tests__W605_W605.py.snap
@@ -6,10 +6,10 @@ expression: checks
     InvalidEscapeSequence: "."
   location:
     row: 2
-    column: 10
+    column: 9
   end_location:
     row: 2
-    column: 11
+    column: 10
   fix: ~
 - kind:
     InvalidEscapeSequence: "."
@@ -24,10 +24,10 @@ expression: checks
     InvalidEscapeSequence: _
   location:
     row: 11
-    column: 6
+    column: 5
   end_location:
     row: 11
-    column: 7
+    column: 6
   fix: ~
 - kind:
     InvalidEscapeSequence: _

--- a/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
+++ b/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
@@ -6,63 +6,63 @@ expression: checks
     UnusedVariable: e
   location:
     row: 3
-    column: 1
+    column: 0
   end_location:
     row: 7
-    column: 1
+    column: 0
   fix: ~
 - kind:
     UnusedVariable: foo
   location:
     row: 20
-    column: 5
+    column: 4
   end_location:
     row: 20
-    column: 8
+    column: 7
   fix: ~
 - kind:
     UnusedVariable: a
   location:
     row: 21
-    column: 6
+    column: 5
   end_location:
     row: 21
-    column: 7
+    column: 6
   fix: ~
 - kind:
     UnusedVariable: b
   location:
     row: 21
-    column: 9
+    column: 8
   end_location:
     row: 21
-    column: 10
+    column: 9
   fix: ~
 - kind:
     UnusedVariable: _
   location:
     row: 35
-    column: 5
+    column: 4
   end_location:
     row: 35
-    column: 6
+    column: 5
   fix: ~
 - kind:
     UnusedVariable: __
   location:
     row: 36
-    column: 5
+    column: 4
   end_location:
     row: 36
-    column: 7
+    column: 6
   fix: ~
 - kind:
     UnusedVariable: _discarded
   location:
     row: 37
-    column: 5
+    column: 4
   end_location:
     row: 37
-    column: 15
+    column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__future_annotations.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations.snap
@@ -8,27 +8,27 @@ expression: checks
       - false
   location:
     row: 5
-    column: 1
+    column: 0
   end_location:
     row: 8
-    column: 2
+    column: 1
   fix:
     patch:
       content: "from models import (\n    Fruit,\n)"
       location:
         row: 5
-        column: 1
+        column: 0
       end_location:
         row: 8
-        column: 2
+        column: 1
     applied: false
 - kind:
     UndefinedName: Bar
   location:
     row: 25
-    column: 19
+    column: 18
   end_location:
     row: 25
-    column: 22
+    column: 21
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__m001.snap
+++ b/src/snapshots/ruff__linter__tests__m001.snap
@@ -6,38 +6,38 @@ expression: checks
     UnusedNOQA: ~
   location:
     row: 9
-    column: 10
+    column: 9
   end_location:
     row: 9
-    column: 18
+    column: 17
   fix:
     patch:
       content: ""
       location:
         row: 9
-        column: 10
+        column: 9
       end_location:
         row: 9
-        column: 18
+        column: 17
     applied: false
 - kind:
     UnusedNOQA:
       - E501
   location:
     row: 13
-    column: 10
+    column: 9
   end_location:
     row: 13
-    column: 24
+    column: 23
   fix:
     patch:
       content: ""
       location:
         row: 13
-        column: 10
+        column: 9
       end_location:
         row: 13
-        column: 24
+        column: 23
     applied: false
 - kind:
     UnusedNOQA:
@@ -45,93 +45,93 @@ expression: checks
       - E501
   location:
     row: 16
-    column: 10
+    column: 9
   end_location:
     row: 16
-    column: 30
+    column: 29
   fix:
     patch:
       content: ""
       location:
         row: 16
-        column: 10
+        column: 9
       end_location:
         row: 16
-        column: 30
+        column: 29
     applied: false
 - kind:
     UnusedNOQA:
       - W191
   location:
     row: 19
-    column: 10
+    column: 9
   end_location:
     row: 19
-    column: 30
+    column: 29
   fix:
     patch:
       content: "  # noqa: F841"
       location:
         row: 19
-        column: 10
+        column: 9
       end_location:
         row: 19
-        column: 30
+        column: 29
     applied: false
 - kind:
     UnusedNOQA:
       - F841
   location:
     row: 44
-    column: 4
+    column: 3
   end_location:
     row: 44
-    column: 24
+    column: 23
   fix:
     patch:
       content: "  # noqa: E501"
       location:
         row: 44
-        column: 4
+        column: 3
       end_location:
         row: 44
-        column: 24
+        column: 23
     applied: false
 - kind:
     UnusedNOQA:
       - E501
   location:
     row: 52
-    column: 4
+    column: 3
   end_location:
     row: 52
-    column: 18
+    column: 17
   fix:
     patch:
       content: ""
       location:
         row: 52
-        column: 4
+        column: 3
       end_location:
         row: 52
-        column: 18
+        column: 17
     applied: false
 - kind:
     UnusedNOQA: ~
   location:
     row: 60
-    column: 4
+    column: 3
   end_location:
     row: 60
-    column: 12
+    column: 11
   fix:
     patch:
       content: ""
       location:
         row: 60
-        column: 4
+        column: 3
       end_location:
         row: 60
-        column: 12
+        column: 11
     applied: false
 

--- a/src/source_code_locator.rs
+++ b/src/source_code_locator.rs
@@ -46,14 +46,14 @@ impl<'a> SourceCodeLocator<'a> {
 
     pub fn slice_source_code_at(&self, location: &Location) -> &'a str {
         let offsets = self.get_or_init_offsets();
-        let offset = offsets[location.row() - 1][location.column() - 1];
+        let offset = offsets[location.row() - 1][location.column()];
         &self.contents[offset..]
     }
 
     pub fn slice_source_code_range(&self, range: &Range) -> &'a str {
         let offsets = self.get_or_init_offsets();
-        let start = offsets[range.location.row() - 1][range.location.column() - 1];
-        let end = offsets[range.end_location.row() - 1][range.end_location.column() - 1];
+        let start = offsets[range.location.row() - 1][range.location.column()];
+        let end = offsets[range.end_location.row() - 1][range.end_location.column()];
         &self.contents[start..end]
     }
 
@@ -63,10 +63,10 @@ impl<'a> SourceCodeLocator<'a> {
         inner: &Range,
     ) -> (&'a str, &'a str, &'a str) {
         let offsets = self.get_or_init_offsets();
-        let outer_start = offsets[outer.location.row() - 1][outer.location.column() - 1];
-        let outer_end = offsets[outer.end_location.row() - 1][outer.end_location.column() - 1];
-        let inner_start = offsets[inner.location.row() - 1][inner.location.column() - 1];
-        let inner_end = offsets[inner.end_location.row() - 1][inner.end_location.column() - 1];
+        let outer_start = offsets[outer.location.row() - 1][outer.location.column()];
+        let outer_end = offsets[outer.end_location.row() - 1][outer.end_location.column()];
+        let inner_start = offsets[inner.location.row() - 1][inner.location.column()];
+        let inner_end = offsets[inner.end_location.row() - 1][inner.end_location.column()];
         (
             &self.contents[outer_start..inner_start],
             &self.contents[inner_start..inner_end],

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,7 +18,7 @@ fn test_stdin_error() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:1: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:0: F401"));
     Ok(())
 }
 
@@ -30,7 +30,7 @@ fn test_stdin_filename() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:1: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:0: F401"));
     Ok(())
 }
 


### PR DESCRIPTION
The biggest change here is that columns are now zero-indexed (while rows remain one-indexed), which matches CPython. \cc @Seamooo 

Resolves #507.