### PR TITLE
Confine subscript annotation checks to `ExprContext::Load`

### DIFF
--- a/resources/test/fixtures/F821_3.py
+++ b/resources/test/fixtures/F821_3.py
@@ -1,0 +1,14 @@
+"""Test (edge case): accesses of object named `dict`."""
+
+# OK
+dict = {"parameters": {}}
+dict["parameters"]["userId"] = "userId"
+dict["parameters"]["itemId"] = "itemId"
+del dict["parameters"]["itemId"]
+
+# F821 Undefined name `key`
+# F821 Undefined name `value`
+x: dict["key", "value"]
+
+# OK
+x: dict[str, str]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -366,6 +366,7 @@ mod tests {
     #[test_case(CheckCode::F821, Path::new("F821_0.py"); "F821_0")]
     #[test_case(CheckCode::F821, Path::new("F821_1.py"); "F821_1")]
     #[test_case(CheckCode::F821, Path::new("F821_2.py"); "F821_2")]
+    #[test_case(CheckCode::F821, Path::new("F821_3.py"); "F821_3")]
     #[test_case(CheckCode::F822, Path::new("F822.py"); "F822")]
     #[test_case(CheckCode::F823, Path::new("F823.py"); "F823")]
     #[test_case(CheckCode::F831, Path::new("F831.py"); "F831")]

--- a/src/snapshots/ruff__linter__tests__F821_F821_3.py.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821_3.py.snap
@@ -1,0 +1,23 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind:
+    UndefinedName: key
+  location:
+    row: 11
+    column: 8
+  end_location:
+    row: 11
+    column: 13
+  fix: ~
+- kind:
+    UndefinedName: value
+  location:
+    row: 11
+    column: 15
+  end_location:
+    row: 11
+    column: 22
+  fix: ~
+


### PR DESCRIPTION
Resolves: #580.