### PR TITLE
Remove static isort classifications for __main__, disutils

### DIFF
--- a/src/isort/categorize.rs
+++ b/src/isort/categorize.rs
@@ -45,9 +45,6 @@ pub fn categorize(
 static STATIC_CLASSIFICATIONS: Lazy<BTreeMap<&'static str, ImportType>> = Lazy::new(|| {
     BTreeMap::from([
         ("__future__", ImportType::Future),
-        ("__main__", ImportType::FirstParty),
-        // Force `disutils` to be considered third-party.
-        ("disutils", ImportType::ThirdParty),
         // Relative imports (e.g., `from . import module`).
         ("", ImportType::FirstParty),
     ])


### PR DESCRIPTION
isort lacks these overrides, and classifies them as third-party by default.

I suspect `disutils` was a typo for `distutils`, which is in the standard library but slated for removal in Python 3.12. However, at least for now, isort classifies it in the standard library.