### PR TITLE
feat: use more precise ranges for imports

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -107,9 +107,3 @@ pub struct Binding {
     /// the binding was last used.
     pub used: Option<(usize, Range)>,
 }
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ImportKind {
-    Import,
-    ImportFrom,
-}

--- a/src/autofix/mod.rs
+++ b/src/autofix/mod.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 pub mod fixer;
 pub mod helpers;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Patch {
     pub content: String,
     pub location: Location,
     pub end_location: Location,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Fix {
     pub patch: Patch,
 }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2988,7 +2988,7 @@ impl<'a> Checker<'a> {
                             check.amend(fix.clone());
                         }
 
-                        checks.push(check)
+                        checks.push(check);
                     }
                 }
             }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2915,7 +2915,8 @@ impl<'a> Checker<'a> {
             if self.settings.enabled.contains(&CheckCode::F401) {
                 // Collect all unused imports by location. (Multiple unused imports at the same
                 // location indicates an `import from`.)
-                type UnusedImport<'s> = (&'s String, &'s Range);
+                type UnusedImport<'a> = (&'a String, &'a Range);
+
                 let mut unused: BTreeMap<(usize, Option<usize>), Vec<UnusedImport>> =
                     BTreeMap::new();
 
@@ -2950,7 +2951,7 @@ impl<'a> Checker<'a> {
                     let parent = defined_in.map(|defined_in| self.parents[defined_in]);
 
                     let in_init_py = self.path.ends_with("__init__.py");
-                    let fix = if self.patch(&CheckCode::F401) && !in_init_py {
+                    let fix = if !in_init_py && self.patch(&CheckCode::F401) {
                         let deleted: Vec<&Stmt> = self
                             .deletions
                             .iter()
@@ -2983,11 +2984,9 @@ impl<'a> Checker<'a> {
                             CheckKind::UnusedImport(full_name.clone(), in_init_py),
                             *range,
                         );
-
                         if let Some(fix) = fix.as_ref() {
                             check.amend(fix.clone());
                         }
-
                         checks.push(check);
                     }
                 }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -3,7 +3,6 @@
 use std::collections::BTreeMap;
 use std::path::Path;
 
-use itertools::Itertools;
 use log::error;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_ast::Withitem;
@@ -19,8 +18,7 @@ use crate::ast::helpers::{
 use crate::ast::operations::extract_all_names;
 use crate::ast::relocate::relocate_expr;
 use crate::ast::types::{
-    Binding, BindingContext, BindingKind, ClassScope, FunctionScope, ImportKind, Node, Range,
-    Scope, ScopeKind,
+    Binding, BindingContext, BindingKind, ClassScope, FunctionScope, Node, Range, Scope, ScopeKind,
 };
 use crate::ast::visitor::{walk_excepthandler, walk_withitem, Visitor};
 use crate::ast::{helpers, operations, visitor};
@@ -594,7 +592,7 @@ where
                                     self.binding_context(),
                                 ),
                                 used: None,
-                                range: Range::from_located(stmt),
+                                range: Range::from_located(alias),
                             },
                         );
                     } else {
@@ -629,12 +627,12 @@ where
                                             .last()
                                             .expect("No current scope found."))]
                                         .id,
-                                        Range::from_located(stmt),
+                                        Range::from_located(alias),
                                     ))
                                 } else {
                                     None
                                 },
-                                range: Range::from_located(stmt),
+                                range: Range::from_located(alias),
                             },
                         );
                     }
@@ -754,9 +752,9 @@ where
                                         .last()
                                         .expect("No current scope found."))]
                                     .id,
-                                    Range::from_located(stmt),
+                                    Range::from_located(alias),
                                 )),
-                                range: Range::from_located(stmt),
+                                range: Range::from_located(alias),
                             },
                         );
 
@@ -768,7 +766,7 @@ where
                             if !ALL_FEATURE_NAMES.contains(&&*alias.node.name) {
                                 self.add_check(Check::new(
                                     CheckKind::FutureFeatureNotDefined(alias.node.name.to_string()),
-                                    Range::from_located(stmt),
+                                    Range::from_located(alias),
                                 ));
                             }
                         }
