### PR TITLE
Reduce newlines in code gen

### DIFF
--- a/src/snapshots/ruff__linter__tests__U013_U013.py.snap
+++ b/src/snapshots/ruff__linter__tests__U013_U013.py.snap
@@ -11,7 +11,7 @@ expression: checks
     column: 52
   fix:
     patch:
-      content: "\nclass MyType1(TypedDict):\n    a: int\n    b: str"
+      content: "class MyType1(TypedDict):\n    a: int\n    b: str"
       location:
         row: 4
         column: 0
@@ -28,7 +28,7 @@ expression: checks
     column: 50
   fix:
     patch:
-      content: "\nclass MyType2(TypedDict):\n    a: int\n    b: str"
+      content: "class MyType2(TypedDict):\n    a: int\n    b: str"
       location:
         row: 7
         column: 0
@@ -45,7 +45,7 @@ expression: checks
     column: 44
   fix:
     patch:
-      content: "\nclass MyType3(TypedDict):\n    a: int\n    b: str"
+      content: "class MyType3(TypedDict):\n    a: int\n    b: str"
       location:
         row: 10
         column: 0
@@ -62,7 +62,7 @@ expression: checks
     column: 30
   fix:
     patch:
-      content: "\nclass MyType4(TypedDict):\n    pass"
+      content: "class MyType4(TypedDict):\n    pass"
       location:
         row: 13
         column: 0
@@ -79,7 +79,7 @@ expression: checks
     column: 46
   fix:
     patch:
-      content: "\nclass MyType5(TypedDict):\n    a: 'hello'"
+      content: "class MyType5(TypedDict):\n    a: 'hello'"
       location:
         row: 16
         column: 0
@@ -96,7 +96,7 @@ expression: checks
     column: 41
   fix:
     patch:
-      content: "\nclass MyType6(TypedDict):\n    a: 'hello'"
+      content: "class MyType6(TypedDict):\n    a: 'hello'"
       location:
         row: 17
         column: 0
@@ -113,7 +113,7 @@ expression: checks
     column: 56
   fix:
     patch:
-      content: "\nclass MyType7(TypedDict):\n    a: NotRequired[dict]"
+      content: "class MyType7(TypedDict):\n    a: NotRequired[dict]"
       location:
         row: 20
         column: 0
@@ -130,7 +130,7 @@ expression: checks
     column: 65
   fix:
     patch:
-      content: "\nclass MyType8(TypedDict, total=False):\n    x: int\n    y: int"
+      content: "class MyType8(TypedDict, total=False):\n    x: int\n    y: int"
       location:
         row: 23
         column: 0
@@ -147,7 +147,7 @@ expression: checks
     column: 59
   fix:
     patch:
-      content: "\nclass MyType10(TypedDict):\n    key: Literal['value']"
+      content: "class MyType10(TypedDict):\n    key: Literal['value']"
       location:
         row: 29
         column: 0


### PR DESCRIPTION
Previously, we inserted a newline at the top if you generated "just" a class, because `initial` was being un-set as soon as you tried to add a newline.
