### PR TITLE
Ignore namedtuple assignment in N806, N815, and N816

### DIFF
--- a/resources/test/fixtures/N806.py
+++ b/resources/test/fixtures/N806.py
@@ -7,5 +7,5 @@ def f():
     Camel = 0
     CONSTANT = 0
     _ = 0
-    MyObj1 = collections.namedtuple("MyObj", ["a", "b"])
-    MyObj2 = namedtuple("AnotherMyObj", ["a", "b"])
+    MyObj1 = collections.namedtuple("MyObj1", ["a", "b"])
+    MyObj2 = namedtuple("MyObj12", ["a", "b"])

--- a/resources/test/fixtures/N806.py
+++ b/resources/test/fixtures/N806.py
@@ -1,5 +1,11 @@
+import collections
+from collections import namedtuple
+
+
 def f():
     lower = 0
     Camel = 0
     CONSTANT = 0
     _ = 0
+    MyObj1 = collections.namedtuple("MyObj", ["a", "b"])
+    MyObj2 = namedtuple("AnotherMyObj", ["a", "b"])

--- a/resources/test/fixtures/N815.py
+++ b/resources/test/fixtures/N815.py
@@ -1,6 +1,12 @@
+import collections
+from collections import namedtuple
+
+
 class C:
     lower = 0
     CONSTANT = 0
     mixedCase = 0
     _mixedCase = 0
     mixed_Case = 0
+    myObj1 = collections.namedtuple("MyObj", ["a", "b"])
+    myObj2 = namedtuple("AnotherMyObj", ["a", "b"])

--- a/resources/test/fixtures/N815.py
+++ b/resources/test/fixtures/N815.py
@@ -8,5 +8,5 @@ class C:
     mixedCase = 0
     _mixedCase = 0
     mixed_Case = 0
-    myObj1 = collections.namedtuple("MyObj", ["a", "b"])
-    myObj2 = namedtuple("AnotherMyObj", ["a", "b"])
+    myObj1 = collections.namedtuple("MyObj1", ["a", "b"])
+    myObj2 = namedtuple("MyObj2", ["a", "b"])

--- a/resources/test/fixtures/N816.py
+++ b/resources/test/fixtures/N816.py
@@ -6,5 +6,5 @@ CONSTANT = 0
 mixedCase = 0
 _mixedCase = 0
 mixed_Case = 0
-myObj1 = collections.namedtuple("MyObj", ["a", "b"])
-myObj2 = namedtuple("AnotherMyObj", ["a", "b"])
+myObj1 = collections.namedtuple("MyObj1", ["a", "b"])
+myObj2 = namedtuple("MyObj2", ["a", "b"])

--- a/resources/test/fixtures/N816.py
+++ b/resources/test/fixtures/N816.py
@@ -1,5 +1,10 @@
+import collections
+from collections import namedtuple
+
 lower = 0
 CONSTANT = 0
 mixedCase = 0
 _mixedCase = 0
 mixed_Case = 0
