### PR TITLE
Make columns indices 1-based in the text output format

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -141,13 +141,7 @@ pub fn lint_stdin(
     // Convert to messages.
     Ok(checks
         .into_iter()
-        .map(|check| Message {
-            kind: check.kind,
-            fixed: check.fix.map(|fix| fix.applied).unwrap_or_default(),
-            location: check.location,
-            end_location: check.end_location,
-            filename: path.to_string_lossy().to_string(),
-        })
+        .map(|check| Message::from_check(path.to_string_lossy().to_string(), check))
         .collect())
 }
 
@@ -189,13 +183,7 @@ pub fn lint_path(
     // Convert to messages.
     let messages: Vec<Message> = checks
         .into_iter()
-        .map(|check| Message {
-            kind: check.kind,
-            fixed: check.fix.map(|fix| fix.applied).unwrap_or_default(),
-            location: check.location,
-            end_location: check.end_location,
-            filename: path.to_string_lossy().to_string(),
-        })
+        .map(|check| Message::from_check(path.to_string_lossy().to_string(), check))
         .collect();
     #[cfg(not(target_family = "wasm"))]
     cache::set(path, &metadata, settings, autofix, &messages, mode);

--- a/src/message.rs
+++ b/src/message.rs
@@ -20,15 +20,11 @@ pub struct Message {
 
 impl Message {
     pub fn from_check(filename: String, check: Check) -> Self {
-        let mut location = check.location;
-        location.go_right();
-        let mut end_location = check.end_location;
-        end_location.go_right();
-        Message {
+        Self {
             kind: check.kind,
             fixed: check.fix.map(|fix| fix.applied).unwrap_or_default(),
-            location,
-            end_location,
+            location: Location::new(check.location.row(), check.location.column() + 1),
+            end_location: Location::new(check.end_location.row(), check.end_location.column() + 1),
             filename,
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -43,7 +43,7 @@ impl fmt::Display for Message {
             ":".cyan(),
             self.location.row(),
             ":".cyan(),
-            self.location.column(),
+            self.location.column() + 1,
             ":".cyan(),
             self.kind.code().as_ref().red().bold(),
             self.kind.body()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,7 +18,7 @@ fn test_stdin_error() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:0: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:1: F401"));
     Ok(())
 }
 
@@ -30,7 +30,7 @@ fn test_stdin_filename() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:0: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:1: F401"));
     Ok(())
 }
 


### PR DESCRIPTION
Not changing the column in JSON errors. Not sure if we want to change that too.

Closes #537.