### PR TITLE
Fix `PLR0402`

### DIFF
--- a/src/pylint/plugins.rs
+++ b/src/pylint/plugins.rs
@@ -110,10 +110,10 @@ pub fn property_with_parameters(
 /// PLR0402
 pub fn consider_using_from_import(checker: &mut Checker, alias: &Alias) {
     if let Some(asname) = &alias.node.asname {
-        if let Some((_, module)) = alias.node.name.rsplit_once('.') {
-            if module == asname {
+        if let Some((module, name)) = alias.node.name.rsplit_once('.') {
+            if name == asname {
                 checker.add_check(Check::new(
-                    CheckKind::ConsiderUsingFromImport(module.to_string(), asname.to_string()),
+                    CheckKind::ConsiderUsingFromImport(module.to_string(), name.to_string()),
                     Range::from_located(alias),
                 ));
             }

--- a/src/pylint/snapshots/ruff__pylint__tests__import_aliasing.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__import_aliasing.py.snap
@@ -4,7 +4,7 @@ expression: checks
 ---
 - kind:
     ConsiderUsingFromImport:
-      - path
+      - os
       - path
   location:
     row: 8
@@ -15,7 +15,7 @@ expression: checks
   fix: ~
 - kind:
     ConsiderUsingFromImport:
-      - foobar
+      - foo.bar
       - foobar
   location:
     row: 10


### PR DESCRIPTION
### Before

```
> cargo run -- --select PLR0402 --show-source resources/test/fixtures/pylint/import_aliasing.py
Found 2 error(s).
resources/test/fixtures/pylint/import_aliasing.py:8:8: PLR0402 Consider using `from path import path`
  |
8 | import os.path as path  # [consider-using-from-import]
  |        ^^^^^^^^^^^^^^^ PLR0402
  |
resources/test/fixtures/pylint/import_aliasing.py:10:8: PLR0402 Consider using `from foobar import foobar`
   |
10 | import foo.bar.foobar as foobar  # [consider-using-from-import]
   |        ^^^^^^^^^^^^^^^^^^^^^^^^ PLR0402
   |
```

### After

```
> cargo run -- --select PLR0402 --show-source resources/test/fixtures/pylint/import_aliasing.py
Found 2 error(s).
resources/test/fixtures/pylint/import_aliasing.py:8:8: PLR0402 Consider using `from os import path`
  |
8 | import os.path as path  # [consider-using-from-import]
  |        ^^^^^^^^^^^^^^^ PLR0402
  |
resources/test/fixtures/pylint/import_aliasing.py:10:8: PLR0402 Consider using `from foo.bar import foobar`
   |
10 | import foo.bar.foobar as foobar  # [consider-using-from-import]
   |        ^^^^^^^^^^^^^^^^^^^^^^^^ PLR0402
   |
```