### PR TITLE
Represent per-file ignores as a map

### DIFF
--- a/crates/flake8_to_ruff/src/converter.rs
+++ b/crates/flake8_to_ruff/src/converter.rs
@@ -42,7 +42,10 @@ pub fn convert(config: HashMap<String, HashMap<String, Option<String>>>) -> Resu
                 }
                 "per-file-ignores" | "per_file_ignores" => {
                     match parser::parse_files_to_codes_mapping(value.as_ref()) {
-                        Ok(per_file_ignores) => options.per_file_ignores = Some(per_file_ignores),
+                        Ok(per_file_ignores) => {
+                            options.per_file_ignores =
+                                Some(parser::collect_per_file_ignores(per_file_ignores))
+                        }
                         Err(e) => eprintln!("Unable to parse '{key}' property: {e}"),
                     }
                 }

--- a/resources/test/fixtures/pyproject.toml
+++ b/resources/test/fixtures/pyproject.toml
@@ -1,13 +1,11 @@
 [tool.ruff]
 line-length = 88
 extend-exclude = [
-    "excluded.py",
-    "migrations",
-    "directory/also_excluded.py",
+  "excluded.py",
+  "migrations",
+  "directory/also_excluded.py",
 ]
-per-file-ignores = [
-    "__init__.py:F401",
-]
+per-file-ignores = { "__init__.py" = ["F401"] }
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"
@@ -17,22 +15,22 @@ avoid-escape = true
 
 [tool.ruff.pep8-naming]
 ignore-names = [
-    "setUp",
-    "tearDown",
-    "setUpClass",
-    "tearDownClass",
-    "setUpModule",
-    "tearDownModule",
-    "asyncSetUp",
-    "asyncTearDown",
-    "setUpTestData",
-    "failureException",
-    "longMessage",
-    "maxDiff",
+  "setUp",
+  "tearDown",
+  "setUpClass",
+  "tearDownClass",
+  "setUpModule",
+  "tearDownModule",
+  "asyncSetUp",
+  "asyncTearDown",
+  "setUpTestData",
+  "failureException",
+  "longMessage",
+  "maxDiff",
 ]
 classmethod-decorators = [
-    "classmethod",
+  "classmethod",
 ]
 staticmethod-decorators = [
-    "staticmethod",
+  "staticmethod",
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -8,8 +9,8 @@ use regex::Regex;
 use crate::checks_gen::CheckCodePrefix;
 use crate::printer::SerializationFormat;
 use crate::settings::configuration::Configuration;
+use crate::settings::types::PatternPrefixPair;
 use crate::settings::types::PythonVersion;
-use crate::settings::types::StrCheckCodePair;
 
 #[derive(Debug, Parser)]
 #[command(author, about = "ruff: An extremely fast Python linter.")]
@@ -61,7 +62,7 @@ pub struct Cli {
     pub extend_exclude: Vec<String>,
     /// List of mappings from file pattern to code to exclude
     #[arg(long, value_delimiter = ',')]
-    pub per_file_ignores: Vec<StrCheckCodePair>,
+    pub per_file_ignores: Vec<PatternPrefixPair>,
     /// Output serialization format for error messages.
     #[arg(long, value_enum, default_value_t=SerializationFormat::Text)]
     pub format: SerializationFormat,
@@ -142,4 +143,18 @@ pub fn warn_on(
             }
         }
     }
+}
+
+/// Collect a list of `PatternPrefixPair` structs as a `BTreeMap`.
+pub fn collect_per_file_ignores(
+    pairs: Vec<PatternPrefixPair>,
+) -> BTreeMap<String, Vec<CheckCodePrefix>> {
+    let mut per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>> = BTreeMap::new();
+    for pair in pairs {
+        per_file_ignores
+            .entry(pair.pattern)
+            .or_insert_with(Vec::new)
+            .push(pair.prefix);
+    }
+    per_file_ignores
 }

--- a/src/settings/configuration.rs
+++ b/src/settings/configuration.rs
@@ -1,6 +1,7 @@
 //! User-provided program settings, taking into account pyproject.toml and command-line options.
 //! Structure mirrors the user-facing representation of the various parameters.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
