### PR TITLE
Allow varargs and kwargs to be prefixed with stars

### DIFF
--- a/resources/test/fixtures/canonical_google_examples.py
+++ b/resources/test/fixtures/canonical_google_examples.py
@@ -44,7 +44,7 @@ expectation.expected.add((
 @expect("D407: Missing dashed underline after section ('Returns')",
         arg_count=3)
 @expect("D413: Missing blank line after last section ('Raises')", arg_count=3)
-def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
+def fetch_bigtable_rows(big_table, keys, other_silly_variable=None, **kwargs):
     """Fetches rows from a Bigtable.
 
     Retrieves rows pertaining to the given keys from the Table instance
@@ -57,6 +57,7 @@ def fetch_bigtable_rows(big_table, keys, other_silly_variable=None):
             to fetch.
         other_silly_variable: Another optional variable, that has a much
             longer name than the other args, and which does nothing.
+        **kwargs: More keyword arguments.
 
     Returns:
         A dict mapping keys to the corresponding table row data

--- a/resources/test/fixtures/canonical_numpy_examples.py
+++ b/resources/test/fixtures/canonical_numpy_examples.py
@@ -73,7 +73,7 @@ expectation.expected.add((
         "(found 'A')", arg_count=3)
 @expect("D413: Missing blank line after last section ('Examples')",
         arg_count=3)
-def foo(var1, var2, long_var_name='hi'):
+def foo(var1, var2, long_var_name='hi', **kwargs):
     r"""A one-line summary that does not use variable names.
 
     Several sentences providing an extended description. Refer to
@@ -91,6 +91,8 @@ def foo(var1, var2, long_var_name='hi'):
         detail, e.g. ``(N,) ndarray`` or ``array_like``.
     long_var_name : {'hi', 'ho'}, optional
         Choices in brackets, default first when optional.
+    **kwargs : int
+        More keyword arguments.
 
     Returns
     -------


### PR DESCRIPTION
Resolves #923.

While the specs say you _should_ use `*args` and `**kwargs` to document these, this PR merely accepts both styles.
