### PR TITLE
Add fix option to `pyproject.toml`

### DIFF
--- a/src/settings/configuration.rs
+++ b/src/settings/configuration.rs
@@ -20,6 +20,7 @@ pub struct Configuration {
     pub extend_exclude: Vec<FilePattern>,
     pub extend_ignore: Vec<CheckCodePrefix>,
     pub extend_select: Vec<CheckCodePrefix>,
+    pub fix: bool,
     pub ignore: Vec<CheckCodePrefix>,
     pub line_length: usize,
     pub per_file_ignores: Vec<PerFileIgnore>,
@@ -91,6 +92,7 @@ impl Configuration {
                 .select
                 .unwrap_or_else(|| vec![CheckCodePrefix::E, CheckCodePrefix::F]),
             extend_select: options.extend_select.unwrap_or_default(),
+            fix: options.fix.unwrap_or_default(),
             ignore: options.ignore.unwrap_or_default(),
             line_length: options.line_length.unwrap_or(88),
             per_file_ignores: options

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -11,15 +11,16 @@ use crate::{flake8_annotations, flake8_quotes, pep8_naming};
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Options {
-    pub line_length: Option<usize>,
+    pub dummy_variable_rgx: Option<String>,
     pub exclude: Option<Vec<String>>,
     pub extend_exclude: Option<Vec<String>>,
-    pub select: Option<Vec<CheckCodePrefix>>,
-    pub extend_select: Option<Vec<CheckCodePrefix>>,
-    pub ignore: Option<Vec<CheckCodePrefix>>,
     pub extend_ignore: Option<Vec<CheckCodePrefix>>,
+    pub extend_select: Option<Vec<CheckCodePrefix>>,
+    pub fix: Option<bool>,
+    pub ignore: Option<Vec<CheckCodePrefix>>,
+    pub line_length: Option<usize>,
     pub per_file_ignores: Option<BTreeMap<String, Vec<CheckCodePrefix>>>,
-    pub dummy_variable_rgx: Option<String>,
+    pub select: Option<Vec<CheckCodePrefix>>,
     pub target_version: Option<PythonVersion>,
     // Plugins
     pub flake8_annotations: Option<flake8_annotations::settings::Options>,

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -134,6 +134,7 @@ mod tests {
             Some(Tools {
                 ruff: Some(Options {
                     line_length: None,
+                    fix: None,
                     exclude: None,
                     extend_exclude: None,
                     select: None,
@@ -162,6 +163,7 @@ line-length = 79
             Some(Tools {
                 ruff: Some(Options {
                     line_length: Some(79),
+                    fix: None,
                     exclude: None,
                     extend_exclude: None,
                     select: None,
@@ -190,6 +192,7 @@ exclude = ["foo.py"]
             Some(Tools {
                 ruff: Some(Options {
                     line_length: None,
+                    fix: None,
                     exclude: Some(vec!["foo.py".to_string()]),
                     extend_exclude: None,
                     select: None,
@@ -218,6 +221,7 @@ select = ["E501"]
             Some(Tools {
                 ruff: Some(Options {
                     line_length: None,
+                    fix: None,
                     exclude: None,
                     extend_exclude: None,
                     select: Some(vec![CheckCodePrefix::E501]),
@@ -247,6 +251,7 @@ ignore = ["E501"]
             Some(Tools {
                 ruff: Some(Options {
                     line_length: None,
+                    fix: None,
                     exclude: None,
                     extend_exclude: None,
                     select: None,
@@ -315,6 +320,7 @@ other-attribute = 1
             config,
             Options {
                 line_length: Some(88),
+                fix: None,
                 exclude: None,
                 extend_exclude: Some(vec![
                     "excluded.py".to_string(),

--- a/src/settings/user.rs
+++ b/src/settings/user.rs
@@ -40,6 +40,7 @@ pub struct UserConfiguration {
     pub extend_exclude: Vec<Exclusion>,
     pub extend_ignore: Vec<CheckCodePrefix>,
     pub extend_select: Vec<CheckCodePrefix>,
+    pub fix: bool,
     pub ignore: Vec<CheckCodePrefix>,
     pub line_length: usize,
     pub per_file_ignores: Vec<(Exclusion, Vec<CheckCode>)>,
@@ -74,6 +75,7 @@ impl UserConfiguration {
                 .collect(),
             extend_ignore: configuration.extend_ignore,
             extend_select: configuration.extend_select,
+            fix: configuration.fix,
             ignore: configuration.ignore,
             line_length: configuration.line_length,
             per_file_ignores: configuration


### PR DESCRIPTION
You can now specify a `fix` default in `pyproject.toml`. On the command-line, providing `--fix` or `--no-fix` will override that setting.

Resolves #636.
