### PR TITLE
Ignore clippy::match-same-arms (pedantic) in a few places

### DIFF
--- a/ruff_dev/src/generate_check_code_prefix.rs
+++ b/ruff_dev/src/generate_check_code_prefix.rs
@@ -77,6 +77,7 @@ pub fn main(cli: &Cli) -> Result<()> {
         .arg_ref_self()
         .ret(Type::new("Vec<CheckCode>"))
         .vis("pub")
+        .line("#[allow(clippy::match_same_arms)]")
         .line("match self {");
     for (prefix, codes) in &prefix_to_codes {
         gen = gen.line(format!(
@@ -96,6 +97,7 @@ pub fn main(cli: &Cli) -> Result<()> {
         .arg_ref_self()
         .ret(Type::new("PrefixSpecificity"))
         .vis("pub")
+        .line("#[allow(clippy::match_same_arms)]")
         .line("match self {");
     for prefix in prefix_to_codes.keys() {
         let num_numeric = prefix.chars().filter(|char| char.is_numeric()).count();

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -881,6 +881,7 @@ impl CheckCode {
     }
 
     pub fn category(&self) -> CheckCategory {
+        #[allow(clippy::match_same_arms)]
         match self {
             CheckCode::E402 => CheckCategory::Pycodestyle,
             CheckCode::E501 => CheckCategory::Pycodestyle,

--- a/src/checks_gen.rs
+++ b/src/checks_gen.rs
@@ -337,6 +337,7 @@ pub enum PrefixSpecificity {
 
 impl CheckCodePrefix {
     pub fn codes(&self) -> Vec<CheckCode> {
+        #[allow(clippy::match_same_arms)]
         match self {
             CheckCodePrefix::A => vec![CheckCode::A001, CheckCode::A002, CheckCode::A003],
             CheckCodePrefix::A0 => vec![CheckCode::A001, CheckCode::A002, CheckCode::A003],
@@ -1221,6 +1222,7 @@ impl CheckCodePrefix {
 
 impl CheckCodePrefix {
     pub fn specificity(&self) -> PrefixSpecificity {
+        #[allow(clippy::match_same_arms)]
         match self {
             CheckCodePrefix::A => PrefixSpecificity::Category,
             CheckCodePrefix::A0 => PrefixSpecificity::Hundreds,


### PR DESCRIPTION
“this match arm has an identical body to another arm”

https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms

We probably wouldn’t enable this lint, but ignoring it in these three functions makes `cargo clippy -- -W clippy::pedantic` run much faster.