### PR TITLE
Fix clippy::inefficient-to-string (pedantic)

### DIFF
--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2594,7 +2594,7 @@ impl<'a> Checker<'a> {
                 if !scope.import_starred && !self.path.ends_with("__init__.py") {
                     if let Some(all_binding) = all_binding {
                         if let Some(names) = &all_names {
-                            for name in names {
+                            for &name in names {
                                 if !scope.values.contains_key(name) {
                                     checks.push(Check::new(
                                         CheckKind::UndefinedExport(name.to_string()),
@@ -2622,7 +2622,7 @@ impl<'a> Checker<'a> {
                             }
                             from_list.sort();
 
-                            for name in names {
+                            for &name in names {
                                 if !scope.values.contains_key(name) {
                                     checks.push(Check::new(
                                         CheckKind::ImportStarUsage(

--- a/src/pyflakes/checks.rs
+++ b/src/pyflakes/checks.rs
@@ -63,13 +63,13 @@ pub fn unused_variables(scope: &Scope, dummy_variable_rgx: &Regex) -> Vec<Check>
         return checks;
     }
 
-    for (name, binding) in scope.values.iter() {
+    for (&name, binding) in scope.values.iter() {
         if binding.used.is_none()
             && matches!(binding.kind, BindingKind::Assignment)
             && !dummy_variable_rgx.is_match(name)
-            && name != &"__tracebackhide__"
-            && name != &"__traceback_info__"
-            && name != &"__traceback_supplement__"
+            && name != "__tracebackhide__"
+            && name != "__traceback_info__"
+            && name != "__traceback_supplement__"
         {
             checks.push(Check::new(
                 CheckKind::UnusedVariable(name.to_string()),

--- a/src/pyupgrade/plugins/deprecated_unittest_alias.rs
+++ b/src/pyupgrade/plugins/deprecated_unittest_alias.rs
@@ -30,7 +30,7 @@ static DEPRECATED_ALIASES: Lazy<FxHashMap<&'static str, &'static str>> = Lazy::n
 /// U005
 pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
     if let ExprKind::Attribute { value, attr, .. } = &expr.node {
-        if let Some(target) = DEPRECATED_ALIASES.get(attr.as_str()) {
+        if let Some(&target) = DEPRECATED_ALIASES.get(attr.as_str()) {
             if let ExprKind::Name { id, .. } = &value.node {
                 if id == "self" {
                     let mut check = Check::new(

--- a/src/pyupgrade/plugins/use_pep585_annotation.rs
+++ b/src/pyupgrade/plugins/use_pep585_annotation.rs
@@ -7,7 +7,7 @@ use crate::checks::{Check, CheckKind};
 
 /// U006
 pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr, id: &str) {
-    let replacement = checker.import_aliases.get(id).unwrap_or(&id);
+    let replacement = *checker.import_aliases.get(id).unwrap_or(&id);
     let mut check = Check::new(
         CheckKind::UsePEP585Annotation(replacement.to_string()),
         Range::from_located(expr),


### PR DESCRIPTION
“`&str` implements `ToString` through a slower blanket impl, but `str` has a fast specialization of `ToString`”

https://rust-lang.github.io/rust-clippy/master/index.html#inefficient_to_string