### PR TITLE
Respect project root in per-file ignores

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ use crate::checks_gen::CheckCodePrefix;
 use crate::logging::LogLevel;
 use crate::printer::SerializationFormat;
 use crate::settings::configuration::Configuration;
-use crate::settings::types::{PatternPrefixPair, PythonVersion};
+use crate::settings::types::{PatternPrefixPair, PerFileIgnore, PythonVersion};
 
 #[derive(Debug, Parser)]
 #[command(author, about = "ruff: An extremely fast Python linter.")]
@@ -168,7 +168,8 @@ pub fn warn_on(
 /// Collect a list of `PatternPrefixPair` structs as a `BTreeMap`.
 pub fn collect_per_file_ignores(
     pairs: Vec<PatternPrefixPair>,
-) -> BTreeMap<String, Vec<CheckCodePrefix>> {
+    project_root: &Option<PathBuf>,
+) -> Vec<PerFileIgnore> {
     let mut per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>> = BTreeMap::new();
     for pair in pairs {
         per_file_ignores
@@ -177,4 +178,7 @@ pub fn collect_per_file_ignores(
             .push(pair.prefix);
     }
     per_file_ignores
+        .iter()
+        .map(|(pattern, prefixes)| PerFileIgnore::new(pattern, prefixes, project_root))
+        .collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -8,7 +7,6 @@ use std::time::Instant;
 #[cfg(not(target_family = "wasm"))]
 use ::ruff::cache;
 use ::ruff::checks::{CheckCode, CheckKind};
-use ::ruff::checks_gen::CheckCodePrefix;
 use ::ruff::cli::{collect_per_file_ignores, extract_log_level, warn_on, Cli, Warnable};
 use ::ruff::fs::iter_python_files;
 use ::ruff::linter::{add_noqa_to_path, autoformat_path, lint_path, lint_stdin};
@@ -252,8 +250,6 @@ fn inner_main() -> Result<ExitCode> {
         .iter()
         .map(|path| FilePattern::from_user(path, &project_root))
         .collect();
-    let per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>> =
-        collect_per_file_ignores(cli.per_file_ignores);
 
     let mut configuration = Configuration::from_pyproject(&pyproject, &project_root)?;
     if !exclude.is_empty() {
@@ -262,8 +258,9 @@ fn inner_main() -> Result<ExitCode> {
     if !extend_exclude.is_empty() {
         configuration.extend_exclude = extend_exclude;
     }
-    if !per_file_ignores.is_empty() {
-        configuration.per_file_ignores = per_file_ignores;
+    if !cli.per_file_ignores.is_empty() {
+        configuration.per_file_ignores =
+            collect_per_file_ignores(cli.per_file_ignores, &project_root);
     }
     if !cli.select.is_empty() {
         warn_on(

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -2,7 +2,7 @@
 //! command-line options. Structure is optimized for internal usage, as opposed
 //! to external visibility or parsing.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::hash::{Hash, Hasher};
 
 use regex::Regex;
@@ -50,7 +50,7 @@ impl Settings {
             flake8_quotes: config.flake8_quotes,
             line_length: config.line_length,
             pep8_naming: config.pep8_naming,
-            per_file_ignores: resolve_per_file_ignores(&config.per_file_ignores),
+            per_file_ignores: config.per_file_ignores,
             target_version: config.target_version,
         }
     }
@@ -146,15 +146,6 @@ fn resolve_codes(
         }
     }
     codes
-}
-
-fn resolve_per_file_ignores(
-    per_file_ignores: &BTreeMap<String, Vec<CheckCodePrefix>>,
-) -> Vec<PerFileIgnore> {
-    per_file_ignores
-        .iter()
-        .map(|(pattern, prefixes)| PerFileIgnore::new(pattern, prefixes, &None))
-        .collect()
 }
 
 #[cfg(test)]

--- a/src/settings/user.rs
+++ b/src/settings/user.rs
@@ -1,10 +1,10 @@
 //! Structs to render user-facing settings.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use regex::Regex;
 
+use crate::checks::CheckCode;
 use crate::checks_gen::CheckCodePrefix;
 use crate::settings::types::{FilePattern, PythonVersion};
 use crate::{flake8_annotations, flake8_quotes, pep8_naming, Configuration};
@@ -42,7 +42,7 @@ pub struct UserConfiguration {
     pub extend_select: Vec<CheckCodePrefix>,
     pub ignore: Vec<CheckCodePrefix>,
     pub line_length: usize,
-    pub per_file_ignores: BTreeMap<String, Vec<CheckCodePrefix>>,
+    pub per_file_ignores: Vec<(Exclusion, Vec<CheckCode>)>,
     pub select: Vec<CheckCodePrefix>,
     pub target_version: PythonVersion,
     // Plugins
@@ -76,7 +76,16 @@ impl UserConfiguration {
             extend_select: configuration.extend_select,
             ignore: configuration.ignore,
             line_length: configuration.line_length,
-            per_file_ignores: configuration.per_file_ignores,
+            per_file_ignores: configuration
+                .per_file_ignores
+                .into_iter()
+                .map(|per_file_ignore| {
+                    (
+                        Exclusion::from_file_pattern(per_file_ignore.pattern),
+                        Vec::from_iter(per_file_ignore.codes),
+                    )
+                })
+                .collect(),
             select: configuration.select,
             target_version: configuration.target_version,
             flake8_annotations: configuration.flake8_annotations,


### PR DESCRIPTION
This was an oversight from a previous refactor (the `&None` was intended to be replaced, but got overlooked).