### PR TITLE
Avoid attempting to fix PEP 604 violations with deferred annotations

### DIFF
--- a/resources/test/fixtures/U006.py
+++ b/resources/test/fixtures/U006.py
@@ -24,3 +24,7 @@ from typing import List as IList
 
 def f(x: IList[str]) -> None:
     ...
+
+
+def f(x: "List[str]") -> None:
+    ...

--- a/resources/test/fixtures/U007.py
+++ b/resources/test/fixtures/U007.py
@@ -1,40 +1,43 @@
+import typing
 from typing import Optional
+from typing import Union
 
 
 def f(x: Optional[str]) -> None:
     ...
 
 
-import typing
-
-
 def f(x: typing.Optional[str]) -> None:
     ...
-
-
-from typing import Union
 
 
 def f(x: Union[str, int, Union[float, bytes]]) -> None:
     ...
 
 
-import typing
-
-
 def f(x: typing.Union[str, int]) -> None:
     ...
 
 
-from typing import Union
+def f(x: typing.Union[(str, int)]) -> None:
+    ...
+
+
+def f(x: typing.Union[(str, int), float]) -> None:
+    ...
 
 
 def f(x: "Union[str, int, Union[float, bytes]]") -> None:
     ...
 
 
-import typing
-
-
 def f(x: "typing.Union[str, int]") -> None:
+    ...
+
+
+def f(x: Union["str", int]) -> None:
+    ...
+
+
+def f(x: Union[("str", "int"), float]) -> None:
     ...

--- a/src/snapshots/ruff__linter__tests__U007_U007.py.snap
+++ b/src/snapshots/ruff__linter__tests__U007_U007.py.snap
@@ -4,138 +4,121 @@ expression: checks
 ---
 - kind: UsePEP604Annotation
   location:
-    row: 4
+    row: 6
     column: 9
   end_location:
-    row: 4
+    row: 6
     column: 22
   fix:
     patch:
       content: str | None
       location:
-        row: 4
+        row: 6
         column: 9
       end_location:
-        row: 4
+        row: 6
         column: 22
     applied: false
 - kind: UsePEP604Annotation
   location:
-    row: 11
+    row: 10
     column: 9
   end_location:
-    row: 11
+    row: 10
     column: 29
   fix:
     patch:
       content: str | None
       location:
-        row: 11
+        row: 10
         column: 9
       end_location:
-        row: 11
+        row: 10
         column: 29
     applied: false
 - kind: UsePEP604Annotation
   location:
-    row: 18
+    row: 14
     column: 9
   end_location:
-    row: 18
+    row: 14
     column: 45
   fix:
     patch:
       content: "str | int | Union[float, bytes]"
       location:
-        row: 18
+        row: 14
         column: 9
       end_location:
-        row: 18
+        row: 14
         column: 45
     applied: false
 - kind: UsePEP604Annotation
   location:
-    row: 18
+    row: 14
     column: 25
   end_location:
-    row: 18
+    row: 14
     column: 44
   fix:
     patch:
       content: float | bytes
       location:
-        row: 18
+        row: 14
         column: 25
       end_location:
-        row: 18
+        row: 14
         column: 44
     applied: false
 - kind: UsePEP604Annotation
   location:
-    row: 25
+    row: 18
     column: 9
   end_location:
-    row: 25
+    row: 18
     column: 31
   fix:
     patch:
       content: str | int
       location:
-        row: 25
+        row: 18
         column: 9
       end_location:
-        row: 25
+        row: 18
         column: 31
     applied: false
 - kind: UsePEP604Annotation
   location:
-    row: 32
+    row: 22
     column: 9
   end_location:
-    row: 32
-    column: 47
-  fix:
-    patch:
-      content: "str | int | Union[float, bytes]"
-      location:
-        row: 32
-        column: 9
-      end_location:
-        row: 32
-        column: 47
-    applied: false
-- kind: UsePEP604Annotation
-  location:
-    row: 32
-    column: 9
-  end_location:
-    row: 32
-    column: 47
-  fix:
-    patch:
-      content: float | bytes
-      location:
-        row: 32
-        column: 9
-      end_location:
-        row: 32
-        column: 47
-    applied: false
-- kind: UsePEP604Annotation
-  location:
-    row: 39
-    column: 9
-  end_location:
-    row: 39
+    row: 22
     column: 33
   fix:
     patch:
       content: str | int
       location:
-        row: 39
+        row: 22
         column: 9
       end_location:
-        row: 39
+        row: 22
         column: 33
+    applied: false
+- kind: UsePEP604Annotation
+  location:
+    row: 26
+    column: 9
+  end_location:
+    row: 26
+    column: 40
+  fix:
+    patch:
+      content: "(str, int) | float"
+      location:
+        row: 26
+        column: 9
+      end_location:
+        row: 26
+        column: 40
     applied: false
 


### PR DESCRIPTION
We now avoid fixing or flagging annotations like `Union["Foo", "Bar"]`. We _also_ avoid fixing or flagging annotations like `"Union[Foo, Bar]"`. These are safer behaviors and also mimic `pyupgrade`.

Resolves #826.