### PR TITLE
Allow long lines that consist of only a URL

### DIFF
--- a/resources/test/fixtures/E501.py
+++ b/resources/test/fixtures/E501.py
@@ -52,3 +52,6 @@ sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor
 
 # OK
 # A very long URL: https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com
+
+# OK
+# https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com

--- a/src/check_lines.rs
+++ b/src/check_lines.rs
@@ -25,7 +25,7 @@ fn should_enforce_line_length(line: &str, length: usize, limit: usize) -> bool {
         if let (Some(first), Some(_)) = (chunks.next(), chunks.next()) {
             // Do not enforce the line length for commented lines that end with a URL
             // or contain only a single word.
-            !(first == "#" && chunks.last().map_or(false, |c| URL_REGEX.is_match(c)))
+            !(first == "#" && chunks.last().map_or(true, |c| URL_REGEX.is_match(c)))
         } else {
             // Single word / no printable chars - no way to make the line shorter
             false


### PR DESCRIPTION
In #920, we changed the line-length detection to allow long lines to end with a URL. However, we introduced a bug for the case in which a comment is _only_ a URL, since `chunks.last` would return `None`, which we defaulted to `false`.

Resolves #950.