### PR TITLE
Add an option to force one-member-per-line for aliased import-froms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1807,24 +1807,6 @@ ban-relative-imports = "all"
 
 ### `isort`
 
-#### [`combine-as-imports`](#combine-as-imports)
-
-Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports)
-option.
-
-**Default value**: `false`
-
-**Type**: `bool`
-
-**Example usage**:
-
-```toml
-[tool.ruff.isort]
-combine-as-imports = true
-```
-
----
-
 #### [`known-first-party`](#known-first-party)
 
 A list of modules to consider first-party, regardless of whether they can be identified as such
@@ -1874,6 +1856,50 @@ A list of modules to consider standard-library, in addition to those known to Ru
 ```toml
 [tool.ruff.isort]
 extra-standard-library = ["path"]
+```
+
+---
+
+#### [`combine-as-imports`](#combine-as-imports)
+
+Combines as imports on the same line. See isort's [`combine-as-imports`](https://pycqa.github.io/isort/docs/configuration/options.html#combine-as-imports)
+option.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+combine-as-imports = true
+```
+
+---
+
+#### [`force-wrap-aliases`](#force-wrap-aliases)
+
+Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`)
+to wrap such that every line contains exactly one member. For example, this formatting would be
+retained, rather than condensing to a single line:
+
+```py
+from .utils import (
+    test_directory as test_directory,
+    test_id as test_id
+)
+```
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+force-wrap-aliases = true
 ```
 
 ### `mccabe`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ build-backend = "maturin"
 [tool.maturin]
 bindings = "bin"
 strip = true
+
+[tool.ruff.isort]
+force-wrap-aliases = true
+combine-as-imports = true

--- a/resources/test/fixtures/isort/force_wrap_aliases.py
+++ b/resources/test/fixtures/isort/force_wrap_aliases.py
@@ -1,0 +1,3 @@
+from .a import a1 as a1, a2 as a2
+from .b import b1 as b1
+from .c import c1

--- a/src/isort/format.rs
+++ b/src/isort/format.rs
@@ -39,6 +39,7 @@ pub fn format_import_from(
     comments: &CommentSet,
     aliases: &[(AliasData, CommentSet)],
     line_length: usize,
+    force_wrap_aliases: bool,
     is_first: bool,
 ) -> String {
     // We can only inline if: (1) none of the aliases have atop comments, and (3)
@@ -51,6 +52,9 @@ pub fn format_import_from(
             .rev()
             .skip(1)
             .all(|(_, CommentSet { inline, .. })| inline.is_empty())
+        && (!force_wrap_aliases
+            || aliases.len() == 1
+            || aliases.iter().all(|(alias, _)| alias.asname.is_none()))
     {
         let (single_line, import_length) =
             format_single_line(import_from, comments, aliases, is_first);

--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -61,6 +61,7 @@ pub fn check_imports(
         &settings.isort.known_third_party,
         &settings.isort.extra_standard_library,
         settings.isort.combine_as_imports,
+        settings.isort.force_wrap_aliases,
     );
 
     if has_leading_content || has_trailing_content {

--- a/src/isort/settings.rs
+++ b/src/isort/settings.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Options {
     pub combine_as_imports: Option<bool>,
+    pub force_wrap_aliases: Option<bool>,
     pub known_first_party: Option<Vec<String>>,
     pub known_third_party: Option<Vec<String>>,
     pub extra_standard_library: Option<Vec<String>>,
@@ -16,6 +17,7 @@ pub struct Options {
 #[derive(Debug, Hash, Default)]
 pub struct Settings {
     pub combine_as_imports: bool,
+    pub force_wrap_aliases: bool,
     pub known_first_party: BTreeSet<String>,
     pub known_third_party: BTreeSet<String>,
     pub extra_standard_library: BTreeSet<String>,
@@ -25,6 +27,7 @@ impl Settings {
     pub fn from_options(options: Options) -> Self {
         Self {
             combine_as_imports: options.combine_as_imports.unwrap_or_default(),
+            force_wrap_aliases: options.force_wrap_aliases.unwrap_or_default(),
             known_first_party: BTreeSet::from_iter(options.known_first_party.unwrap_or_default()),
             known_third_party: BTreeSet::from_iter(options.known_third_party.unwrap_or_default()),
             extra_standard_library: BTreeSet::from_iter(

--- a/src/isort/snapshots/ruff__isort__tests__force_wrap_aliases.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__force_wrap_aliases.py.snap
@@ -1,0 +1,20 @@
+---
+source: src/isort/mod.rs
+expression: checks
+---
+- kind: UnsortedImports
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 4
+    column: 0
+  fix:
+    content: "from .a import a1 as a1\nfrom .a import a2 as a2\nfrom .b import b1 as b1\nfrom .c import c1\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 4
+      column: 0
+

--- a/src/isort/snapshots/ruff__isort__tests__force_wrap_aliases_force_wrap_aliases.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__force_wrap_aliases_force_wrap_aliases.py.snap
@@ -1,0 +1,20 @@
+---
+source: src/isort/mod.rs
+expression: checks
+---
+- kind: UnsortedImports
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 4
+    column: 0
+  fix:
+    content: "from .a import (\n    a1 as a1,\n    a2 as a2,\n)\nfrom .b import b1 as b1\nfrom .c import c1\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 4
+      column: 0
+


### PR DESCRIPTION
This PR adds a `force-wrap-aliases` setting, which lets you preserve one-per-line imports when using import aliases, like so:

```py
from .utils import (
    test_directory as test_directory,
    test_id as test_id,
)
```

Specifically, we enforce multi-line formatting when this setting is enabled, the import-from has more than one member, and at least one member is aliased.

Resolves: #1046.
