### PR TITLE
Test snapshots with inline checks

### DIFF
--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__defaults.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__defaults.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 8
+    column: 7
   fix: ~
 - kind:
     MissingTypeFunctionArgument: a
@@ -35,8 +35,8 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 14
-    column: 0
+    row: 13
+    column: 7
   fix: ~
 - kind:
     MissingTypeFunctionArgument: b
@@ -62,8 +62,8 @@ expression: checks
     row: 19
     column: 0
   end_location:
-    row: 24
-    column: 0
+    row: 23
+    column: 7
   fix: ~
 - kind:
     MissingReturnTypePublicFunction: foo
@@ -71,8 +71,8 @@ expression: checks
     row: 24
     column: 0
   end_location:
-    row: 29
-    column: 0
+    row: 28
+    column: 4
   fix: ~
 - kind:
     DynamicallyTypedExpression: a

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__mypy_init_return.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__mypy_init_return.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 5
     column: 4
   end_location:
-    row: 10
-    column: 0
+    row: 9
+    column: 7
   fix: ~
 - kind:
     MissingReturnTypeMagicMethod: __init__
@@ -17,8 +17,8 @@ expression: checks
     row: 11
     column: 4
   end_location:
-    row: 16
-    column: 0
+    row: 15
+    column: 4
   fix: ~
 - kind:
     MissingReturnTypePrivateFunction: __init__
@@ -26,7 +26,7 @@ expression: checks
     row: 40
     column: 0
   end_location:
-    row: 42
-    column: 0
+    row: 41
+    column: 3
   fix: ~
 

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__suppress_none_returning.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__suppress_none_returning.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 45
     column: 0
   end_location:
-    row: 50
-    column: 0
+    row: 49
+    column: 7
   fix: ~
 - kind:
     MissingReturnTypePublicFunction: foo
@@ -17,7 +17,7 @@ expression: checks
     row: 50
     column: 0
   end_location:
-    row: 56
-    column: 0
+    row: 55
+    column: 6
   fix: ~
 

--- a/src/isort/snapshots/ruff__isort__tests__combine_import_froms.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__combine_import_froms.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 6
-    column: 0
+    row: 5
+    column: 55
   fix:
     patch:
       content: "from collections import (\n    AsyncIterable,\n    Awaitable,\n    ChainMap,\n    Collection,\n    MutableMapping,\n    MutableSequence,\n)\n"

--- a/src/isort/snapshots/ruff__isort__tests__deduplicate_imports.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__deduplicate_imports.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 4
+    column: 16
   fix:
     patch:
       content: "import os\nimport os as os1\nimport os as os2\n"

--- a/src/isort/snapshots/ruff__isort__tests__import_from_after_import.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__import_from_after_import.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 3
-    column: 0
+    row: 2
+    column: 9
   fix:
     patch:
       content: "import os\nfrom collections import Collection\n"

--- a/src/isort/snapshots/ruff__isort__tests__preserve_indentation.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__preserve_indentation.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 2
     column: 0
   end_location:
-    row: 4
-    column: 0
+    row: 3
+    column: 9
   fix:
     patch:
       content: "    import os\n    import sys\n"
@@ -24,8 +24,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 6
+    column: 9
   fix:
     patch:
       content: "    import os\n    import sys\n"

--- a/src/isort/snapshots/ruff__isort__tests__reorder_within_section.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__reorder_within_section.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 3
-    column: 0
+    row: 2
+    column: 9
   fix:
     patch:
       content: "import os\nimport sys\n"

--- a/src/isort/snapshots/ruff__isort__tests__separate_first_party_imports.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__separate_first_party_imports.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 6
-    column: 0
+    row: 5
+    column: 32
   fix:
     patch:
       content: "import os\nimport sys\n\nimport numpy as np\n\nimport leading_prefix\nfrom leading_prefix import Class\n"

--- a/src/isort/snapshots/ruff__isort__tests__separate_future_imports.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__separate_future_imports.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 4
-    column: 0
+    row: 3
+    column: 34
   fix:
     patch:
       content: "from __future__ import annotations\n\nimport os\nimport sys\n"

--- a/src/isort/snapshots/ruff__isort__tests__separate_third_party_imports.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__separate_third_party_imports.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 4
+    column: 9
   fix:
     patch:
       content: "import os\nimport sys\n\nimport numpy as np\nimport pandas as pd\n"

--- a/src/snapshots/ruff__linter__tests__A001_A001.py.snap
+++ b/src/snapshots/ruff__linter__tests__A001_A001.py.snap
@@ -89,8 +89,8 @@ expression: checks
     row: 10
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 11
+    column: 4
   fix: ~
 - kind:
     BuiltinVariableShadowing: slice
@@ -98,8 +98,8 @@ expression: checks
     row: 13
     column: 0
   end_location:
-    row: 16
-    column: 0
+    row: 14
+    column: 4
   fix: ~
 - kind:
     BuiltinVariableShadowing: ValueError
@@ -107,8 +107,8 @@ expression: checks
     row: 18
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 19
+    column: 3
   fix: ~
 - kind:
     BuiltinVariableShadowing: memoryview

--- a/src/snapshots/ruff__linter__tests__A001_A001.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__A001_A001.py_remarks.snap
@@ -22,19 +22,19 @@ expression: output.finish().to_string()
   
 | def bytes():
 |     pass
-| 
-| class slice:
 |> Variable `bytes` is shadowing a python builtin
+  
+| class slice:
 |     pass
-| 
-| try:
 |> Variable `slice` is shadowing a python builtin
+  
+  try:
       ...
 | except ImportError as ValueError:
 |     ...
-| 
-| for memoryview, *bytearray in []:
 |> Variable `ValueError` is shadowing a python builtin
+  
+| for memoryview, *bytearray in []:
 |> Variable `memoryview` is shadowing a python builtin
 |> Variable `bytearray` is shadowing a python builtin
       pass

--- a/src/snapshots/ruff__linter__tests__A001_A001.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__A001_A001.py_remarks.snap
@@ -1,0 +1,50 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import some as sum
+|> Variable `sum` is shadowing a python builtin
+| from some import other as int
+|> Variable `int` is shadowing a python builtin
+  
+| print = 1
+|> Variable `print` is shadowing a python builtin
+| copyright: 'annotation' = 2
+|> Variable `copyright` is shadowing a python builtin
+| (complex := 3)
+|> Variable `complex` is shadowing a python builtin
+| float = object = 4
+|> Variable `float` is shadowing a python builtin
+|> Variable `object` is shadowing a python builtin
+| min, max = 5, 6
+|> Variable `min` is shadowing a python builtin
+|> Variable `max` is shadowing a python builtin
+  
+| def bytes():
+|     pass
+| 
+| class slice:
+|> Variable `bytes` is shadowing a python builtin
+|     pass
+| 
+| try:
+|> Variable `slice` is shadowing a python builtin
+      ...
+| except ImportError as ValueError:
+|     ...
+| 
+| for memoryview, *bytearray in []:
+|> Variable `ValueError` is shadowing a python builtin
+|> Variable `memoryview` is shadowing a python builtin
+|> Variable `bytearray` is shadowing a python builtin
+      pass
+  
+| with open('file') as str, open('file2') as (all, any):
+|> Variable `str` is shadowing a python builtin
+|> Variable `all` is shadowing a python builtin
+|> Variable `any` is shadowing a python builtin
+      pass
+  
+| [0 for sum in ()]
+|> Variable `sum` is shadowing a python builtin
+

--- a/src/snapshots/ruff__linter__tests__A002_A002.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__A002_A002.py_remarks.snap
@@ -1,0 +1,21 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| def func1(str, /, type, *complex, Exception, **getattr):
+|> Argument `str` is shadowing a python builtin
+|> Argument `type` is shadowing a python builtin
+|> Argument `complex` is shadowing a python builtin
+|> Argument `Exception` is shadowing a python builtin
+|> Argument `getattr` is shadowing a python builtin
+      pass
+  
+  
+| async def func2(bytes):
+|> Argument `bytes` is shadowing a python builtin
+      pass
+  
+  
+| map([], lambda float: ...)
+|> Argument `float` is shadowing a python builtin
+

--- a/src/snapshots/ruff__linter__tests__A003_A003.py.snap
+++ b/src/snapshots/ruff__linter__tests__A003_A003.py.snap
@@ -17,7 +17,7 @@ expression: checks
     row: 7
     column: 4
   end_location:
-    row: 9
-    column: 0
+    row: 8
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__A003_A003.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__A003_A003.py_remarks.snap
@@ -11,4 +11,5 @@ expression: output.finish().to_string()
   
 |     def str(self):
 |         pass
+|> Class attribute `str` is shadowing a python builtin
 

--- a/src/snapshots/ruff__linter__tests__A003_A003.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__A003_A003.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class MyClass:
+|     ImportError = 4
+|> Class attribute `ImportError` is shadowing a python builtin
+  
+      def __init__(self):
+          self.float = 5  # is fine
+  
+|     def str(self):
+|         pass
+

--- a/src/snapshots/ruff__linter__tests__B002_B002.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B002_B002.py_remarks.snap
@@ -1,0 +1,27 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B002 - on lines 15 and 20
+  """
+  
+  
+  def this_is_all_fine(n):
+      x = n + 1
+      y = 1 + n
+      z = +x + y
+      return +z
+  
+  
+  def this_is_buggy(n):
+|     x = ++n
+|> Python does not support the unary prefix increment.
+      return x
+  
+  
+  def this_is_buggy_too(n):
+|     return ++n
+|> Python does not support the unary prefix increment.
+

--- a/src/snapshots/ruff__linter__tests__B003_B003.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B003_B003.py_remarks.snap
@@ -1,0 +1,24 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B003 - on line 9
+  """
+  
+  import os
+  from os import environ
+  
+| os.environ = {}
+|> Assigning to `os.environ` doesn't clear the environment.
+  environ = {}  # that's fine, assigning a new meaning to the module-level name
+  
+  
+  class Object:
+      os = None
+  
+  
+  o = Object()
+  o.os.environ = {}
+

--- a/src/snapshots/ruff__linter__tests__B004_B004.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B004_B004.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def this_is_a_bug():
+      o = object()
+|     if hasattr(o, "__call__"):
+|>  Using `hasattr(x, '__call__')` to test if x is callable is unreliable. Use `callable(x)` for consistent results.
+          print("Ooh, callable! Or is it?")
+|     if getattr(o, "__call__", False):
+|>  Using `hasattr(x, '__call__')` to test if x is callable is unreliable. Use `callable(x)` for consistent results.
+          print("Ooh, callable! Or is it?")
+  
+  
+  def this_is_fine():
+      o = object()
+      if callable(o):
+          print("Ooh, this is actually callable.")
+

--- a/src/snapshots/ruff__linter__tests__B005_B005.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B005_B005.py_remarks.snap
@@ -1,0 +1,37 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  s = "qwe"
+  s.strip(s)  # no warning
+  s.strip("we")  # no warning
+| s.strip(".facebook.com")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  s.strip("e")  # no warning
+  s.strip("\n\t ")  # no warning
+| s.strip(r"\n\t ")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  s.lstrip(s)  # no warning
+  s.lstrip("we")  # no warning
+| s.lstrip(".facebook.com")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  s.lstrip("e")  # no warning
+  s.lstrip("\n\t ")  # no warning
+| s.lstrip(r"\n\t ")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  s.rstrip(s)  # no warning
+  s.rstrip("we")  # warning
+| s.rstrip(".facebook.com")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  s.rstrip("e")  # no warning
+  s.rstrip("\n\t ")  # no warning
+| s.rstrip(r"\n\t ")  # warning
+|> Using `.strip()` with multi-character strings is misleading the reader.
+  
+  from somewhere import other_type, strip
+  
+  strip("we")  # no warning
+  other_type().lstrip()  # no warning
+  other_type().rstrip(["a", "b", "c"])  # no warning
+  other_type().strip("a", "b")  # no warning
+

--- a/src/snapshots/ruff__linter__tests__B006_B006_B008.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B006_B006_B008.py_remarks.snap
@@ -1,0 +1,203 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import collections
+  import datetime as dt
+  import logging
+  import operator
+  import random
+  import re
+  import time
+  import types
+  from operator import attrgetter, itemgetter, methodcaller
+  from types import MappingProxyType
+  
+  
+  # B006
+  # Allow immutable literals/calls/comprehensions
+  def this_is_okay(value=(1, 2, 3)):
+      ...
+  
+  
+  async def and_this_also(value=tuple()):
+      pass
+  
+  
+  def frozenset_also_okay(value=frozenset()):
+      pass
+  
+  
+  def mappingproxytype_okay(
+      value=MappingProxyType({}), value2=types.MappingProxyType({})
+  ):
+      pass
+  
+  
+  def re_compile_ok(value=re.compile("foo")):
+      pass
+  
+  
+  def operators_ok(
+      v=operator.attrgetter("foo"),
+      v2=operator.itemgetter("foo"),
+      v3=operator.methodcaller("foo"),
+  ):
+      pass
+  
+  
+  def operators_ok_unqualified(
+      v=attrgetter("foo"),
+      v2=itemgetter("foo"),
+      v3=methodcaller("foo"),
+  ):
+      pass
+  
+  
+  def kwonlyargs_immutable(*, value=()):
+      ...
+  
+  
+  # Flag mutable literals/comprehensions
+  
+  
+| def this_is_wrong(value=[1, 2, 3]):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+| def this_is_also_wrong(value={}):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+| def and_this(value=set()):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+| def this_too(value=collections.OrderedDict()):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+| async def async_this_too(value=collections.defaultdict()):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+| def dont_forget_me(value=collections.deque()):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+  # N.B. we're also flagging the function call in the comprehension
+| def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+|> Do not use mutable data structures for argument defaults.
+      pass
+  
+  
+| def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+|> Do not use mutable data structures for argument defaults.
+      pass
+  
+  
+| def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+|> Do not use mutable data structures for argument defaults.
+      pass
+  
+  
+| def kwonlyargs_mutable(*, value=[]):
+|> Do not use mutable data structures for argument defaults.
+      ...
+  
+  
+  # Recommended approach for mutable defaults
+  def do_this_instead(value=None):
+      if value is None:
+          value = set()
+  
+  
+  # B008
+  # Flag function calls as default args (including if they are part of a sub-expression)
+  def in_fact_all_calls_are_wrong(value=time.time()):
+      ...
+  
+  
+  def f(when=dt.datetime.now() + dt.timedelta(days=7)):
+      pass
+  
+  
+  def can_even_catch_lambdas(a=(lambda x: x)()):
+      ...
+  
+  
+  # Recommended approach for function calls as default args
+  LOGGER = logging.getLogger(__name__)
+  
+  
+  def do_this_instead_of_calls_in_defaults(logger=LOGGER):
+      # That makes it more obvious that this one value is reused.
+      ...
+  
+  
+  # Handle inf/infinity/nan special case
+  def float_inf_okay(value=float("inf")):
+      pass
+  
+  
+  def float_infinity_okay(value=float("infinity")):
+      pass
+  
+  
+  def float_plus_infinity_okay(value=float("+infinity")):
+      pass
+  
+  
+  def float_minus_inf_okay(value=float("-inf")):
+      pass
+  
+  
+  def float_nan_okay(value=float("nan")):
+      pass
+  
+  
+  def float_minus_NaN_okay(value=float("-NaN")):
+      pass
+  
+  
+  def float_infinity_literal(value=float("1e999")):
+      pass
+  
+  
+  # But don't allow standard floats
+  def float_int_is_wrong(value=float(3)):
+      pass
+  
+  
+  def float_str_not_inf_or_nan_is_wrong(value=float("3.14")):
+      pass
+  
+  
+  # B006 and B008
+  # We should handle arbitrary nesting of these B008.
+| def nested_combo(a=[float(3), dt.datetime.now()]):
+|> Do not use mutable data structures for argument defaults.
+      pass
+  
+  
+  # Don't flag nested B006 since we can't guarantee that
+  # it isn't made mutable by the outer operation.
+  def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+      pass
+  
+  
+  # B008-ception.
+  def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+      pass
+  
+  
+  # Ignore lambda contents since they are evaluated at call time.
+  def foo(f=lambda x: print(x)):
+      f(1)
+

--- a/src/snapshots/ruff__linter__tests__B007_B007.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B007_B007.py_remarks.snap
@@ -1,0 +1,40 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  for i in range(10):
+      print(i)
+  
+  print(i)  # name no longer defined on Python 3; no warning yet
+  
+| for i in range(10):  # name not used within the loop; B007
+|> Loop control variable `i` not used within the loop body.
+      print(10)
+  
+  print(i)  # name no longer defined on Python 3; no warning yet
+  
+  
+  for _ in range(10):  # _ is okay for a throw-away variable
+      print(10)
+  
+  
+  for i in range(10):
+      for j in range(10):
+|         for k in range(10):  # k not used, i and j used transitively
+|> Loop control variable `k` not used within the loop body.
+              print(i + j)
+  
+  
+  def strange_generator():
+      for i in range(10):
+          for j in range(10):
+              for k in range(10):
+                  for l in range(10):
+                      yield i, (j, (k, l))
+  
+  
+| for i, (j, (k, l)) in strange_generator():  # i, k not used
+|> Loop control variable `i` not used within the loop body.
+|> Loop control variable `k` not used within the loop body.
+      print(j, l)
+

--- a/src/snapshots/ruff__linter__tests__B008_B006_B008.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B008_B006_B008.py_remarks.snap
@@ -1,0 +1,207 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import collections
+  import datetime as dt
+  import logging
+  import operator
+  import random
+  import re
+  import time
+  import types
+  from operator import attrgetter, itemgetter, methodcaller
+  from types import MappingProxyType
+  
+  
+  # B006
+  # Allow immutable literals/calls/comprehensions
+  def this_is_okay(value=(1, 2, 3)):
+      ...
+  
+  
+  async def and_this_also(value=tuple()):
+      pass
+  
+  
+  def frozenset_also_okay(value=frozenset()):
+      pass
+  
+  
+  def mappingproxytype_okay(
+      value=MappingProxyType({}), value2=types.MappingProxyType({})
+  ):
+      pass
+  
+  
+  def re_compile_ok(value=re.compile("foo")):
+      pass
+  
+  
+  def operators_ok(
+      v=operator.attrgetter("foo"),
+      v2=operator.itemgetter("foo"),
+      v3=operator.methodcaller("foo"),
+  ):
+      pass
+  
+  
+  def operators_ok_unqualified(
+      v=attrgetter("foo"),
+      v2=itemgetter("foo"),
+      v3=methodcaller("foo"),
+  ):
+      pass
+  
+  
+  def kwonlyargs_immutable(*, value=()):
+      ...
+  
+  
+  # Flag mutable literals/comprehensions
+  
+  
+  def this_is_wrong(value=[1, 2, 3]):
+      ...
+  
+  
+  def this_is_also_wrong(value={}):
+      ...
+  
+  
+  def and_this(value=set()):
+      ...
+  
+  
+  def this_too(value=collections.OrderedDict()):
+      ...
+  
+  
+  async def async_this_too(value=collections.defaultdict()):
+      ...
+  
+  
+  def dont_forget_me(value=collections.deque()):
+      ...
+  
+  
+  # N.B. we're also flagging the function call in the comprehension
+| def list_comprehension_also_not_okay(default=[i**2 for i in range(3)]):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+| def dict_comprehension_also_not_okay(default={i: i**2 for i in range(3)}):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+| def set_comprehension_also_not_okay(default={i**2 for i in range(3)}):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  def kwonlyargs_mutable(*, value=[]):
+      ...
+  
+  
+  # Recommended approach for mutable defaults
+  def do_this_instead(value=None):
+      if value is None:
+          value = set()
+  
+  
+  # B008
+  # Flag function calls as default args (including if they are part of a sub-expression)
+| def in_fact_all_calls_are_wrong(value=time.time()):
+|> Do not perform function calls in argument defaults.
+      ...
+  
+  
+| def f(when=dt.datetime.now() + dt.timedelta(days=7)):
+|> Do not perform function calls in argument defaults.
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+| def can_even_catch_lambdas(a=(lambda x: x)()):
+|> Do not perform function calls in argument defaults.
+      ...
+  
+  
+  # Recommended approach for function calls as default args
+  LOGGER = logging.getLogger(__name__)
+  
+  
+  def do_this_instead_of_calls_in_defaults(logger=LOGGER):
+      # That makes it more obvious that this one value is reused.
+      ...
+  
+  
+  # Handle inf/infinity/nan special case
+  def float_inf_okay(value=float("inf")):
+      pass
+  
+  
+  def float_infinity_okay(value=float("infinity")):
+      pass
+  
+  
+  def float_plus_infinity_okay(value=float("+infinity")):
+      pass
+  
+  
+  def float_minus_inf_okay(value=float("-inf")):
+      pass
+  
+  
+  def float_nan_okay(value=float("nan")):
+      pass
+  
+  
+  def float_minus_NaN_okay(value=float("-NaN")):
+      pass
+  
+  
+| def float_infinity_literal(value=float("1e999")):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  # But don't allow standard floats
+| def float_int_is_wrong(value=float(3)):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+| def float_str_not_inf_or_nan_is_wrong(value=float("3.14")):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  # B006 and B008
+  # We should handle arbitrary nesting of these B008.
+| def nested_combo(a=[float(3), dt.datetime.now()]):
+|> Do not perform function calls in argument defaults.
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  # Don't flag nested B006 since we can't guarantee that
+  # it isn't made mutable by the outer operation.
+| def no_nested_b006(a=map(lambda s: s.upper(), ["a", "b", "c"])):
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  # B008-ception.
+| def nested_b008(a=random.randint(0, dt.datetime.now().year)):
+|> Do not perform function calls in argument defaults.
+|> Do not perform function calls in argument defaults.
+      pass
+  
+  
+  # Ignore lambda contents since they are evaluated at call time.
+  def foo(f=lambda x: print(x)):
+      f(1)
+

