### PR TITLE
Fix B015 false positive on comparison deep inside expression statement

### DIFF
--- a/resources/test/fixtures/B015.py
+++ b/resources/test/fixtures/B015.py
@@ -22,3 +22,6 @@ data = [x for x in [1, 2, 3] if x in (1, 2)]
 
 class TestClass:
     1 == 1
+
+
+print(1 == 1)

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -809,6 +809,11 @@ where
                 }
             }
             StmtKind::Delete { .. } => {}
+            StmtKind::Expr { value, .. } => {
+                if self.settings.enabled.contains(&CheckCode::B015) {
+                    flake8_bugbear::plugins::useless_comparison(self, value)
+                }
+            }
             _ => {}
         }
 
@@ -1333,12 +1338,6 @@ where
                         comparators,
                         self.locate_check(Range::from_located(expr)),
                     ));
-                }
-
-                if self.settings.enabled.contains(&CheckCode::B015) {
-                    if let Some(parent) = self.parents.last() {
-                        flake8_bugbear::plugins::useless_comparison(self, left, parent);
-                    }
                 }
             }
             ExprKind::Constant {

--- a/src/flake8_bugbear/plugins/useless_comparison.rs
+++ b/src/flake8_bugbear/plugins/useless_comparison.rs
@@ -1,14 +1,14 @@
-use rustpython_ast::{Expr, Stmt, StmtKind};
+use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::{CheckLocator, Range};
 use crate::check_ast::Checker;
 use crate::checks::{Check, CheckKind};
 
-pub fn useless_comparison(checker: &mut Checker, expr: &Expr, parent: &Stmt) {
-    if let StmtKind::Expr { .. } = &parent.node {
+pub fn useless_comparison(checker: &mut Checker, expr: &Expr) {
+    if let ExprKind::Compare { left, .. } = &expr.node {
         checker.add_check(Check::new(
             CheckKind::UselessComparison,
-            checker.locate_check(Range::from_located(expr)),
+            checker.locate_check(Range::from_located(left)),
         ));
     }
 }


### PR DESCRIPTION
We only want to complain about a “pointless comparison” if the comparison is the entire statement, not if it’s just part of a statement.

```python
x < y  # error
print(x < y)  # no error
```