### PR TITLE
docs(integrations): neovim `null-ls` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,9 +647,12 @@ Ruff can also be integrated via [efm](https://github.com/neovim/nvim-lspconfig/b
 in just a [few lines](https://github.com/JafarAbdi/myconfigs/blob/6f0b6b2450e92ec8fc50422928cd22005b919110/efm-langserver/config.yaml#L14-L20).
 
 For neovim users using [`null-ls`](https://github.com/jose-elias-alvarez/null-ls.nvim), this is already [integrated](https://github.com/jose-elias-alvarez/null-ls.nvim).
-<details open>
-<summary>To enable ruff for both diagnostics and using `--fix` as a formatter:</summary>
+
+<details>
+<summary>However, to enable ruff in null-ls for both diagnostics and formatting:</summary>
 <br>
+
+```lua
 local null_ls = require("null-ls")
 local methods = require("null-ls.methods")
 local helpers = require("null-ls.helpers")
@@ -678,6 +681,7 @@ null_ls.setup({
         null_ls.builtins.diagnostics.ruff,
     }
 })
+```
 </details>
 
 ### Language Server Protocol (Unofficial)

--- a/README.md
+++ b/README.md
@@ -646,6 +646,40 @@ for coc.nvim.
 Ruff can also be integrated via [efm](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#efm)
 in just a [few lines](https://github.com/JafarAbdi/myconfigs/blob/6f0b6b2450e92ec8fc50422928cd22005b919110/efm-langserver/config.yaml#L14-L20).
 
+For neovim users using [`null-ls`](https://github.com/jose-elias-alvarez/null-ls.nvim), this is already [integrated](https://github.com/jose-elias-alvarez/null-ls.nvim).
+<details open>
+<summary>To enable ruff for both diagnostics and using `--fix` as a formatter:</summary>
+<br>
+local null_ls = require("null-ls")
+local methods = require("null-ls.methods")
+local helpers = require("null-ls.helpers")
+
+local function ruff_fix()
+    return helpers.make_builtin({
+        name = "ruff",
+        meta = {
+            url = "https://github.com/charliermarsh/ruff/",
+            description = "An extremely fast Python linter, written in Rust.",
+        },
+        method = methods.internal.FORMATTING,
+        filetypes = { "python" },
+        generator_opts = {
+            command = "ruff",
+            args = { "--fix", "-e", "-n", "--stdin-filename", "$FILENAME", "-" },
+            to_stdin = true
+        },
+        factory = helpers.formatter_factory
+    })
+end
+
+null_ls.setup({
+    sources = {
+        ruff_fix(),
+        null_ls.builtins.diagnostics.ruff,
+    }
+})
+</details>
+
 ### Language Server Protocol (Unofficial)
 
 [`ruffd`](https://github.com/Seamooo/ruffd) is a Rust-based language server for Ruff that implements


### PR DESCRIPTION
This PR just adds some documentation on how to integrate `ruff` with `null-ls` which is a handy plugin in `neovim` for integrating diagnostic and formatting tools and expose them as an LSP to neovim.

I had some difficulty making the `--fix` directive work through this as `null-ls` cleanly separates diagnostic from formatting tools but I thought it would be worth documenting a work-around.

Please feel free to close this PR if you think this is out of scope!

Also, blazingly fast is an understatement, keep up the good work :)