--- a/src/snapshots/ruff__linter__tests__B009_B009_B010.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B009_B009_B010.py_remarks.snap
@@ -1,0 +1,56 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B009 - Line 17, 18, 19, 44
+  B010 - Line 28, 29, 30
+  """
+  
+  # Valid getattr usage
+  getattr(foo, bar)
+  getattr(foo, "bar", None)
+  getattr(foo, "bar{foo}".format(foo="a"), None)
+  getattr(foo, "bar{foo}".format(foo="a"))
+  getattr(foo, bar, None)
+  getattr(foo, "123abc")
+  getattr(foo, "except")
+  
+  # Invalid usage
+| getattr(foo, "bar")
+|> Do not call `getattr` with a constant attribute value, it is not any safer than normal property access.
+| getattr(foo, "_123abc")
+|> Do not call `getattr` with a constant attribute value, it is not any safer than normal property access.
+| getattr(foo, "abc123")
+|> Do not call `getattr` with a constant attribute value, it is not any safer than normal property access.
+  
+  # Valid setattr usage
+  setattr(foo, bar, None)
+  setattr(foo, "bar{foo}".format(foo="a"), None)
+  setattr(foo, "123abc", None)
+  setattr(foo, "except", None)
+  
+  # Invalid usage
+  setattr(foo, "bar", None)
+  setattr(foo, "_123abc", None)
+  setattr(foo, "abc123", None)
+  
+  # Allow use of setattr within lambda expression
+  # since assignment is not valid in this context.
+  c = lambda x: setattr(x, "some_attr", 1)
+  
+  
+  class FakeCookieStore:
+      def __init__(self, has_setter):
+          self.cookie_filter = None
+          if has_setter:
+              self.setCookieFilter = lambda func: setattr(self, "cookie_filter", func)
+  
+  
+  # getattr is still flagged within lambda though
+| c = lambda x: getattr(x, "some_attr")
+|> Do not call `getattr` with a constant attribute value, it is not any safer than normal property access.
+  # should be replaced with
+  c = lambda x: x.some_attr
+

--- a/src/snapshots/ruff__linter__tests__B011_B011.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B011_B011.py_remarks.snap
@@ -1,0 +1,17 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B011 - on line 8
+  B011 - on line 10
+  """
+  
+  assert 1 != 2
+| assert False
+|> Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+  assert 1 != 2, "message"
+| assert False, "message"
+|> Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
+

--- a/src/snapshots/ruff__linter__tests__B013_B013.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B013_B013.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  try:
+      pass
+| except (ValueError,):
+|> A length-one tuple literal is redundant. Write `except ValueError:` instead of `except (ValueError,):`.
+      pass
+  except AttributeError:
+      pass
+  except (ImportError, TypeError):
+      pass
+

--- a/src/snapshots/ruff__linter__tests__B014_B014.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B014_B014.py_remarks.snap
@@ -1,0 +1,84 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B014 - on lines 11, 17, 28, 42, 49, 56, and 74.
+  """
+  
+  import binascii
+  import re
+  
+  try:
+      pass
+  except (Exception, TypeError):
+      # TypeError is a subclass of Exception, so it doesn't add anything
+      pass
+  
+  try:
+      pass
+| except (OSError, OSError) as err:
+|> Exception handler with duplicate exception: `OSError`
+      # Duplicate exception types are useless
+      pass
+  
+  
+  class MyError(Exception):
+      pass
+  
+  
+  try:
+      pass
+| except (MyError, MyError):
+|> Exception handler with duplicate exception: `MyError`
+      # Detect duplicate non-builtin errors
+      pass
+  
+  
+  try:
+      pass
+  except (MyError, Exception) as e:
+      # Don't assume that we're all subclasses of Exception
+      pass
+  
+  
+  try:
+      pass
+  except (MyError, BaseException) as e:
+      # But we *can* assume that everything is a subclass of BaseException
+      pass
+  
+  
+  try:
+      pass
+| except (re.error, re.error):
+|> Exception handler with duplicate exception: `re.error`
+      # Duplicate exception types as attributes
+      pass
+  
+  
+  try:
+      pass
+  except (IOError, EnvironmentError, OSError):
+      # Detect if a primary exception and any its aliases are present.
+      #
+      # Since Python 3.3, IOError, EnvironmentError, WindowsError, mmap.error,
+      # socket.error and select.error are aliases of OSError. See PEP 3151 for
+      # more info.
+      pass
+  
+  
+  try:
+      pass
+  except (MyException, NotImplemented):
+      # NotImplemented is not an exception, let's not crash on it.
+      pass
+  
+  
+  try:
+      pass
+  except (ValueError, binascii.Error):
+      # binascii.Error is a subclass of ValueError.
+      pass
+

--- a/src/snapshots/ruff__linter__tests__B015_B015.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B015_B015.py_remarks.snap
@@ -1,0 +1,36 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  assert 1 == 1
+  
+| 1 == 1
+|> Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
+  
+  assert 1 in (1, 2)
+  
+| 1 in (1, 2)
+|> Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
+  
+  
+  if 1 == 2:
+      pass
+  
+  
+  def test():
+      assert 1 in (1, 2)
+  
+|     1 in (1, 2)
+|> Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
+  
+  
+  data = [x for x in [1, 2, 3] if x in (1, 2)]
+  
+  
+  class TestClass:
+|     1 == 1
+|> Pointless comparison. This comparison does nothing but waste CPU instructions. Either prepend `assert` or remove it.
+  
+  
+  print(1 == 1)
+

--- a/src/snapshots/ruff__linter__tests__B016_B016.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B016_B016.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B016 - on lines 6, 7, and 8
+  """
+  
+| raise False
+|> Cannot raise a literal. Did you intend to return it or raise an Exception?
+| raise 1
+|> Cannot raise a literal. Did you intend to return it or raise an Exception?
+| raise "string"
+|> Cannot raise a literal. Did you intend to return it or raise an Exception?
+  raise Exception(False)
+  raise Exception(1)
+  raise Exception("string")
+

--- a/src/snapshots/ruff__linter__tests__B017_B017.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B017_B017.py_remarks.snap
@@ -1,0 +1,42 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B017 - on lines 20
+  """
+  import asyncio
+  import unittest
+  
+  CONSTANT = True
+  
+  
+  def something_else() -> None:
+      for i in (1, 2, 3):
+          print(i)
+  
+  
+  class Foo:
+      pass
+  
+  
+  class Foobar(unittest.TestCase):
+      def evil_raises(self) -> None:
+|         with self.assertRaises(Exception):
+|             raise Exception("Evil I say!")
+| 
+|     def context_manager_raises(self) -> None:
+|> `assertRaises(Exception):` should be considered evil.
+          with self.assertRaises(Exception) as ex:
+              raise Exception("Context manager is good")
+          self.assertEqual("Context manager is good", str(ex.exception))
+  
+      def regex_raises(self) -> None:
+          with self.assertRaisesRegex(Exception, "Regex is good"):
+              raise Exception("Regex is good")
+  
+      def raises_with_absolute_reference(self):
+          with self.assertRaises(asyncio.CancelledError):
+              Foo()
+

--- a/src/snapshots/ruff__linter__tests__B018_B018.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B018_B018.py_remarks.snap
@@ -1,0 +1,88 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class Foo1:
+      """abc"""
+  
+  
+  class Foo2:
+      """abc"""
+  
+      a = 2
+      "str"  # Str (no raise)
+      f"{int}"  # JoinedStr (no raise)
+|     1j  # Number (complex)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     1  # Number (int)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     1.0  # Number (float)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     b"foo"  # Binary
+|> Found useless expression. Either assign it to a variable or remove it.
+|     True  # NameConstant (True)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     False  # NameConstant (False)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     None  # NameConstant (None)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     [1, 2]  # list
+|> Found useless expression. Either assign it to a variable or remove it.
+|     {1, 2}  # set
+|> Found useless expression. Either assign it to a variable or remove it.
+|     {"foo": "bar"}  # dict
+|> Found useless expression. Either assign it to a variable or remove it.
+  
+  
+  class Foo3:
+|     123
+|> Found useless expression. Either assign it to a variable or remove it.
+      a = 2
+      "str"
+|     1
+|> Found useless expression. Either assign it to a variable or remove it.
+  
+  
+  def foo1():
+      """my docstring"""
+  
+  
+  def foo2():
+      """my docstring"""
+      a = 2
+      "str"  # Str (no raise)
+      f"{int}"  # JoinedStr (no raise)
+|     1j  # Number (complex)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     1  # Number (int)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     1.0  # Number (float)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     b"foo"  # Binary
+|> Found useless expression. Either assign it to a variable or remove it.
+|     True  # NameConstant (True)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     False  # NameConstant (False)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     None  # NameConstant (None)
+|> Found useless expression. Either assign it to a variable or remove it.
+|     [1, 2]  # list
+|> Found useless expression. Either assign it to a variable or remove it.
+|     {1, 2}  # set
+|> Found useless expression. Either assign it to a variable or remove it.
+|     {"foo": "bar"}  # dict
+|> Found useless expression. Either assign it to a variable or remove it.
+  
+  
+  def foo3():
+|     123
+|> Found useless expression. Either assign it to a variable or remove it.
+      a = 2
+      "str"
+|     3
+|> Found useless expression. Either assign it to a variable or remove it.
+  
+  
+  def foo4():
+      ...
+

--- a/src/snapshots/ruff__linter__tests__B025_B025.py.snap
+++ b/src/snapshots/ruff__linter__tests__B025_B025.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 15
     column: 0
   end_location:
-    row: 22
-    column: 0
+    row: 20
+    column: 5
   fix: ~
 - kind:
     DuplicateTryBlockException: pickle.PickleError
@@ -17,8 +17,8 @@ expression: checks
     row: 22
     column: 0
   end_location:
-    row: 31
-    column: 0
+    row: 29
+    column: 5
   fix: ~
 - kind:
     DuplicateTryBlockException: TypeError
@@ -26,8 +26,8 @@ expression: checks
     row: 31
     column: 0
   end_location:
-    row: 39
-    column: 0
+    row: 38
+    column: 5
   fix: ~
 - kind:
     DuplicateTryBlockException: ValueError
@@ -35,7 +35,7 @@ expression: checks
     row: 31
     column: 0
   end_location:
-    row: 39
-    column: 0
+    row: 38
+    column: 5
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__B025_B025.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B025_B025.py_remarks.snap
@@ -22,9 +22,9 @@ expression: output.finish().to_string()
 |     a = 2
 | except ValueError:
 |     a = 2
-| 
-| try:
 |> try-except block with duplicate exception `ValueError`
+  
+| try:
 |     a = 1
 | except pickle.PickleError:
 |     a = 2
@@ -32,9 +32,9 @@ expression: output.finish().to_string()
 |     a = 2
 | except pickle.PickleError:
 |     a = 2
-| 
-| try:
 |> try-except block with duplicate exception `pickle.PickleError`
+  
+| try:
 |     a = 1
 | except (ValueError, TypeError):
 |     a = 2
@@ -42,4 +42,6 @@ expression: output.finish().to_string()
 |     a = 2
 | except (OSError, TypeError):
 |     a = 2
+|> try-except block with duplicate exception `TypeError`
+|> try-except block with duplicate exception `ValueError`
 

--- a/src/snapshots/ruff__linter__tests__B025_B025.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B025_B025.py_remarks.snap
@@ -1,0 +1,45 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B025 - on lines 15, 22, 31
+  """
+  
+  import pickle
+  
+  try:
+      a = 1
+  except ValueError:
+      a = 2
+  finally:
+      a = 3
+  
+| try:
+|     a = 1
+| except ValueError:
+|     a = 2
+| except ValueError:
+|     a = 2
+| 
+| try:
+|> try-except block with duplicate exception `ValueError`
+|     a = 1
+| except pickle.PickleError:
+|     a = 2
+| except ValueError:
+|     a = 2
+| except pickle.PickleError:
+|     a = 2
+| 
+| try:
+|> try-except block with duplicate exception `pickle.PickleError`
+|     a = 1
+| except (ValueError, TypeError):
+|     a = 2
+| except ValueError:
+|     a = 2
+| except (OSError, TypeError):
+|     a = 2
+

--- a/src/snapshots/ruff__linter__tests__B026_B026.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__B026_B026.py_remarks.snap
@@ -1,0 +1,33 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """
+  Should emit:
+  B026 - on lines 16, 17, 18, 19, 20, 21
+  """
+  
+  
+  def foo(bar, baz, bam):
+      print(bar, baz, bam)
+  
+  
+  bar_baz = ["bar", "baz"]
+  
+  foo("bar", "baz", bam="bam")
+  foo("bar", baz="baz", bam="bam")
+  foo(bar="bar", baz="baz", bam="bam")
+| foo(bam="bam", *["bar", "baz"])
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+| foo(bam="bam", *bar_baz)
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+| foo(baz="baz", bam="bam", *["bar"])
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+| foo(bar="bar", baz="baz", bam="bam", *[])
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+| foo(bam="bam", *["bar"], *["baz"])
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+| foo(*["bar"], bam="bam", *["baz"])
+|> Star-arg unpacking after a keyword argument is strongly discouraged.
+

--- a/src/snapshots/ruff__linter__tests__C400_C400.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C400_C400.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| x = list(x for x in range(3))
+|> Unnecessary generator (rewrite as a `list` comprehension)
+| x = list(
+|     x for x in range(3)
+| )
+|> Unnecessary generator (rewrite as a `list` comprehension)
+

--- a/src/snapshots/ruff__linter__tests__C401_C401.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C401_C401.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| x = set(x for x in range(3))
+|> Unnecessary generator (rewrite as a `set` comprehension)
+| x = set(
+|     x for x in range(3)
+| )
+|> Unnecessary generator (rewrite as a `set` comprehension)
+

--- a/src/snapshots/ruff__linter__tests__C402_C402.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C402_C402.py_remarks.snap
@@ -1,0 +1,12 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| dict((x, x) for x in range(3))
+|> Unnecessary generator (rewrite as a `dict` comprehension)
+| dict(
+|     (x, x) for x in range(3)
+| )
+|> Unnecessary generator (rewrite as a `dict` comprehension)
+  dict(((x, x) for x in range(3)), z=3)
+

--- a/src/snapshots/ruff__linter__tests__C403_C403.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C403_C403.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| s = set([x for x in range(3)])
+|> Unnecessary `list` comprehension (rewrite as a `set` comprehension)
+| s = set(
+|     [x for x in range(3)]
+| )
+|> Unnecessary `list` comprehension (rewrite as a `set` comprehension)
+

--- a/src/snapshots/ruff__linter__tests__C404_C404.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C404_C404.py_remarks.snap
@@ -1,0 +1,8 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| dict([(i, i) for i in range(3)])
+|> Unnecessary `list` comprehension (rewrite as a `dict` comprehension)
+  dict([(i, i) for i in range(3)], z=4)
+

--- a/src/snapshots/ruff__linter__tests__C405_C405.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C405_C405.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| s1 = set([1, 2])
+|> Unnecessary `list` literal (rewrite as a `set` literal)
+| s2 = set((1, 2))
+|> Unnecessary `tuple` literal (rewrite as a `set` literal)
+| s3 = set([])
+|> Unnecessary `list` literal (rewrite as a `set` literal)
+| s4 = set(())
+|> Unnecessary `tuple` literal (rewrite as a `set` literal)
+  s5 = set()
+

--- a/src/snapshots/ruff__linter__tests__C406_C406.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C406_C406.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| d1 = dict([(1, 2)])
+|> Unnecessary `list` literal (rewrite as a `dict` literal)
+| d2 = dict(((1, 2),))
+|> Unnecessary `tuple` literal (rewrite as a `dict` literal)
+| d3 = dict([])
+|> Unnecessary `list` literal (rewrite as a `dict` literal)
+| d4 = dict(())
+|> Unnecessary `tuple` literal (rewrite as a `dict` literal)
+  d5 = dict()
+

--- a/src/snapshots/ruff__linter__tests__C408_C408.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C408_C408.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| t = tuple()
+|> Unnecessary `tuple` call (rewrite as a literal)
+| l = list()
+|> Unnecessary `list` call (rewrite as a literal)
+| d1 = dict()
+|> Unnecessary `dict` call (rewrite as a literal)
+| d2 = dict(a=1)
+|> Unnecessary `dict` call (rewrite as a literal)
+  d3 = dict(**d2)
+

--- a/src/snapshots/ruff__linter__tests__C409_C409.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C409_C409.py_remarks.snap
@@ -1,0 +1,20 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| t1 = tuple([])
+|> Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+| t2 = tuple([1, 2])
+|> Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+| t3 = tuple((1, 2))
+|> Unnecessary `tuple` literal passed to `tuple()` (remove the outer call to `tuple()`)
+| t4 = tuple([
+|     1,
+|     2
+| ])
+|> Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+| t5 = tuple(
+|     (1, 2)
+| )
+|> Unnecessary `tuple` literal passed to `tuple()` (remove the outer call to `tuple()`)
+

--- a/src/snapshots/ruff__linter__tests__C410_C410.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C410_C410.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| l1 = list([1, 2])
+|> Unnecessary `list` literal passed to `list()` (remove the outer call to `list()`)
+| l2 = list((1, 2))
+|> Unnecessary `tuple` literal passed to `list()` (rewrite as a `list` literal)
+| l3 = list([])
+|> Unnecessary `list` literal passed to `list()` (remove the outer call to `list()`)
+| l4 = list(())
+|> Unnecessary `tuple` literal passed to `list()` (rewrite as a `list` literal)
+

--- a/src/snapshots/ruff__linter__tests__C411_C411.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C411_C411.py_remarks.snap
@@ -1,0 +1,8 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = [1, 2, 3]
+| list([i for i in x])
+|> Unnecessary `list` call (remove the outer call to `list()`)
+

--- a/src/snapshots/ruff__linter__tests__C413_C413.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C413_C413.py_remarks.snap
@@ -1,0 +1,15 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = [2, 3, 1]
+  list(x)
+| list(sorted(x))
+|> Unnecessary `list` call around `sorted()`
+| reversed(sorted(x))
+|> Unnecessary `reversed` call around `sorted()`
+| reversed(sorted(x, key=lambda e: e))
+|> Unnecessary `reversed` call around `sorted()`
+| reversed(sorted(x, reverse=True))
+|> Unnecessary `reversed` call around `sorted()`
+

--- a/src/snapshots/ruff__linter__tests__C414_C414.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C414_C414.py_remarks.snap
@@ -1,0 +1,32 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = [1, 2, 3]
+| list(list(x))
+|> Unnecessary `list` call within `list()`
+| list(tuple(x))
+|> Unnecessary `tuple` call within `list()`
+| tuple(list(x))
+|> Unnecessary `list` call within `tuple()`
+| tuple(tuple(x))
+|> Unnecessary `tuple` call within `tuple()`
+| set(set(x))
+|> Unnecessary `set` call within `set()`
+| set(list(x))
+|> Unnecessary `list` call within `set()`
+| set(tuple(x))
+|> Unnecessary `tuple` call within `set()`
+| set(sorted(x))
+|> Unnecessary `sorted` call within `set()`
+| set(reversed(x))
+|> Unnecessary `reversed` call within `set()`
+| sorted(list(x))
+|> Unnecessary `list` call within `sorted()`
+| sorted(tuple(x))
+|> Unnecessary `tuple` call within `sorted()`
+| sorted(sorted(x))
+|> Unnecessary `sorted` call within `sorted()`
+| sorted(reversed(x))
+|> Unnecessary `reversed` call within `sorted()`
+

--- a/src/snapshots/ruff__linter__tests__C415_C415.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C415_C415.py_remarks.snap
@@ -1,0 +1,18 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  lst = [2, 1, 3]
+| a = set(lst[::-1])
+|> Unnecessary subscript reversal of iterable within `set()`
+| b = reversed(lst[::-1])
+|> Unnecessary subscript reversal of iterable within `reversed()`
+| c = sorted(lst[::-1])
+|> Unnecessary subscript reversal of iterable within `sorted()`
+| d = sorted(lst[::-1], reverse=True)
+|> Unnecessary subscript reversal of iterable within `sorted()`
+  e = set(lst[2:-1])
+  f = set(lst[:1:-1])
+  g = set(lst[::1])
+  h = set(lst[::-2])
+

