### PR TITLE
Rewrite type annotations on Python 3.7 when __future__ enabled

### DIFF
--- a/resources/test/fixtures/future_annotations.py
+++ b/resources/test/fixtures/future_annotations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import List, Optional
 
 from models import (
     Fruit,
@@ -28,3 +29,12 @@ class Foo:
     @classmethod
     def d(cls) -> Fruit:
         return cls(x=0, y=0)
+
+
+def f(x: int) -> List[int]:
+    y = List[int]()
+    y.append(x)
+    return y
+
+
+x: Optional[int] = None

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -399,6 +399,7 @@ mod tests {
     use crate::checks::CheckCode;
     use crate::linter::test_path;
     use crate::settings;
+    use crate::settings::types::PythonVersion;
 
     #[test_case(CheckCode::A001, Path::new("A001.py"); "A001")]
     #[test_case(CheckCode::A002, Path::new("A002.py"); "A002")]
@@ -688,6 +689,66 @@ mod tests {
         let mut checks = test_path(
             Path::new("./resources/test/fixtures/future_annotations.py"),
             &settings::Settings::for_rules(vec![CheckCode::F401, CheckCode::F821]),
+            true,
+        )?;
+        checks.sort_by_key(|check| check.location);
+        insta::assert_yaml_snapshot!(checks);
+        Ok(())
+    }
+
+    #[test]
+    fn future_annotations_pep_585_p37() -> Result<()> {
+        let mut checks = test_path(
+            Path::new("./resources/test/fixtures/future_annotations.py"),
+            &settings::Settings {
+                target_version: PythonVersion::Py37,
+                ..settings::Settings::for_rule(CheckCode::U006)
+            },
+            true,
+        )?;
+        checks.sort_by_key(|check| check.location);
+        insta::assert_yaml_snapshot!(checks);
+        Ok(())
+    }
+
+    #[test]
+    fn future_annotations_pep_585_py310() -> Result<()> {
+        let mut checks = test_path(
+            Path::new("./resources/test/fixtures/future_annotations.py"),
+            &settings::Settings {
+                target_version: PythonVersion::Py310,
+                ..settings::Settings::for_rule(CheckCode::U006)
+            },
+            true,
+        )?;
+        checks.sort_by_key(|check| check.location);
+        insta::assert_yaml_snapshot!(checks);
+        Ok(())
+    }
+
+    #[test]
+    fn future_annotations_pep_604_p37() -> Result<()> {
+        let mut checks = test_path(
+            Path::new("./resources/test/fixtures/future_annotations.py"),
+            &settings::Settings {
+                target_version: PythonVersion::Py37,
+                ..settings::Settings::for_rule(CheckCode::U007)
+            },
+            true,
+        )?;
+        checks.sort_by_key(|check| check.location);
+        insta::assert_yaml_snapshot!(checks);
+        Ok(())
+    }
+
+    #[test]
+    fn future_annotations_pep_604_py310() -> Result<()> {
+        let mut checks = test_path(
+            Path::new("./resources/test/fixtures/future_annotations.py"),
+            &settings::Settings {
+                target_version: PythonVersion::Py310,
+                ..settings::Settings::for_rule(CheckCode::U007)
+            },
             true,
         )?;
         checks.sort_by_key(|check| check.location);

--- a/src/snapshots/ruff__linter__tests__future_annotations.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations.snap
@@ -7,27 +7,27 @@ expression: checks
       - - models.Nut
       - false
   location:
-    row: 5
+    row: 6
     column: 0
   end_location:
-    row: 8
+    row: 9
     column: 1
   fix:
     patch:
       content: "from models import (\n    Fruit,\n)"
       location:
-        row: 5
+        row: 6
         column: 0
       end_location:
-        row: 8
+        row: 9
         column: 1
 - kind:
     UndefinedName: Bar
   location:
-    row: 25
+    row: 26
     column: 18
   end_location:
-    row: 25
+    row: 26
     column: 21
   fix: ~
 

--- a/src/snapshots/ruff__linter__tests__future_annotations_pep_585_p37.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations_pep_585_p37.snap
@@ -1,0 +1,22 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind:
+    UsePEP585Annotation: List
+  location:
+    row: 34
+    column: 17
+  end_location:
+    row: 34
+    column: 21
+  fix:
+    patch:
+      content: list
+      location:
+        row: 34
+        column: 17
+      end_location:
+        row: 34
+        column: 21
+

--- a/src/snapshots/ruff__linter__tests__future_annotations_pep_585_py310.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations_pep_585_py310.snap
@@ -1,0 +1,39 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind:
+    UsePEP585Annotation: List
+  location:
+    row: 34
+    column: 17
+  end_location:
+    row: 34
+    column: 21
+  fix:
+    patch:
+      content: list
+      location:
+        row: 34
+        column: 17
+      end_location:
+        row: 34
+        column: 21
+- kind:
+    UsePEP585Annotation: List
+  location:
+    row: 35
+    column: 8
+  end_location:
+    row: 35
+    column: 12
+  fix:
+    patch:
+      content: list
+      location:
+        row: 35
+        column: 8
+      end_location:
+        row: 35
+        column: 12
+

--- a/src/snapshots/ruff__linter__tests__future_annotations_pep_604_p37.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations_pep_604_p37.snap
@@ -1,0 +1,21 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind: UsePEP604Annotation
+  location:
+    row: 40
+    column: 3
+  end_location:
+    row: 40
+    column: 16
+  fix:
+    patch:
+      content: int | None
+      location:
+        row: 40
+        column: 3
+      end_location:
+        row: 40
+        column: 16
+

--- a/src/snapshots/ruff__linter__tests__future_annotations_pep_604_py310.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations_pep_604_py310.snap
@@ -1,0 +1,21 @@
+---
+source: src/linter.rs
+expression: checks
+---
+- kind: UsePEP604Annotation
+  location:
+    row: 40
+    column: 3
+  end_location:
+    row: 40
+    column: 16
+  fix:
+    patch:
+      content: int | None
+      location:
+        row: 40
+        column: 3
+      end_location:
+        row: 40
+        column: 16
+


### PR DESCRIPTION
Resolves #949.