+myObj1 = collections.namedtuple("MyObj", ["a", "b"])
+myObj2 = namedtuple("AnotherMyObj", ["a", "b"])

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2164,19 +2164,21 @@ impl<'a> Checker<'a> {
 
             if self.settings.enabled.contains(&CheckCode::N806) {
                 if matches!(self.current_scope().kind, ScopeKind::Function(..)) {
-                    pep8_naming::checks::non_lowercase_variable_in_function(self, expr, parent, id)
+                    pep8_naming::plugins::non_lowercase_variable_in_function(self, expr, parent, id)
                 }
             }
 
             if self.settings.enabled.contains(&CheckCode::N815) {
                 if matches!(self.current_scope().kind, ScopeKind::Class(..)) {
-                    pep8_naming::checks::mixed_case_variable_in_class_scope(self, expr, parent, id)
+                    pep8_naming::plugins::mixed_case_variable_in_class_scope(self, expr, parent, id)
                 }
             }
 
             if self.settings.enabled.contains(&CheckCode::N816) {
                 if matches!(self.current_scope().kind, ScopeKind::Module) {
-                    pep8_naming::checks::mixed_case_variable_in_global_scope(self, expr, parent, id)
+                    pep8_naming::plugins::mixed_case_variable_in_global_scope(
+                        self, expr, parent, id,
+                    )
                 }
             }
 

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2163,32 +2163,20 @@ impl<'a> Checker<'a> {
             }
 
             if self.settings.enabled.contains(&CheckCode::N806) {
-                let current =
-                    &self.scopes[*(self.scope_stack.last().expect("No current scope found."))];
-                if let Some(check) =
-                    pep8_naming::checks::non_lowercase_variable_in_function(current, expr, id)
-                {
-                    self.add_check(check);
+                if matches!(self.current_scope().kind, ScopeKind::Function(..)) {
+                    pep8_naming::checks::non_lowercase_variable_in_function(self, expr, parent, id)
                 }
             }
 
             if self.settings.enabled.contains(&CheckCode::N815) {
-                let current =
-                    &self.scopes[*(self.scope_stack.last().expect("No current scope found."))];
-                if let Some(check) =
-                    pep8_naming::checks::mixed_case_variable_in_class_scope(current, expr, id)
-                {
-                    self.add_check(check);
+                if matches!(self.current_scope().kind, ScopeKind::Class(..)) {
+                    pep8_naming::checks::mixed_case_variable_in_class_scope(self, expr, parent, id)
                 }
             }
 
             if self.settings.enabled.contains(&CheckCode::N816) {
-                let current =
-                    &self.scopes[*(self.scope_stack.last().expect("No current scope found."))];
-                if let Some(check) =
-                    pep8_naming::checks::mixed_case_variable_in_global_scope(current, expr, id)
-                {
-                    self.add_check(check);
+                if matches!(self.current_scope().kind, ScopeKind::Module) {
+                    pep8_naming::checks::mixed_case_variable_in_global_scope(self, expr, parent, id)
                 }
             }
 

--- a/src/pep8_naming/checks.rs
+++ b/src/pep8_naming/checks.rs
@@ -1,26 +1,11 @@
-use fnv::{FnvHashMap, FnvHashSet};
-use rustpython_ast::{Arguments, Expr, ExprKind, Stmt, StmtKind};
+use rustpython_ast::{Arguments, Expr, ExprKind, Stmt};
 
-use crate::ast::helpers::{compose_call_path, match_call_path};
 use crate::ast::types::{Range, Scope, ScopeKind};
-use crate::check_ast::Checker;
 use crate::checks::{Check, CheckKind};
 use crate::pep8_naming::helpers;
 use crate::pep8_naming::helpers::FunctionType;
 use crate::pep8_naming::settings::Settings;
 use crate::python::string::{self};
-
-fn is_namedtuple_assignment(
-    stmt: &Stmt,
-    from_imports: &FnvHashMap<&str, FnvHashSet<&str>>,
-) -> bool {
-    if let StmtKind::Assign { value, .. } = &stmt.node {
-        return compose_call_path(value)
-            .map(|call_path| match_call_path(&call_path, "collections.namedtuple", from_imports))
-            .unwrap_or(false);
-    }
-    false
-}
 
 /// N801
 pub fn invalid_class_name(class_def: &Stmt, name: &str) -> Option<Check> {
@@ -115,21 +100,6 @@ pub fn invalid_first_argument_name_for_method(
     None
 }
 
-/// N806
-pub fn non_lowercase_variable_in_function(
-    checker: &mut Checker,
-    expr: &Expr,
-    stmt: &Stmt,
-    name: &str,
-) {
-    if !is_namedtuple_assignment(stmt, &checker.from_imports) && name.to_lowercase() != name {
-        checker.add_check(Check::new(
-            CheckKind::NonLowercaseVariableInFunction(name.to_string()),
-            Range::from_located(expr),
-        ));
-    }
-}
-
 /// N807
 pub fn dunder_function_name(scope: &Scope, stmt: &Stmt, name: &str) -> Option<Check> {
     if matches!(scope.kind, ScopeKind::Class(_)) {
@@ -206,36 +176,6 @@ pub fn camelcase_imported_as_constant(
         ));
     }
     None
-}
-
-/// N815
-pub fn mixed_case_variable_in_class_scope(
-    checker: &mut Checker,
-    expr: &Expr,
-    stmt: &Stmt,
-    name: &str,
-) {
-    if !is_namedtuple_assignment(stmt, &checker.from_imports) && helpers::is_mixed_case(name) {
-        checker.add_check(Check::new(
-            CheckKind::MixedCaseVariableInClassScope(name.to_string()),
-            Range::from_located(expr),
-        ));
-    }
-}
-
-/// N816
-pub fn mixed_case_variable_in_global_scope(
-    checker: &mut Checker,
-    expr: &Expr,
-    stmt: &Stmt,
-    name: &str,
-) {
-    if !is_namedtuple_assignment(stmt, &checker.from_imports) && helpers::is_mixed_case(name) {
-        checker.add_check(Check::new(
-            CheckKind::MixedCaseVariableInGlobalScope(name.to_string()),
-            Range::from_located(expr),
-        ));
-    }
 }
 
 /// N817

--- a/src/pep8_naming/mod.rs
+++ b/src/pep8_naming/mod.rs
@@ -1,3 +1,4 @@
 pub mod checks;
 mod helpers;
+pub mod plugins;
 pub mod settings;

--- a/src/pep8_naming/plugins.rs
+++ b/src/pep8_naming/plugins.rs
@@ -1,0 +1,58 @@
+use rustpython_ast::{Expr, Stmt};
+
+use crate::ast::types::Range;
+use crate::check_ast::Checker;
+use crate::checks::CheckKind;
+use crate::pep8_naming::helpers;
+use crate::Check;
+
+/// N806
+pub fn non_lowercase_variable_in_function(
+    checker: &mut Checker,
+    expr: &Expr,
+    stmt: &Stmt,
+    name: &str,
+) {
+    if name.to_lowercase() != name
+        && !helpers::is_namedtuple_assignment(stmt, &checker.from_imports)
+    {
+        checker.add_check(Check::new(
+            CheckKind::NonLowercaseVariableInFunction(name.to_string()),
+            Range::from_located(expr),
+        ));
+    }
+}
+
+/// N815
+pub fn mixed_case_variable_in_class_scope(
+    checker: &mut Checker,
+    expr: &Expr,
+    stmt: &Stmt,
+    name: &str,
+) {
+    if helpers::is_mixed_case(name)
+        && !helpers::is_namedtuple_assignment(stmt, &checker.from_imports)
+    {
+        checker.add_check(Check::new(
+            CheckKind::MixedCaseVariableInClassScope(name.to_string()),
+            Range::from_located(expr),
+        ));
+    }
+}
+
+/// N816
+pub fn mixed_case_variable_in_global_scope(
+    checker: &mut Checker,
+    expr: &Expr,
+    stmt: &Stmt,
+    name: &str,
+) {
+    if helpers::is_mixed_case(name)
+        && !helpers::is_namedtuple_assignment(stmt, &checker.from_imports)
+    {
+        checker.add_check(Check::new(
+            CheckKind::MixedCaseVariableInGlobalScope(name.to_string()),
+            Range::from_located(expr),
+        ));
+    }
+}

--- a/src/snapshots/ruff__linter__tests__N806_N806.py.snap
+++ b/src/snapshots/ruff__linter__tests__N806_N806.py.snap
@@ -5,19 +5,19 @@ expression: checks
 - kind:
     NonLowercaseVariableInFunction: Camel
   location:
-    row: 3
+    row: 7
     column: 4
   end_location:
-    row: 3
+    row: 7
     column: 9
   fix: ~
 - kind:
     NonLowercaseVariableInFunction: CONSTANT
   location:
-    row: 4
+    row: 8
     column: 4
   end_location:
-    row: 4
+    row: 8
     column: 12
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N815_N815.py.snap
+++ b/src/snapshots/ruff__linter__tests__N815_N815.py.snap
@@ -5,28 +5,28 @@ expression: checks
 - kind:
     MixedCaseVariableInClassScope: mixedCase
   location:
-    row: 4
+    row: 8
     column: 4
   end_location:
-    row: 4
+    row: 8
     column: 13
   fix: ~
 - kind:
     MixedCaseVariableInClassScope: _mixedCase
   location:
-    row: 5
+    row: 9
     column: 4
   end_location:
-    row: 5
+    row: 9
     column: 14
   fix: ~
 - kind:
     MixedCaseVariableInClassScope: mixed_Case
   location:
-    row: 6
+    row: 10
     column: 4
   end_location:
-    row: 6
+    row: 10
     column: 14
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__N816_N816.py.snap
+++ b/src/snapshots/ruff__linter__tests__N816_N816.py.snap
@@ -5,28 +5,28 @@ expression: checks
 - kind:
     MixedCaseVariableInGlobalScope: mixedCase
   location:
-    row: 3
+    row: 6
     column: 0
   end_location:
-    row: 3
+    row: 6
     column: 9
   fix: ~
 - kind:
     MixedCaseVariableInGlobalScope: _mixedCase
   location:
-    row: 4
+    row: 7
     column: 0
   end_location:
-    row: 4
+    row: 7
     column: 10
   fix: ~
 - kind:
     MixedCaseVariableInGlobalScope: mixed_Case
   location:
-    row: 5
+    row: 8
     column: 0
   end_location:
-    row: 5
+    row: 8
     column: 10
   fix: ~
 


### PR DESCRIPTION
`pep8-naming` ignores `namedtuple` assignment in N806, N815, and N816. This PR implements it.

https://github.com/PyCQA/pep8-naming/blob/b3492eeede12a26d35c0ee9e6b9c37a7e5484bf6/src/pep8ext_naming.py#L450