@@ -9,7 +10,7 @@ use regex::Regex;
 
 use crate::checks_gen::CheckCodePrefix;
 use crate::settings::pyproject::load_options;
-use crate::settings::types::{FilePattern, PerFileIgnore, PythonVersion};
+use crate::settings::types::{FilePattern, PythonVersion};
 use crate::{flake8_quotes, pep8_naming};
 
 #[derive(Debug)]
@@ -21,7 +22,7 @@ pub struct Configuration {
     pub extend_select: Vec<CheckCodePrefix>,
     pub ignore: Vec<CheckCodePrefix>,
     pub line_length: usize,
-    pub per_file_ignores: Vec<PerFileIgnore>,
+    pub per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>>,
     pub select: Vec<CheckCodePrefix>,
     pub target_version: PythonVersion,
     // Plugins
@@ -91,12 +92,7 @@ impl Configuration {
             extend_select: options.extend_select.unwrap_or_default(),
             ignore: options.ignore.unwrap_or_default(),
             line_length: options.line_length.unwrap_or(88),
-            per_file_ignores: options
-                .per_file_ignores
-                .unwrap_or_default()
-                .into_iter()
-                .map(|pair| PerFileIgnore::new(pair, project_root))
-                .collect(),
+            per_file_ignores: options.per_file_ignores.unwrap_or_default(),
             // Plugins
             flake8_quotes: options
                 .flake8_quotes

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,7 +1,7 @@
 //! Effective program settings, taking into account pyproject.toml and command-line options.
 //! Structure is optimized for internal usage, as opposed to external visibility or parsing.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
 
 use regex::Regex;
@@ -47,7 +47,7 @@ impl Settings {
             flake8_quotes: config.flake8_quotes,
             line_length: config.line_length,
             pep8_naming: config.pep8_naming,
-            per_file_ignores: config.per_file_ignores,
+            per_file_ignores: resolve_per_file_ignores(&config.per_file_ignores),
             target_version: config.target_version,
         }
     }
@@ -56,10 +56,10 @@ impl Settings {
         Self {
             dummy_variable_rgx: Regex::new("^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$").unwrap(),
             enabled: BTreeSet::from([check_code]),
-            exclude: vec![],
-            extend_exclude: vec![],
+            exclude: Default::default(),
+            extend_exclude: Default::default(),
             line_length: 88,
-            per_file_ignores: vec![],
+            per_file_ignores: Default::default(),
             target_version: PythonVersion::Py310,
             flake8_quotes: Default::default(),
             pep8_naming: Default::default(),
@@ -70,10 +70,10 @@ impl Settings {
         Self {
             dummy_variable_rgx: Regex::new("^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$").unwrap(),
             enabled: BTreeSet::from_iter(check_codes),
-            exclude: vec![],
-            extend_exclude: vec![],
+            exclude: Default::default(),
+            extend_exclude: Default::default(),
             line_length: 88,
-            per_file_ignores: vec![],
+            per_file_ignores: Default::default(),
             target_version: PythonVersion::Py310,
             flake8_quotes: Default::default(),
             pep8_naming: Default::default(),
@@ -134,6 +134,15 @@ fn resolve_codes(
         }
     }
     codes
+}
+
+fn resolve_per_file_ignores(
+    per_file_ignores: &BTreeMap<String, Vec<CheckCodePrefix>>,
+) -> Vec<PerFileIgnore> {
+    per_file_ignores
+        .iter()
+        .map(|(pattern, prefixes)| PerFileIgnore::new(pattern, prefixes, &None))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -1,9 +1,11 @@
 //! Options that the user can provide via pyproject.toml.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::checks_gen::CheckCodePrefix;
-use crate::settings::types::{PythonVersion, StrCheckCodePair};
+use crate::settings::types::PythonVersion;
 use crate::{flake8_quotes, pep8_naming};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -16,7 +18,7 @@ pub struct Options {
     pub extend_select: Option<Vec<CheckCodePrefix>>,
     pub ignore: Option<Vec<CheckCodePrefix>>,
     pub extend_ignore: Option<Vec<CheckCodePrefix>>,
-    pub per_file_ignores: Option<Vec<StrCheckCodePair>>,
+    pub per_file_ignores: Option<BTreeMap<String, Vec<CheckCodePrefix>>>,
     pub dummy_variable_rgx: Option<String>,
     pub target_version: Option<PythonVersion>,
     // Plugins

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -96,6 +96,7 @@ pub fn load_options(pyproject: &Option<PathBuf>) -> Result<Options> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::env::current_dir;
     use std::path::PathBuf;
     use std::str::FromStr;
@@ -107,7 +108,7 @@ mod tests {
     use crate::settings::pyproject::{
         find_project_root, find_pyproject_toml, parse_pyproject_toml, Options, Pyproject, Tools,
     };
-    use crate::settings::types::StrCheckCodePair;
+    use crate::settings::types::PatternPrefixPair;
     use crate::{flake8_quotes, pep8_naming};
 
     #[test]
@@ -319,10 +320,10 @@ other-attribute = 1
                 extend_select: None,
                 ignore: None,
                 extend_ignore: None,
-                per_file_ignores: Some(vec![StrCheckCodePair {
-                    pattern: "__init__.py".to_string(),
-                    code: CheckCodePrefix::F401
-                }]),
+                per_file_ignores: Some(BTreeMap::from([(
+                    "__init__.py".to_string(),
+                    vec![CheckCodePrefix::F401]
+                ),])),
                 dummy_variable_rgx: None,
                 target_version: None,
                 flake8_quotes: Some(flake8_quotes::settings::Options {
@@ -357,21 +358,21 @@ other-attribute = 1
 
     #[test]
     fn str_check_code_pair_strings() {
-        let result = StrCheckCodePair::from_str("foo:E501");
+        let result = PatternPrefixPair::from_str("foo:E501");
         assert!(result.is_ok());
-        let result = StrCheckCodePair::from_str("foo: E501");
+        let result = PatternPrefixPair::from_str("foo: E501");
         assert!(result.is_ok());
-        let result = StrCheckCodePair::from_str("E501:foo");
+        let result = PatternPrefixPair::from_str("E501:foo");
         assert!(result.is_err());
-        let result = StrCheckCodePair::from_str("E501");
+        let result = PatternPrefixPair::from_str("E501");
         assert!(result.is_err());
-        let result = StrCheckCodePair::from_str("foo");
+        let result = PatternPrefixPair::from_str("foo");
         assert!(result.is_err());
-        let result = StrCheckCodePair::from_str("foo:E501:E402");
+        let result = PatternPrefixPair::from_str("foo:E501:E402");
         assert!(result.is_err());
-        let result = StrCheckCodePair::from_str("**/bar:E501");
+        let result = PatternPrefixPair::from_str("**/bar:E501");
         assert!(result.is_ok());
-        let result = StrCheckCodePair::from_str("bar:E502");
+        let result = PatternPrefixPair::from_str("bar:E502");
         assert!(result.is_err());
     }
 }

--- a/src/settings/user.rs
+++ b/src/settings/user.rs
@@ -1,11 +1,12 @@
 //! Structs to render user-facing settings.
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use regex::Regex;
 
 use crate::checks_gen::CheckCodePrefix;
-use crate::settings::types::{FilePattern, PerFileIgnore, PythonVersion};
+use crate::settings::types::{FilePattern, PythonVersion};
 use crate::{flake8_quotes, pep8_naming, Configuration};
 
 /// Struct to render user-facing exclusion patterns.
@@ -41,7 +42,7 @@ pub struct UserConfiguration {
     pub extend_select: Vec<CheckCodePrefix>,
     pub ignore: Vec<CheckCodePrefix>,
     pub line_length: usize,
-    pub per_file_ignores: Vec<PerFileIgnore>,
+    pub per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>>,
     pub select: Vec<CheckCodePrefix>,
     pub target_version: PythonVersion,
     // Plugins


### PR DESCRIPTION
This was originally suggested by @tgross35 in #486, and I think it's a good idea. TOML supports these kinds of structures, so why not encode the expectation in the types?
