### PR TITLE
Add shell completions support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3c9eae0de7bf8e3f904a5e40612b21fb2e2e566456d177809a48b892d24da"
+dependencies = [
+ "clap 4.0.22",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4160b4a4f72ef58bd766bad27c09e6ef1cc9d82a22f6a0f55d152985a4a48e31"
+dependencies = [
+ "clap 4.0.22",
+ "clap_complete",
+ "clap_complete_fig",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b30e010e669cd021e5004f3be26cff6b7c08d2a8a0d65b48d43a8cc0efd6c3"
+dependencies = [
+ "clap 4.0.22",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1816,7 @@ dependencies = [
  "cachedir",
  "chrono",
  "clap 4.0.22",
+ "clap_complete_command",
  "clearscreen",
  "colored",
  "common-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bitflags = { version = "1.3.2" }
 cachedir = { version = "0.3.0" }
 chrono = { version = "0.4.21", default-features = false, features = ["clock"] }
 clap = { version = "4.0.1", features = ["derive"] }
+clap_complete_command = "0.4.0"
 colored = { version = "2.0.0" }
 common-path = { version = "1.0.0" }
 dirs = { version = "4.0.0" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,6 +114,9 @@ pub struct Cli {
     /// Explain a rule.
     #[arg(long)]
     pub explain: Option<CheckCode>,
+    /// Generate shell completion
+    #[arg(long, hide = true, value_name = "SHELL")]
+    pub generate_shell_completion: Option<clap_complete_command::Shell>,
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use ::ruff::settings::{pyproject, Settings};
 use ::ruff::updates;
 use ::ruff::{cache, commands};
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use log::{debug, error};
 use notify::{raw_watcher, RecursiveMode, Watcher};
@@ -258,6 +258,11 @@ fn inner_main() -> Result<ExitCode> {
 
     if let Some(code) = cli.explain {
         commands::explain(&code, cli.format)?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if let Some(shell) = cli.generate_shell_completion {
+        shell.generate(&mut Cli::command(), &mut std::io::stdout());
         return Ok(ExitCode::SUCCESS);
     }
 


### PR DESCRIPTION
Can be used in Homebrew formula to generate shell completions, for example https://github.com/Homebrew/homebrew-core/blob/4c4619c1a5046fe134f761043f52f07f71dd2cab/Formula/maturin.rb#L26

Ideally it should be a subcommand so [`generate_completions_from_executable`](https://rubydoc.brew.sh/Formula#generate_completions_from_executable-instance_method) can be used in formula, otherwise you may need to do it manually like https://github.com/Homebrew/homebrew-core/commit/377a1348a967aa7da8a90e264c92dc159b4b3aed due to `FILES` argument is always required.