### PR TITLE
Default to isort's import sort logic

### DIFF
--- a/resources/test/fixtures/isort/order_by_type.py
+++ b/resources/test/fixtures/isort/order_by_type.py
@@ -1,0 +1,12 @@
+import StringIO
+import glob
+import os
+import shutil
+import tempfile
+import time
+from subprocess import PIPE, Popen, STDOUT
+from module import Class, CONSTANT, function, BASIC, Apple
+import foo
+import FOO
+import BAR
+import bar

--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -5,7 +5,7 @@ use crate::ast::types::Range;
 use crate::autofix::{fixer, Fix};
 use crate::checks::CheckKind;
 use crate::docstrings::helpers::leading_space;
-use crate::isort::sort_imports;
+use crate::isort::format_imports;
 use crate::{Check, Settings, SourceCodeLocator};
 
 fn extract_range(body: &[&Stmt]) -> Range {
@@ -62,7 +62,7 @@ pub fn check_imports(
     let has_trailing_content = match_trailing_content(&body, locator);
 
     // Generate the sorted import block.
-    let expected = sort_imports(
+    let expected = format_imports(
         body,
         &settings.line_length,
         &settings.src,

--- a/src/isort/snapshots/ruff__isort__tests__order_by_type.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__order_by_type.py.snap
@@ -1,0 +1,22 @@
+---
+source: src/isort/mod.rs
+expression: checks
+---
+- kind: UnsortedImports
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 13
+    column: 0
+  fix:
+    patch:
+      content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, STDOUT, Popen\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import BASIC, CONSTANT, Apple, Class, function\n"
+      location:
+        row: 1
+        column: 0
+      end_location:
+        row: 13
+        column: 0
+    applied: false
+

--- a/src/isort/sorting.rs
+++ b/src/isort/sorting.rs
@@ -1,0 +1,34 @@
+/// See: https://github.com/PyCQA/isort/blob/12cc5fbd67eebf92eb2213b03c07b138ae1fb448/isort/sorting.py#L13
+use crate::python::string;
+
+#[derive(PartialOrd, Ord, PartialEq, Eq)]
+pub enum Prefix {
+    Constants,
+    Classes,
+    Variables,
+}
+
+pub fn module_key(module_name: &str) -> String {
+    module_name.to_lowercase()
+}
+
+pub fn member_key(member_name: &str) -> (Prefix, String) {
+    (
+        if member_name.len() > 1 && string::is_upper(member_name) {
+            // Ex) `CONSTANT`
+            Prefix::Constants
+        } else if member_name
+            .chars()
+            .next()
+            .map(|char| char.is_uppercase())
+            .unwrap_or(false)
+        {
+            // Ex) `Class`
+            Prefix::Classes
+        } else {
+            // Ex) `variable`
+            Prefix::Variables
+        },
+        member_name.to_lowercase(),
+    )
+}

--- a/src/isort/types.rs
+++ b/src/isort/types.rs
@@ -53,3 +53,11 @@ pub struct ImportBlock<'a> {
     // Set of (name, asname).
     pub import: BTreeSet<AliasData<'a>>,
 }
+
+#[derive(Debug, Default)]
+pub struct OrderedImportBlock<'a> {
+    // Map from (module, level) to `AliasData`.
+    pub import_from: Vec<(ImportFromData<'a>, Vec<AliasData<'a>>)>,
+    // Set of (name, asname).
+    pub import: Vec<AliasData<'a>>,
+}

--- a/src/pep8_naming/checks.rs
+++ b/src/pep8_naming/checks.rs
@@ -5,6 +5,7 @@ use crate::checks::{Check, CheckKind};
 use crate::pep8_naming::helpers;
 use crate::pep8_naming::helpers::FunctionType;
 use crate::pep8_naming::settings::Settings;
+use crate::python::string;
 
 /// N801
 pub fn invalid_class_name(class_def: &Stmt, name: &str) -> Option<Check> {
@@ -133,7 +134,7 @@ pub fn constant_imported_as_non_constant(
     name: &str,
     asname: &str,
 ) -> Option<Check> {
-    if helpers::is_upper(name) && !helpers::is_upper(asname) {
+    if string::is_upper(name) && !string::is_upper(asname) {
         return Some(Check::new(
             CheckKind::ConstantImportedAsNonConstant(name.to_string(), asname.to_string()),
             Range::from_located(import_from),
@@ -148,7 +149,7 @@ pub fn lowercase_imported_as_non_lowercase(
     name: &str,
     asname: &str,
 ) -> Option<Check> {
-    if !helpers::is_upper(name) && helpers::is_lower(name) && asname.to_lowercase() != asname {
+    if !string::is_upper(name) && string::is_lower(name) && asname.to_lowercase() != asname {
         return Some(Check::new(
             CheckKind::LowercaseImportedAsNonLowercase(name.to_string(), asname.to_string()),
             Range::from_located(import_from),
@@ -163,7 +164,7 @@ pub fn camelcase_imported_as_lowercase(
     name: &str,
     asname: &str,
 ) -> Option<Check> {
-    if helpers::is_camelcase(name) && helpers::is_lower(asname) {
+    if helpers::is_camelcase(name) && string::is_lower(asname) {
         return Some(Check::new(
             CheckKind::CamelcaseImportedAsLowercase(name.to_string(), asname.to_string()),
             Range::from_located(import_from),
@@ -179,8 +180,8 @@ pub fn camelcase_imported_as_constant(
     asname: &str,
 ) -> Option<Check> {
     if helpers::is_camelcase(name)
-        && !helpers::is_lower(asname)
-        && helpers::is_upper(asname)
+        && !string::is_lower(asname)
+        && string::is_upper(asname)
         && !helpers::is_acronym(name, asname)
     {
         return Some(Check::new(
@@ -230,8 +231,8 @@ pub fn camelcase_imported_as_acronym(
     asname: &str,
 ) -> Option<Check> {
     if helpers::is_camelcase(name)
-        && !helpers::is_lower(asname)
-        && helpers::is_upper(asname)
+        && !string::is_lower(asname)
+        && string::is_upper(asname)
         && helpers::is_acronym(name, asname)
     {
         return Some(Check::new(

--- a/src/pep8_naming/helpers.rs
+++ b/src/pep8_naming/helpers.rs
@@ -4,6 +4,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::helpers::match_name_or_attr;
 use crate::ast::types::{Scope, ScopeKind};
 use crate::pep8_naming::settings::Settings;
+use crate::python::string::{is_lower, is_upper};
 
 const CLASS_METHODS: [&str; 3] = ["__new__", "__init_subclass__", "__class_getitem__"];
 const METACLASS_BASES: [&str; 2] = ["type", "ABCMeta"];
@@ -59,30 +60,6 @@ pub fn function_type(
     }
 }
 
-pub fn is_lower(s: &str) -> bool {
-    let mut cased = false;
-    for c in s.chars() {
-        if c.is_uppercase() {
-            return false;
-        } else if !cased && c.is_lowercase() {
-            cased = true;
-        }
-    }
-    cased
-}
-
-pub fn is_upper(s: &str) -> bool {
-    let mut cased = false;
-    for c in s.chars() {
-        if c.is_lowercase() {
-            return false;
-        } else if !cased && c.is_uppercase() {
-            cased = true;
-        }
-    }
-    cased
-}
-
 pub fn is_camelcase(name: &str) -> bool {
     !is_lower(name) && !is_upper(name) && !name.contains('_')
 }
@@ -103,31 +80,7 @@ pub fn is_acronym(name: &str, asname: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::pep8_naming::helpers::{
-        is_acronym, is_camelcase, is_lower, is_mixed_case, is_upper,
-    };
-
-    #[test]
-    fn test_is_lower() -> () {
-        assert!(is_lower("abc"));
-        assert!(is_lower("a_b_c"));
-        assert!(is_lower("a2c"));
-        assert!(!is_lower("aBc"));
-        assert!(!is_lower("ABC"));
-        assert!(!is_lower(""));
-        assert!(!is_lower("_"));
-    }
-
-    #[test]
-    fn test_is_upper() -> () {
-        assert!(is_upper("ABC"));
-        assert!(is_upper("A_B_C"));
-        assert!(is_upper("A2C"));
-        assert!(!is_upper("aBc"));
-        assert!(!is_upper("abc"));
-        assert!(!is_upper(""));
-        assert!(!is_upper("_"));
-    }
+    use crate::pep8_naming::helpers::{is_acronym, is_camelcase, is_mixed_case};
 
     #[test]
     fn test_is_camelcase() -> () {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,5 +1,6 @@
 pub mod builtins;
 pub mod future;
 pub mod keyword;
+pub mod string;
 pub mod sys;
 pub mod typing;

--- a/src/python/string.rs
+++ b/src/python/string.rs
@@ -1,0 +1,50 @@
+pub fn is_lower(s: &str) -> bool {
+    let mut cased = false;
+    for c in s.chars() {
+        if c.is_uppercase() {
+            return false;
+        } else if !cased && c.is_lowercase() {
+            cased = true;
+        }
+    }
+    cased
+}
+
+pub fn is_upper(s: &str) -> bool {
+    let mut cased = false;
+    for c in s.chars() {
+        if c.is_lowercase() {
+            return false;
+        } else if !cased && c.is_uppercase() {
+            cased = true;
+        }
+    }
+    cased
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::python::string::{is_lower, is_upper};
+
+    #[test]
+    fn test_is_lower() -> () {
+        assert!(is_lower("abc"));
+        assert!(is_lower("a_b_c"));
+        assert!(is_lower("a2c"));
+        assert!(!is_lower("aBc"));
+        assert!(!is_lower("ABC"));
+        assert!(!is_lower(""));
+        assert!(!is_lower("_"));
+    }
+
+    #[test]
+    fn test_is_upper() -> () {
+        assert!(is_upper("ABC"));
+        assert!(is_upper("A_B_C"));
+        assert!(is_upper("A2C"));
+        assert!(!is_upper("aBc"));
+        assert!(!is_upper("abc"));
+        assert!(!is_upper(""));
+        assert!(!is_upper("_"));
+    }
+}


### PR DESCRIPTION
We now resolve to isort's sorting logic -- which is a little complicated, but in short:

- Modules are sorted in a case-insensitive way.
- Module _members_ (the targets in an `import from`) are sorted based on a heuristic that tries to order constants, then classes, then all other variables.

Resolves #673.
