### PR TITLE
Add CI filter on rust and python files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "**.py"
+      - "**.rs"
   pull_request:
     branches: [main]
+    paths:
+      - "**.py"
+      - "**.rs"
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
This avoids running the CI for nothing when the files checked (Python and Rust) are unchanged.
Maybe there are more `paths` to add, like `Cargo.toml`.