### PR TITLE
Add ruff.__main__ wrapper to allow invocation as ‘python -m ruff’

### DIFF
--- a/ruff/__main__.py
+++ b/ruff/__main__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+import sysconfig
+
+if __name__ == "__main__":
+    ruff = os.path.join(sysconfig.get_path("scripts"), "ruff")
+    os.spawnv(os.P_WAIT, ruff, [ruff, *sys.argv[1:]])


### PR DESCRIPTION
Fixes #658.