### PR TITLE
Track type definitions and annotations separately

### DIFF
--- a/resources/test/fixtures/pyupgrade/future_annotations.py
+++ b/resources/test/fixtures/pyupgrade/future_annotations.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, TypeAlias, Union
 
 from models import (
     Fruit,
@@ -38,3 +38,5 @@ def f(x: int) -> List[int]:
 
 
 x: Optional[int] = None
+
+MyList: TypeAlias = Union[List[int], List[str]]

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -4,8 +4,6 @@ use rustpython_parser::ast::{
     PatternKind, Stmt, StmtKind, Unaryop, Withitem,
 };
 
-use crate::ast::helpers::match_name_or_attr;
-
 pub trait Visitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         walk_stmt(self, stmt);
@@ -150,11 +148,7 @@ pub fn walk_stmt<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
         } => {
             visitor.visit_annotation(annotation);
             if let Some(expr) = value {
-                if match_name_or_attr(annotation, "TypeAlias") {
-                    visitor.visit_annotation(expr);
-                } else {
-                    visitor.visit_expr(expr);
-                }
+                visitor.visit_expr(expr);
             }
             visitor.visit_expr(target);
         }

--- a/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_585_py310.snap
+++ b/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_585_py310.snap
@@ -34,4 +34,36 @@ expression: checks
     end_location:
       row: 35
       column: 12
+- kind:
+    UsePEP585Annotation: List
+  location:
+    row: 42
+    column: 26
+  end_location:
+    row: 42
+    column: 30
+  fix:
+    content: list
+    location:
+      row: 42
+      column: 26
+    end_location:
+      row: 42
+      column: 30
+- kind:
+    UsePEP585Annotation: List
+  location:
+    row: 42
+    column: 37
+  end_location:
+    row: 42
+    column: 41
+  fix:
+    content: list
+    location:
+      row: 42
+      column: 37
+    end_location:
+      row: 42
+      column: 41
 

--- a/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_604_py310.snap
+++ b/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_604_py310.snap
@@ -17,4 +17,19 @@ expression: checks
     end_location:
       row: 40
       column: 16
+- kind: UsePEP604Annotation
+  location:
+    row: 42
+    column: 20
+  end_location:
+    row: 42
+    column: 47
+  fix:
+    content: "List[int] | List[str]"
+    location:
+      row: 42
+      column: 20
+    end_location:
+      row: 42
+      column: 47
 


### PR DESCRIPTION
Previously, we used `self.in_annotation` to detect that we're in a type definition (which implies that, for example, strings need to be treated as forward annotations). We _also_ used this to enable rewriting type annotations when `from __future__ import annotations` was imported pre-Python 3.9 or 3.10 (which can only be safely rewritten when used as annotations, and not as runtime constructs).

This PR splits that tracking into two separate pieces of state: one to track whether we're in an _actual_ annotation (as defined by the AST), and another to track whether we're in a type definition.

Resolves #979.
