### PR TITLE
Add `--explain`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use clap::{command, Parser};
 use regex::Regex;
 use rustc_hash::FxHashMap;
 
+use crate::checks::CheckCode;
 use crate::checks_gen::CheckCodePrefix;
 use crate::logging::LogLevel;
 use crate::printer::SerializationFormat;
@@ -113,7 +114,7 @@ pub struct Cli {
     pub stdin_filename: Option<String>,
     /// Explain a rule.
     #[arg(long)]
-    pub explain: Option<String>,
+    pub explain: Option<CheckCode>,
 }
 
 impl Cli {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,9 @@ pub struct Cli {
     /// The name of the file when passing it through stdin.
     #[arg(long)]
     pub stdin_filename: Option<String>,
+    /// Explain a rule.
+    #[arg(long)]
+    pub explain: Option<String>,
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,13 +309,8 @@ fn inner_main() -> Result<ExitCode> {
     }
 
     if let Some(code) = cli.explain {
-        match explain(&code, cli.format) {
-            Ok(()) => return Ok(ExitCode::SUCCESS),
-            Err(error) => {
-                eprintln!("{}", error);
-                return Ok(ExitCode::FAILURE);
-            }
-        }
+        explain(&code, cli.format)?;
+        return Ok(ExitCode::SUCCESS);
     }
 
     if cli.show_settings && cli.show_files {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Explanation<'a> {
     summary: &'a str,
 }
 
-fn explain(code: &CheckCode, format: SerializationFormat) -> Result<ExitCode> {
+fn explain(code: &CheckCode, format: SerializationFormat) -> Result<()> {
     match format {
         SerializationFormat::Text => {
             println!(
@@ -81,8 +81,8 @@ fn explain(code: &CheckCode, format: SerializationFormat) -> Result<ExitCode> {
                 })?
             );
         }
-    }
-    Ok(ExitCode::SUCCESS)
+    };
+    Ok(())
 }
 
 fn show_files(files: &[PathBuf], settings: &Settings) {
@@ -309,7 +309,13 @@ fn inner_main() -> Result<ExitCode> {
     }
 
     if let Some(code) = cli.explain {
-        return explain(&code, cli.format);
+        match explain(&code, cli.format) {
+            Ok(()) => return Ok(ExitCode::SUCCESS),
+            Err(error) => {
+                eprintln!("{}", error);
+                return Ok(ExitCode::FAILURE);
+            }
+        }
     }
 
     if cli.show_settings && cli.show_files {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,36 +62,28 @@ struct Explanation<'a> {
     summary: &'a str,
 }
 
-fn explain(code: &str, format: SerializationFormat) -> Result<ExitCode> {
-    match CheckCode::from_str(&code) {
-        Ok(code) => {
-            match format {
-                SerializationFormat::Text => {
-                    println!(
-                        "{} ({}): {}",
-                        code.as_ref(),
-                        code.category().title(),
-                        code.kind().summary()
-                    );
-                }
-                SerializationFormat::Json => {
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&Explanation {
-                            code: code.as_ref(),
-                            category: &code.category().title(),
-                            summary: &code.kind().summary(),
-                        })?
-                    );
-                }
-            }
-            Ok(ExitCode::SUCCESS)
+fn explain(code: &CheckCode, format: SerializationFormat) -> Result<ExitCode> {
+    match format {
+        SerializationFormat::Text => {
+            println!(
+                "{} ({}): {}",
+                code.as_ref(),
+                code.category().title(),
+                code.kind().summary()
+            );
         }
-        Err(_) => {
-            eprintln!("Unknown code: {}", code);
-            Ok(ExitCode::FAILURE)
+        SerializationFormat::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Explanation {
+                    code: code.as_ref(),
+                    category: &code.category().title(),
+                    summary: &code.kind().summary(),
+                })?
+            );
         }
     }
+    Ok(ExitCode::SUCCESS)
 }
 
 fn show_files(files: &[PathBuf], settings: &Settings) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use std::str::FromStr;
 use std::sync::mpsc::channel;
 use std::time::Instant;
 
@@ -77,7 +76,7 @@ fn explain(code: &CheckCode, format: SerializationFormat) -> Result<ExitCode> {
                 "{}",
                 serde_json::to_string_pretty(&Explanation {
                     code: code.as_ref(),
-                    category: &code.category().title(),
+                    category: code.category().title(),
                     summary: &code.kind().summary(),
                 })?
             );


### PR DESCRIPTION
This PR adds `--explain` for explaining a ruff fule.

Related to https://github.com/charliermarsh/vscode-ruff/pull/26.

```
> cargo run -- --explain C600
error: Invalid value 'C600' for '--explain <EXPLAIN>': Matching variant not found

> cargo run -- --explain C403 .
C403 (flake8-comprehensions): Unnecessary `list` comprehension (rewrite as a `set` comprehension)

> cargo run -- --explain C403 --format json .
{
  "code": "C403",
  "category": "flake8-comprehensions",
  "summary": "Unnecessary `list` comprehension (rewrite as a `set` comprehension)"
}
```