--- a/src/snapshots/ruff__linter__tests__C416_C416.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C416_C416.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = [1, 2, 3]
+| [i for i in x]
+|> Unnecessary `list` comprehension (rewrite using `list()`)
+| {i for i in x}
+|> Unnecessary `set` comprehension (rewrite using `set()`)
+  
+  [i for i in x if i > 1]
+  [i for i in x for j in x]
+

--- a/src/snapshots/ruff__linter__tests__C417_C417.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__C417_C417.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  nums = [1, 2, 3]
+| map(lambda x: x + 1, nums)
+|> Unnecessary `map` usage (rewrite using a generator expression)
+| map(lambda x: str(x), nums)
+|> Unnecessary `map` usage (rewrite using a generator expression)
+| list(map(lambda x: x * 2, nums))
+|> Unnecessary `map` usage (rewrite using a `list` comprehension)
+|> Unnecessary `map` usage (rewrite using a generator expression)
+| set(map(lambda x: x % 2 == 0, nums))
+|> Unnecessary `map` usage (rewrite using a `set` comprehension)
+|> Unnecessary `map` usage (rewrite using a generator expression)
+| dict(map(lambda v: (v, v**2), nums))
+|> Unnecessary `map` usage (rewrite using a `dict` comprehension)
+|> Unnecessary `map` usage (rewrite using a generator expression)
+

--- a/src/snapshots/ruff__linter__tests__D100_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D100_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| # No docstring, so we can test D100
+|> Missing docstring in public module
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D101_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D101_D.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 14
     column: 0
   end_location:
-    row: 67
-    column: 0
+    row: 64
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D101_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D101_D.py_remarks.snap
@@ -66,10 +66,10 @@ expression: output.finish().to_string()
 |     @expect('D102: Missing docstring in public method')
 |     def __call__(self=None, x=None, y=None, z=None):
 |         pass
-| 
-| 
-| @expect('D419: Docstring is empty')
 |> Missing docstring in public class
+  
+  
+  @expect('D419: Docstring is empty')
   def function():
       """ """
       def ok_since_nested():

--- a/src/snapshots/ruff__linter__tests__D101_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D101_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+| class class_:
+| 
+|     expect('meta', 'D419: Docstring is empty')
+| 
+|     class meta:
+|         """"""
+| 
+|     @expect('D102: Missing docstring in public method')
+|     def method(self=None):
+|         pass
+| 
+|     def _ok_since_private(self=None):
+|         pass
+| 
+|     @overload
+|     def overloaded_method(self, a: int) -> str:
+|         ...
+| 
+|     @overload
+|     def overloaded_method(self, a: str) -> str:
+|         """Foo bar documentation."""
+|         ...
+| 
+|     def overloaded_method(a):
+|         """Foo bar documentation."""
+|         return str(a)
+| 
+|     expect('overloaded_method',
+|            "D418: Function/ Method decorated with @overload"
+|            " shouldn't contain a docstring")
+| 
+|     @property
+|     def foo(self):
+|         """The foo of the thing, which isn't in imperitive mood."""
+|         return "hello"
+| 
+|     @expect('D102: Missing docstring in public method')
+|     def __new__(self=None):
+|         pass
+| 
+|     @expect('D107: Missing docstring in __init__')
+|     def __init__(self=None):
+|         pass
+| 
+|     @expect('D105: Missing docstring in magic method')
+|     def __str__(self=None):
+|         pass
+| 
+|     @expect('D102: Missing docstring in public method')
+|     def __call__(self=None, x=None, y=None, z=None):
+|         pass
+| 
+| 
+| @expect('D419: Docstring is empty')
+|> Missing docstring in public class
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D102_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D102_D.py.snap
@@ -23,7 +23,7 @@ expression: checks
     row: 63
     column: 4
   end_location:
-    row: 67
-    column: 0
+    row: 64
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D102_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D102_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+|     def method(self=None):
+|         pass
+| 
+|     def _ok_since_private(self=None):
+|> Missing docstring in public method
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+|     def __new__(self=None):
+|         pass
+| 
+|     @expect('D107: Missing docstring in __init__')
+|> Missing docstring in public method
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+|     def __call__(self=None, x=None, y=None, z=None):
+|         pass
+| 
+| 
+| @expect('D419: Docstring is empty')
+|> Missing docstring in public method
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D102_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D102_D.py_remarks.snap
@@ -68,10 +68,10 @@ expression: output.finish().to_string()
       @expect('D102: Missing docstring in public method')
 |     def __call__(self=None, x=None, y=None, z=None):
 |         pass
-| 
-| 
-| @expect('D419: Docstring is empty')
 |> Missing docstring in public method
+  
+  
+  @expect('D419: Docstring is empty')
   def function():
       """ """
       def ok_since_nested():

--- a/src/snapshots/ruff__linter__tests__D103_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D103_D.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 395
     column: 0
   end_location:
-    row: 396
-    column: 0
+    row: 395
+    column: 27
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D103_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D103_D.py_remarks.snap
@@ -397,8 +397,8 @@ expression: output.finish().to_string()
   
   @expect("D103: Missing docstring in public function")
 | def oneliner_d102(): return
-| 
 |> Missing docstring in public function
+  
   
   @expect("D400: First line should end with a period (not 'r')")
   @expect("D415: First line should end with a period, question mark,"

--- a/src/snapshots/ruff__linter__tests__D103_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D103_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+| def oneliner_d102(): return
+| 
+|> Missing docstring in public function
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D104_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D104_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D105_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D105_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+|     def __str__(self=None):
+|         pass
+| 
+|     @expect('D102: Missing docstring in public method')
+|> Missing docstring in magic method
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D106_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D106_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D107_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D107_D.py.snap
@@ -15,7 +15,7 @@ expression: checks
     row: 529
     column: 4
   end_location:
-    row: 533
-    column: 0
+    row: 530
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D107_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D107_D.py_remarks.snap
@@ -533,9 +533,9 @@ expression: output.finish().to_string()
   
 |     def __init__(self, x):
 |         pass
-| 
-| 
-| expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
 |> Missing docstring in `__init__`
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
          'D100: Missing docstring in public module')
 

--- a/src/snapshots/ruff__linter__tests__D107_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D107_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+|     def __init__(self=None):
+|         pass
+| 
+|     @expect('D105: Missing docstring in magic method')
+|> Missing docstring in `__init__`
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+|     def __init__(self, x):
+|         pass
+| 
+| 
+| expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+|> Missing docstring in `__init__`
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D201_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D201_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+|     """Leading space."""
+|> No blank lines allowed before function docstring (found 1)
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+|     """Trailing and leading space."""
+|> No blank lines allowed before function docstring (found 1)
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D202_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D202_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+|     """Leading space."""
+|> No blank lines allowed after function docstring (found 1)
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+|     """Trailing and leading space."""
+|> No blank lines allowed after function docstring (found 1)
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D203_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D203_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+|     """Leading space missing."""
+|> 1 blank line required before class docstring
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+|     """Leading and trailing space missing."""
+|> 1 blank line required before class docstring
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+|     """A Blah.
+| 
+|     Parameters
+|     ----------
+|     x : int
+| 
+|     """
+|> 1 blank line required before class docstring
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D204_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D204_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+|     """TrailingSpace."""
+|> 1 blank line required after class docstring
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+|     """Leading and trailing space missing."""
+|> 1 blank line required after class docstring
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D205_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D205_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+|     """Summary.
+|     Description.
+| 
+|     """
+|> 1 blank line required between summary line and description
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+|     """Summary.
+| 
+| 
+|     Description.
+| 
+|     """
+|> 1 blank line required between summary line and description
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D206_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D206_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D207_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D207_D.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 227
     column: 0
   end_location:
-    row: 227
-    column: 0
+    row: 225
+    column: 11
   fix:
     patch:
       content: "    "
@@ -24,8 +24,8 @@ expression: checks
     row: 435
     column: 0
   end_location:
-    row: 435
-    column: 0
+    row: 433
+    column: 50
   fix:
     patch:
       content: "                                    "

--- a/src/snapshots/ruff__linter__tests__D207_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D207_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+| Description.
+|> Docstring is under-indented
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+|     Second Line
+|> Docstring is under-indented
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D207_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D207_D.py_remarks.snap
@@ -227,9 +227,9 @@ expression: output.finish().to_string()
   @expect('D213: Multi-line docstring summary should start at the second line')
   def asdfsdf():
       """Summary.
-  
-| Description.
 |> Docstring is under-indented
+  
+  Description.
   
       """
   
@@ -436,9 +436,9 @@ expression: output.finish().to_string()
   @expect("D207: Docstring is under-indented")
   @expect('D213: Multi-line docstring summary should start at the second line')
   def docstring_start_in_same_line(): """First Line.
-  
-|     Second Line
 |> Docstring is under-indented
+  
+      Second Line
       """
   
   

--- a/src/snapshots/ruff__linter__tests__D208_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D208_D.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 247
     column: 0
   end_location:
-    row: 247
-    column: 0
+    row: 245
+    column: 11
   fix:
     patch:
       content: "    "
@@ -24,8 +24,8 @@ expression: checks
     row: 259
     column: 0
   end_location:
-    row: 259
-    column: 0
+    row: 257
+    column: 12
   fix:
     patch:
       content: "    "
@@ -41,8 +41,8 @@ expression: checks
     row: 267
     column: 0
   end_location:
-    row: 267
-    column: 0
+    row: 265
+    column: 11
   fix:
     patch:
       content: "    "

--- a/src/snapshots/ruff__linter__tests__D208_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D208_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+|        Description.
+|> Docstring is over-indented
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+|         """
+|> Docstring is over-indented
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+|         Description.
+|> Docstring is over-indented
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D208_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D208_D.py_remarks.snap
@@ -247,9 +247,9 @@ expression: output.finish().to_string()
   @expect('D213: Multi-line docstring summary should start at the second line')
   def asdfsdsdf24():
       """Summary.
-  
-|        Description.
 |> Docstring is over-indented
+  
+         Description.
   
       """
   
@@ -260,18 +260,18 @@ expression: output.finish().to_string()
       """Summary.
   
       Description.
-  
-|         """
 |> Docstring is over-indented
+  
+          """
   
   
   @expect('D208: Docstring is over-indented')
   @expect('D213: Multi-line docstring summary should start at the second line')
   def asdfsdfsdsdsdfsdf24():
       """Summary.
-  
-|         Description.
 |> Docstring is over-indented
+  
+          Description.
   
       """
   

--- a/src/snapshots/ruff__linter__tests__D209_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D209_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+|     """Summary.
+| 
+|     Description."""
+|> Multi-line docstring closing quotes should be on a separate line
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D210_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D210_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+|     """Whitespace at the end. """
+|> No whitespaces allowed surrounding docstring text
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+|     """ Whitespace at everywhere. """
+|> No whitespaces allowed surrounding docstring text
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+|     """ Whitespace at the beginning.
+| 
+|     This is the end.
+|     """
+|> No whitespaces allowed surrounding docstring text
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D211_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D211_D.py_remarks.snap
@@ -1,0 +1,541 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+|     """With leading space."""
+|> No blank lines allowed before class docstring
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+|     """TrailingSpace."""
+|> No blank lines allowed before class docstring
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D212_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D212_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+|     """
+|     Wrong.
+|     """
+|> Multi-line docstring summary should start at the first line
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D213_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D213_D.py_remarks.snap
@@ -1,0 +1,555 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+|     """Summary.
+|     Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+|     """Summary.
+| 
+| 
+|     Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+|     """Summary.
+| 
+|     Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+|     """Summary.
+| 
+| Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+|     """Summary.
+| 
+|     Description.
+| 
+| """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+|     """Summary.
+| 
+|        Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+|     """Summary.
+| 
+|     Description.
+| 
+|         """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+|     """Summary.
+| 
+|         Description.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+|     """Summary.
+| 
+|     Description."""
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+|     """ Whitespace at the beginning.
+| 
+|     This is the end.
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+|     """Exclude some backslashes from D301.
+| 
+|     In particular, line continuations \
+|     and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+|     They are considered to be intentionally unescaped.
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+|     """First line.
+| 
+|     More lines.
+|     """
+|> Multi-line docstring summary should start at the second line
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+|     """One liner.
+| 
+|     Multi-line comments. OK to have extra blank line
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+| def docstring_start_in_same_line(): """First Line.
+| 
+|     Second Line
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+|     """Check for a bug where the previous function caused an assertion.
+| 
+|     The assertion was caused in the next function, so this one is necessary.
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+|     """A Blah.
+| 
+|     Parameters
+|     ----------
+|     x : int
+| 
+|     """
+|> Multi-line docstring summary should start at the second line
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D214_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D214_sections.py_remarks.snap
@@ -1,0 +1,503 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|         Returns
+|     -------
+|     A value of some sort.
+| 
+|     """
+|> Section is over-indented ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D215_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D215_sections.py_remarks.snap
@@ -1,0 +1,504 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|         -------
+|     A value of some sort.
+| 
+|     """
+|> Section underline is over-indented ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|         -------
+|     """
+|> Section underline is over-indented ("Returns")
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D300_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D300_D.py_remarks.snap
@@ -1,0 +1,544 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+|     r'''Summary.'''
+|> Use """triple double quotes"""
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+|     R'''Summary.'''
+|> Use """triple double quotes"""
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+|     r'Summary.'
+|> Use """triple double quotes"""
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+|     R'Summary.'
+|> Use """triple double quotes"""
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+|     R'Sum\mary.'
+|> Use """triple double quotes"""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D400_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D400_D.py_remarks.snap
@@ -1,0 +1,555 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+|     """
+|     Wrong.
+|     """
+|> First line should end with a period
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+|     """Whitespace at the end. """
+|> First line should end with a period
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+|     """ Whitespace at everywhere. """
+|> First line should end with a period
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+|     """Summary"""
+|> First line should end with a period
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+| def oneliner_withdoc(): """One liner"""
+|> First line should end with a period
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period
+      func()
+      pass
+  
+  
+  @ignored_decorator
+| def oneliner_ignored_decorator(): """One liner"""
+|> First line should end with a period
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+| def oneliner_with_decorator_expecting_errors(): """One liner"""
+|> First line should end with a period
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+|     """Runs something"""
+|> First line should end with a period
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+|     """Runs something"""
+|> First line should end with a period
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+|     """Runs something"""
+|> First line should end with a period
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+|     """Bad (E501) but decorated"""
+|> First line should end with a period
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+|     """Test a valid something!"""
+|> First line should end with a period
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+|     """Test a valid something"""
+|> First line should end with a period
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D402_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D402_D.py_remarks.snap
@@ -1,0 +1,540 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+|     """Signature: foobar()."""
+|> First line should not be the function's signature
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D403_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D403_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D404_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D404_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D405_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D405_sections.py_remarks.snap
@@ -1,0 +1,504 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     returns
+|     -------
+|     A value of some sort.
+| 
+|     """
+|> Section name should be properly capitalized ("returns")
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Section name should be properly capitalized ("Short summary")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D406_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D406_sections.py_remarks.snap
@@ -1,0 +1,506 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns:
+|     -------
+|     A value of some sort.
+| 
+|     """
+|> Section name should end with a newline ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Section name should end with a newline ("Raises")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args:
+|         note: A random string.
+| 
+|     Returns:
+| 
+|     Raises:
+|         RandomError: A random error that occurs randomly.
+| 
+|     """
+|> Section name should end with a newline ("Returns")
+|> Section name should end with a newline ("Raises")
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D407_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D407_sections.py_remarks.snap
@@ -1,0 +1,517 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|     A value of some sort.
+| 
+|     """
+|> Missing dashed underline after section ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+| 
+|     """
+|> Missing dashed underline after section ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Missing dashed underline after section ("Raises")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args:
+|         note: A random string.
+| 
+|     Returns:
+| 
+|     Raises:
+|         RandomError: A random error that occurs randomly.
+| 
+|     """
+|> Missing dashed underline after section ("Returns")
+|> Missing dashed underline after section ("Raises")
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args
+|         note: A random string.
+| 
+|     """
+|> Missing dashed underline after section ("Args")
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+|         """Nested function test for docstrings.
+| 
+|         Will this work when referencing x?
+| 
+|         Args:
+|             x: Test something
+| that is broken.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args:
+|         x (int): The greatest integer.
+| 
+|     """
+|> Missing dashed underline after section ("Args")
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             test: A parameter.
+|             another_test: Another parameter.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter. The parameter below is missing description.
+|             y:
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             a:
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+|         """Do stuff.
+| 
+|         Args:
+|             skip (:attr:`.Skip`):
+|                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+|                 Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+|                 mauris, semper id vehicula ac, feugiat ut tortor.
+|             verbose (bool):
+|                 If True, print out as much infromation as possible.
+|                 If False, print out concise "one-liner" information.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+|         """Reproducing issue #437.
+| 
+| Testing this incorrectly indented docstring.
+| 
+|         Args:
+|             x: Test argument.
+| 
+|         """
+|> Missing dashed underline after section ("Args")
+

