### PR TITLE
Remove rust version from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ your proposed change.
 
 ### Prerequisites
 
-ruff is written in Rust (1.63.0). You'll need to install the
+ruff is written in Rust. You'll need to install the
 [Rust toolchain](https://www.rust-lang.org/tools/install) for development.
 
 You'll also need [Insta](https://insta.rs/docs/) to update snapshot tests:


### PR DESCRIPTION
It's getting out of sync, the project is using 1.65.0 currently. Once rustup is set up, invoking cargo commands will trigger installation of the necessary toolchain specified in rust-toolchain.