### PR TITLE
fix(flake8_boolean_trap): add whitelist for dict methods

### DIFF
--- a/resources/test/fixtures/FBT.py
+++ b/resources/test/fixtures/FBT.py
@@ -38,14 +38,16 @@ def function(
 def used(do):
     return do
 
+
 used("a", True)
 used(do=True)
 
-# avoid FBT003 from explicit whitelist
+
+# Avoid FBT003 for explicitly allowed methods.
 """
 FBT003 Boolean positional value on dict
 """
-a = {"a":"b"}
+a = {"a": "b"}
 a.get("hello", False)
 {}.get("hello", False)
 {}.setdefault("hello", True)
@@ -53,4 +55,3 @@ a.get("hello", False)
 {}.pop(True, False)
 dict.fromkeys(("world",), True)
 {}.deploy(True, False)
-

--- a/resources/test/fixtures/FBT.py
+++ b/resources/test/fixtures/FBT.py
@@ -40,3 +40,17 @@ def used(do):
 
 used("a", True)
 used(do=True)
+
+# avoid FBT003 from explicit whitelist
+"""
+FBT003 Boolean positional value on dict
+"""
+a = {"a":"b"}
+a.get("hello", False)
+{}.get("hello", False)
+{}.setdefault("hello", True)
+{}.pop("hello", False)
+{}.pop(True, False)
+dict.fromkeys(("world",), True)
+{}.deploy(True, False)
+

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -1638,7 +1638,7 @@ where
                 // flake8-boolean-trap
                 if self.settings.enabled.contains(&CheckCode::FBT003) {
                     flake8_boolean_trap::plugins::check_boolean_positional_value_in_function_call(
-                        self, args,
+                        self, args, func,
                     );
                 }
                 if let ExprKind::Name { id, ctx } = &func.node {

--- a/src/flake8_boolean_trap/plugins.rs
+++ b/src/flake8_boolean_trap/plugins.rs
@@ -5,7 +5,18 @@ use crate::ast::types::Range;
 use crate::check_ast::Checker;
 use crate::checks::{Check, CheckKind};
 
-const FUNC_NAME_WHITELIST: &[&str] = &["get", "setdefault", "pop", "fromkeys"];
+const FUNC_NAME_ALLOWLIST: &[&str] = &["get", "setdefault", "pop", "fromkeys"];
+
+/// Returns `true` if an argument is allowed to use a boolean trap. To return
+/// `true`, the function name must be explicitly allowed, and the argument must
+/// be either the first or second argument in the call.
+fn allow_boolean_trap(func: &Expr) -> bool {
+    if let ExprKind::Attribute { attr, .. } = &func.node {
+        FUNC_NAME_ALLOWLIST.contains(&attr.as_ref())
+    } else {
+        false
+    }
+}
 
 fn is_boolean_arg(arg: &Expr) -> bool {
     matches!(
@@ -21,32 +32,6 @@ fn add_if_boolean(checker: &mut Checker, arg: &Expr, kind: CheckKind) {
     if is_boolean_arg(arg) {
         checker.add_check(Check::new(kind, Range::from_located(arg)));
     }
-}
-
-/// Returns true if an argument fulfills all whiltelist conditions.
-///
-/// Conditions:
-/// * function name must be explicitly whitelisted
-/// * argument in function call must be one of the first two
-fn is_whitelisted(arg: &Expr, func: &Expr, args: &[Expr]) -> bool {
-    if let ExprKind::Attribute { attr, .. } = &func.node {
-        FUNC_NAME_WHITELIST.contains(&attr.as_ref()) & args[..2].contains(arg)
-    } else {
-        false
-    }
-}
-
-fn add_if_boolean_and_not_whitelisted(
-    checker: &mut Checker,
-    arg: &Expr,
-    kind: CheckKind,
-    func: &Expr,
-    args: &[Expr],
-) {
-    if is_whitelisted(arg, func, args) {
-        return;
-    }
-    add_if_boolean(checker, arg, kind);
 }
 
 pub fn check_positional_boolean_in_def(checker: &mut Checker, arguments: &Arguments) {
@@ -93,13 +78,14 @@ pub fn check_boolean_positional_value_in_function_call(
     args: &[Expr],
     func: &Expr,
 ) {
-    for arg in args {
-        add_if_boolean_and_not_whitelisted(
+    for (index, arg) in args.iter().enumerate() {
+        if index < 2 && allow_boolean_trap(func) {
+            continue;
+        }
+        add_if_boolean(
             checker,
             arg,
             CheckKind::BooleanPositionalValueInFunctionCall,
-            func,
-            args,
         );
     }
 }

--- a/src/flake8_boolean_trap/plugins.rs
+++ b/src/flake8_boolean_trap/plugins.rs
@@ -5,6 +5,8 @@ use crate::ast::types::Range;
 use crate::check_ast::Checker;
 use crate::checks::{Check, CheckKind};
 
+const FUNC_NAME_WHITELIST: &[&str] = &["get", "setdefault", "pop", "fromkeys"];
+
 fn is_boolean_arg(arg: &Expr) -> bool {
     matches!(
         &arg.node,
@@ -19,6 +21,32 @@ fn add_if_boolean(checker: &mut Checker, arg: &Expr, kind: CheckKind) {
     if is_boolean_arg(arg) {
         checker.add_check(Check::new(kind, Range::from_located(arg)));
     }
+}
+
+/// Returns true if an argument fulfills all whiltelist conditions.
+///
+/// Conditions:
+/// * function name must be explicitly whitelisted
+/// * argument in function call must be one of the first two
+fn is_whitelisted(arg: &Expr, func: &Expr, args: &[Expr]) -> bool {
+    if let ExprKind::Attribute { attr, .. } = &func.node {
+        FUNC_NAME_WHITELIST.contains(&attr.as_ref()) & args[..2].contains(arg)
+    } else {
+        false
+    }
+}
+
+fn add_if_boolean_and_not_whitelisted(
+    checker: &mut Checker,
+    arg: &Expr,
+    kind: CheckKind,
+    func: &Expr,
+    args: &[Expr],
+) {
+    if is_whitelisted(arg, func, args) {
+        return;
+    }
+    add_if_boolean(checker, arg, kind);
 }
 
 pub fn check_positional_boolean_in_def(checker: &mut Checker, arguments: &Arguments) {
@@ -60,12 +88,18 @@ pub fn check_boolean_default_value_in_function_definition(
     }
 }
 
-pub fn check_boolean_positional_value_in_function_call(checker: &mut Checker, args: &[Expr]) {
+pub fn check_boolean_positional_value_in_function_call(
+    checker: &mut Checker,
+    args: &[Expr],
+    func: &Expr,
+) {
     for arg in args {
-        add_if_boolean(
+        add_if_boolean_and_not_whitelisted(
             checker,
             arg,
             CheckKind::BooleanPositionalValueInFunctionCall,
+            func,
+            args,
         );
     }
 }

--- a/src/snapshots/ruff__linter__tests__FBT003_FBT.py.snap
+++ b/src/snapshots/ruff__linter__tests__FBT003_FBT.py.snap
@@ -4,26 +4,26 @@ expression: checks
 ---
 - kind: BooleanPositionalValueInFunctionCall
   location:
-    row: 41
+    row: 42
     column: 10
   end_location:
-    row: 41
+    row: 42
     column: 14
   fix: ~
 - kind: BooleanPositionalValueInFunctionCall
   location:
-    row: 55
+    row: 57
     column: 10
   end_location:
-    row: 55
+    row: 57
     column: 14
   fix: ~
 - kind: BooleanPositionalValueInFunctionCall
   location:
-    row: 55
+    row: 57
     column: 16
   end_location:
-    row: 55
+    row: 57
     column: 21
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__FBT003_FBT.py.snap
+++ b/src/snapshots/ruff__linter__tests__FBT003_FBT.py.snap
@@ -10,4 +10,20 @@ expression: checks
     row: 41
     column: 14
   fix: ~
+- kind: BooleanPositionalValueInFunctionCall
+  location:
+    row: 55
+    column: 10
+  end_location:
+    row: 55
+    column: 14
+  fix: ~
+- kind: BooleanPositionalValueInFunctionCall
+  location:
+    row: 55
+    column: 16
+  end_location:
+    row: 55
+    column: 21
+  fix: ~
 


### PR DESCRIPTION
This commit enables the skipping of FBT003 based on two conditions:

* function name must be explicitly whitelisted (for now, common dict methods). In the future, more could be added based on user requests.
* argument in function call must be one of the first two. The idea is to skip only things like `{}.get(False, "default")` (for boolean keys) and `{}.get(key, True)` (for boolean defaults). Other method signature with a name in the whitelist can still potentially generate FBT003.

fixes #893