### PR TITLE
Handle multiple unused submodule imports

### DIFF
--- a/resources/test/fixtures/pyflakes/F401_0.py
+++ b/resources/test/fixtures/pyflakes/F401_0.py
@@ -85,3 +85,11 @@ else:
 
 
 CustomInt: TypeAlias = "np.int8 | np.int16"
+
+# Test: referencing an import completely
+import a.b.c.d
+foo = a.b.c.d
+
+# Test: referencing an import via subscript
+from django.core.cache import caches
+caches["default"].clear()

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -311,6 +311,15 @@ pub fn count_trailing_lines(stmt: &Stmt, locator: &SourceCodeLocator) -> usize {
         .count()
 }
 
+/// Returns 'true' if the expression is only composed of attribute access.
+pub fn is_deep_attribute_access(expr: &Expr) -> bool {
+    match &expr.node {
+        ExprKind::Attribute { value, .. } => is_deep_attribute_access(value),
+        ExprKind::Name { .. } => true,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/src/pyflakes/mod.rs
+++ b/src/pyflakes/mod.rs
@@ -2204,7 +2204,6 @@ mod tests {
         flakes(
             r#"
         import fu
-        import fu.bar
         fu.x
         "#,
             &[],
@@ -2212,7 +2211,6 @@ mod tests {
 
         flakes(
             r#"
-        import fu.bar
         import fu
         fu.x
         "#,
@@ -2228,7 +2226,6 @@ mod tests {
         flakes(
             r#"
         import foo as f
-        import foo.bar
         f.bar.do_something()
         "#,
             &[],
@@ -2237,7 +2234,6 @@ mod tests {
         flakes(
             r#"
         import foo as f
-        import foo.bar.blah
         f.bar.blah.do_something()
         "#,
             &[],
@@ -2248,13 +2244,13 @@ mod tests {
 
     #[test]
     fn unused_package_with_submodule_import() -> Result<()> {
-        // When a package and its submodule are imported, only report once.
+        // When a package and its submodule are imported, report both.
         flakes(
             r#"
         import fu
         import fu.bar
         "#,
-            &[CheckCode::F401],
+            &[CheckCode::F401, CheckCode::F401],
         )?;
 
         Ok(())

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F401_F401_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F401_F401_0.py.snap
@@ -40,6 +40,42 @@ expression: checks
       column: 1
 - kind:
     UnusedImport:
+      - multiprocessing.process
+      - false
+  location:
+    row: 10
+    column: 7
+  end_location:
+    row: 10
+    column: 30
+  fix:
+    content: ""
+    location:
+      row: 10
+      column: 0
+    end_location:
+      row: 11
+      column: 0
+- kind:
+    UnusedImport:
+      - logging.config
+      - false
+  location:
+    row: 11
+    column: 7
+  end_location:
+    row: 11
+    column: 21
+  fix:
+    content: ""
+    location:
+      row: 11
+      column: 0
+    end_location:
+      row: 12
+      column: 0
+- kind:
+    UnusedImport:
       - logging.handlers
       - false
   location:
@@ -128,4 +164,22 @@ expression: checks
     end_location:
       row: 52
       column: 21
+- kind:
+    UnusedImport:
+      - pyarrow.csv
+      - false
+  location:
+    row: 71
+    column: 7
+  end_location:
+    row: 71
+    column: 18
+  fix:
+    content: ""
+    location:
+      row: 71
+      column: 0
+    end_location:
+      row: 72
+      column: 0
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F401_F401_1.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F401_F401_1.py.snap
@@ -2,5 +2,22 @@
 source: src/pyflakes/mod.rs
 expression: checks
 ---
-[]
+- kind:
+    UnusedImport:
+      - pyarrow.csv
+      - false
+  location:
+    row: 3
+    column: 7
+  end_location:
+    row: 3
+    column: 18
+  fix:
+    content: ""
+    location:
+      row: 3
+      column: 0
+    end_location:
+      row: 4
+      column: 0
 


### PR DESCRIPTION
I've got the tests and the right behaviour in place, but the code is not pretty right now. 

- [x] Cleanup code

---

This resolves the issue where ruff doesn't see any unused imports in code like this:

    import multiprocessing.pool
    import multiprocessing.process
    z = multiprocessing.pool.ThreadPool()

The underlying issue was twofold:

1. When tracking submodule imports, we used the first part of the module (multiprocessing in this example) as the key in the bindings map. Therefore both submodule imports would end up as one entry, with no way to differentiate between them.

2. When tracking references to imports, we only looked at Name expressions. A compound (attribute) expression such as multiprocessing.process resulted in two attempts to mark names/imports used:

   One for multiprocessing and one for process. Marking multiprocessing used together with the issue in 1) meant that all imports of multiprocessing were marked as used.

The solution:

1. For submodule imports, use the full name as key in the bindings map.

2. Detect Attribute access (such as foo.bar.baz, but not foo.bar["baz"]) and use that to check if it matches an import. If the visitor is not in such an Attribute in the tree right now, keep looking at Name expressions.

   With an attribute access like `multiprocessing.pool.ThreadPool`, iterate through all parts of it and try to look them up in bindings. This is necessary because certain modules can have different access patterns, e.g.

       import os
       os.path.exists("foo")

  instead of

       import os.path
       os.path.exists("foo")

Closes #60 