--- a/src/snapshots/ruff__linter__tests__D408_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D408_sections.py_remarks.snap
@@ -1,0 +1,503 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+| 
+|     -------
+|     A value of some sort.
+| 
+|     """
+|> Section underline should be in the line following the section's name ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D409_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D409_sections.py_remarks.snap
@@ -1,0 +1,504 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|     --
+|     A value of some sort.
+| 
+|     """
+|> Section underline should match the length of its name ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Section underline should match the length of its name ("Returns")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D410_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D410_sections.py_remarks.snap
@@ -1,0 +1,504 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|     -------
+|     Yields
+|     ------
+| 
+|     Raises
+|     ------
+|     Questions.
+| 
+|     """
+|> Missing blank line after section ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Missing blank line after section ("Returns")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D411_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D411_sections.py_remarks.snap
@@ -1,0 +1,505 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|     -------
+|     Yields
+|     ------
+| 
+|     Raises
+|     ------
+|     Questions.
+| 
+|     """
+|> Missing blank line before section ("Yields")
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     The function's description.
+|     Returns
+|     -------
+|     A value of some sort.
+| 
+|     """
+|> Missing blank line before section ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> Missing blank line before section ("Raises")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D412_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D412_sections.py_remarks.snap
@@ -1,0 +1,503 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Short summary
+|     -------------
+| 
+|     This is the function's description, which will also specify what it
+|     returns.
+| 
+|     Returns
+|     ------
+|     Many many wonderful things.
+|     Raises:
+|     My attention.
+| 
+|     """
+|> No blank lines allowed between a section header and its content ("Short summary")
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D413_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D413_sections.py_remarks.snap
@@ -1,0 +1,502 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D414_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D414_sections.py_remarks.snap
@@ -1,0 +1,507 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+| 
+|     """
+|> Section has no content ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|     -------
+|     Yields
+|     ------
+| 
+|     Raises
+|     ------
+|     Questions.
+| 
+|     """
+|> Section has no content ("Returns")
+|> Section has no content ("Yields")
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+|     """Toggle the gizmo.
+| 
+|     Returns
+|         -------
+|     """
+|> Section has no content ("Returns")
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args:
+|         note: A random string.
+| 
+|     Returns:
+| 
+|     Raises:
+|         RandomError: A random error that occurs randomly.
+| 
+|     """
+|> Section has no content ("Returns")
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+      def bar(y=2):  # noqa: D207, D213, D406, D407
+          """Nested function test for docstrings.
+  
+          Will this work when referencing x?
+  
+          Args:
+              x: Test something
+  that is broken.
+  
+          """
+          print(x)
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+  def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          x (int): The greatest integer.
+  
+      """
+  
+  
+  class TestGoogle:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+      def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter. The parameter below is missing description.
+              y:
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+      def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              x: Another parameter.
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+      def test_missing_docstring(a, b):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              a:
+  
+          """
+  
+      @staticmethod
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+  def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      x : int
+          The greatest integer in the history \
+  of the entire world.
+  
+      """
+  
+  
+  class TestNumpy:  # noqa: D203
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+      def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, t : int
+              Some parameters.
+  
+  
+          """
+  
+      @classmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+      def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          z
+          x
+              Another parameter. The parameters y, test below are
+              missing descriptions. The parameter z above is also missing
+              a description.
+          y
+          test
+  
+          """
+  
+      @staticmethod
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+      def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Parameters
+          ----------
+          x, y
+              Another parameter.
+          t : int
+              Yet another parameter.
+  
+          """
+  
+      @staticmethod
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+      def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+          """Reproducing issue #437.
+  
+  Testing this incorrectly indented docstring.
+  
+          Args:
+              x: Test argument.
+  
+          """
+

--- a/src/snapshots/ruff__linter__tests__D415_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D415_D.py_remarks.snap
@@ -1,0 +1,554 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+|     """
+|     Wrong.
+|     """
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+|     """Whitespace at the end. """
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+|     """ Whitespace at everywhere. """
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+|     """Summary"""
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+| def oneliner_withdoc(): """One liner"""
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      func()
+      pass
+  
+  
+  @ignored_decorator
+| def oneliner_ignored_decorator(): """One liner"""
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+| def oneliner_with_decorator_expecting_errors(): """One liner"""
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+|     """Runs something"""
+|> First line should end with a period, question mark, or exclamation point
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+|     """Bad (E501) but decorated"""
+|> First line should end with a period, question mark, or exclamation point
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+|     """Test a valid something"""
+|> First line should end with a period, question mark, or exclamation point
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D416_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D416_D.py_remarks.snap
@@ -1,0 +1,539 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D417_canonical_google_examples.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D417_canonical_google_examples.py_remarks.snap
@@ -1,0 +1,113 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A one line summary of the module or program, terminated by a period.
+  
+  Leave one blank line.  The rest of this docstring should contain an
+  overall description of the module or program.  Optionally, it may also
+  contain a brief description of exported classes and functions and/or usage
+  examples.
+  
+    Typical usage example:
+  
+    foo = ClassFoo()
+    bar = foo.FunctionBar()
+  """
+  # above: "2.8.2 Modules" section example
+  # https://google.github.io/styleguide/pyguide.html#382-modules
+  
+  # Examples from the official "Google Python Style Guide" documentation:
+  #     * As HTML: https://google.github.io/styleguide/pyguide.html
+  #     * Source Markdown:
+  #         https://github.com/google/styleguide/blob/gh-pages/pyguide.md
+  
+  import os
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  # module docstring expected violations:
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D213: Multi-line docstring summary should start at the second line"))
+  
+  
+  # "3.8.3 Functions and Methods" section example
+  # https://google.github.io/styleguide/pyguide.html#383-functions-and-methods
+  @expect("D213: Multi-line docstring summary should start at the second line",
+          arg_count=3)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Fetch', not 'Fetches')", arg_count=3)
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')", arg_count=3)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')", arg_count=3)
+  @expect("D407: Missing dashed underline after section ('Raises')", arg_count=3)
+  @expect("D407: Missing dashed underline after section ('Returns')",
+          arg_count=3)
+  @expect("D413: Missing blank line after last section ('Raises')", arg_count=3)
+  def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
+      """Fetches rows from a Bigtable.
+  
+      Retrieves rows pertaining to the given keys from the Table instance
+      represented by big_table.  Silly things may happen if
+      other_silly_variable is not None.
+  
+      Args:
+          big_table: An open Bigtable Table instance.
+          keys: A sequence of strings representing the key of each table row
+              to fetch.
+          other_silly_variable: Another optional variable, that has a much
+              longer name than the other args, and which does nothing.
+  
+      Returns:
+          A dict mapping keys to the corresponding table row data
+          fetched. Each row is represented as a tuple of strings. For
+          example:
+  
+          {'Serak': ('Rigel VII', 'Preparer'),
+           'Zim': ('Irk', 'Invader'),
+           'Lrrr': ('Omicron Persei 8', 'Emperor')}
+  
+          If a key from the keys argument is missing from the dictionary,
+          then that row was not found in the table.
+  
+      Raises:
+          IOError: An error occurred accessing the bigtable.Table object.
+      """
+  
+  
+  # "3.8.4 Classes" section example
+  # https://google.github.io/styleguide/pyguide.html#384-classes
+  @expect("D203: 1 blank line required before class docstring (found 0)")
+  @expect("D213: Multi-line docstring summary should start at the second line")
+  @expect("D406: Section name should end with a newline "
+          "('Attributes', not 'Attributes:')")
+  @expect("D407: Missing dashed underline after section ('Attributes')")
+  @expect("D413: Missing blank line after last section ('Attributes')")
+  class SampleClass:
+      """Summary of class here.
+  
+      Longer class information....
+      Longer class information....
+  
+      Attributes:
+          likes_spam: A boolean indicating if we like SPAM or not.
+          eggs: An integer count of the eggs we have laid.
+      """
+  
+      @expect("D401: First line should be in imperative mood "
+              "(perhaps 'Init', not 'Inits')", arg_count=2)
+      def __init__(self, likes_spam=False):
+          """Inits SampleClass with blah."""
+          if self:  # added to avoid NameError when run via @expect decorator
+              self.likes_spam = likes_spam
+              self.eggs = 0
+  
+      @expect("D401: First line should be in imperative mood "
+              "(perhaps 'Perform', not 'Performs')", arg_count=1)
+      def public_method(self):
+          """Performs operation blah."""
+

--- a/src/snapshots/ruff__linter__tests__D417_canonical_numpy_examples.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D417_canonical_numpy_examples.py_remarks.snap
@@ -1,0 +1,168 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """This is the docstring for the example.py module.  Modules names should
+  have short, all-lowercase names.  The module name may have underscores if
+  this improves readability.
+  
+  Every module should have a docstring at the very top of the file.  The
+  module's docstring may extend over multiple lines.  If your docstring does
+  extend over multiple lines, the closing three quotation marks must be on
+  a line by itself, preferably preceded by a blank line.
+  
+  """
+  
+  # Example source file from the official "numpydoc docstring guide"
+  # documentation (with the modification of commenting out all the original
+  # ``import`` lines, plus adding this note and ``Expectation`` code):
+  #     * As HTML: https://numpydoc.readthedocs.io/en/latest/example.html
+  #     * Source Python:
+  #         https://github.com/numpy/numpydoc/blob/master/doc/example.py
+  
+  # from __future__ import division, absolute_import, print_function
+  #
+  # import os  # standard library imports first
+  #
+  # Do NOT import using *, e.g. from numpy import *
+  #
+  # Import the module using
+  #
+  #   import numpy
+  #
+  # instead or import individual functions as needed, e.g
+  #
+  #  from numpy import array, zeros
+  #
+  # If you prefer the use of abbreviated module names, we suggest the
+  # convention used by NumPy itself::
+  #
+  # import numpy as np
+  # import matplotlib as mpl
+  # import matplotlib.pyplot as plt
+  #
+  # These abbreviated names are not to be used in docstrings; users must
+  # be able to paste and execute docstrings after importing only the
+  # numpy module itself, unabbreviated.
+  
+  import os
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  # module docstring expected violations:
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D205: 1 blank line required between summary line and description "
+      "(found 0)"))
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D213: Multi-line docstring summary should start at the second line"))
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D400: First line should end with a period (not 'd')"))
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D404: First word of the docstring should not be `This`"))
+  expectation.expected.add((
+      os.path.normcase(__file__),
+      "D415: First line should end with a period, question mark, or exclamation "
+      "point (not 'd')"))
+  
+  
+  @expect("D213: Multi-line docstring summary should start at the second line",
+          arg_count=3)
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'A')", arg_count=3)
+  @expect("D413: Missing blank line after last section ('Examples')",
+          arg_count=3)
+  def foo(var1, var2, long_var_name='hi'):
+      r"""A one-line summary that does not use variable names.
+  
+      Several sentences providing an extended description. Refer to
+      variables using back-ticks, e.g. `var`.
+  
+      Parameters
+      ----------
+      var1 : array_like
+          Array_like means all those objects -- lists, nested lists, etc. --
+          that can be converted to an array.  We can also refer to
+          variables like `var1`.
+      var2 : int
+          The type above can either refer to an actual Python type
+          (e.g. ``int``), or describe the type of the variable in more
+          detail, e.g. ``(N,) ndarray`` or ``array_like``.
+      long_var_name : {'hi', 'ho'}, optional
+          Choices in brackets, default first when optional.
+  
+      Returns
+      -------
+      type
+          Explanation of anonymous return value of type ``type``.
+      describe : type
+          Explanation of return value named `describe`.
+      out : type
+          Explanation of `out`.
+      type_without_description
+  
+      Other Parameters
+      ----------------
+      only_seldom_used_keywords : type
+          Explanation
+      common_parameters_listed_above : type
+          Explanation
+  
+      Raises
+      ------
+      BadException
+          Because you shouldn't have done that.
+  
+      See Also
+      --------
+      numpy.array : Relationship (optional).
+      numpy.ndarray : Relationship (optional), which could be fairly long, in
+                      which case the line wraps here.
+      numpy.dot, numpy.linalg.norm, numpy.eye
+  
+      Notes
+      -----
+      Notes about the implementation algorithm (if needed).
+  
+      This can have multiple paragraphs.
+  
+      You may include some math:
+  
+      .. math:: X(e^{j\omega } ) = x(n)e^{ - j\omega n}
+  
+      And even use a Greek symbol like :math:`\omega` inline.
+  
+      References
+      ----------
+      Cite the relevant literature, e.g. [1]_.  You may also cite these
+      references in the notes section above.
+  
+      .. [1] O. McNoleg, "The integration of GIS, remote sensing,
+         expert systems and adaptive co-kriging for environmental habitat
+         modelling of the Highland Haggis using object-oriented, fuzzy-logic
+         and neural-network techniques," Computers & Geosciences, vol. 22,
+         pp. 585-588, 1996.
+  
+      Examples
+      --------
+      These are written in doctest format, and should illustrate how to
+      use the function.
+  
+      >>> a = [1, 2, 3]
+      >>> print([x + 3 for x in a])
+      [4, 5, 6]
+      >>> print("a\nb")
+      a
+      b
+      """
+      # After closing class docstring, there should be one blank line to
+      # separate following codes (according to PEP257).
+      # But for function, method and module, there should be no blank lines
+      # after closing the docstring.
+      pass
+

--- a/src/snapshots/ruff__linter__tests__D417_sections.py.snap
+++ b/src/snapshots/ruff__linter__tests__D417_sections.py.snap
@@ -9,8 +9,8 @@ expression: checks
     row: 283
     column: 4
   end_location:
-    row: 296
-    column: 0
+    row: 293
+    column: 8
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -19,8 +19,8 @@ expression: checks
     row: 300
     column: 0
   end_location:
-    row: 309
-    column: 0
+    row: 306
+    column: 3
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -76,8 +76,8 @@ expression: checks
     row: 389
     column: 0
   end_location:
-    row: 401
-    column: 0
+    row: 398
+    column: 3
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -121,7 +121,7 @@ expression: checks
     row: 489
     column: 4
   end_location:
-    row: 498
-    column: 0
+    row: 497
+    column: 3
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D417_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D417_sections.py_remarks.snap
@@ -1,0 +1,512 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """A valid module docstring."""
+  
+  from .expected import Expectation
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  
+  _D213 = 'D213: Multi-line docstring summary should start at the second line'
+  _D400 = "D400: First line should end with a period (not '!')"
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Returns', not 'returns')")
+  def not_capitalized():  # noqa: D416
+      """Toggle the gizmo.
+  
+      returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D406: Section name should end with a newline "
+          "('Returns', not 'Returns:')")
+  def superfluous_suffix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns:
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  def no_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D407: Missing dashed underline after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def no_underline_and_no_description():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  @expect("D411: Missing blank line before section ('Yields')")
+  @expect("D414: Section has no content ('Yields')")
+  def consecutive_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      Yields
+      ------
+  
+      Raises
+      ------
+      Questions.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D408: Section underline should be in the line following the "
+          "section's name ('Returns')")
+  def blank_line_before_underline():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+  
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 2)")
+  def bad_underline_length():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      --
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D413: Missing blank line after last section ('Returns')")
+  def no_blank_line_after_last_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+      -------
+      A value of some sort.
+      """
+  
+  
+  @expect(_D213)
+  @expect("D411: Missing blank line before section ('Returns')")
+  def no_blank_line_before_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      The function's description.
+      Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D214: Section is over-indented ('Returns')")
+  def section_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+          Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  def section_underline_overindented():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D215: Section underline is over-indented (in section 'Returns')")
+  @expect("D413: Missing blank line after last section ('Returns')")
+  @expect("D414: Section has no content ('Returns')")
+  def section_underline_overindented_and_contentless():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Returns
+          -------
+      """
+  
+  
+  @expect(_D213)
+  def ignore_non_actual_section():  # noqa: D416
+      """Toggle the gizmo.
+  
+      This is the function's description, which will also specify what it
+      returns
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  @expect("D400: First line should end with a period (not 's')")
+  @expect("D415: First line should end with a period, question "
+          "mark, or exclamation point (not 's')")
+  @expect("D205: 1 blank line required between summary line and description "
+          "(found 0)")
+  def section_name_in_first_line():  # noqa: D416
+      """Returns
+      -------
+      A value of some sort.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D405: Section name should be properly capitalized "
+          "('Short Summary', not 'Short summary')")
+  @expect("D412: No blank lines allowed between a section header and its "
+          "content ('Short Summary')")
+  @expect("D409: Section underline should match the length of its name "
+          "(Expected 7 dashes in section 'Returns', got 6)")
+  @expect("D410: Missing blank line after section ('Returns')")
+  @expect("D411: Missing blank line before section ('Raises')")
+  @expect("D406: Section name should end with a newline "
+          "('Raises', not 'Raises:')")
+  @expect("D407: Missing dashed underline after section ('Raises')")
+  def multiple_sections():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Short summary
+      -------------
+  
+      This is the function's description, which will also specify what it
+      returns.
+  
+      Returns
+      ------
+      Many many wonderful things.
+      Raises:
+      My attention.
+  
+      """
+  
+  
+  @expect(_D213)
+  def false_positive_section_prefix():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      attributes_are_fun: attributes for the function.
+  
+      """
+  
+  
+  @expect(_D213)
+  def section_names_as_parameter_names():  # noqa: D416
+      """Toggle the gizmo.
+  
+      Parameters
+      ----------
+      notes : list
+          A list of wonderful notes.
+      examples: list
+          A list of horrible examples.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D414: Section has no content ('Returns')")
+  def valid_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args:
+          note: A random string.
+  
+      Returns:
+  
+      Raises:
+          RandomError: A random error that occurs randomly.
+  
+      """
+  
+  
+  @expect(_D213)
+  @expect("D416: Section name should end with a colon "
+          "('Args:', not 'Args')")
+  def missing_colon_google_style_section():  # noqa: D406, D407
+      """Toggle the gizmo.
+  
+      Args
+          note: A random string.
+  
+      """
+  
+  
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'bar' docstring)", func_name="bar")
+  def _test_nested_functions():
+      x = 1
+  
+|     def bar(y=2):  # noqa: D207, D213, D406, D407
+|         """Nested function test for docstrings.
+| 
+|         Will this work when referencing x?
+| 
+|         Args:
+|             x: Test something
+| that is broken.
+| 
+|         """
+|         print(x)
+| 
+| 
+| @expect(_D213)
+|> Missing argument description in the docstring: `y`
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_google_args' docstring)")
+| def test_missing_google_args(x=1, y=2, _private=3):  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Args:
+|         x (int): The greatest integer.
+| 
+|     """
+| 
+| 
+| class TestGoogle:  # noqa: D203
+|> Missing argument description in the docstring: `y`
+      """Test class."""
+  
+      def test_method(self, test, another_test, _):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Args:
+              test: A parameter.
+              another_test: Another parameter.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+|     def test_missing_args(self, test, x, y, z=3, _private_arg=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter.
+| 
+|         """
+| 
+|     @classmethod
+|> Missing argument descriptions in the docstring: `test`, `y`, `z`
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=5)
+|     def test_missing_args_class_method(cls, test, x, y, _, z=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter. The parameter below is missing description.
+|             y:
+| 
+|         """
+| 
+|     @staticmethod
+|> Missing argument descriptions in the docstring: `test`, `y`, `z`
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, y, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=4)
+|     def test_missing_args_static_method(a, x, y, _test, z=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             x: Another parameter.
+| 
+|         """
+| 
+|     @staticmethod
+|> Missing argument descriptions in the docstring: `a`, `y`, `z`
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, b are missing descriptions in "
+              "'test_missing_docstring' docstring)", arg_count=2)
+|     def test_missing_docstring(a, b):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Args:
+|             a:
+| 
+|         """
+| 
+|     @staticmethod
+|> Missing argument descriptions in the docstring: `a`, `b`
+      def test_hanging_indent(skip, verbose):  # noqa: D213, D407
+          """Do stuff.
+  
+          Args:
+              skip (:attr:`.Skip`):
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Etiam at tellus a tellus faucibus maximus. Curabitur tellus
+                  mauris, semper id vehicula ac, feugiat ut tortor.
+              verbose (bool):
+                  If True, print out as much infromation as possible.
+                  If False, print out concise "one-liner" information.
+  
+          """
+  
+  
+  @expect(_D213)
+  @expect("D417: Missing argument descriptions in the docstring "
+          "(argument(s) y are missing descriptions in "
+          "'test_missing_numpy_args' docstring)")
+| def test_missing_numpy_args(_private_arg=0, x=1, y=2):  # noqa: D406, D407
+|     """Toggle the gizmo.
+| 
+|     Parameters
+|     ----------
+|     x : int
+|         The greatest integer in the history \
+| of the entire world.
+| 
+|     """
+| 
+| 
+| class TestNumpy:  # noqa: D203
+|> Missing argument description in the docstring: `y`
+      """Test class."""
+  
+      def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
+          """Test a valid args section.
+  
+          Some long string with a \
+  line continuation.
+  
+          Parameters
+          ----------
+          test, another_test
+              Some parameters without type.
+          z : some parameter with a very long type description that requires a \
+  line continuation.
+              But no further description.
+          x, y : int
+              Some integer parameters.
+  
+          """
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args' docstring)", arg_count=5)
+|     def test_missing_args(self, test, x, y, z=3, t=1, _private=0):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Parameters
+|         ----------
+|         x, t : int
+|             Some parameters.
+| 
+| 
+|         """
+| 
+|     @classmethod
+|> Missing argument descriptions in the docstring: `test`, `y`, `z`
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) test, y, z are missing descriptions in "
+              "'test_missing_args_class_method' docstring)", arg_count=4)
+|     def test_missing_args_class_method(cls, test, x, y, z=3):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Parameters
+|         ----------
+|         z
+|         x
+|             Another parameter. The parameters y, test below are
+|             missing descriptions. The parameter z above is also missing
+|             a description.
+|         y
+|         test
+| 
+|         """
+| 
+|     @staticmethod
+|> Missing argument descriptions in the docstring: `test`, `y`, `z`
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) a, z are missing descriptions in "
+              "'test_missing_args_static_method' docstring)", arg_count=3)
+|     def test_missing_args_static_method(a, x, y, z=3, t=1):  # noqa: D213, D407
+|         """Test a valid args section.
+| 
+|         Parameters
+|         ----------
+|         x, y
+|             Another parameter.
+|         t : int
+|             Yet another parameter.
+| 
+|         """
+| 
+|     @staticmethod
+|> Missing argument descriptions in the docstring: `a`, `z`
+      def test_mixing_numpy_and_google(danger):  # noqa: D213
+          """Repro for #388.
+  
+          Parameters
+          ----------
+          danger
+              Zoneeeeee!
+  
+          """
+  
+  
+  class TestIncorrectIndent:  # noqa: D203
+      """Test class."""
+  
+      @expect("D417: Missing argument descriptions in the docstring "
+              "(argument(s) y are missing descriptions in "
+              "'test_incorrect_indent' docstring)", arg_count=3)
+|     def test_incorrect_indent(self, x=1, y=2):  # noqa: D207, D213, D407
+|         """Reproducing issue #437.
+| 
+| Testing this incorrectly indented docstring.
+| 
+|         Args:
+|             x: Test argument.
+| 
+|         """
+

--- a/src/snapshots/ruff__linter__tests__D417_sections.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D417_sections.py_remarks.snap
@@ -295,10 +295,10 @@ expression: output.finish().to_string()
 | 
 |         """
 |         print(x)
-| 
-| 
-| @expect(_D213)
 |> Missing argument description in the docstring: `y`
+  
+  
+  @expect(_D213)
   @expect("D417: Missing argument descriptions in the docstring "
           "(argument(s) y are missing descriptions in "
           "'test_missing_google_args' docstring)")
@@ -309,10 +309,10 @@ expression: output.finish().to_string()
 |         x (int): The greatest integer.
 | 
 |     """
-| 
-| 
-| class TestGoogle:  # noqa: D203
 |> Missing argument description in the docstring: `y`
+  
+  
+  class TestGoogle:  # noqa: D203
       """Test class."""
   
       def test_method(self, test, another_test, _):  # noqa: D213, D407
@@ -406,10 +406,10 @@ expression: output.finish().to_string()
 | of the entire world.
 | 
 |     """
-| 
-| 
-| class TestNumpy:  # noqa: D203
 |> Missing argument description in the docstring: `y`
+  
+  
+  class TestNumpy:  # noqa: D203
       """Test class."""
   
       def test_method(self, test, another_test, z, _, x=1, y=2, _private_arg=1):  # noqa: D213, D407
@@ -509,4 +509,5 @@ expression: output.finish().to_string()
 |             x: Test argument.
 | 
 |         """
+|> Missing argument description in the docstring: `y`
 

