### PR TITLE
Fix unnecessary params in `lru_cache`

### DIFF
--- a/resources/test/fixtures/U011_0.py
+++ b/resources/test/fixtures/U011_0.py
@@ -24,6 +24,56 @@ def fixme4():
     pass
 
 
+@lru_cache( # A 
+) # B
+def fixme5():
+    pass
+
+
+@lru_cache(
+    # A
+)   # B
+def fixme6():
+    pass
+
+
+@functools.lru_cache(
+    # A
+    maxsize = None) # B
+def fixme7():
+    pass
+
+
+@functools.lru_cache(
+    # A1
+    maxsize = None
+    # A2
+) # B
+def fixme8():
+    pass
+
+
+@functools.lru_cache(
+    # A1
+    maxsize = 
+    None
+    # A2
+
+)
+def fixme9():
+    pass
+
+
+@functools.lru_cache(
+    # A1
+    maxsize = 
+    None
+    # A2
+)
+def fixme10():
+    pass
+
+
 @lru_cache
 def correct1():
     pass

--- a/src/pyupgrade/fixes.rs
+++ b/src/pyupgrade/fixes.rs
@@ -132,3 +132,35 @@ pub fn remove_super_arguments(locator: &SourceCodeLocator, expr: &Expr) -> Optio
 
     None
 }
+
+/// U011 -fix
+pub fn remove_unnecessary_lur_cache_params(
+    locator: &SourceCodeLocator,
+    decor_at: Location,
+) -> Option<Fix> {
+    let contents = locator.slice_source_code_at(&decor_at);
+    let fix_start = lexer::make_tokenizer(&contents)
+        .flatten()
+        .find_map(|(start, tok, _)| {
+            if matches!(tok, Tok::Lpar) {
+                Some(helpers::to_absolute(&start, &decor_at))
+            } else {
+                None
+            }
+        });
+
+    let fix_end = lexer::make_tokenizer(&contents)
+        .flatten()
+        .find_map(|(_, tok, end)| {
+            if matches!(tok, Tok::Rpar) {
+                Some(helpers::to_absolute(&end, &decor_at))
+            } else {
+                None
+            }
+        });
+
+    return match (fix_start, fix_end) {
+        (Some(start), Some(end)) => Some(Fix::replacement("".to_string(), start, end)),
+        _ => None,
+    };
+}

--- a/src/pyupgrade/fixes.rs
+++ b/src/pyupgrade/fixes.rs
@@ -134,33 +134,33 @@ pub fn remove_super_arguments(locator: &SourceCodeLocator, expr: &Expr) -> Optio
 }
 
 /// U011 -fix
-pub fn remove_unnecessary_lur_cache_params(
+pub fn remove_unnecessary_lru_cache_params(
     locator: &SourceCodeLocator,
-    decor_at: Location,
+    decor_at: &Location,
 ) -> Option<Fix> {
-    let contents = locator.slice_source_code_at(&decor_at);
-    let fix_start = lexer::make_tokenizer(&contents)
-        .flatten()
-        .find_map(|(start, tok, _)| {
-            if matches!(tok, Tok::Lpar) {
-                Some(helpers::to_absolute(&start, &decor_at))
-            } else {
-                None
+    let contents = locator.slice_source_code_at(decor_at);
+    let mut fix_start = None;
+    let mut fix_end = None;
+    let mut count: usize = 0;
+    for (start, tok, end) in lexer::make_tokenizer(&contents).flatten() {
+        if matches!(tok, Tok::Lpar) {
+            if count == 0 {
+                fix_start = Some(helpers::to_absolute(&start, decor_at));
             }
-        });
+            count += 1;
+        }
 
-    let fix_end = lexer::make_tokenizer(&contents)
-        .flatten()
-        .find_map(|(_, tok, end)| {
-            if matches!(tok, Tok::Rpar) {
-                Some(helpers::to_absolute(&end, &decor_at))
-            } else {
-                None
+        if matches!(tok, Tok::Rpar) {
+            count -= 1;
+            if count == 0 {
+                fix_end = Some(helpers::to_absolute(&end, decor_at));
+                break;
             }
-        });
+        }
+    }
 
     match (fix_start, fix_end) {
-        (Some(start), Some(end)) => Some(Fix::replacement("".to_string(), start, end)),
+        (Some(start), Some(end)) => Some(Fix::deletion(start, end)),
         _ => None,
     }
 }

--- a/src/pyupgrade/fixes.rs
+++ b/src/pyupgrade/fixes.rs
@@ -159,8 +159,8 @@ pub fn remove_unnecessary_lur_cache_params(
             }
         });
 
-    return match (fix_start, fix_end) {
+    match (fix_start, fix_end) {
         (Some(start), Some(end)) => Some(Fix::replacement("".to_string(), start, end)),
         _ => None,
-    };
+    }
 }

