### PR TITLE
Mark nonlocal variables as used in parent scopes

### DIFF
--- a/resources/test/fixtures/F841.py
+++ b/resources/test/fixtures/F841.py
@@ -35,3 +35,20 @@ def f4():
     _ = 1
     __ = 1
     _discarded = 1
+
+
+a = 1
+
+
+def f5():
+    global a
+
+    # Used in `f7` via `nonlocal`.
+    b = 1
+
+    def f6():
+        # F841
+        b = 1
+
+    def f7():
+        nonlocal b

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -83,6 +83,7 @@ pub enum BindingKind {
     Binding,
     LoopVar,
     Global,
+    Nonlocal,
     Builtin,
     ClassDefinition,
     Definition,

--- a/src/snapshots/ruff__linter__tests__F841_F841.py.snap
+++ b/src/snapshots/ruff__linter__tests__F841_F841.py.snap
@@ -47,4 +47,13 @@ expression: checks
     row: 21
     column: 9
   fix: ~
+- kind:
+    UnusedVariable: b
+  location:
+    row: 51
+    column: 8
+  end_location:
+    row: 51
+    column: 9
+  fix: ~
 

--- a/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
+++ b/src/snapshots/ruff__linter__tests__f841_dummy_variable_rgx.snap
@@ -65,4 +65,13 @@ expression: checks
     row: 37
     column: 14
   fix: ~
+- kind:
+    UnusedVariable: b
+  location:
+    row: 51
+    column: 8
+  end_location:
+    row: 51
+    column: 9
+  fix: ~
 


### PR DESCRIPTION
In #800, I modified our handling of `StmtKind::Global` to avoid setting a binding in every parent scope. This inadvertently changed the behavior for `StmtKind::Nonlocal` too (I just missed that it was the same pattern branch), causing us to _not_ mark nonlocal variables as used at the defining site in the parent scope.

Resolves #820.