--- a/src/snapshots/ruff__linter__tests__D418_D.py.snap
+++ b/src/snapshots/ruff__linter__tests__D418_D.py.snap
@@ -23,7 +23,7 @@ expression: checks
     row: 105
     column: 0
   end_location:
-    row: 110
-    column: 0
+    row: 107
+    column: 3
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__D418_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D418_D.py_remarks.snap
@@ -111,10 +111,10 @@ expression: output.finish().to_string()
 | def overloaded_func(a: str) -> str:
 |     """Foo bar documentation."""
 |     ...
-| 
-| 
-| def overloaded_func(a):
 |> Function decorated with `@overload` shouldn't contain a docstring
+  
+  
+  def overloaded_func(a):
       """Foo bar documentation."""
       return str(a)
   

--- a/src/snapshots/ruff__linter__tests__D418_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D418_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+          """"""
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+|     def overloaded_method(self, a: str) -> str:
+|         """Foo bar documentation."""
+|         ...
+| 
+|     def overloaded_method(a):
+|> Function decorated with `@overload` shouldn't contain a docstring
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+      """ """
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+          ''
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+|     def nested_overloaded_func(a: str) -> str:
+|         """Foo bar documentation."""
+|         ...
+| 
+|     def nested_overloaded_func(a):
+|> Function decorated with `@overload` shouldn't contain a docstring
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+| def overloaded_func(a: str) -> str:
+|     """Foo bar documentation."""
+|     ...
+| 
+| 
+| def overloaded_func(a):
+|> Function decorated with `@overload` shouldn't contain a docstring
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__D419_D.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__D419_D.py_remarks.snap
@@ -1,0 +1,542 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  # No docstring, so we can test D100
+  from functools import wraps
+  import os
+  from .expected import Expectation
+  from typing import overload
+  
+  
+  expectation = Expectation()
+  expect = expectation.expect
+  
+  expect('class_', 'D101: Missing docstring in public class')
+  
+  
+  class class_:
+  
+      expect('meta', 'D419: Docstring is empty')
+  
+      class meta:
+|         """"""
+|> Docstring is empty
+  
+      @expect('D102: Missing docstring in public method')
+      def method(self=None):
+          pass
+  
+      def _ok_since_private(self=None):
+          pass
+  
+      @overload
+      def overloaded_method(self, a: int) -> str:
+          ...
+  
+      @overload
+      def overloaded_method(self, a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def overloaded_method(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+      expect('overloaded_method',
+             "D418: Function/ Method decorated with @overload"
+             " shouldn't contain a docstring")
+  
+      @property
+      def foo(self):
+          """The foo of the thing, which isn't in imperitive mood."""
+          return "hello"
+  
+      @expect('D102: Missing docstring in public method')
+      def __new__(self=None):
+          pass
+  
+      @expect('D107: Missing docstring in __init__')
+      def __init__(self=None):
+          pass
+  
+      @expect('D105: Missing docstring in magic method')
+      def __str__(self=None):
+          pass
+  
+      @expect('D102: Missing docstring in public method')
+      def __call__(self=None, x=None, y=None, z=None):
+          pass
+  
+  
+  @expect('D419: Docstring is empty')
+  def function():
+|     """ """
+|> Docstring is empty
+      def ok_since_nested():
+          pass
+  
+      @expect('D419: Docstring is empty')
+      def nested():
+|         ''
+|> Docstring is empty
+  
+  
+  def function_with_nesting():
+      """Foo bar documentation."""
+      @overload
+      def nested_overloaded_func(a: int) -> str:
+          ...
+  
+      @overload
+      def nested_overloaded_func(a: str) -> str:
+          """Foo bar documentation."""
+          ...
+  
+      def nested_overloaded_func(a):
+          """Foo bar documentation."""
+          return str(a)
+  
+  
+  expect('nested_overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @overload
+  def overloaded_func(a: int) -> str:
+      ...
+  
+  
+  @overload
+  def overloaded_func(a: str) -> str:
+      """Foo bar documentation."""
+      ...
+  
+  
+  def overloaded_func(a):
+      """Foo bar documentation."""
+      return str(a)
+  
+  
+  expect('overloaded_func',
+         "D418: Function/ Method decorated with @overload"
+         " shouldn't contain a docstring")
+  
+  
+  @expect('D200: One-line docstring should fit on one line with quotes '
+          '(found 3)')
+  @expect('D212: Multi-line docstring summary should start at the first line')
+  def asdlkfasd():
+      """
+      Wrong.
+      """
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  def leading_space():
+  
+      """Leading space."""
+  
+  
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_space():
+      """Leading space."""
+  
+      pass
+  
+  
+  @expect('D201: No blank lines allowed before function docstring (found 1)')
+  @expect('D202: No blank lines allowed after function docstring (found 1)')
+  def trailing_and_leading_space():
+  
+      """Trailing and leading space."""
+  
+      pass
+  
+  
+  expect('LeadingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  
+  
+  class LeadingSpaceMissing:
+      """Leading space missing."""
+  
+  
+  expect('WithLeadingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class WithLeadingSpace:
+  
+      """With leading space."""
+  
+  
+  expect('TrailingSpace',
+         'D204: 1 blank line required after class docstring (found 0)')
+  expect('TrailingSpace',
+         'D211: No blank lines allowed before class docstring (found 1)')
+  
+  
+  class TrailingSpace:
+  
+      """TrailingSpace."""
+      pass
+  
+  
+  expect('LeadingAndTrailingSpaceMissing',
+         'D203: 1 blank line required before class docstring (found 0)')
+  expect('LeadingAndTrailingSpaceMissing',
+         'D204: 1 blank line required after class docstring (found 0)')
+  
+  
+  class LeadingAndTrailingSpaceMissing:
+      """Leading and trailing space missing."""
+      pass
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 0)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_zero_separating_blanks():
+      """Summary.
+      Description.
+  
+      """
+  
+  
+  @expect('D205: 1 blank line required between summary line and description '
+          '(found 2)')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_two_separating_blanks():
+      """Summary.
+  
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multi_line_one_separating_blanks():
+      """Summary.
+  
+      Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdf():
+      """Summary.
+  
+  Description.
+  
+      """
+  
+  
+  @expect('D207: Docstring is under-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdsdfsdffsdf():
+      """Summary.
+  
+      Description.
+  
+  """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdf24():
+      """Summary.
+  
+         Description.
+  
+      """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdsdfsdf24():
+      """Summary.
+  
+      Description.
+  
+          """
+  
+  
+  @expect('D208: Docstring is over-indented')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfsdfsdsdsdfsdf24():
+      """Summary.
+  
+          Description.
+  
+      """
+  
+  
+  @expect('D209: Multi-line docstring closing quotes should be on a separate '
+          'line')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def asdfljdf24():
+      """Summary.
+  
+      Description."""
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def endswith():
+      """Whitespace at the end. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  def around():
+      """ Whitespace at everywhere. """
+  
+  
+  @expect('D210: No whitespaces allowed surrounding docstring text')
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def multiline():
+      """ Whitespace at the beginning.
+  
+      This is the end.
+      """
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw():
+      r'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'\'\'-quotes)')
+  def triple_single_quotes_raw_uppercase():
+      R'''Summary.'''
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw():
+      r'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  def single_quotes_raw_uppercase():
+      R'Summary.'
+  
+  
+  @expect('D300: Use """triple double quotes""" (found \'-quotes)')
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def single_quotes_raw_uppercase_backslash():
+      R'Sum\mary.'
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash():
+      """Sum\\mary."""
+  
+  
+  @expect('D301: Use r""" if any backslashes in a docstring')
+  def double_quotes_backslash_uppercase():
+      R"""Sum\\mary."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def exceptions_of_D301():
+      """Exclude some backslashes from D301.
+  
+      In particular, line continuations \
+      and unicode literals \u0394 and \N{GREEK CAPITAL LETTER DELTA}.
+      They are considered to be intentionally unescaped.
+      """
+  
+  
+  @expect("D400: First line should end with a period (not 'y')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'y')")
+  def lwnlkjl():
+      """Summary"""
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Return', not 'Returns')")
+  def liouiwnlkjl():
+      """Returns foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245():
+      """Constructor for a foo."""
+  
+  
+  @expect("D401: First line should be in imperative mood; try rephrasing "
+          "(found 'Constructor')")
+  def sdgfsdg23245777():
+      """Constructor."""
+  
+  
+  @expect('D402: First line should not be the function\'s "signature"')
+  def foobar():
+      """Signature: foobar()."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def new_209():
+      """First line.
+  
+      More lines.
+      """
+      pass
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def old_209():
+      """One liner.
+  
+      Multi-line comments. OK to have extra blank line
+  
+      """
+  
+  
+  @expect("D103: Missing docstring in public function")
+  def oneliner_d102(): return
+  
+  
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_withdoc(): """One liner"""
+  
+  
+  def ignored_decorator(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  def decorator_for_test(func):   # noqa: D400,D401,D415
+      """Runs something"""
+      func()
+      pass
+  
+  
+  @ignored_decorator
+  def oneliner_ignored_decorator(): """One liner"""
+  
+  
+  @decorator_for_test
+  @expect("D400: First line should end with a period (not 'r')")
+  @expect("D415: First line should end with a period, question mark,"
+          " or exclamation point (not 'r')")
+  def oneliner_with_decorator_expecting_errors(): """One liner"""
+  
+  
+  @decorator_for_test
+  def valid_oneliner_with_decorator(): """One liner."""
+  
+  
+  @expect("D207: Docstring is under-indented")
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def docstring_start_in_same_line(): """First Line.
+  
+      Second Line
+      """
+  
+  
+  def function_with_lambda_arg(x=lambda y: y):
+      """Wrap the given lambda."""
+  
+  
+  @expect('D213: Multi-line docstring summary should start at the second line')
+  def a_following_valid_function(x=None):
+      """Check for a bug where the previous function caused an assertion.
+  
+      The assertion was caused in the next function, so this one is necessary.
+  
+      """
+  
+  
+  def outer_function():
+      """Do something."""
+      def inner_function():
+          """Do inner something."""
+          return 0
+  
+  
+  @expect("D400: First line should end with a period (not 'g')")
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def docstring_bad():
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_all():  # noqa
+      """Runs something"""
+      pass
+  
+  
+  def docstring_bad_ignore_one():  # noqa: D400,D401,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect("D401: First line should be in imperative mood "
+          "(perhaps 'Run', not 'Runs')")
+  def docstring_ignore_some_violations_but_catch_D401():  # noqa: E501,D400,D415
+      """Runs something"""
+      pass
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initiate', not 'Initiates')"
+  )
+  def docstring_initiates():
+      """Initiates the process."""
+  
+  
+  @expect(
+      "D401: First line should be in imperative mood "
+      "(perhaps 'Initialize', not 'Initializes')"
+  )
+  def docstring_initializes():
+      """Initializes the process."""
+  
+  
+  @wraps(docstring_bad_ignore_one)
+  def bad_decorated_function():
+      """Bad (E501) but decorated"""
+      pass
+  
+  
+  def valid_google_string():  # noqa: D400
+      """Test a valid something!"""
+  
+  
+  @expect("D415: First line should end with a period, question mark, "
+          "or exclamation point (not 'g')")
+  def bad_google_string():  # noqa: D400
+      """Test a valid something"""
+  
+  
+  # This is reproducing a bug where AttributeError is raised when parsing class
+  # parameters as functions for Google / Numpy conventions.
+  class Blah:  # noqa: D203,D213
+      """A Blah.
+  
+      Parameters
+      ----------
+      x : int
+  
+      """
+  
+      def __init__(self, x):
+          pass
+  
+  
+  expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+         'D100: Missing docstring in public module')
+

--- a/src/snapshots/ruff__linter__tests__E402_E402.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E402_E402.py_remarks.snap
@@ -1,0 +1,38 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Top-level docstring."""
+  
+  __all__ = ["y"]
+  __version__: str = "0.1.0"
+  
+  import a
+  
+  try:
+      import b
+  except ImportError:
+      pass
+  else:
+      pass
+  
+  import c
+  
+  if x > 0:
+      import d
+  else:
+      import e
+  
+  y = x + 1
+  
+| import f
+|> Module level import not at top of file
+  
+  
+  def foo() -> None:
+      import e
+  
+  
+  if __name__ == "__main__":
+      import g
+

--- a/src/snapshots/ruff__linter__tests__E501_E501.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E501_E501.py_remarks.snap
@@ -1,0 +1,60 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Lorem ipsum dolor sit amet.
+  
+      https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
+  
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+|> Line too long (123 > 88 characters)
+  """
+  
+  _ = """Lorem ipsum dolor sit amet.
+  
+      https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
+  
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  """  # noqa: E501
+  
+  _ = "---------------------------------------------------------------------------AAAAAAA"
+  _ = "---------------------------------------------------------------------------亜亜亜亜亜亜亜"
+  
+  
+  def caller(string: str) -> None:
+      assert string is not None
+  
+  
+  caller(
+      """
+|     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+|> Line too long (127 > 88 characters)
+      """,
+  )
+  
+  
+  caller(
+      """
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      """,  # noqa: E501
+  )
+  
+  multiple_strings_per_line = {
+      # OK
+      "Lorem ipsum dolor": "sit amet",
+      # E501 Line too long
+|     "Lorem ipsum dolor": "sit amet consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+|> Line too long (132 > 88 characters)
+      # E501 Line too long
+      "Lorem ipsum dolor": """
+| sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+|> Line too long (105 > 88 characters)
+  """,
+      # OK
+      "Lorem ipsum dolor": "sit amet consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",  # noqa: E501
+      # OK
+      "Lorem ipsum dolor": """
+  sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+  """,  # noqa: E501
+  }
+

--- a/src/snapshots/ruff__linter__tests__E711_E711.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E711_E711.py_remarks.snap
@@ -1,0 +1,63 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E711
+| if res == None:
+|> Comparison to `None` should be `cond is None`
+      pass
+  #: E711
+| if res != None:
+|> Comparison to `None` should be `cond is not None`
+      pass
+  #: E711
+| if None == res:
+|> Comparison to `None` should be `cond is None`
+      pass
+  #: E711
+| if None != res:
+|> Comparison to `None` should be `cond is not None`
+      pass
+  #: E711
+| if res[1] == None:
+|> Comparison to `None` should be `cond is None`
+      pass
+  #: E711
+| if res[1] != None:
+|> Comparison to `None` should be `cond is not None`
+      pass
+  #: E711
+| if None != res[1]:
+|> Comparison to `None` should be `cond is not None`
+      pass
+  #: E711
+| if None == res[1]:
+|> Comparison to `None` should be `cond is None`
+      pass
+  
+  #: Okay
+  if x not in y:
+      pass
+  
+  if not (X in Y or X is Z):
+      pass
+  
+  if not (X in Y):
+      pass
+  
+  if x is not y:
+      pass
+  
+  if X is not Y is not Z:
+      pass
+  
+  if TrueElement.get_element(True) == TrueElement.get_element(False):
+      pass
+  
+  if (True) == TrueElement or x == TrueElement:
+      pass
+  
+  assert (not foo) in bar
+  assert {"x": not foo} in bar
+  assert [42, not foo] in bar
+

--- a/src/snapshots/ruff__linter__tests__E712_E712.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E712_E712.py_remarks.snap
@@ -1,0 +1,60 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E712
+| if res == True:
+|> Comparison to `True` should be `cond is True`
+      pass
+  #: E712
+| if res != False:
+|> Comparison to `False` should be `cond is not False`
+      pass
+  #: E712
+| if True != res:
+|> Comparison to `True` should be `cond is not True`
+      pass
+  #: E712
+| if False == res:
+|> Comparison to `False` should be `cond is False`
+      pass
+  #: E712
+| if res[1] == True:
+|> Comparison to `True` should be `cond is True`
+      pass
+  #: E712
+| if res[1] != False:
+|> Comparison to `False` should be `cond is not False`
+      pass
+  #: E712
+| var = 1 if cond == True else -1 if cond == False else cond
+|> Comparison to `True` should be `cond is True`
+|> Comparison to `False` should be `cond is False`
+  #: E712
+| if (True) == TrueElement or x == TrueElement:
+|> Comparison to `True` should be `cond is True`
+      pass
+  
+  #: Okay
+  if x not in y:
+      pass
+  
+  if not (X in Y or X is Z):
+      pass
+  
+  if not (X in Y):
+      pass
+  
+  if x is not y:
+      pass
+  
+  if X is not Y is not Z:
+      pass
+  
+  if TrueElement.get_element(True) == TrueElement.get_element(False):
+      pass
+  
+  assert (not foo) in bar
+  assert {"x": not foo} in bar
+  assert [42, not foo] in bar
+

--- a/src/snapshots/ruff__linter__tests__E713_E713.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E713_E713.py_remarks.snap
@@ -1,0 +1,48 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E713
+| if not X in Y:
+|> Test for membership should be `not in`
+      pass
+  #: E713
+| if not X.B in Y:
+|> Test for membership should be `not in`
+      pass
+  #: E713
+| if not X in Y and Z == "zero":
+|> Test for membership should be `not in`
+      pass
+  #: E713
+| if X == "zero" or not Y in Z:
+|> Test for membership should be `not in`
+      pass
+  #: E713
+| if not (X in Y):
+|> Test for membership should be `not in`
+      pass
+  
+  #: Okay
+  if x not in y:
+      pass
+  
+  if not (X in Y or X is Z):
+      pass
+  
+  if x is not y:
+      pass
+  
+  if X is not Y is not Z:
+      pass
+  
+  if TrueElement.get_element(True) == TrueElement.get_element(False):
+      pass
+  
+  if (True) == TrueElement or x == TrueElement:
+      pass
+  
+  assert (not foo) in bar
+  assert {"x": not foo} in bar
+  assert [42, not foo] in bar
+

--- a/src/snapshots/ruff__linter__tests__E714_E714.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E714_E714.py_remarks.snap
@@ -1,0 +1,46 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E714
+| if not X is Y:
+|> Test for object identity should be `is not`
+      pass
+  #: E714
+| if not X.B is Y:
+|> Test for object identity should be `is not`
+      pass
+  #: E714
+| if not X is Y is not Z:
+|> Test for object identity should be `is not`
+      pass
+  
+  #: Okay
+  if not X is not Y:
+      pass
+  
+  if x not in y:
+      pass
+  
+  if not (X in Y or X is Z):
+      pass
+  
+  if not (X in Y):
+      pass
+  
+  if x is not y:
+      pass
+  
+  if X is not Y is not Z:
+      pass
+  
+  if TrueElement.get_element(True) == TrueElement.get_element(False):
+      pass
+  
+  if (True) == TrueElement or x == TrueElement:
+      pass
+  
+  assert (not foo) in bar
+  assert {"x": not foo} in bar
+  assert [42, not foo] in bar
+

--- a/src/snapshots/ruff__linter__tests__E721_E721.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E721_E721.py_remarks.snap
@@ -1,0 +1,75 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E721
+| if type(res) == type(42):
+|> Do not compare types, use `isinstance()`
+      pass
+  #: E721
+| if type(res) != type(""):
+|> Do not compare types, use `isinstance()`
+      pass
+  #: E721
+  import types
+  
+| if res == types.IntType:
+|> Do not compare types, use `isinstance()`
+      pass
+  #: E721
+  import types
+  
+| if type(res) is not types.ListType:
+|> Do not compare types, use `isinstance()`
+      pass
+  #: E721
+| assert type(res) == type(False) or type(res) == type(None)
+|> Do not compare types, use `isinstance()`
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) == type([])
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) == type(())
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) == type((0,))
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) == type((0))
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) != type((1,))
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) is type((1,))
+|> Do not compare types, use `isinstance()`
+  #: E721
+| assert type(res) is not type((1,))
+|> Do not compare types, use `isinstance()`
+  #: E211 E721
+| assert type(res) == type(
+|     [
+|         2,
+|     ]
+| )
+|> Do not compare types, use `isinstance()`
+  #: E201 E201 E202 E721
+| assert type(res) == type(())
+|> Do not compare types, use `isinstance()`
+  #: E201 E202 E721
+| assert type(res) == type((0,))
+|> Do not compare types, use `isinstance()`
+  
+  #: Okay
+  import types
+  
+  if isinstance(res, int):
+      pass
+  if isinstance(res, str):
+      pass
+  if isinstance(res, types.MethodType):
+      pass
+  if type(a) != type(b) or type(a) == type(ccc):
+      pass
+

--- a/src/snapshots/ruff__linter__tests__E722_E722.py.snap
+++ b/src/snapshots/ruff__linter__tests__E722_E722.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 6
+    column: 7
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 11
     column: 0
   end_location:
-    row: 14
-    column: 0
+    row: 13
+    column: 7
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 16
     column: 0
   end_location:
-    row: 19
-    column: 0
+    row: 18
+    column: 7
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E722_E722.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E722_E722.py_remarks.snap
@@ -1,0 +1,41 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E722
+  try:
+      pass
+| except:
+|     pass
+| #: E722
+| try:
+|> Do not use bare `except`
+      pass
+  except Exception:
+      pass
+| except:
+|     pass
+| #: E722
+| try:
+|> Do not use bare `except`
+      pass
+| except:
+|     pass
+| #: Okay
+| fake_code = """"
+|> Do not use bare `except`
+  try:
+      do_something()
+  except:
+      pass
+  """
+  try:
+      pass
+  except Exception:
+      pass
+  #: Okay
+  from . import compute_type
+  
+  if compute_type(foo) == 5:
+      pass
+

--- a/src/snapshots/ruff__linter__tests__E722_E722.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E722_E722.py_remarks.snap
@@ -8,22 +8,22 @@ expression: output.finish().to_string()
 | except:
 |     pass
 | #: E722
-| try:
 |> Do not use bare `except`
+  try:
       pass
   except Exception:
       pass
 | except:
 |     pass
 | #: E722
-| try:
 |> Do not use bare `except`
+  try:
       pass
 | except:
 |     pass
 | #: Okay
-| fake_code = """"
 |> Do not use bare `except`
+  fake_code = """"
   try:
       do_something()
   except:

--- a/src/snapshots/ruff__linter__tests__E731_E731.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E731_E731.py_remarks.snap
@@ -1,0 +1,31 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: E731
+| f = lambda x: 2 * x
+|> Do not assign a lambda expression, use a def
+  #: E731
+| f = lambda x: 2 * x
+|> Do not assign a lambda expression, use a def
+  #: E731
+  while False:
+|     this = lambda y, z: 2 * x
+|> Do not assign a lambda expression, use a def
+  
+  
+  f = object()
+  #: E731
+| f.method = lambda: "Method"
+|> Do not assign a lambda expression, use a def
+  
+  f = {}
+  #: E731
+| f["a"] = lambda x: x ** 2
+|> Do not assign a lambda expression, use a def
+  
+  f = []
+  f.append(lambda x: x ** 2)
+  
+  lambda: "no-op"
+

--- a/src/snapshots/ruff__linter__tests__E741_E741.py.snap
+++ b/src/snapshots/ruff__linter__tests__E741_E741.py.snap
@@ -215,8 +215,8 @@ expression: checks
     row: 71
     column: 0
   end_location:
-    row: 74
-    column: 0
+    row: 72
+    column: 4
   fix: ~
 - kind:
     AmbiguousVariableName: l

--- a/src/snapshots/ruff__linter__tests__E741_E741.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E741_E741.py_remarks.snap
@@ -1,0 +1,105 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from contextlib import contextmanager
+  
+| l = 0
+|> Ambiguous variable name: `l`
+| I = 0
+|> Ambiguous variable name: `I`
+| O = 0
+|> Ambiguous variable name: `O`
+| l: int = 0
+|> Ambiguous variable name: `l`
+  
+| a, l = 0, 1
+|> Ambiguous variable name: `l`
+| [a, l] = 0, 1
+|> Ambiguous variable name: `l`
+| a, *l = 0, 1, 2
+|> Ambiguous variable name: `l`
+| a = l = 0
+|> Ambiguous variable name: `l`
+  
+  o = 0
+  i = 0
+  
+| for l in range(3):
+|> Ambiguous variable name: `l`
+      pass
+  
+  
+| for a, l in zip(range(3), range(3)):
+|> Ambiguous variable name: `l`
+      pass
+  
+  
+  def f1():
+|     global l
+|> Ambiguous variable name: `l`
+|     l = 0
+|> Ambiguous variable name: `l`
+  
+  
+  def f2():
+|     l = 0
+|> Ambiguous variable name: `l`
+  
+      def f3():
+|         nonlocal l
+|> Ambiguous variable name: `l`
+|         l = 1
+|> Ambiguous variable name: `l`
+  
+      f3()
+      return l
+  
+  
+| def f4(l, /, I):
+|> Ambiguous variable name: `l`
+|> Ambiguous variable name: `I`
+      return l, I, O
+  
+  
+| def f5(l=0, *, I=1):
+|> Ambiguous variable name: `l`
+|> Ambiguous variable name: `I`
+      return l, I
+  
+  
+| def f6(*l, **I):
+|> Ambiguous variable name: `l`
+|> Ambiguous variable name: `I`
+      return l, I
+  
+  
+  @contextmanager
+  def ctx1():
+      yield 0
+  
+  
+| with ctx1() as l:
+|> Ambiguous variable name: `l`
+      pass
+  
+  
+  @contextmanager
+  def ctx2():
+      yield 0, 1
+  
+  
+| with ctx2() as (a, l):
+|> Ambiguous variable name: `l`
+      pass
+  
+  try:
+      pass
+| except ValueError as l:
+|     pass
+| 
+| if (l := 5) > 0:
+|> Ambiguous variable name: `l`
+|> Ambiguous variable name: `l`
+      pass
+

--- a/src/snapshots/ruff__linter__tests__E741_E741.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E741_E741.py_remarks.snap
@@ -97,9 +97,9 @@ expression: output.finish().to_string()
       pass
 | except ValueError as l:
 |     pass
-| 
-| if (l := 5) > 0:
 |> Ambiguous variable name: `l`
+  
+| if (l := 5) > 0:
 |> Ambiguous variable name: `l`
       pass
 

--- a/src/snapshots/ruff__linter__tests__E742_E742.py.snap
+++ b/src/snapshots/ruff__linter__tests__E742_E742.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 4
   fix: ~
 - kind:
     AmbiguousClassName: I
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 4
   fix: ~
 - kind:
     AmbiguousClassName: O
@@ -26,7 +26,7 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 10
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E742_E742.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E742_E742.py_remarks.snap
@@ -1,0 +1,22 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| class l:
+|     pass
+| 
+| 
+| class I:
+|> Ambiguous class name: `l`
+|     pass
+| 
+| 
+| class O:
+|> Ambiguous class name: `I`
+|     pass
+| 
+| 
+| class X:
+|> Ambiguous class name: `O`
+      pass
+

--- a/src/snapshots/ruff__linter__tests__E742_E742.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E742_E742.py_remarks.snap
@@ -4,19 +4,19 @@ expression: output.finish().to_string()
 ---
 | class l:
 |     pass
-| 
-| 
-| class I:
 |> Ambiguous class name: `l`
+  
+  
+| class I:
 |     pass
-| 
-| 
-| class O:
 |> Ambiguous class name: `I`
+  
+  
+| class O:
 |     pass
-| 
-| 
-| class X:
 |> Ambiguous class name: `O`
+  
+  
+  class X:
       pass
 

--- a/src/snapshots/ruff__linter__tests__E743_E743.py.snap
+++ b/src/snapshots/ruff__linter__tests__E743_E743.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 4
   fix: ~
 - kind:
     AmbiguousFunctionName: I
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 4
   fix: ~
 - kind:
     AmbiguousFunctionName: O
@@ -26,7 +26,7 @@ expression: checks
     row: 10
     column: 4
   end_location:
-    row: 14
-    column: 0
+    row: 11
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E743_E743.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E743_E743.py_remarks.snap
@@ -1,0 +1,23 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| def l():
+|     pass
+| 
+| 
+| def I():
+|> Ambiguous function name: `l`
+|     pass
+| 
+| 
+| class X:
+|> Ambiguous function name: `I`
+|     def O(self):
+|         pass
+| 
+| 
+| def x():
+|> Ambiguous function name: `O`
+      pass
+

--- a/src/snapshots/ruff__linter__tests__E743_E743.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E743_E743.py_remarks.snap
@@ -4,20 +4,20 @@ expression: output.finish().to_string()
 ---
 | def l():
 |     pass
-| 
-| 
-| def I():
 |> Ambiguous function name: `l`
+  
+  
+| def I():
 |     pass
-| 
-| 
-| class X:
 |> Ambiguous function name: `I`
+  
+  
+  class X:
 |     def O(self):
 |         pass
-| 
-| 
-| def x():
 |> Ambiguous function name: `O`
+  
+  
+  def x():
       pass
 

--- a/src/snapshots/ruff__linter__tests__E999_E999.py.snap
+++ b/src/snapshots/ruff__linter__tests__E999_E999.py.snap
@@ -8,7 +8,7 @@ expression: checks
     row: 2
     column: 0
   end_location:
-    row: 2
-    column: 0
+    row: 1
+    column: 8
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__E999_E999.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E999_E999.py_remarks.snap
@@ -1,0 +1,8 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def x():
+| 
+|> SyntaxError: Got unexpected EOF
+

--- a/src/snapshots/ruff__linter__tests__E999_E999.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__E999_E999.py_remarks.snap
@@ -3,6 +3,6 @@ source: src/linter.rs
 expression: output.finish().to_string()
 ---
   def x():
-| 
 |> SyntaxError: Got unexpected EOF
+  
 

--- a/src/snapshots/ruff__linter__tests__F401_F401_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_0.py_remarks.snap
@@ -1,0 +1,100 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from __future__ import all_feature_names
+| import functools, os
+|> `functools` imported but unused
+  from datetime import datetime
+| from collections import (
+|     Counter,
+|     OrderedDict,
+|     namedtuple,
+| )
+|> `collections.OrderedDict` imported but unused
+  import multiprocessing.pool
+  import multiprocessing.process
+  import logging.config
+| import logging.handlers
+|> `logging.handlers` imported but unused
+  from typing import (
+      TYPE_CHECKING,
+      NamedTuple,
+      Dict,
+      Type,
+      TypeVar,
+      List,
+      Set,
+      Union,
+      cast,
+  )
+  from dataclasses import MISSING, field
+  
+  from blah import ClassA, ClassB, ClassC
+  
+  if TYPE_CHECKING:
+      from models import Fruit, Nut, Vegetable
+  
+  
+  if TYPE_CHECKING:
+|     import shelve
+|> `shelve` imported but unused
+|     import importlib
+|> `importlib` imported but unused
+  
+  if TYPE_CHECKING:
+      """Hello, world!"""
+|     import pathlib
+|> `pathlib` imported but unused
+  
+      z = 1
+  
+  
+  class X:
+      datetime: datetime
+      foo: Type["NamedTuple"]
+  
+      def a(self) -> "namedtuple":
+          x = os.environ["1"]
+          y = Counter()
+          z = multiprocessing.pool.ThreadPool()
+  
+      def b(self) -> None:
+|         import pickle
+|> `pickle` imported but unused
+  
+  
+  __all__ = ["ClassA"] + ["ClassB"]
+  __all__ += ["ClassC"]
+  
+  X = TypeVar("X")
+  Y = TypeVar("Y", bound="Dict")
+  Z = TypeVar("Z", "List", "Set")
+  
+  a = list["Fruit"]
+  b = Union["""Nut""", None]
+  c = cast("Vegetable", b)
+  
+  Field = lambda default=MISSING: field(default=default)
+  
+  
+  # Test: access a sub-importation via an alias.
+  import pyarrow as pa
+  import pyarrow.csv
+  
+  print(pa.csv.read_csv("test.csv"))
+  
+  
+  # Test: referencing an import via TypeAlias.
+  import sys
+  
+  import numpy as np
+  
+  if sys.version_info >= (3, 10):
+      from typing import TypeAlias
+  else:
+      from typing_extensions import TypeAlias
+  
+  
+  CustomInt: TypeAlias = "np.int8 | np.int16"
+

--- a/src/snapshots/ruff__linter__tests__F401_F401_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_1.py_remarks.snap
@@ -1,0 +1,10 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Access a sub-importation via an alias."""
+  import pyarrow as pa
+  import pyarrow.csv
+  
+  print(pa.csv.read_csv("test.csv"))
+

--- a/src/snapshots/ruff__linter__tests__F401_F401_2.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_2.py_remarks.snap
@@ -1,0 +1,17 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: referencing an import via TypeAlias."""
+  import sys
+  
+  import numpy as np
+  
+  if sys.version_info >= (3, 10):
+      from typing import TypeAlias
+  else:
+      from typing_extensions import TypeAlias
+  
+  
+  CustomInt: TypeAlias = "np.int8 | np.int16"
+

--- a/src/snapshots/ruff__linter__tests__F401_F401_3.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_3.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: referencing an import via TypeAlias (with future annotations)."""
+  from __future__ import annotations
+  
+  import sys
+  
+  import numpy as np
+  
+  if sys.version_info >= (3, 10):
+      from typing import TypeAlias
+  else:
+      from typing_extensions import TypeAlias
+  
+  
+  CustomInt: TypeAlias = np.int8 | np.int16
+

--- a/src/snapshots/ruff__linter__tests__F401_F401_4.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_4.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: referencing an import via TypeAlias (with future annotations and quotes)."""
+  from __future__ import annotations
+  
+  import sys
+  
+  import numpy as np
+  
+  if sys.version_info >= (3, 10):
+      from typing import TypeAlias
+  else:
+      from typing_extensions import TypeAlias
+  
+  
+  CustomInt: TypeAlias = "np.int8 | np.int16"
+

--- a/src/snapshots/ruff__linter__tests__F401_F401_5.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_5.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: removal of multi-segment and aliases imports."""
+| from a.b import c
+|> `a.b.c` imported but unused
+| from d.e import f as g
+|> `d.e.f` imported but unused
+| import h.i
+|> `h.i` imported but unused
+| import j.k as l
+|> `j.k` imported but unused
+

--- a/src/snapshots/ruff__linter__tests__F402_F402.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F402_F402.py_remarks.snap
@@ -1,0 +1,16 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import os
+  import os.path as path
+  
+  
+| for os in range(3):
+|> Import `os` from line 1 shadowed by loop variable
+      pass
+  
+| for path in range(3):
+|> Import `path` from line 2 shadowed by loop variable
+      pass
+

--- a/src/snapshots/ruff__linter__tests__F403_F403.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F403_F403.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| from F634 import *
+|> `from F634 import *` used; unable to detect undefined names
+| from F634 import *  # noqa: E501
+|> `from F634 import *` used; unable to detect undefined names
+  
+  from F634 import *  # noqa
+  from F634 import *  # noqa: F403
+  from F634 import *  # noqa: F403, E501
+

--- a/src/snapshots/ruff__linter__tests__F404_F404.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F404_F404.py_remarks.snap
@@ -1,0 +1,12 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Docstring"""
+  from __future__ import absolute_import
+  
+  from collections import namedtuple
+  
+| from __future__ import print_function
+|> `from __future__` imports must occur at the beginning of the file
+

--- a/src/snapshots/ruff__linter__tests__F405_F405.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F405_F405.py_remarks.snap
@@ -1,0 +1,18 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from mymodule import *
+  
+  
+  def print_name():
+|     print(name)
+|> `name` may be undefined, or defined from star imports: `mymodule`
+  
+  
+  def print_name(name):
+      print(name)
+  
+| __all__ = ['a']
+|> `a` may be undefined, or defined from star imports: `mymodule`
+

--- a/src/snapshots/ruff__linter__tests__F406_F406.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F406_F406.py_remarks.snap
@@ -1,0 +1,16 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from F634 import *
+  
+  
+  def f():
+|     from F634 import *
+|> `from F634 import *` only allowed at module level
+  
+  
+  class F:
+|     from F634 import *
+|> `from F634 import *` only allowed at module level
+

--- a/src/snapshots/ruff__linter__tests__F407_F407.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F407_F407.py_remarks.snap
@@ -1,0 +1,8 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from __future__ import print_function
+| from __future__ import non_existent_feature
+|> Future feature `non_existent_feature` is not defined
+

--- a/src/snapshots/ruff__linter__tests__F541_F541.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F541_F541.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  a = "abc"
+  b = f"ghi{'jkl'}"
+  
+| c = f"def"
+|> f-string without any placeholders
+| d = f"def" + "ghi"
+|> f-string without any placeholders
+  e = (
+|     f"def" +
+|> f-string without any placeholders
+      "ghi"
+  )
+  
+  g = f"ghi{123:{45}}"
+

--- a/src/snapshots/ruff__linter__tests__F601_F601.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F601_F601.py_remarks.snap
@@ -1,0 +1,20 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = {
+      "a": 1,
+|     "a": 2,
+|> Dictionary key literal repeated
+      "b": 3,
+      ("a", "b"): 3,
+      ("a", "b"): 4,
+      1.0: 2,
+      1: 0,
+|     1: 3,
+|> Dictionary key literal repeated
+      b"123": 1,
+|     b"123": 4,
+|> Dictionary key literal repeated
+  }
+

--- a/src/snapshots/ruff__linter__tests__F602_F602.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F602_F602.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  a = 1
+  b = 2
+  x = {
+      a: 1,
+|     a: 2,
+|> Dictionary key `a` repeated
+      b: 3,
+  }
+

--- a/src/snapshots/ruff__linter__tests__F622_F622.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F622_F622.py_remarks.snap
@@ -1,0 +1,9 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| *a, *b, c = (1, 2, 3)
+|> Two starred expressions in assignment
+  *a, b, c = (1, 2, 3)
+  a, b, *c = (1, 2, 3)
+

--- a/src/snapshots/ruff__linter__tests__F631_F631.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F631_F631.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| assert (False, "x")
+|> Assert test is a non-empty tuple, which is always `True`
+| assert (False,)
+|> Assert test is a non-empty tuple, which is always `True`
+  assert ()
+  assert True
+

--- a/src/snapshots/ruff__linter__tests__F632_F632.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F632_F632.py_remarks.snap
@@ -1,0 +1,16 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| if x is "abc":
+|> Use `==` and `!=` to compare constant literals
+      pass
+  
+| if 123 is not y:
+|> Use `==` and `!=` to compare constant literals
+      pass
+  
+| if "123" is x < 3:
+|> Use `==` and `!=` to compare constant literals
+      pass
+

--- a/src/snapshots/ruff__linter__tests__F633_F633.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F633_F633.py_remarks.snap
@@ -1,0 +1,10 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from __future__ import print_function
+  import sys
+  
+| print >> sys.stderr, "Hello"
+|> Use of `>>` is invalid with `print` function
+

--- a/src/snapshots/ruff__linter__tests__F634_F634.py.snap
+++ b/src/snapshots/ruff__linter__tests__F634_F634.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 4
-    column: 0
+    row: 2
+    column: 4
   fix: ~
 - kind: IfTuple
   location:

--- a/src/snapshots/ruff__linter__tests__F634_F634.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F634_F634.py_remarks.snap
@@ -4,9 +4,9 @@ expression: output.finish().to_string()
 ---
 | if (1, 2):
 |     pass
-| 
-| for _ in range(5):
 |> If test is a tuple, which is always `True`
+  
+  for _ in range(5):
       if True:
           pass
 |     elif (3, 4):

--- a/src/snapshots/ruff__linter__tests__F634_F634.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F634_F634.py_remarks.snap
@@ -1,0 +1,17 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| if (1, 2):
+|     pass
+| 
+| for _ in range(5):
+|> If test is a tuple, which is always `True`
+      if True:
+          pass
+|     elif (3, 4):
+|         pass
+|     elif ():
+|> If test is a tuple, which is always `True`
+          pass
+

--- a/src/snapshots/ruff__linter__tests__F701_F701.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F701_F701.py_remarks.snap
@@ -1,0 +1,32 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  for i in range(10):
+      break
+  else:
+|     break
+|> `break` outside loop
+  
+  i = 0
+  while i < 10:
+      i += 1
+      break
+  
+  
+  def f():
+      for i in range(10):
+          break
+  
+|     break
+|> `break` outside loop
+  
+  
+  class Foo:
+|     break
+|> `break` outside loop
+  
+  
+| break
+|> `break` outside loop
+

--- a/src/snapshots/ruff__linter__tests__F702_F702.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F702_F702.py_remarks.snap
@@ -1,0 +1,32 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  for i in range(10):
+      continue
+  else:
+|     continue
+|> `continue` not properly in loop
+  
+  i = 0
+  while i < 10:
+      i += 1
+      continue
+  
+  
+  def f():
+      for i in range(10):
+          continue
+  
+|     continue
+|> `continue` not properly in loop
+  
+  
+  class Foo:
+|     continue
+|> `continue` not properly in loop
+  
+  
+| continue
+|> `continue` not properly in loop
+

--- a/src/snapshots/ruff__linter__tests__F704_F704.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F704_F704.py_remarks.snap
@@ -1,0 +1,18 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def f() -> int:
+      yield 1
+  
+  
+  class Foo:
+|     yield 2
+|> `yield` or `yield from` statement outside of a function
+  
+  
+| yield 3
+|> `yield` or `yield from` statement outside of a function
+| yield from 3
+|> `yield` or `yield from` statement outside of a function
+

--- a/src/snapshots/ruff__linter__tests__F706_F706.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F706_F706.py_remarks.snap
@@ -1,0 +1,16 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def f() -> int:
+      return 1
+  
+  
+  class Foo:
+|     return 2
+|> `return` statement outside of a function/method
+  
+  
+| return 3
+|> `return` statement outside of a function/method
+

--- a/src/snapshots/ruff__linter__tests__F707_F707.py.snap
+++ b/src/snapshots/ruff__linter__tests__F707_F707.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 4
+    column: 4
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 10
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 11
+    column: 4
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 19
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 20
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__F707_F707.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F707_F707.py_remarks.snap
@@ -6,16 +6,16 @@ expression: output.finish().to_string()
       pass
 | except:
 |     pass
-| except ValueError:
 |> An `except:` block as not the last exception handler
+  except ValueError:
       pass
   
   try:
       pass
 | except:
 |     pass
-| except ValueError:
 |> An `except:` block as not the last exception handler
+  except ValueError:
       pass
   finally:
       pass
@@ -24,8 +24,8 @@ expression: output.finish().to_string()
       pass
 | except:
 |     pass
-| except ValueError:
 |> An `except:` block as not the last exception handler
+  except ValueError:
       pass
   else:
       pass

--- a/src/snapshots/ruff__linter__tests__F707_F707.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F707_F707.py_remarks.snap
@@ -1,0 +1,54 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  try:
+      pass
+| except:
+|     pass
+| except ValueError:
+|> An `except:` block as not the last exception handler
+      pass
+  
+  try:
+      pass
+| except:
+|     pass
+| except ValueError:
+|> An `except:` block as not the last exception handler
+      pass
+  finally:
+      pass
+  
+  try:
+      pass
+| except:
+|     pass
+| except ValueError:
+|> An `except:` block as not the last exception handler
+      pass
+  else:
+      pass
+  
+  try:
+      pass
+  except:
+      pass
+  
+  try:
+      pass
+  except ValueError:
+      pass
+  except:
+      pass
+  
+  try:
+      pass
+  except ValueError:
+      pass
+  
+  try:
+      pass
+  finally:
+      pass
+

--- a/src/snapshots/ruff__linter__tests__F722_F722.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F722_F722.py_remarks.snap
@@ -1,0 +1,16 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class A:
+      pass
+  
+  
+  def f() -> "A":
+      pass
+  
+  
+| def g() -> "///":
+|> Syntax error in forward annotation: `///`
+      pass
+

--- a/src/snapshots/ruff__linter__tests__F821_F821_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821_0.py_remarks.snap
@@ -1,0 +1,149 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def get_name():
+|     return self.name
+|> Undefined name `self`
+  
+  
+  def get_name():
+|     return (self.name,)
+|> Undefined name `self`
+  
+  
+  def get_name():
+|     del self.name
+|> Undefined name `self`
+  
+  
+  def get_name(self):
+      return self.name
+  
+  
+  x = list()
+  
+  
+  def randdec(maxprec, maxexp):
+|     return numeric_string(maxprec, maxexp)
+|> Undefined name `numeric_string`
+  
+  
+  def ternary_optarg(prec, exp_range, itr):
+      for _ in range(100):
+          a = randdec(prec, 2 * exp_range)
+          b = randdec(prec, 2 * exp_range)
+          c = randdec(prec, 2 * exp_range)
+          yield a, b, c, None
+          yield a, b, c, None, None
+  
+  
+  class Foo:
+      CLASS_VAR = 1
+      REFERENCES_CLASS_VAR = {"CLASS_VAR": CLASS_VAR}
+      ANNOTATED_CLASS_VAR: int = 2
+  
+  
+  from typing import Literal
+  
+  
+  class Class:
+      copy_on_model_validation: Literal["none", "deep", "shallow"]
+      post_init_call: Literal["before_validation", "after_validation"]
+  
+      def __init__(self):
+          Class
+  
+  
+  try:
+      x = 1 / 0
+  except Exception as e:
+      print(e)
+  
+  
+  y: int = 1
+  
+| x: "Bar" = 1
+|> Undefined name `Bar`
+  
+  [first] = ["yup"]
+  
+  
+  from typing import List, TypedDict
+  
+  
+  class Item(TypedDict):
+      nodes: List[TypedDict("Node", {"name": str})]
+  
+  
+  from enum import Enum
+  
+  
+  class Ticket:
+      class Status(Enum):
+          OPEN = "OPEN"
+          CLOSED = "CLOSED"
+  
+      def set_status(self, status: Status):
+          self.status = status
+  
+  
+  def update_tomato():
+|     print(TOMATO)
+|> Undefined name `TOMATO`
+      TOMATO = "cherry tomato"
+  
+  
+| A = f'{B}'
+|> Undefined name `B`
+  A = (
+|     f'B'
+|> Undefined name `B`
+      f'{B}'
+  )
+  
+  
+  from typing import Annotated, Literal
+  
+  
+  def arbitrary_callable() -> None:
+      ...
+  
+  
+  class PEP593Test:
+      field: Annotated[
+          int,
+          "base64",
+          arbitrary_callable(),
+          123,
+          (1, 2, 3),
+      ]
+      field_with_stringified_type: Annotated[
+          "PEP593Test",
+          123,
+      ]
+      field_with_undefined_stringified_type: Annotated[
+|         "PEP593Test123",
+|> Undefined name `PEP593Test123`
+          123,
+      ]
+      field_with_nested_subscript: Annotated[
+          dict[Literal["foo"], str],
+          123,
+      ]
+      field_with_undefined_nested_subscript: Annotated[
+|         dict["foo", "bar"],  # Expected to fail as undefined.
+|> Undefined name `foo`
+|> Undefined name `bar`
+          123,
+      ]
+  
+  
+  def in_ipython_notebook() -> bool:
+      try:
+          # autoimported by notebooks
+          get_ipython()  # type: ignore[name-defined]
+      except NameError:
+          return False  # not in notebook
+      return True
+

--- a/src/snapshots/ruff__linter__tests__F821_F821_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821_1.py_remarks.snap
@@ -1,0 +1,39 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: typing module imports."""
+  from foo import cast
+  
+  # OK
+  x = cast("Model")
+  
+  from typing import cast
+  
+  
+  # F821 Undefined name `Model`
+| x = cast("Model", x)
+|> Undefined name `Model`
+  
+  
+  import typing
+  
+  
+  # F821 Undefined name `Model`
+| x = typing.cast("Model", x)
+|> Undefined name `Model`
+  
+  
+  from typing import Pattern
+  
+  # F821 Undefined name `Model`
+| x = Pattern["Model"]
+|> Undefined name `Model`
+  
+  
+  from typing.re import Match
+  
+  # F821 Undefined name `Model`
+| x = Match["Model"]
+|> Undefined name `Model`
+

--- a/src/snapshots/ruff__linter__tests__F821_F821_2.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821_2.py_remarks.snap
@@ -1,0 +1,24 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test: typing_extensions module imports."""
+  from foo import Literal
+  
+  # F821 Undefined name `Model`
+| x: Literal["Model"]
+|> Undefined name `Model`
+  
+  from typing_extensions import Literal
+  
+  
+  # OK
+  x: Literal["Model"]
+  
+  
+  import typing_extensions
+  
+  
+  # OK
+  x: typing_extensions.Literal["Model"]
+

--- a/src/snapshots/ruff__linter__tests__F821_F821_3.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F821_F821_3.py_remarks.snap
@@ -1,0 +1,21 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  """Test (edge case): accesses of object named `dict`."""
+  
+  # OK
+  dict = {"parameters": {}}
+  dict["parameters"]["userId"] = "userId"
+  dict["parameters"]["itemId"] = "itemId"
+  del dict["parameters"]["itemId"]
+  
+  # F821 Undefined name `key`
+  # F821 Undefined name `value`
+| x: dict["key", "value"]
+|> Undefined name `key`
+|> Undefined name `value`
+  
+  # OK
+  x: dict[str, str]
+

--- a/src/snapshots/ruff__linter__tests__F822_F822.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F822_F822.py_remarks.snap
@@ -1,0 +1,9 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  a = 1
+  
+| __all__ = ["a", "b"]
+|> Undefined name `b` in `__all__`
+

--- a/src/snapshots/ruff__linter__tests__F823_F823.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F823_F823.py_remarks.snap
@@ -1,0 +1,33 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  my_dict = {}
+  my_var = 0
+  
+  
+  def foo():
+|     my_var += 1
+|> Local variable `my_var` referenced before assignment
+  
+  
+  def bar():
+      global my_var
+      my_var += 1
+  
+  
+  def baz():
+      global my_var
+      global my_dict
+      my_dict[my_var] += 1
+  
+  
+  def dec(x):
+      return x
+  
+  
+  @dec
+  def f():
+      dec = 1
+      return dec
+

--- a/src/snapshots/ruff__linter__tests__F831_F831.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F831_F831.py_remarks.snap
@@ -1,0 +1,18 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| def foo(x: int, y: int, x: int) -> None:
+|> Duplicate argument name in function definition
+      pass
+  
+  
+| def bar(x: int, y: int, *, x: int) -> None:
+|> Duplicate argument name in function definition
+      pass
+  
+  
+| def baz(x: int, y: int, **x: int) -> None:
+|> Duplicate argument name in function definition
+      pass
+

--- a/src/snapshots/ruff__linter__tests__F841_F841.py.snap
+++ b/src/snapshots/ruff__linter__tests__F841_F841.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 4
+    column: 4
   fix: ~
 - kind:
     UnusedVariable: z

--- a/src/snapshots/ruff__linter__tests__F841_F841.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F841_F841.py_remarks.snap
@@ -1,0 +1,47 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  try:
+      1 / 0
+| except ValueError as e:
+|     pass
+| 
+| 
+| try:
+|> Local variable `e` is assigned to but never used
+      1 / 0
+  except ValueError as e:
+      print(e)
+  
+  
+  def f1():
+      x = 1
+      y = 2
+|     z = x + y
+|> Local variable `z` is assigned to but never used
+  
+  
+  def f2():
+|     foo = (1, 2)
+|> Local variable `foo` is assigned to but never used
+|     (a, b) = (1, 2)
+|> Local variable `a` is assigned to but never used
+|> Local variable `b` is assigned to but never used
+  
+      bar = (1, 2)
+      (c, d) = bar
+  
+      (x, y) = baz = bar
+  
+  
+  def f3():
+      locals()
+      x = 1
+  
+  
+  def f4():
+      _ = 1
+      __ = 1
+      _discarded = 1
+

--- a/src/snapshots/ruff__linter__tests__F841_F841.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F841_F841.py_remarks.snap
@@ -6,10 +6,10 @@ expression: output.finish().to_string()
       1 / 0
 | except ValueError as e:
 |     pass
-| 
-| 
-| try:
 |> Local variable `e` is assigned to but never used
+  
+  
+  try:
       1 / 0
   except ValueError as e:
       print(e)

--- a/src/snapshots/ruff__linter__tests__F901_F901.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__F901_F901.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def f() -> None:
+|     raise NotImplemented()
+|> `raise NotImplemented` should be `raise NotImplementedError`
+  
+  
+  def g() -> None:
+|     raise NotImplemented
+|> `raise NotImplemented` should be `raise NotImplementedError`
+

--- a/src/snapshots/ruff__linter__tests__N801_N801.py.snap
+++ b/src/snapshots/ruff__linter__tests__N801_N801.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 4
   fix: ~
 - kind:
     InvalidClassName: _bad
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 4
   fix: ~
 - kind:
     InvalidClassName: bad_class
@@ -26,8 +26,8 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 10
+    column: 4
   fix: ~
 - kind:
     InvalidClassName: Bad_Class
@@ -35,8 +35,8 @@ expression: checks
     row: 13
     column: 0
   end_location:
-    row: 17
-    column: 0
+    row: 14
+    column: 4
   fix: ~
 - kind:
     InvalidClassName: BAD_CLASS
@@ -44,7 +44,7 @@ expression: checks
     row: 17
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 18
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N801_N801.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N801_N801.py_remarks.snap
@@ -4,30 +4,30 @@ expression: output.finish().to_string()
 ---
 | class bad:
 |     pass
-| 
-| 
-| class _bad:
 |> Class name `bad` should use CapWords convention 
+  
+  
+| class _bad:
 |     pass
-| 
-| 
-| class bad_class:
 |> Class name `_bad` should use CapWords convention 
+  
+  
+| class bad_class:
 |     pass
-| 
-| 
-| class Bad_Class:
 |> Class name `bad_class` should use CapWords convention 
+  
+  
+| class Bad_Class:
 |     pass
-| 
-| 
-| class BAD_CLASS:
 |> Class name `Bad_Class` should use CapWords convention 
+  
+  
+| class BAD_CLASS:
 |     pass
-| 
-| 
-| class Good:
 |> Class name `BAD_CLASS` should use CapWords convention 
+  
+  
+  class Good:
       pass
   
   

--- a/src/snapshots/ruff__linter__tests__N801_N801.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N801_N801.py_remarks.snap
@@ -1,0 +1,44 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| class bad:
+|     pass
+| 
+| 
+| class _bad:
+|> Class name `bad` should use CapWords convention 
+|     pass
+| 
+| 
+| class bad_class:
+|> Class name `_bad` should use CapWords convention 
+|     pass
+| 
+| 
+| class Bad_Class:
+|> Class name `bad_class` should use CapWords convention 
+|     pass
+| 
+| 
+| class BAD_CLASS:
+|> Class name `Bad_Class` should use CapWords convention 
+|     pass
+| 
+| 
+| class Good:
+|> Class name `BAD_CLASS` should use CapWords convention 
+      pass
+  
+  
+  class _Good:
+      pass
+  
+  
+  class GoodClass:
+      pass
+  
+  
+  class GOOD:
+      pass
+

--- a/src/snapshots/ruff__linter__tests__N802_N802.py.snap
+++ b/src/snapshots/ruff__linter__tests__N802_N802.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 8
-    column: 0
+    row: 5
+    column: 4
   fix: ~
 - kind:
     InvalidFunctionName: _Bad
@@ -17,8 +17,8 @@ expression: checks
     row: 8
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 9
+    column: 4
   fix: ~
 - kind:
     InvalidFunctionName: BAD
@@ -26,8 +26,8 @@ expression: checks
     row: 12
     column: 0
   end_location:
-    row: 16
-    column: 0
+    row: 13
+    column: 4
   fix: ~
 - kind:
     InvalidFunctionName: BAD_FUNC
@@ -35,8 +35,8 @@ expression: checks
     row: 16
     column: 0
   end_location:
-    row: 20
-    column: 0
+    row: 17
+    column: 4
   fix: ~
 - kind:
     InvalidFunctionName: testTest
@@ -44,7 +44,7 @@ expression: checks
     row: 40
     column: 4
   end_location:
-    row: 42
-    column: 0
+    row: 41
+    column: 11
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N802_N802.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N802_N802.py_remarks.snap
@@ -1,0 +1,50 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import unittest
+  
+  
+| def Bad():
+|     pass
+| 
+| 
+| def _Bad():
+|> Function name `Bad` should be lowercase
+|     pass
+| 
+| 
+| def BAD():
+|> Function name `_Bad` should be lowercase
+|     pass
+| 
+| 
+| def BAD_FUNC():
+|> Function name `BAD` should be lowercase
+|     pass
+| 
+| 
+| def good():
+|> Function name `BAD_FUNC` should be lowercase
+      pass
+  
+  
+  def _good():
+      pass
+  
+  
+  def good_func():
+      pass
+  
+  
+  def tearDownModule():
+      pass
+  
+  
+  class Test(unittest.TestCase):
+      def tearDown(self):
+          return super().tearDown()
+  
+|     def testTest(self):
+|         assert True
+

--- a/src/snapshots/ruff__linter__tests__N802_N802.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N802_N802.py_remarks.snap
@@ -7,25 +7,25 @@ expression: output.finish().to_string()
   
 | def Bad():
 |     pass
-| 
-| 
-| def _Bad():
 |> Function name `Bad` should be lowercase
+  
+  
+| def _Bad():
 |     pass
-| 
-| 
-| def BAD():
 |> Function name `_Bad` should be lowercase
+  
+  
+| def BAD():
 |     pass
-| 
-| 
-| def BAD_FUNC():
 |> Function name `BAD` should be lowercase
+  
+  
+| def BAD_FUNC():
 |     pass
-| 
-| 
-| def good():
 |> Function name `BAD_FUNC` should be lowercase
+  
+  
+  def good():
       pass
   
   
@@ -47,4 +47,5 @@ expression: output.finish().to_string()
   
 |     def testTest(self):
 |         assert True
+|> Function name `testTest` should be lowercase
 

--- a/src/snapshots/ruff__linter__tests__N803_N803.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N803_N803.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| def func(_, a, A):
+|> Argument name `A` should be lowercase
+      return _, a, A
+  
+  
+  class Class:
+|     def method(self, _, a, A):
+|> Argument name `A` should be lowercase
+          return _, a, A
+

--- a/src/snapshots/ruff__linter__tests__N804_N804.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N804_N804.py_remarks.snap
@@ -1,0 +1,50 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from abc import ABCMeta
+  
+  
+  class Class:
+      def bad_method(this):
+          pass
+  
+      if False:
+  
+          def extra_bad_method(this):
+              pass
+  
+      def good_method(self):
+          pass
+  
+      @classmethod
+      def class_method(cls):
+          pass
+  
+      @staticmethod
+      def static_method(x):
+          return x
+  
+      def __init__(self):
+          ...
+  
+      def __new__(cls, *args, **kwargs):
+          ...
+  
+|     def __init_subclass__(self, default_name, **kwargs):
+|> First argument of a class method should be named `cls`
+          ...
+  
+  
+  class MetaClass(ABCMeta):
+|     def bad_method(self):
+|> First argument of a class method should be named `cls`
+          pass
+  
+      def good_method(cls):
+          pass
+  
+  
+  def func(x):
+      return x
+

--- a/src/snapshots/ruff__linter__tests__N805_N805.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N805_N805.py_remarks.snap
@@ -1,0 +1,50 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from abc import ABCMeta
+  
+  
+  class Class:
+|     def bad_method(this):
+|> First argument of a method should be named `self`
+          pass
+  
+      if False:
+  
+|         def extra_bad_method(this):
+|> First argument of a method should be named `self`
+              pass
+  
+      def good_method(self):
+          pass
+  
+      @classmethod
+      def class_method(cls):
+          pass
+  
+      @staticmethod
+      def static_method(x):
+          return x
+  
+      def __init__(self):
+          ...
+  
+      def __new__(cls, *args, **kwargs):
+          ...
+  
+      def __init_subclass__(self, default_name, **kwargs):
+          ...
+  
+  
+  class MetaClass(ABCMeta):
+      def bad_method(self):
+          pass
+  
+      def good_method(cls):
+          pass
+  
+  
+  def func(x):
+      return x
+

--- a/src/snapshots/ruff__linter__tests__N806_N806.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N806_N806.py_remarks.snap
@@ -1,0 +1,12 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def f():
+      lower = 0
+|     Camel = 0
+|> Variable `Camel` in function should be lowercase
+|     CONSTANT = 0
+|> Variable `CONSTANT` in function should be lowercase
+      _ = 0
+

--- a/src/snapshots/ruff__linter__tests__N807_N807.py.snap
+++ b/src/snapshots/ruff__linter__tests__N807_N807.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N807_N807.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N807_N807.py_remarks.snap
@@ -4,10 +4,10 @@ expression: output.finish().to_string()
 ---
 | def __bad__():
 |     pass
-| 
-| 
-| def __good():
 |> Function name should not start and end with `__`
+  
+  
+  def __good():
       pass
   
   

--- a/src/snapshots/ruff__linter__tests__N807_N807.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N807_N807.py_remarks.snap
@@ -1,0 +1,21 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| def __bad__():
+|     pass
+| 
+| 
+| def __good():
+|> Function name should not start and end with `__`
+      pass
+  
+  
+  def good__():
+      pass
+  
+  
+  class Class:
+      def __good__(self):
+          pass
+

--- a/src/snapshots/ruff__linter__tests__N811_N811.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N811_N811.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import mod.CONST as const
+|> Constant `CONST` imported as non-constant `const`
+| from mod import CONSTANT as constant
+|> Constant `CONSTANT` imported as non-constant `constant`
+| from mod import ANOTHER_CONSTANT as another_constant
+|> Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`
+

--- a/src/snapshots/ruff__linter__tests__N812_N812.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N812_N812.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import modl.lowercase as Lower
+|> Lowercase `lowercase` imported as non-lowercase `Lower`
+| from mod import lowercase as Lowercase
+|> Lowercase `lowercase` imported as non-lowercase `Lowercase`
+| from mod import another_lowercase as AnotherLowercase
+|> Lowercase `another_lowercase` imported as non-lowercase `AnotherLowercase`
+

--- a/src/snapshots/ruff__linter__tests__N813_N813.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N813_N813.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import mod.Camel as camel
+|> Camelcase `Camel` imported as lowercase `camel`
+| from mod import CamelCase as camelcase
+|> Camelcase `CamelCase` imported as lowercase `camelcase`
+| from mod import AnotherCamelCase as another_camelcase
+|> Camelcase `AnotherCamelCase` imported as lowercase `another_camelcase`
+

--- a/src/snapshots/ruff__linter__tests__N814_N814.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N814_N814.py_remarks.snap
@@ -1,0 +1,11 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import mod.Camel as CAMEL
+|> Camelcase `Camel` imported as constant `CAMEL`
+| from mod import CamelCase as CAMELCASE
+|> Camelcase `CamelCase` imported as constant `CAMELCASE`
+| from mod import AnotherCamelCase as ANOTHER_CAMELCASE
+|> Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`
+

--- a/src/snapshots/ruff__linter__tests__N815_N815.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N815_N815.py_remarks.snap
@@ -1,0 +1,14 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class C:
+      lower = 0
+      CONSTANT = 0
+|     mixedCase = 0
+|> Variable `mixedCase` in class scope should not be mixedCase
+|     _mixedCase = 0
+|> Variable `_mixedCase` in class scope should not be mixedCase
+|     mixed_Case = 0
+|> Variable `mixed_Case` in class scope should not be mixedCase
+

--- a/src/snapshots/ruff__linter__tests__N816_N816.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N816_N816.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  lower = 0
+  CONSTANT = 0
+| mixedCase = 0
+|> Variable `mixedCase` in global scope should not be mixedCase
+| _mixedCase = 0
+|> Variable `_mixedCase` in global scope should not be mixedCase
+| mixed_Case = 0
+|> Variable `mixed_Case` in global scope should not be mixedCase
+

--- a/src/snapshots/ruff__linter__tests__N817_N817.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N817_N817.py_remarks.snap
@@ -1,0 +1,9 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| import mod.CaMel as CM
+|> Camelcase `CaMel` imported as acronym `CM`
+| from mod import CamelCase as CC
+|> Camelcase `CamelCase` imported as acronym `CC`
+

--- a/src/snapshots/ruff__linter__tests__N818_N818.py.snap
+++ b/src/snapshots/ruff__linter__tests__N818_N818.py.snap
@@ -8,7 +8,7 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 11
-    column: 0
+    row: 10
+    column: 4
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N818_N818.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N818_N818.py_remarks.snap
@@ -1,0 +1,15 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class Error(Exception):
+      pass
+  
+  
+  class AnotherError(Exception):
+      pass
+  
+  
+| class C(Exception):
+|     pass
+

--- a/src/snapshots/ruff__linter__tests__N818_N818.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__N818_N818.py_remarks.snap
@@ -12,4 +12,5 @@ expression: output.finish().to_string()
   
 | class C(Exception):
 |     pass
+|> Exception name `C` should be named with an Error suffix
 

--- a/src/snapshots/ruff__linter__tests__RUF001_RUF001.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__RUF001_RUF001.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| x = "𝐁ad string"
+|> String contains ambiguous unicode character '𝐁' (did you mean 'B'?)
+  
+  
+  def f():
+      """Here's a docstring with an unusual parenthesis: ）"""
+      # And here's a comment with an unusual punctuation mark: ᜵
+      ...
+

--- a/src/snapshots/ruff__linter__tests__RUF002_RUF002.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__RUF002_RUF002.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = "𝐁ad string"
+  
+  
+  def f():
+|     """Here's a docstring with an unusual parenthesis: ）"""
+|> Docstring contains ambiguous unicode character '）' (did you mean ')'?)
+      # And here's a comment with an unusual punctuation mark: ᜵
+      ...
+

--- a/src/snapshots/ruff__linter__tests__RUF003_RUF003.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__RUF003_RUF003.py_remarks.snap
@@ -1,0 +1,13 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  x = "𝐁ad string"
+  
+  
+  def f():
+      """Here's a docstring with an unusual parenthesis: ）"""
+|     # And here's a comment with an unusual punctuation mark: ᜵
+|> Comment contains ambiguous unicode character '᜵' (did you mean '/'?)
+      ...
+

--- a/src/snapshots/ruff__linter__tests__T201_T201.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__T201_T201.py_remarks.snap
@@ -1,0 +1,7 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| print("Hello, world!")  # T201
+|> `print` found
+

--- a/src/snapshots/ruff__linter__tests__T203_T203.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__T203_T203.py_remarks.snap
@@ -1,0 +1,17 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from pprint import pprint
+  
+| pprint("Hello, world!")  # T203
+|> `pprint` found
+  
+  
+  import pprint
+  
+| pprint.pprint("Hello, world!")  # T203
+|> `pprint` found
+  
+  pprint.pformat("Hello, world!")
+

--- a/src/snapshots/ruff__linter__tests__U001_U001.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U001_U001.py_remarks.snap
@@ -1,0 +1,20 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class A:
+|     __metaclass__ = type
+|> `__metaclass__ = type` is implied
+  
+  
+  class B:
+|     __metaclass__ = type
+|> `__metaclass__ = type` is implied
+  
+      def __init__(self) -> None:
+          pass
+  
+  
+  class C(metaclass=type):
+      pass
+

--- a/src/snapshots/ruff__linter__tests__U002_U002.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U002_U002.py_remarks.snap
@@ -1,0 +1,23 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from os.path import abspath
+  
+| x = abspath(__file__)
+|> `abspath(__file__)` is unnecessary in Python 3.9 and later
+  
+  
+  import os
+  
+  
+| y = os.path.abspath(__file__)
+|> `abspath(__file__)` is unnecessary in Python 3.9 and later
+  
+  
+  from os import path
+  
+  
+| z = path.abspath(__file__)
+|> `abspath(__file__)` is unnecessary in Python 3.9 and later
+

--- a/src/snapshots/ruff__linter__tests__U003_U003.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U003_U003.py_remarks.snap
@@ -1,0 +1,15 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| type('')
+|> Use `str` instead of `type(...)`
+| type(b'')
+|> Use `bytes` instead of `type(...)`
+| type(0)
+|> Use `int` instead of `type(...)`
+| type(0.)
+|> Use `float` instead of `type(...)`
+| type(0j)
+|> Use `complex` instead of `type(...)`
+

--- a/src/snapshots/ruff__linter__tests__U004_U004.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U004_U004.py_remarks.snap
@@ -1,0 +1,166 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class A:
+      ...
+  
+  
+| class A(object):
+|> Class `A` inherits from object
+      ...
+  
+  
+  class A(
+|     object,
+|> Class `A` inherits from object
+  ):
+      ...
+  
+  
+  class A(
+|     object,
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object,
+|> Class `A` inherits from object
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object
+|> Class `A` inherits from object
+  ):
+      ...
+  
+  
+  class A(
+|     object
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object,
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object,
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+  class A(
+      #
+|     object
+|> Class `A` inherits from object
+      #
+  ):
+      ...
+  
+  
+| class B(A, object):
+|> Class `B` inherits from object
+      ...
+  
+  
+| class B(object, A):
+|> Class `B` inherits from object
+      ...
+  
+  
+  class B(
+|     object,
+|> Class `B` inherits from object
+      A,
+  ):
+      ...
+  
+  
+  class B(
+      A,
+|     object,
+|> Class `B` inherits from object
+  ):
+      ...
+  
+  
+  class B(
+|     object,
+|> Class `B` inherits from object
+      # Comment on A.
+      A,
+  ):
+      ...
+  
+  
+  class B(
+      # Comment on A.
+      A,
+|     object,
+|> Class `B` inherits from object
+  ):
+      ...
+  
+  
+  def f():
+|     class A(object):
+|> Class `A` inherits from object
+          ...
+  
+  
+  class A(
+|     object,
+|> Class `A` inherits from object
+  ):
+      ...
+  
+  
+  class A(
+|     object,  # )
+|> Class `A` inherits from object
+  ):
+      ...
+  
+  
+  class A(
+|     object  # )
+|> Class `A` inherits from object
+      ,
+  ):
+      ...
+  
+  
+  object = A
+  
+  
+  class B(object):
+      ...
+

--- a/src/snapshots/ruff__linter__tests__U005_U005.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U005_U005.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import unittest
+  
+  
+  class Suite(unittest.TestCase):
+      def test(self) -> None:
+|         self.assertEquals (1, 2)
+|> `assertEquals` is deprecated, use `assertEqual` instead
+|         self.assertEquals(1, 2)
+|> `assertEquals` is deprecated, use `assertEqual` instead
+          self.assertEqual(3, 4)
+|         self.failUnlessAlmostEqual(1, 1.1)
+|> `failUnlessAlmostEqual` is deprecated, use `assertAlmostEqual` instead
+|         self.assertNotRegexpMatches("a", "b")
+|> `assertNotRegexpMatches` is deprecated, use `assertNotRegex` instead
+

--- a/src/snapshots/ruff__linter__tests__U006_U006.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U006_U006.py_remarks.snap
@@ -1,0 +1,19 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from typing import List
+  
+  
+| def f(x: List[str]) -> None:
+|> Use `list` instead of `List` for type annotations
+      ...
+  
+  
+  import typing
+  
+  
+| def f(x: typing.List[str]) -> None:
+|> Use `list` instead of `List` for type annotations
+      ...
+

--- a/src/snapshots/ruff__linter__tests__U007_U007.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U007_U007.py_remarks.snap
@@ -1,0 +1,53 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  from typing import Optional
+  
+  
+| def f(x: Optional[str]) -> None:
+|> Use `X | Y` for type annotations
+      ...
+  
+  
+  import typing
+  
+  
+| def f(x: typing.Optional[str]) -> None:
+|> Use `X | Y` for type annotations
+      ...
+  
+  
+  from typing import Union
+  
+  
+| def f(x: Union[str, int, Union[float, bytes]]) -> None:
+|> Use `X | Y` for type annotations
+|> Use `X | Y` for type annotations
+      ...
+  
+  
+  import typing
+  
+  
+| def f(x: typing.Union[str, int]) -> None:
+|> Use `X | Y` for type annotations
+      ...
+  
+  
+  from typing import Union
+  
+  
+| def f(x: "Union[str, int, Union[float, bytes]]") -> None:
+|> Use `X | Y` for type annotations
+|> Use `X | Y` for type annotations
+      ...
+  
+  
+  import typing
+  
+  
+| def f(x: "typing.Union[str, int]") -> None:
+|> Use `X | Y` for type annotations
+      ...
+

--- a/src/snapshots/ruff__linter__tests__U008_U008.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U008_U008.py_remarks.snap
@@ -1,0 +1,75 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  class Parent:
+      def method(self):
+          pass
+  
+      def wrong(self):
+          pass
+  
+  
+  class Child(Parent):
+      def method(self):
+          parent = super()  # ok
+          super().method()  # ok
+          Parent.method(self)  # ok
+          Parent.super(1, 2)  # ok
+  
+      def wrong(self):
+|         parent = super(Child, self)  # wrong
+|> Use `super()` instead of `super(__class__, self)`
+|         super(Child, self).method  # wrong
+|> Use `super()` instead of `super(__class__, self)`
+|         super(
+|             Child,
+|             self,
+|         ).method()  # wrong
+|> Use `super()` instead of `super(__class__, self)`
+  
+  
+  class BaseClass:
+      def f(self):
+          print("f")
+  
+  
+  def defined_outside(self):
+      super(MyClass, self).f()  # CANNOT use super()
+  
+  
+  class MyClass(BaseClass):
+      def normal(self):
+|         super(MyClass, self).f()  # can use super()
+|> Use `super()` instead of `super(__class__, self)`
+          super().f()
+  
+      def different_argument(self, other):
+          super(MyClass, other).f()  # CANNOT use super()
+  
+      def comprehension_scope(self):
+          [super(MyClass, self).f() for x in [1]]  # CANNOT use super()
+  
+      def inner_functions(self):
+          def outer_argument():
+              super(MyClass, self).f()  # CANNOT use super()
+  
+          def inner_argument(self):
+|             super(MyClass, self).f()  # can use super()
+|> Use `super()` instead of `super(__class__, self)`
+              super().f()
+  
+          outer_argument()
+          inner_argument(self)
+  
+      def inner_class(self):
+          class InnerClass:
+              super(MyClass, self).f()  # CANNOT use super()
+  
+              def method(inner_self):
+                  super(MyClass, self).f()  # CANNOT use super()
+  
+          InnerClass().method()
+  
+      defined_outside = defined_outside
+

--- a/src/snapshots/ruff__linter__tests__U009_U009_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U009_U009_0.py_remarks.snap
@@ -1,0 +1,9 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| # coding=utf8
+|> utf-8 encoding declaration is unnecessary
+  
+  print('Hello world')
+

--- a/src/snapshots/ruff__linter__tests__U009_U009_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U009_U009_1.py_remarks.snap
@@ -1,0 +1,10 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #!/usr/bin/python
+| # -*- coding: utf-8 -*-
+|> utf-8 encoding declaration is unnecessary
+  
+  print('Hello world')
+

--- a/src/snapshots/ruff__linter__tests__U009_U009_2.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U009_U009_2.py_remarks.snap
@@ -1,0 +1,10 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #!/usr/bin/python
+  # A coding comment is only valid in the first two lines, so this one is not checked.
+  # -*- coding: utf-8 -*-
+  
+  print('Hello world')
+

--- a/src/snapshots/ruff__linter__tests__U009_U009_3.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U009_U009_3.py_remarks.snap
@@ -1,0 +1,9 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #!/usr/bin/python
+  # -*- coding: something-else -*-
+  
+  print('Hello world')
+

--- a/src/snapshots/ruff__linter__tests__U010_U010.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U010_U010.py_remarks.snap
@@ -1,0 +1,15 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+| from __future__ import annotations, nested_scopes, generators
+|> Unnessary __future__ import `nested_scopes` for target Python version
+|> Unnessary __future__ import `generators` for target Python version
+  
+| from __future__ import absolute_import, division
+|> Unnessary __future__ import `absolute_import` for target Python version
+|> Unnessary __future__ import `division` for target Python version
+  
+| from __future__ import generator_stop
+|> Unnessary __future__ import `generator_stop` for target Python version
+

--- a/src/snapshots/ruff__linter__tests__U011_U011_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U011_U011_0.py_remarks.snap
@@ -1,0 +1,118 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import functools
+  from functools import lru_cache
+  
+  
+| @lru_cache()
+|> Unnessary parameters to functools.lru_cache
+  def fixme1():
+      pass
+  
+  
+  @other_deco_after
+| @functools.lru_cache()
+|> Unnessary parameters to functools.lru_cache
+  def fixme2():
+      pass
+  
+  
+| @lru_cache(maxsize=None)
+|> Unnessary parameters to functools.lru_cache
+  def fixme3():
+      pass
+  
+  
+| @functools.lru_cache(maxsize=None)
+|> Unnessary parameters to functools.lru_cache
+  @other_deco_before
+  def fixme4():
+      pass
+  
+  
+| @lru_cache( # A 
+| ) # B
+|> Unnessary parameters to functools.lru_cache
+  def fixme5():
+      pass
+  
+  
+| @lru_cache(
+|     # A
+| )   # B
+|> Unnessary parameters to functools.lru_cache
+  def fixme6():
+      pass
+  
+  
+| @functools.lru_cache(
+|     # A
+|     maxsize = None) # B
+|> Unnessary parameters to functools.lru_cache
+  def fixme7():
+      pass
+  
+  
+| @functools.lru_cache(
+|     # A1
+|     maxsize = None
+|     # A2
+| ) # B
+|> Unnessary parameters to functools.lru_cache
+  def fixme8():
+      pass
+  
+  
+| @functools.lru_cache(
+|     # A1
+|     maxsize = 
+|     None
+|     # A2
+| 
+| )
+|> Unnessary parameters to functools.lru_cache
+  def fixme9():
+      pass
+  
+  
+| @functools.lru_cache(
+|     # A1
+|     maxsize = 
+|     None
+|     # A2
+| )
+|> Unnessary parameters to functools.lru_cache
+  def fixme10():
+      pass
+  
+  
+  @lru_cache
+  def correct1():
+      pass
+  
+  
+  @functools.lru_cache
+  def correct2():
+      pass
+  
+  
+  @functoools.lru_cache(maxsize=64)
+  def correct3():
+      pass
+  
+  
+  def user_func():
+      pass
+  
+  
+  @lru_cache(user_func)
+  def correct4():
+      pass
+  
+  
+  @lru_cache(user_func, maxsize=None)
+  def correct5():
+      pass
+

--- a/src/snapshots/ruff__linter__tests__U011_U011_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__U011_U011_1.py_remarks.snap
@@ -1,0 +1,20 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  import functools
+  
+  
+  def lru_cache(maxsize=None):
+      pass
+  
+  
+  @lru_cache()
+  def dont_fixme():
+      pass
+  
+  
+  @lru_cache(maxsize=None)
+  def dont_fixme():
+      pass
+

--- a/src/snapshots/ruff__linter__tests__W292_W292_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__W292_W292_0.py_remarks.snap
@@ -1,0 +1,8 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def fn() -> None:
+|     pass
+|> No newline at end of file
+

--- a/src/snapshots/ruff__linter__tests__W292_W292_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__W292_W292_1.py_remarks.snap
@@ -1,0 +1,7 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def fn() -> None:
+      pass  # noqa: W292
+

--- a/src/snapshots/ruff__linter__tests__W292_W292_2.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__W292_W292_2.py_remarks.snap
@@ -1,0 +1,7 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  def fn() -> None:
+      pass
+

--- a/src/snapshots/ruff__linter__tests__W605_W605_0.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__W605_W605_0.py_remarks.snap
@@ -1,0 +1,44 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: W605:1:10
+| regex = '\.png$'
+|> Invalid escape sequence: '\.'
+  
+  #: W605:2:1
+  regex = '''
+| \.png$
+|> Invalid escape sequence: '\.'
+  '''
+  
+  #: W605:2:6
+  f(
+|     '\_'
+|> Invalid escape sequence: '\_'
+  )
+  
+  #: W605:4:6
+  """
+  multi-line
+  literal
+| with \_ somewhere
+|> Invalid escape sequence: '\_'
+  in the middle
+  """
+  
+  #: Okay
+  regex = r'\.png$'
+  regex = '\\.png$'
+  regex = r'''
+  \.png$
+  '''
+  regex = r'''
+  \\.png$
+  '''
+  s = '\\'
+  regex = '\w'  # noqa
+  regex = '''
+  \w
+  '''  # noqa
+

--- a/src/snapshots/ruff__linter__tests__W605_W605_1.py_remarks.snap
+++ b/src/snapshots/ruff__linter__tests__W605_W605_1.py_remarks.snap
@@ -1,0 +1,44 @@
+---
+source: src/linter.rs
+expression: output.finish().to_string()
+---
+  #: W605:1:10
+| regex = '\.png$'
+|> Invalid escape sequence: '\.'
+  
+  #: W605:2:1
+  regex = '''
+| \.png$
+|> Invalid escape sequence: '\.'
+  '''
+  
+  #: W605:2:6
+  f(
+|     '\_'
+|> Invalid escape sequence: '\_'
+  )
+  
+  #: W605:4:6
+  """
+  multi-line
+  literal
+| with \_ somewhere
+|> Invalid escape sequence: '\_'
+  in the middle
+  """
+  
+  #: Okay
+  regex = r'\.png$'
+  regex = '\\.png$'
+  regex = r'''
+  \.png$
+  '''
+  regex = r'''
+  \\.png$
+  '''
+  s = '\\'
+  regex = '\w'  # noqa
+  regex = '''
+  \w
+  '''  # noqa
+

--- a/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
+++ b/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 4
+    column: 4
   fix: ~
 - kind:
     UnusedVariable: foo

--- a/src/source_code_locator.rs
+++ b/src/source_code_locator.rs
@@ -25,6 +25,11 @@ impl<'a> SourceCodeLocator<'a> {
         self.rope.get_or_init(|| Rope::from_str(self.contents))
     }
 
+    pub fn get_source_code_at_line(&self, line_idx: usize) -> Cow<'_, str> {
+        let rope = self.get_or_init_rope();
+        Cow::from(rope.line(line_idx - 1))
+    }
+
     pub fn slice_source_code_at(&self, location: &Location) -> Cow<'_, str> {
         let rope = self.get_or_init_rope();
         let offset = rope.line_to_char(location.row() - 1) + location.column();


### PR DESCRIPTION
This is a massive diff because I'm introducing new snapshots. The first and third commit are the relevant ones. To motivate this a bit:

When developing new lints or checking existing lints, I did one of these two things:

* manually "translated" the location from the yaml snapshot and check against the test fixture
* run cargo against the test fixtures

I also noticed that some test fixtures have inline comments/decorators to clarify what is expected.

---

What I'm doing here is to add a new snapshot (to potentially replace the existing one eventually) that inlines the checks into the source code, similar to what we'd expect with https://github.com/charliermarsh/ruff/issues/525 (which I've been looking into, hence this first step).
Looking at these snapshots it's easier to visually confirm the correct location (currently just row based though).

What I did notice is that in some cases the end location is pretty far off, due to whitespace following it. The third commit is an attempt to narrow down this location to have a closer match.

Example initial snapshot

![carbon](https://user-images.githubusercontent.com/50333/201335542-b6fed52e-cf6b-400d-862e-d66c275a89f4.png)

Example snapshot with narrowed down location

![carbon2](https://user-images.githubusercontent.com/50333/201335537-6f47f535-813b-48da-b92c-ee36459673e9.png)