### PR TITLE
Update README.md to use table for per-file-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,7 @@ For example, you could configure Ruff to only enforce a subset of rules with:
 line-length = 88
 select = ["E", "F"]
 ignore = ["E501"]
-per-file-ignores = [
-    "__init__.py:F401",
-    "path/to/file.py:F401"
-]
+per-file-ignores = {"__init__.py" = ["F401"], "path/to/file.py" = ["F401"]}
 ```
 
 Plugin configurations should be expressed as subsections, e.g.:


### PR DESCRIPTION
It is however a bit unhandy like this, because you're not allowed to have newlines in inline tables in TOML.

So either it needs to be on one line or one should use the syntax:

```toml
[tool.ruff.per-file-ignores]
"__init__.py" = ["F401"]
"path/to/file.py" = ["F401"]
```