--- a/src/pyupgrade/fixes.rs
+++ b/src/pyupgrade/fixes.rs
@@ -133,7 +133,7 @@ pub fn remove_super_arguments(locator: &SourceCodeLocator, expr: &Expr) -> Optio
     None
 }
 
-/// U011 -fix
+/// U011
 pub fn remove_unnecessary_lru_cache_params(
     locator: &SourceCodeLocator,
     decor_at: &Location,
@@ -158,7 +158,6 @@ pub fn remove_unnecessary_lru_cache_params(
             }
         }
     }
-
     match (fix_start, fix_end) {
         (Some(start), Some(end)) => Some(Fix::deletion(start, end)),
         _ => None,

--- a/src/pyupgrade/plugins/unnecessary_lru_cache_params.rs
+++ b/src/pyupgrade/plugins/unnecessary_lru_cache_params.rs
@@ -11,7 +11,7 @@ pub fn unnecessary_lru_cache_params(checker: &mut Checker, decorator_list: &[Exp
     ) {
         if checker.patch() {
             if let Some(fix) =
-                fixes::remove_unnecessary_lur_cache_params(checker.locator, check.location)
+                fixes::remove_unnecessary_lru_cache_params(checker.locator, &check.location)
             {
                 check.amend(fix);
             }

--- a/src/pyupgrade/plugins/unnecessary_lru_cache_params.rs
+++ b/src/pyupgrade/plugins/unnecessary_lru_cache_params.rs
@@ -1,14 +1,21 @@
 use rustpython_parser::ast::Expr;
 
 use crate::check_ast::Checker;
-use crate::pyupgrade::checks;
+use crate::pyupgrade::{checks, fixes};
 
 pub fn unnecessary_lru_cache_params(checker: &mut Checker, decorator_list: &[Expr]) {
-    if let Some(check) = checks::unnecessary_lru_cache_params(
+    if let Some(mut check) = checks::unnecessary_lru_cache_params(
         decorator_list,
         checker.settings.target_version,
         checker.from_imports.get("functools"),
     ) {
+        if checker.patch() {
+            if let Some(fix) =
+                fixes::remove_unnecessary_lur_cache_params(checker.locator, check.location)
+            {
+                check.amend(fix);
+            }
+        }
         checker.add_check(check);
     }
 }

--- a/src/snapshots/ruff__linter__tests__U011_U011_0.py.snap
+++ b/src/snapshots/ruff__linter__tests__U011_U011_0.py.snap
@@ -9,7 +9,16 @@ expression: checks
   end_location:
     row: 5
     column: 12
-  fix: ~
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 5
+        column: 10
+      end_location:
+        row: 5
+        column: 12
+    applied: false
 - kind: UnnecessaryLRUCacheParams
   location:
     row: 11
@@ -17,7 +26,16 @@ expression: checks
   end_location:
     row: 11
     column: 22
-  fix: ~
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 11
+        column: 20
+      end_location:
+        row: 11
+        column: 22
+    applied: false
 - kind: UnnecessaryLRUCacheParams
   location:
     row: 16
@@ -25,7 +43,16 @@ expression: checks
   end_location:
     row: 16
     column: 24
-  fix: ~
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 16
+        column: 10
+      end_location:
+        row: 16
+        column: 24
+    applied: false
 - kind: UnnecessaryLRUCacheParams
   location:
     row: 21
@@ -33,5 +60,116 @@ expression: checks
   end_location:
     row: 21
     column: 34
-  fix: ~
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 21
+        column: 20
+      end_location:
+        row: 21
+        column: 34
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 27
+    column: 1
+  end_location:
+    row: 28
+    column: 1
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 27
+        column: 10
+      end_location:
+        row: 28
+        column: 1
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 33
+    column: 1
+  end_location:
+    row: 35
+    column: 1
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 33
+        column: 10
+      end_location:
+        row: 35
+        column: 1
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 40
+    column: 1
+  end_location:
+    row: 42
+    column: 19
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 40
+        column: 20
+      end_location:
+        row: 42
+        column: 19
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 47
+    column: 1
+  end_location:
+    row: 51
+    column: 1
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 47
+        column: 20
+      end_location:
+        row: 51
+        column: 1
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 56
+    column: 1
+  end_location:
+    row: 62
+    column: 1
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 56
+        column: 20
+      end_location:
+        row: 62
+        column: 1
+    applied: false
+- kind: UnnecessaryLRUCacheParams
+  location:
+    row: 67
+    column: 1
+  end_location:
+    row: 72
+    column: 1
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 67
+        column: 20
+      end_location:
+        row: 72
+        column: 1
+    applied: false
 


### PR DESCRIPTION
This PR closes the issue #642

- [x] Fix: Remove param list from `lru_cache` decorator
- [x] Added more tests to check various formatting in fixable cases
- [x] cargo +nightly fmt, clippy, test