### PR TITLE
Fix clippy::sort-unstable (pedantic)

### DIFF
--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -245,7 +245,7 @@ pub fn check_lines(
         }
     }
 
-    ignored.sort();
+    ignored.sort_unstable();
     for index in ignored.iter().rev() {
         checks.swap_remove(*index);
     }


### PR DESCRIPTION
“an unstable sort typically performs faster without any observable difference for this data type”

https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive