### PR TITLE
Fix E731

### DIFF
--- a/resources/test/fixtures/E731.py
+++ b/resources/test/fixtures/E731.py
@@ -8,14 +8,12 @@ while False:
 
 
 f = object()
-#: E731
 f.method = lambda: "Method"
 
 f = {}
-#: E731
-f["a"] = lambda x: x ** 2
+f["a"] = lambda x: x**2
 
 f = []
-f.append(lambda x: x ** 2)
+f.append(lambda x: x**2)
 
 lambda: "no-op"

--- a/resources/test/fixtures/E731.py
+++ b/resources/test/fixtures/E731.py
@@ -11,9 +11,11 @@ f = object()
 f.method = lambda: "Method"
 
 f = {}
-f["a"] = lambda x: x**2
+f["a"] = lambda x: x ** 2
 
 f = []
-f.append(lambda x: x**2)
+f.append(lambda x: x ** 2)
+
+f = g = lambda x: x ** 2
 
 lambda: "no-op"

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -895,10 +895,12 @@ where
             }
             StmtKind::Assign { targets, value, .. } => {
                 if self.settings.enabled.contains(&CheckCode::E731) {
-                    if let Some(check) =
-                        pycodestyle::checks::do_not_assign_lambda(value, Range::from_located(stmt))
-                    {
-                        self.add_check(check);
+                    if let [target] = &targets[..] {
+                        if let Some(check) =
+                            pycodestyle::checks::do_not_assign_lambda(target, value, stmt)
+                        {
+                            self.add_check(check);
+                        }
                     }
                 }
                 if self.settings.enabled.contains(&CheckCode::U001) {
@@ -915,13 +917,12 @@ where
                     }
                 }
             }
-            StmtKind::AnnAssign { value, .. } => {
+            StmtKind::AnnAssign { target, value, .. } => {
                 if self.settings.enabled.contains(&CheckCode::E731) {
                     if let Some(value) = value {
-                        if let Some(check) = pycodestyle::checks::do_not_assign_lambda(
-                            value,
-                            Range::from_located(stmt),
-                        ) {
+                        if let Some(check) =
+                            pycodestyle::checks::do_not_assign_lambda(target, value, stmt)
+                        {
                             self.add_check(check);
                         }
                     }

--- a/src/pycodestyle/checks.rs
+++ b/src/pycodestyle/checks.rs
@@ -1,6 +1,6 @@
 use itertools::izip;
 use rustpython_ast::Location;
-use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Unaryop};
+use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Stmt, Unaryop};
 
 use crate::ast::types::Range;
 use crate::checks::{Check, CheckKind, RejectedCmpop};
@@ -47,12 +47,16 @@ pub fn ambiguous_function_name(name: &str, location: Range) -> Option<Check> {
 }
 
 /// E731
-pub fn do_not_assign_lambda(value: &Expr, location: Range) -> Option<Check> {
-    if let ExprKind::Lambda { .. } = &value.node {
-        Some(Check::new(CheckKind::DoNotAssignLambda, location))
-    } else {
-        None
+pub fn do_not_assign_lambda(target: &Expr, value: &Expr, stmt: &Stmt) -> Option<Check> {
+    if let ExprKind::Name { .. } = &target.node {
+        if let ExprKind::Lambda { .. } = &value.node {
+            return Some(Check::new(
+                CheckKind::DoNotAssignLambda,
+                Range::from_located(stmt),
+            ));
+        }
     }
+    None
 }
 
 /// E713, E714

--- a/src/snapshots/ruff__linter__tests__E731_E731.py.snap
+++ b/src/snapshots/ruff__linter__tests__E731_E731.py.snap
@@ -26,20 +26,4 @@ expression: checks
     row: 7
     column: 29
   fix: ~
-- kind: DoNotAssignLambda
-  location:
-    row: 12
-    column: 0
-  end_location:
-    row: 12
-    column: 27
-  fix: ~
-- kind: DoNotAssignLambda
-  location:
-    row: 16
-    column: 0
-  end_location:
-    row: 16
-    column: 25
-  fix: ~
 


### PR DESCRIPTION
E731 should be only emitted when the assignment target is a `Name`.

```python
a = lambda: None  # bad, should be converted to `def a(): return None`.
a.b = lambda: None  # ok
a["b"] = lambda  # ok
```

```bash
# Flake8

> flake8 --select E731 resources/test/fixtures/E731.py
resources/test/fixtures/E731.py:2:1: E731 do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:4:1: E731 do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:7:5: E731 do not assign a lambda expression, use a def

# Current

> cargo run -- --select E731 resources/test/fixtures/E731.py
resources/test/fixtures/E731.py:2:1: E731 Do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:4:1: E731 Do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:7:5: E731 Do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:12:1: E731 Do not assign a lambda expression, use a def  👈
resources/test/fixtures/E731.py:16:1: E731 Do not assign a lambda expression, use a def  👈

# With fix

> cargo run -- --select E731 resources/test/fixtures/E731.py
resources/test/fixtures/E731.py:2:1: E731 Do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:4:1: E731 Do not assign a lambda expression, use a def
resources/test/fixtures/E731.py:7:5: E731 Do not assign a lambda expression, use a def


```