### PR TITLE
Limit PEP 604 checks to Python 3.10+

### DIFF
--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -1059,7 +1059,7 @@ where
             ExprKind::Subscript { value, slice, .. } => {
                 // Ex) typing.List[...]
                 if self.settings.enabled.contains(&CheckCode::U007)
-                    && self.settings.target_version >= PythonVersion::Py39
+                    && self.settings.target_version >= PythonVersion::Py310
                 {
                     pyupgrade::plugins::use_pep604_annotation(self, expr, value, slice);
                 }


### PR DESCRIPTION
Resolves #755.