### PR TITLE
Trim dedented sections for arg detection

### DIFF
--- a/src/pydocstyle/plugins.rs
+++ b/src/pydocstyle/plugins.rs
@@ -1359,7 +1359,10 @@ static GOOGLE_ARGS_REGEX: Lazy<Regex> =
 
 fn args_section(checker: &mut Checker, definition: &Definition, context: &SectionContext) {
     let mut args_sections: Vec<String> = vec![];
-    for line in textwrap::dedent(&context.following_lines.join("\n")).lines() {
+    for line in textwrap::dedent(&context.following_lines.join("\n"))
+        .trim()
+        .lines()
+    {
         if line
             .chars()
             .next()


### PR DESCRIPTION
I missed a trim that was causing an edge case to fail in argument detection!

Resolves #792.
