### PR TITLE
Relax lowercase condition in N806

### DIFF
--- a/resources/test/fixtures/N806.py
+++ b/resources/test/fixtures/N806.py
@@ -2,3 +2,4 @@ def f():
     lower = 0
     Camel = 0
     CONSTANT = 0
+    _ = 0

--- a/src/pep8_naming/checks.rs
+++ b/src/pep8_naming/checks.rs
@@ -118,7 +118,7 @@ pub fn non_lowercase_variable_in_function(scope: &Scope, expr: &Expr, name: &str
     if !matches!(scope.kind, ScopeKind::Function(FunctionScope { .. })) {
         return None;
     }
-    if !is_lower(name) {
+    if name.to_lowercase() != name {
         return Some(Check::new(
             CheckKind::NonLowercaseVariableInFunction(name.to_string()),
             Range::from_located(expr),


### PR DESCRIPTION
Source: https://github.com/PyCQA/pep8-naming/blob/b3492eeede12a26d35c0ee9e6b9c37a7e5484bf6/src/pep8ext_naming.py#L499.

Resolves: #560.
