### PR TITLE
Adjust `UnusedNOQA` start location

### DIFF
--- a/resources/test/fixtures/M001.py
+++ b/resources/test/fixtures/M001.py
@@ -18,6 +18,14 @@ def f() -> None:
     # Invalid (and unimplemented)
     d = 1  # noqa: F841, W191
 
+    # fmt: off
+    # Invalid - no space before #
+    d = 1# noqa: E501
+
+    # Invalid - many spaces before #
+    d = 1                       # noqa: E501
+    # fmt: on
+
 
 # Valid
 _ = """Lorem ipsum dolor sit amet.

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -231,12 +231,8 @@ pub fn check_lines(
                                 ));
                             } else {
                                 check.amend(Fix::replacement(
-                                    format!(
-                                        "{}# noqa: {}",
-                                        " ".repeat(spaces),
-                                        valid_codes.join(", ")
-                                    ),
-                                    Location::new(row + 1, start - spaces),
+                                    format!("# noqa: {}", valid_codes.join(", ")),
+                                    Location::new(row + 1, start),
                                     Location::new(row + 1, lines[row].chars().count()),
                                 ));
                             }

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -103,7 +103,7 @@ pub fn check_lines(
                     matches.push(check.kind.code().as_ref());
                     ignored.push(index)
                 }
-                (Directive::Codes(_, _, codes), matches) => {
+                (Directive::Codes(.., codes), matches) => {
                     if codes.contains(&check.kind.code().as_ref()) {
                         matches.push(check.kind.code().as_ref());
                         ignored.push(index);
@@ -133,7 +133,7 @@ pub fn check_lines(
                     (Directive::All(..), matches) => {
                         matches.push(check.kind.code().as_ref());
                     }
-                    (Directive::Codes(_, _, codes), matches) => {
+                    (Directive::Codes(.., codes), matches) => {
                         if codes.contains(&check.kind.code().as_ref()) {
                             matches.push(check.kind.code().as_ref());
                         } else {
@@ -170,7 +170,7 @@ pub fn check_lines(
                 (Directive::All(..), matches) => {
                     matches.push(check.kind.code().as_ref());
                 }
-                (Directive::Codes(_, _, codes), matches) => {
+                (Directive::Codes(.., codes), matches) => {
                     if codes.contains(&check.kind.code().as_ref()) {
                         matches.push(check.kind.code().as_ref());
                     } else {
@@ -186,7 +186,7 @@ pub fn check_lines(
     if enforce_noqa {
         for (row, (directive, matches)) in noqa_directives {
             match directive {
-                Directive::All(start, end) => {
+                Directive::All(spaces, start, end) => {
                     if matches.is_empty() {
                         let mut check = Check::new(
                             CheckKind::UnusedNOQA(None),
@@ -197,14 +197,14 @@ pub fn check_lines(
                         );
                         if autofix.patch() && settings.fixable.contains(check.kind.code()) {
                             check.amend(Fix::deletion(
-                                Location::new(row + 1, start),
+                                Location::new(row + 1, start - spaces),
                                 Location::new(row + 1, lines[row].chars().count()),
                             ));
                         }
                         line_checks.push(check);
                     }
                 }
-                Directive::Codes(start, end, codes) => {
+                Directive::Codes(spaces, start, end, codes) => {
                     let mut invalid_codes = vec![];
                     let mut valid_codes = vec![];
                     for code in codes {
@@ -226,13 +226,17 @@ pub fn check_lines(
                         if autofix.patch() && settings.fixable.contains(check.kind.code()) {
                             if valid_codes.is_empty() {
                                 check.amend(Fix::deletion(
-                                    Location::new(row + 1, start),
+                                    Location::new(row + 1, start - spaces),
                                     Location::new(row + 1, lines[row].chars().count()),
                                 ));
                             } else {
                                 check.amend(Fix::replacement(
-                                    format!("  # noqa: {}", valid_codes.join(", ")),
-                                    Location::new(row + 1, start),
+                                    format!(
+                                        "{}# noqa: {}",
+                                        " ".repeat(spaces),
+                                        valid_codes.join(", ")
+                                    ),
+                                    Location::new(row + 1, start - spaces),
                                     Location::new(row + 1, lines[row].chars().count()),
                                 ));
                             }

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -101,8 +101,8 @@ fn add_noqa_inner(
                     Directive::None => {
                         output.push_str(line);
                     }
-                    Directive::All(_, start, _) => output.push_str(&line[..(start)]),
-                    Directive::Codes(_, start, ..) => output.push_str(&line[..(start)]),
+                    Directive::All(_, start, _) => output.push_str(&line[..start]),
+                    Directive::Codes(_, start, ..) => output.push_str(&line[..start]),
                 };
                 let codes: Vec<&str> = codes.iter().map(|code| code.as_ref()).collect();
                 output.push_str("# noqa: ");

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -10,32 +10,40 @@ use regex::Regex;
 use crate::checks::{Check, CheckCode};
 
 static NO_QA_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"(?P<noqa>\s*(?i:# noqa)(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?)")
-        .expect("Invalid regex")
+    Regex::new(
+        r"(?P<spaces>\s*)(?P<noqa>(?i:# noqa)(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?)",
+    )
+    .expect("Invalid regex")
 });
 static SPLIT_COMMA_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"[,\s]").expect("Invalid regex"));
 
 #[derive(Debug)]
 pub enum Directive<'a> {
     None,
-    All(usize, usize),
-    Codes(usize, usize, Vec<&'a str>),
+    All(usize, usize, usize),
+    Codes(usize, usize, usize, Vec<&'a str>),
 }
 
 pub fn extract_noqa_directive(line: &str) -> Directive {
     match NO_QA_REGEX.captures(line) {
-        Some(caps) => match caps.name("noqa") {
-            Some(noqa) => match caps.name("codes") {
-                Some(codes) => Directive::Codes(
-                    noqa.start(),
-                    noqa.end(),
-                    SPLIT_COMMA_REGEX
-                        .split(codes.as_str())
-                        .map(|code| code.trim())
-                        .filter(|code| !code.is_empty())
-                        .collect(),
-                ),
-                None => Directive::All(noqa.start(), noqa.end()),
+        Some(caps) => match caps.name("spaces") {
+            Some(spaces) => match caps.name("noqa") {
+                Some(noqa) => match caps.name("codes") {
+                    Some(codes) => Directive::Codes(
+                        spaces.as_str().chars().count(),
+                        noqa.start(),
+                        noqa.end(),
+                        SPLIT_COMMA_REGEX
+                            .split(codes.as_str())
+                            .map(|code| code.trim())
+                            .filter(|code| !code.is_empty())
+                            .collect(),
+                    ),
+                    None => {
+                        Directive::All(spaces.as_str().chars().count(), noqa.start(), noqa.end())
+                    }
+                },
+                None => Directive::None,
             },
             None => Directive::None,
         },
@@ -93,11 +101,17 @@ fn add_noqa_inner(
                     Directive::None => {
                         output.push_str(line);
                     }
-                    Directive::All(start, _) => output.push_str(&line[..start]),
-                    Directive::Codes(start, ..) => output.push_str(&line[..start]),
+                    Directive::All(spaces, start, _) => {
+                        output.push_str(&line[..(start - spaces)]);
+                        output.push_str(" ".repeat(spaces).as_str());
+                    }
+                    Directive::Codes(spaces, start, ..) => {
+                        output.push_str(&line[..(start - spaces)]);
+                        output.push_str(" ".repeat(spaces).as_str());
+                    }
                 };
                 let codes: Vec<&str> = codes.iter().map(|code| code.as_ref()).collect();
-                output.push_str("  # noqa: ");
+                output.push_str("# noqa: ");
                 output.push_str(&codes.join(", "));
                 output.push('\n');
                 count += 1;

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -100,12 +100,14 @@ fn add_noqa_inner(
                 match extract_noqa_directive(line) {
                     Directive::None => {
                         output.push_str(line);
+                        output.push_str("  # noqa: ");
                     }
-                    Directive::All(_, start, _) => output.push_str(&line[..start]),
-                    Directive::Codes(_, start, ..) => output.push_str(&line[..start]),
+                    Directive::All(_, start, _) | Directive::Codes(_, start, ..) => {
+                        output.push_str(&line[..start]);
+                        output.push_str("# noqa: ");
+                    }
                 };
                 let codes: Vec<&str> = codes.iter().map(|code| code.as_ref()).collect();
-                output.push_str("# noqa: ");
                 output.push_str(&codes.join(", "));
                 output.push('\n');
                 count += 1;

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -101,14 +101,8 @@ fn add_noqa_inner(
                     Directive::None => {
                         output.push_str(line);
                     }
-                    Directive::All(spaces, start, _) => {
-                        output.push_str(&line[..(start - spaces)]);
-                        output.push_str(" ".repeat(spaces).as_str());
-                    }
-                    Directive::Codes(spaces, start, ..) => {
-                        output.push_str(&line[..(start - spaces)]);
-                        output.push_str(" ".repeat(spaces).as_str());
-                    }
+                    Directive::All(_, start, _) => output.push_str(&line[..(start)]),
+                    Directive::Codes(_, start, ..) => output.push_str(&line[..(start)]),
                 };
                 let codes: Vec<&str> = codes.iter().map(|code| code.as_ref()).collect();
                 output.push_str("# noqa: ");

--- a/src/snapshots/ruff__linter__tests__m001.snap
+++ b/src/snapshots/ruff__linter__tests__m001.snap
@@ -137,10 +137,10 @@ expression: checks
     column: 23
   fix:
     patch:
-      content: "  # noqa: E501"
+      content: "# noqa: E501"
       location:
         row: 52
-        column: 3
+        column: 5
       end_location:
         row: 52
         column: 23

--- a/src/snapshots/ruff__linter__tests__m001.snap
+++ b/src/snapshots/ruff__linter__tests__m001.snap
@@ -6,7 +6,7 @@ expression: checks
     UnusedNOQA: ~
   location:
     row: 9
-    column: 9
+    column: 11
   end_location:
     row: 9
     column: 17
@@ -25,7 +25,7 @@ expression: checks
       - E501
   location:
     row: 13
-    column: 9
+    column: 11
   end_location:
     row: 13
     column: 23
@@ -45,7 +45,7 @@ expression: checks
       - E501
   location:
     row: 16
-    column: 9
+    column: 11
   end_location:
     row: 16
     column: 29
@@ -61,16 +61,17 @@ expression: checks
     applied: false
 - kind:
     UnusedNOQA:
+      - F841
       - W191
   location:
     row: 19
-    column: 9
+    column: 11
   end_location:
     row: 19
     column: 29
   fix:
     patch:
-      content: "  # noqa: F841"
+      content: ""
       location:
         row: 19
         column: 9
@@ -80,58 +81,105 @@ expression: checks
     applied: false
 - kind:
     UnusedNOQA:
+      - E501
+  location:
+    row: 23
+    column: 9
+  end_location:
+    row: 23
+    column: 21
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 23
+        column: 9
+      end_location:
+        row: 23
+        column: 21
+    applied: false
+- kind:
+    UnusedVariable: d
+  location:
+    row: 26
+    column: 4
+  end_location:
+    row: 26
+    column: 5
+  fix: ~
+- kind:
+    UnusedNOQA:
+      - E501
+  location:
+    row: 26
+    column: 32
+  end_location:
+    row: 26
+    column: 44
+  fix:
+    patch:
+      content: ""
+      location:
+        row: 26
+        column: 9
+      end_location:
+        row: 26
+        column: 44
+    applied: false
+- kind:
+    UnusedNOQA:
       - F841
   location:
-    row: 44
-    column: 3
+    row: 52
+    column: 5
   end_location:
-    row: 44
+    row: 52
     column: 23
   fix:
     patch:
       content: "  # noqa: E501"
       location:
-        row: 44
+        row: 52
         column: 3
       end_location:
-        row: 44
+        row: 52
         column: 23
     applied: false
 - kind:
     UnusedNOQA:
       - E501
   location:
-    row: 52
-    column: 3
+    row: 60
+    column: 5
   end_location:
-    row: 52
+    row: 60
     column: 17
   fix:
     patch:
       content: ""
       location:
-        row: 52
+        row: 60
         column: 3
       end_location:
-        row: 52
+        row: 60
         column: 17
     applied: false
 - kind:
     UnusedNOQA: ~
   location:
-    row: 60
-    column: 3
+    row: 68
+    column: 5
   end_location:
-    row: 60
+    row: 68
     column: 11
   fix:
     patch:
       content: ""
       location:
-        row: 60
+        row: 68
         column: 3
       end_location:
-        row: 60
+        row: 68
         column: 11
     applied: false
 


### PR DESCRIPTION
This PR adjusts the start location of `UnusedNOQA` to make it look less confusing.

## Before

<img width="548" alt="image" src="https://user-images.githubusercontent.com/17039389/202848331-f4186673-a180-440a-87e9-3a8dc8ac4e64.png">

It looks like this line contains a single violation but contains two.

## After

<img width="548" alt="image" src="https://user-images.githubusercontent.com/17039389/202848431-fe2b4c8d-8930-449f-ba6f-798ec14941a7.png">

It's clear that this line contains two violations.