@@ -830,6 +828,7 @@ where
                             None => alias.node.name.to_string(),
                             Some(parent) => format!("{parent}.{}", alias.node.name),
                         };
+                        let range = Range::from_located(alias);
                         self.add_binding(
                             name,
                             Binding {
@@ -852,12 +851,12 @@ where
                                             .last()
                                             .expect("No current scope found."))]
                                         .id,
-                                        Range::from_located(stmt),
+                                        range,
                                     ))
                                 } else {
                                     None
                                 },
-                                range: Range::from_located(stmt),
+                                range,
                             },
                         );
                     }
@@ -2916,68 +2915,53 @@ impl<'a> Checker<'a> {
             if self.settings.enabled.contains(&CheckCode::F401) {
                 // Collect all unused imports by location. (Multiple unused imports at the same
                 // location indicates an `import from`.)
-                let mut unused: BTreeMap<(ImportKind, usize, Option<usize>), Vec<&str>> =
+                type UnusedImport<'s> = (&'s String, &'s Range);
+                let mut unused: BTreeMap<(usize, Option<usize>), Vec<UnusedImport>> =
                     BTreeMap::new();
 
                 for (name, binding) in &scope.values {
-                    if !matches!(
-                        binding.kind,
-                        BindingKind::Importation(..)
-                            | BindingKind::SubmoduleImportation(..)
-                            | BindingKind::FromImportation(..)
-                    ) {
-                        continue;
-                    }
+                    let (full_name, context) = match &binding.kind {
+                        BindingKind::Importation(_, full_name, context)
+                        | BindingKind::SubmoduleImportation(_, full_name, context)
+                        | BindingKind::FromImportation(_, full_name, context) => {
+                            (full_name, context)
+                        }
+                        _ => continue,
+                    };
 
-                    let used = binding.used.is_some()
+                    // Skip used exports from `__all__`
+                    if binding.used.is_some()
                         || all_names
                             .as_ref()
                             .map(|names| names.contains(name))
-                            .unwrap_or_default();
-
-                    if !used {
-                        match &binding.kind {
-                            BindingKind::FromImportation(_, full_name, context) => {
-                                unused
-                                    .entry((
-                                        ImportKind::ImportFrom,
-                                        context.defined_by,
-                                        context.defined_in,
-                                    ))
-                                    .or_default()
-                                    .push(full_name);
-                            }
-                            BindingKind::Importation(_, full_name, context)
-                            | BindingKind::SubmoduleImportation(_, full_name, context) => {
-                                unused
-                                    .entry((
-                                        ImportKind::Import,
-                                        context.defined_by,
-                                        context.defined_in,
-                                    ))
-                                    .or_default()
-                                    .push(full_name);
-                            }
-                            _ => unreachable!("Already filtered on BindingKind."),
-                        }
+                            .unwrap_or_default()
+                    {
+                        continue;
                     }
+
+                    unused
+                        .entry((context.defined_by, context.defined_in))
+                        .or_default()
+                        .push((full_name, &binding.range));
                 }
 
-                for ((kind, defined_by, defined_in), full_names) in unused {
+                for ((defined_by, defined_in), unused_import) in unused {
                     let child = self.parents[defined_by];
                     let parent = defined_in.map(|defined_in| self.parents[defined_in]);
 
-                    let fix = if self.patch(&CheckCode::F401) {
+                    let in_init_py = self.path.ends_with("__init__.py");
+                    let fix = if self.patch(&CheckCode::F401) && !in_init_py {
                         let deleted: Vec<&Stmt> = self
                             .deletions
                             .iter()
                             .map(|index| self.parents[*index])
                             .collect();
-                        match match kind {
-                            ImportKind::Import => pyflakes::fixes::remove_unused_imports,
-                            ImportKind::ImportFrom => pyflakes::fixes::remove_unused_import_froms,
-                        }(
-                            self.locator, &full_names, child, parent, &deleted
+                        match pyflakes::fixes::remove_unused_imports(
+                            self.locator,
+                            &unused_import,
+                            child,
+                            parent,
+                            &deleted,
                         ) {
                             Ok(fix) => {
                                 if fix.patch.content.is_empty() || fix.patch.content == "pass" {
@@ -2994,26 +2978,17 @@ impl<'a> Checker<'a> {
                         None
                     };
 
-                    if self.path.ends_with("__init__.py") {
-                        checks.push(Check::new(
-                            CheckKind::UnusedImport(
-                                full_names.into_iter().sorted().map(String::from).collect(),
-                                true,
-                            ),
-                            Range::from_located(child),
-                        ));
-                    } else {
+                    for (full_name, range) in unused_import {
                         let mut check = Check::new(
-                            CheckKind::UnusedImport(
-                                full_names.into_iter().sorted().map(String::from).collect(),
-                                false,
-                            ),
-                            Range::from_located(child),
+                            CheckKind::UnusedImport(full_name.clone(), in_init_py),
+                            *range,
                         );
-                        if let Some(fix) = fix {
-                            check.amend(fix);
+
+                        if let Some(fix) = fix.as_ref() {
+                            check.amend(fix.clone());
                         }
-                        checks.push(check);
+
+                        checks.push(check)
                     }
                 }
             }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -2945,7 +2945,7 @@ impl<'a> Checker<'a> {
                         .push((full_name, &binding.range));
                 }
 
-                for ((defined_by, defined_in), unused_import) in unused {
+                for ((defined_by, defined_in), unused_imports) in unused {
                     let child = self.parents[defined_by];
                     let parent = defined_in.map(|defined_in| self.parents[defined_in]);
 
@@ -2958,7 +2958,7 @@ impl<'a> Checker<'a> {
                             .collect();
                         match pyflakes::fixes::remove_unused_imports(
                             self.locator,
-                            &unused_import,
+                            &unused_imports,
                             child,
                             parent,
                             &deleted,
@@ -2978,7 +2978,7 @@ impl<'a> Checker<'a> {
                         None
                     };
 
-                    for (full_name, range) in unused_import {
+                    for (full_name, range) in unused_imports {
                         let mut check = Check::new(
                             CheckKind::UnusedImport(full_name.clone(), in_init_py),
                             *range,

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -449,7 +449,7 @@ pub enum CheckKind {
     UndefinedExport(String),
     UndefinedLocal(String),
     UndefinedName(String),
-    UnusedImport(Vec<String>, bool),
+    UnusedImport(String, bool),
     UnusedVariable(String),
     YieldOutsideFunction,
     // flake8-builtins
@@ -685,7 +685,7 @@ impl CheckCode {
             CheckCode::W292 => CheckKind::NoNewLineAtEndOfFile,
             CheckCode::W605 => CheckKind::InvalidEscapeSequence('c'),
             // pyflakes
-            CheckCode::F401 => CheckKind::UnusedImport(vec!["...".to_string()], false),
+            CheckCode::F401 => CheckKind::UnusedImport("...".to_string(), false),
             CheckCode::F402 => CheckKind::ImportShadowedByLoopVar("...".to_string(), 1),
             CheckCode::F403 => CheckKind::ImportStarUsed("...".to_string()),
             CheckCode::F404 => CheckKind::LateFutureImport,
@@ -1603,12 +1603,11 @@ impl CheckKind {
             CheckKind::UndefinedName(name) => {
                 format!("Undefined name `{name}`")
             }
-            CheckKind::UnusedImport(names, in_init_py) => {
-                let names = names.iter().map(|name| format!("`{name}`")).join(", ");
+            CheckKind::UnusedImport(name, in_init_py) => {
                 if *in_init_py {
-                    format!("{names} imported but unused and missing from `__all__`")
+                    format!("`{name}` imported but unused and missing from `__all__`")
                 } else {
-                    format!("{names} imported but unused")
+                    format!("`{name}` imported but unused")
                 }
             }
             CheckKind::UnusedVariable(name) => {

--- a/src/pyflakes/fixes.rs
+++ b/src/pyflakes/fixes.rs
@@ -28,10 +28,13 @@ pub fn remove_unused_imports(
 
     let (aliases, import_module) = match body.body.first_mut() {
         Some(SmallStatement::Import(import_body)) => Ok((&mut import_body.names, None)),
-        Some(SmallStatement::ImportFrom(import_body)) => match &mut import_body.names {
-            ImportNames::Aliases(names) => Ok((names, import_body.module.as_ref())),
-            _ => Err(anyhow::anyhow!("Expected node to be: Aliases")),
-        },
+        Some(SmallStatement::ImportFrom(import_body)) => {
+            if let ImportNames::Aliases(names) = &mut import_body.names {
+                Ok((names, import_body.module.as_ref()))
+            } else {
+                Err(anyhow::anyhow!("Expected node to be: Aliases"))
+            }
+        }
         _ => Err(anyhow::anyhow!(
             "Expected node to be: SmallStatement::ImportFrom or SmallStatement::Import"
         )),

--- a/src/pyflakes/fixes.rs
+++ b/src/pyflakes/fixes.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use libcst_native::{
     Codegen, CodegenState, CompOp, Comparison, ComparisonTarget, Expr, Expression, ImportNames,
-    NameOrAttribute, SmallStatement, Statement,
+    SmallStatement, Statement,
 };
 use rustpython_ast::Stmt;
 
@@ -14,7 +14,7 @@ use crate::source_code_locator::SourceCodeLocator;
 /// Generate a Fix to remove any unused imports from an `import` statement.
 pub fn remove_unused_imports(
     locator: &SourceCodeLocator,
-    full_names: &[&str],
+    unused_imports: &Vec<(&String, &Range)>,
     stmt: &Stmt,
     parent: Option<&Stmt>,
     deleted: &[&Stmt],
@@ -25,93 +25,37 @@ pub fn remove_unused_imports(
     let Some(Statement::Simple(body)) = tree.body.first_mut() else {
         return Err(anyhow::anyhow!("Expected node to be: Statement::Simple"));
     };
-    let Some(SmallStatement::Import(body)) = body.body.first_mut() else {
-        return Err(anyhow::anyhow!(
-            "Expected node to be: SmallStatement::ImportFrom"
-        ));
-    };
-    let aliases = &mut body.names;
+
+    let (aliases, import_module) = match body.body.first_mut() {
+        Some(SmallStatement::Import(import_body)) => Ok((&mut import_body.names, None)),
+        Some(SmallStatement::ImportFrom(import_body)) => match &mut import_body.names {
+            ImportNames::Aliases(names) => Ok((names, import_body.module.as_ref())),
+            _ => Err(anyhow::anyhow!("Expected node to be: Aliases")),
+        },
+        _ => Err(anyhow::anyhow!(
+            "Expected node to be: SmallStatement::ImportFrom or SmallStatement::Import"
+        )),
+    }?;
 
     // Preserve the trailing comma (or not) from the last entry.
     let trailing_comma = aliases.last().and_then(|alias| alias.comma.clone());
 
-    // Identify unused imports from within the `import`.
-    let mut removable = vec![];
-    for (index, alias) in aliases.iter().enumerate() {
-        if full_names.contains(&compose_module_path(&alias.name).as_str()) {
-            removable.push(index);
+    for (name_to_remove, _) in unused_imports {
+        let alias_index = aliases.iter().position(|alias| {
+            let full_name = match import_module {
+                Some(module_name) => format!(
+                    "{}.{}",
+                    compose_module_path(module_name),
+                    compose_module_path(&alias.name)
+                ),
+                None => compose_module_path(&alias.name),
+            };
+            &full_name.as_str() == name_to_remove
+        });
+
+        if let Some(index) = alias_index {
+            aliases.remove(index);
         }
-    }
-    // TODO(charlie): This is quadratic.
-    for index in removable.iter().rev() {
-        aliases.remove(*index);
-    }
-
-    if let Some(alias) = aliases.last_mut() {
-        alias.comma = trailing_comma;
-    }
-
-    if aliases.is_empty() {
-        helpers::remove_stmt(stmt, parent, deleted)
-    } else {
-        let mut state = CodegenState::default();
-        tree.codegen(&mut state);
-
-        Ok(Fix::replacement(
-            state.to_string(),
-            stmt.location,
-            stmt.end_location.unwrap(),
-        ))
-    }
-}
-
-/// Generate a Fix to remove any unused imports from an `import from` statement.
-pub fn remove_unused_import_froms(
-    locator: &SourceCodeLocator,
-    full_names: &[&str],
-    stmt: &Stmt,
-    parent: Option<&Stmt>,
-    deleted: &[&Stmt],
-) -> Result<Fix> {
-    let module_text = locator.slice_source_code_range(&Range::from_located(stmt));
-    let mut tree = match_module(&module_text)?;
-
-    let Some(Statement::Simple(body)) = tree.body.first_mut() else {
-        return Err(anyhow::anyhow!("Expected node to be: Statement::Simple"));
-    };
-    let Some(SmallStatement::ImportFrom(body)) = body.body.first_mut() else {
-        return Err(anyhow::anyhow!(
-            "Expected node to be: SmallStatement::ImportFrom"
-        ));
-    };
-
-    let ImportNames::Aliases(aliases) = &mut body.names else {
-        return Err(anyhow::anyhow!("Expected node to be: Aliases"));
-    };
-
-    // Preserve the trailing comma (or not) from the last entry.
-    let trailing_comma = aliases.last().and_then(|alias| alias.comma.clone());
-
-    // Identify unused imports from within the `import from`.
-    let mut removable = vec![];
-    for (index, alias) in aliases.iter().enumerate() {
-        if let NameOrAttribute::N(name) = &alias.name {
-            let import_name = name.value.to_string();
-            let full_name = body
-                .module
-                .as_ref()
-                .map(compose_module_path)
-                .map(|module_name| format!("{module_name}.{import_name}"))
-                .unwrap_or(import_name);
-
-            if full_names.contains(&full_name.as_str()) {
-                removable.push(index);
-            }
-        }
-    }
-    // TODO(charlie): This is quadratic.
-    for index in removable.iter().rev() {
-        aliases.remove(*index);
     }
 
     if let Some(alias) = aliases.last_mut() {

--- a/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_0.py.snap
@@ -4,14 +4,14 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - - functools
+      - functools
       - false
   location:
     row: 2
-    column: 0
+    column: 7
   end_location:
     row: 2
-    column: 20
+    column: 16
   fix:
     patch:
       content: import os
@@ -23,14 +23,14 @@ expression: checks
         column: 20
 - kind:
     UnusedImport:
-      - - collections.OrderedDict
+      - collections.OrderedDict
       - false
   location:
-    row: 4
-    column: 0
+    row: 6
+    column: 4
   end_location:
-    row: 8
-    column: 1
+    row: 6
+    column: 15
   fix:
     patch:
       content: "from collections import (\n    Counter,\n    namedtuple,\n)"
@@ -42,11 +42,11 @@ expression: checks
         column: 1
 - kind:
     UnusedImport:
-      - - logging.handlers
+      - logging.handlers
       - false
   location:
     row: 12
-    column: 0
+    column: 7
   end_location:
     row: 12
     column: 23
@@ -61,11 +61,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - shelve
+      - shelve
       - false
   location:
     row: 32
-    column: 4
+    column: 11
   end_location:
     row: 32
     column: 17
@@ -80,11 +80,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - importlib
+      - importlib
       - false
   location:
     row: 33
-    column: 4
+    column: 11
   end_location:
     row: 33
     column: 20
@@ -99,11 +99,11 @@ expression: checks
         column: 20
 - kind:
     UnusedImport:
-      - - pathlib
+      - pathlib
       - false
   location:
     row: 37
-    column: 4
+    column: 11
   end_location:
     row: 37
     column: 18
@@ -118,11 +118,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - pickle
+      - pickle
       - false
   location:
     row: 52
-    column: 8
+    column: 15
   end_location:
     row: 52
     column: 21

--- a/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_5.py.snap
@@ -4,11 +4,11 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - - a.b.c
+      - a.b.c
       - false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 17
@@ -23,11 +23,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - d.e.f
+      - d.e.f
       - false
   location:
     row: 3
-    column: 0
+    column: 16
   end_location:
     row: 3
     column: 22
@@ -42,11 +42,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - h.i
+      - h.i
       - false
   location:
     row: 4
-    column: 0
+    column: 7
   end_location:
     row: 4
     column: 10
@@ -61,11 +61,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - j.k
+      - j.k
       - false
   location:
     row: 5
-    column: 0
+    column: 7
   end_location:
     row: 5
     column: 15

--- a/src/snapshots/ruff__linter__tests__F401_F401_6.py.snap
+++ b/src/snapshots/ruff__linter__tests__F401_F401_6.py.snap
@@ -4,11 +4,11 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - - background.BackgroundTasks
+      - background.BackgroundTasks
       - false
   location:
     row: 7
-    column: 0
+    column: 24
   end_location:
     row: 7
     column: 39
@@ -23,11 +23,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - datastructures.UploadFile
+      - datastructures.UploadFile
       - false
   location:
     row: 10
-    column: 0
+    column: 28
   end_location:
     row: 10
     column: 52
@@ -42,11 +42,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - background
+      - background
       - false
   location:
     row: 17
-    column: 0
+    column: 7
   end_location:
     row: 17
     column: 17
@@ -61,11 +61,11 @@ expression: checks
         column: 0
 - kind:
     UnusedImport:
-      - - datastructures
+      - datastructures
       - false
   location:
     row: 20
-    column: 0
+    column: 7
   end_location:
     row: 20
     column: 35

--- a/src/snapshots/ruff__linter__tests__F407_F407.py.snap
+++ b/src/snapshots/ruff__linter__tests__F407_F407.py.snap
@@ -6,7 +6,7 @@ expression: checks
     FutureFeatureNotDefined: non_existent_feature
   location:
     row: 2
-    column: 0
+    column: 23
   end_location:
     row: 2
     column: 43

--- a/src/snapshots/ruff__linter__tests__future_annotations.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations.snap
@@ -4,14 +4,14 @@ expression: checks
 ---
 - kind:
     UnusedImport:
-      - - models.Nut
+      - models.Nut
       - false
   location:
-    row: 6
-    column: 0
+    row: 7
+    column: 4
   end_location:
-    row: 9
-    column: 1
+    row: 7
+    column: 7
   fix:
     patch:
       content: "from models import (\n    Fruit,\n)"

--- a/src/snapshots/ruff__linter__tests__future_annotations.snap
+++ b/src/snapshots/ruff__linter__tests__future_annotations.snap
@@ -7,10 +7,10 @@ expression: checks
       - models.Nut
       - false
   location:
-    row: 7
+    row: 8
     column: 4
   end_location:
-    row: 7
+    row: 8
     column: 7
   fix:
     patch:

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -18,7 +18,7 @@ fn test_stdin_error() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:1: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("-:1:8: F401"));
     Ok(())
 }
 
@@ -30,7 +30,7 @@ fn test_stdin_filename() -> Result<()> {
         .write_stdin("import os\n")
         .assert()
         .failure();
-    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:1: F401"));
+    assert!(str::from_utf8(&output.get_output().stdout)?.contains("F401.py:1:8: F401"));
     Ok(())
 }
 


### PR DESCRIPTION
Closes #946

- All import bindings except "*" now use range from `alias`
- Consolidated `fix` functions for plain and `from` imports
- Removed `ImportKind` enum (unused)
- Reporting unused `from` imports separately