### PR TITLE
Automatically wrap certain simple docstrings

### DIFF
--- a/resources/test/fixtures/E501.py
+++ b/resources/test/fixtures/E501.py
@@ -49,3 +49,8 @@ sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor
 sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 """,  # noqa: E501
 }
+
+
+class Foo:
+    field1: int = 0
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."""

--- a/resources/test/fixtures/E501.py
+++ b/resources/test/fixtures/E501.py
@@ -49,4 +49,3 @@ sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor
 sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 """,  # noqa: E501
 }
-

--- a/resources/test/fixtures/E501.py
+++ b/resources/test/fixtures/E501.py
@@ -50,7 +50,3 @@ sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor
 """,  # noqa: E501
 }
 
-
-class Foo:
-    field1: int = 0
-    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."""


### PR DESCRIPTION
Automatic line length wrapping is a huge can of worms.

This PR starts to address one isolated case where we can automatically solve line length wrapping, namely for some docstrings. Example:

```python
class Account:
    address: str = None
    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."""
```

is automatically corrected to

```python
class Account:
    address: str = None
    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
    eiusmod tempor incididunt ut labore et dolore magna aliqua."""
```

I'm guessing there's more checking that needs to happen (e.g. this might wrap things that we don't want, like reStructuredText values). This PR serves as a starting point.