### PR TITLE
Ignore clippy::unreadable-literal (pedantic) for CONFUSABLES

### DIFF
--- a/src/rules/checks.rs
+++ b/src/rules/checks.rs
@@ -10,6 +10,7 @@ use crate::{Check, Settings};
 
 /// See: https://github.com/microsoft/vscode/blob/095ddabc52b82498ee7f718a34f9dd11d59099a8/src/vs/base/common/strings.ts#L1094
 static CONFUSABLES: Lazy<FxHashMap<u32, u32>> = Lazy::new(|| {
+    #[allow(clippy::unreadable_literal)]
     FxHashMap::from_iter([
         (8232, 32),
         (8233, 32),


### PR DESCRIPTION
“long literal lacking separators”

https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

This occurs 838 times and isn’t worth fixing here.