### PR TITLE
Style fixes

### DIFF
--- a/src/ast/operations.rs
+++ b/src/ast/operations.rs
@@ -93,20 +93,19 @@ pub fn in_nested_block<'a>(parents: &mut impl Iterator<Item = &'a Stmt>) -> bool
 
 /// Check if a node represents an unpacking assignment.
 pub fn is_unpacking_assignment(stmt: &Stmt) -> bool {
-    if let StmtKind::Assign { targets, value, .. } = &stmt.node {
-        if !targets.iter().any(|child| {
-            matches!(
-                child.node,
-                ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. }
-            )
-        }) {
-            return false;
-        }
-        match &value.node {
-            ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. } => return false,
-            _ => {}
-        }
-        return true;
+    let StmtKind::Assign { targets, value, .. } = &stmt.node else {
+        return false;
+    };
+    if !targets.iter().any(|child| {
+        matches!(
+            child.node,
+            ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. }
+        )
+    }) {
+        return false;
     }
-    false
+    !matches!(
+        &value.node,
+        ExprKind::Set { .. } | ExprKind::List { .. } | ExprKind::Tuple { .. }
+    )
 }

--- a/src/check_ast.rs
+++ b/src/check_ast.rs
@@ -3117,7 +3117,7 @@ impl<'a> Checker<'a> {
                                 Some(fix)
                             }
                             Err(e) => {
-                                error!("Failed to remove unused imports: {}", e);
+                                error!("Failed to remove unused imports: {e}");
                                 None
                             }
                         }

--- a/src/checks.rs
+++ b/src/checks.rs
@@ -2617,8 +2617,7 @@ mod tests {
         for check_code in CheckCode::iter() {
             assert!(
                 CheckCode::from_str(check_code.as_ref()).is_ok(),
-                "{:?} could not be round-trip serialized.",
-                check_code
+                "{check_code:?} could not be round-trip serialized."
             );
         }
     }

--- a/src/docstrings/extraction.rs
+++ b/src/docstrings/extraction.rs
@@ -7,20 +7,20 @@ use crate::visibility::{Modifier, VisibleScope};
 
 /// Extract a docstring from a function or class body.
 pub fn docstring_from(suite: &[Stmt]) -> Option<&Expr> {
-    if let Some(stmt) = suite.first() {
-        if let StmtKind::Expr { value } = &stmt.node {
-            if matches!(
-                &value.node,
-                ExprKind::Constant {
-                    value: Constant::Str(_),
-                    ..
-                }
-            ) {
-                return Some(value);
-            }
+    let stmt = suite.first()?;
+    let StmtKind::Expr { value } = &stmt.node else {
+        return None;
+    };
+    if !matches!(
+        &value.node,
+        ExprKind::Constant {
+            value: Constant::Str(_),
+            ..
         }
+    ) {
+        return None;
     }
-    None
+    Some(value)
 }
 
 /// Extract a `Definition` from the AST node defined by a `Stmt`.

--- a/src/flake8_bandit/plugins/exec_used.rs
+++ b/src/flake8_bandit/plugins/exec_used.rs
@@ -5,10 +5,11 @@ use crate::checks::{Check, CheckKind};
 
 /// S102
 pub fn exec_used(expr: &Expr, func: &Expr) -> Option<Check> {
-    if let ExprKind::Name { id, .. } = &func.node {
-        if id == "exec" {
-            return Some(Check::new(CheckKind::ExecUsed, Range::from_located(expr)));
-        }
+    let ExprKind::Name { id, .. } = &func.node else {
+        return None;
+    };
+    if id != "exec" {
+        return None;
     }
-    None
+    Some(Check::new(CheckKind::ExecUsed, Range::from_located(expr)))
 }

--- a/src/flake8_bandit/plugins/hardcoded_password_default.rs
+++ b/src/flake8_bandit/plugins/hardcoded_password_default.rs
@@ -5,16 +5,15 @@ use crate::checks::{Check, CheckKind};
 use crate::flake8_bandit::helpers::{matches_password_name, string_literal};
 
 fn check_password_kwarg(arg: &Located<ArgData>, default: &Expr) -> Option<Check> {
-    if let Some(string) = string_literal(default) {
-        let kwarg_name = &arg.node.arg;
-        if matches_password_name(kwarg_name) {
-            return Some(Check::new(
-                CheckKind::HardcodedPasswordDefault(string.to_string()),
-                Range::from_located(default),
-            ));
-        }
+    let string = string_literal(default)?;
+    let kwarg_name = &arg.node.arg;
+    if !matches_password_name(kwarg_name) {
+        return None;
     }
-    None
+    Some(Check::new(
+        CheckKind::HardcodedPasswordDefault(string.to_string()),
+        Range::from_located(default),
+    ))
 }
 
 /// S107

--- a/src/flake8_bandit/plugins/hardcoded_password_func_arg.rs
+++ b/src/flake8_bandit/plugins/hardcoded_password_func_arg.rs
@@ -9,17 +9,15 @@ pub fn hardcoded_password_func_arg(keywords: &[Keyword]) -> Vec<Check> {
     keywords
         .iter()
         .filter_map(|keyword| {
-            if let Some(string) = string_literal(&keyword.node.value) {
-                if let Some(arg) = &keyword.node.arg {
-                    if matches_password_name(arg) {
-                        return Some(Check::new(
-                            CheckKind::HardcodedPasswordFuncArg(string.to_string()),
-                            Range::from_located(keyword),
-                        ));
-                    }
-                }
+            let string = string_literal(&keyword.node.value)?;
+            let arg = keyword.node.arg.as_ref()?;
+            if !matches_password_name(arg) {
+                return None;
             }
-            None
+            Some(Check::new(
+                CheckKind::HardcodedPasswordFuncArg(string.to_string()),
+                Range::from_located(keyword),
+            ))
         })
         .collect()
 }

--- a/src/flake8_bandit/plugins/hardcoded_password_string.rs
+++ b/src/flake8_bandit/plugins/hardcoded_password_string.rs
@@ -29,15 +29,14 @@ pub fn compare_to_hardcoded_password_string(left: &Expr, comparators: &[Expr]) -
     comparators
         .iter()
         .filter_map(|comp| {
-            if let Some(string) = string_literal(comp) {
-                if is_password_target(left) {
-                    return Some(Check::new(
-                        CheckKind::HardcodedPasswordString(string.to_string()),
-                        Range::from_located(comp),
-                    ));
-                }
+            let string = string_literal(comp)?;
+            if !is_password_target(left) {
+                return None;
             }
-            None
+            Some(Check::new(
+                CheckKind::HardcodedPasswordString(string.to_string()),
+                Range::from_located(comp),
+            ))
         })
         .collect()
 }

--- a/src/flake8_blind_except/plugins.rs
+++ b/src/flake8_blind_except/plugins.rs
@@ -6,17 +6,18 @@ use crate::checks::{Check, CheckKind};
 
 pub fn blind_except(checker: &mut Checker, handlers: &[Excepthandler]) {
     for handler in handlers {
-        let ExcepthandlerKind::ExceptHandler { type_, .. } = &handler.node;
-        if let Some(type_) = type_ {
-            if let ExprKind::Name { id, .. } = &type_.node {
-                for exception in ["BaseException", "Exception"] {
-                    if id == exception {
-                        checker.add_check(Check::new(
-                            CheckKind::BlindExcept,
-                            Range::from_located(type_),
-                        ));
-                    }
-                }
+        let ExcepthandlerKind::ExceptHandler { type_: Some(type_), .. } = &handler.node else {
+            continue;
+        };
+        let ExprKind::Name { id, .. } = &type_.node else {
+            continue;
+        };
+        for exception in ["BaseException", "Exception"] {
+            if id == exception {
+                checker.add_check(Check::new(
+                    CheckKind::BlindExcept,
+                    Range::from_located(type_),
+                ));
             }
         }
     }

--- a/src/flake8_bugbear/plugins/assert_false.rs
+++ b/src/flake8_bugbear/plugins/assert_false.rs
@@ -38,23 +38,24 @@ fn assertion_error(msg: Option<&Expr>) -> Stmt {
 
 /// B011
 pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option<&Expr>) {
-    if let ExprKind::Constant {
+    let ExprKind::Constant {
         value: Constant::Bool(false),
         ..
-    } = &test.node
-    {
-        let mut check = Check::new(CheckKind::DoNotAssertFalse, Range::from_located(test));
-        if checker.patch(check.kind.code()) {
-            let mut generator = SourceGenerator::new();
-            generator.unparse_stmt(&assertion_error(msg));
-            if let Ok(content) = generator.generate() {
-                check.amend(Fix::replacement(
-                    content,
-                    stmt.location,
-                    stmt.end_location.unwrap(),
-                ));
-            }
+    } = &test.node else {
+        return;
+    };
+
+    let mut check = Check::new(CheckKind::DoNotAssertFalse, Range::from_located(test));
+    if checker.patch(check.kind.code()) {
+        let mut generator = SourceGenerator::new();
+        generator.unparse_stmt(&assertion_error(msg));
+        if let Ok(content) = generator.generate() {
+            check.amend(Fix::replacement(
+                content,
+                stmt.location,
+                stmt.end_location.unwrap(),
+            ));
         }
-        checker.add_check(check);
     }
+    checker.add_check(check);
 }

--- a/src/flake8_bugbear/plugins/assert_raises_exception.rs
+++ b/src/flake8_bugbear/plugins/assert_raises_exception.rs
@@ -7,25 +7,34 @@ use crate::checks::{Check, CheckKind};
 
 /// B017
 pub fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items: &[Withitem]) {
-    if let Some(item) = items.first() {
-        let item_context = &item.context_expr;
-        if let ExprKind::Call { func, args, .. } = &item_context.node {
-            if args.len() == 1
-                && item.optional_vars.is_none()
-                && matches!(&func.node, ExprKind::Attribute { attr, .. } if attr == "assertRaises")
-                && match_module_member(
-                    args.first().unwrap(),
-                    "",
-                    "Exception",
-                    &checker.from_imports,
-                    &checker.import_aliases,
-                )
-            {
-                checker.add_check(Check::new(
-                    CheckKind::NoAssertRaisesException,
-                    Range::from_located(stmt),
-                ));
-            }
-        }
+    let Some(item) = items.first() else {
+        return;
+    };
+    let item_context = &item.context_expr;
+    let ExprKind::Call { func, args, .. } = &item_context.node else {
+        return;
+    };
+    if args.len() != 1 {
+        return;
     }
+    if item.optional_vars.is_some() {
+        return;
+    }
+    if !matches!(&func.node, ExprKind::Attribute { attr, .. } if attr == "assertRaises") {
+        return;
+    }
+    if !match_module_member(
+        args.first().unwrap(),
+        "",
+        "Exception",
+        &checker.from_imports,
+        &checker.import_aliases,
+    ) {
+        return;
+    }
+
+    checker.add_check(Check::new(
+        CheckKind::NoAssertRaisesException,
+        Range::from_located(stmt),
+    ));
 }

--- a/src/flake8_bugbear/plugins/assignment_to_os_environ.rs
+++ b/src/flake8_bugbear/plugins/assignment_to_os_environ.rs
@@ -6,19 +6,24 @@ use crate::checks::{Check, CheckKind};
 
 /// B003
 pub fn assignment_to_os_environ(checker: &mut Checker, targets: &[Expr]) {
-    if targets.len() == 1 {
-        let target = &targets[0];
-        if let ExprKind::Attribute { value, attr, .. } = &target.node {
-            if attr == "environ" {
-                if let ExprKind::Name { id, .. } = &value.node {
-                    if id == "os" {
-                        checker.add_check(Check::new(
-                            CheckKind::AssignmentToOsEnviron,
-                            Range::from_located(target),
-                        ));
-                    }
-                }
-            }
-        }
+    if targets.len() != 1 {
+        return;
     }
+    let target = &targets[0];
+    let ExprKind::Attribute { value, attr, .. } = &target.node else {
+        return;
+    };
+    if attr != "environ" {
+        return;
+    }
+    let ExprKind::Name { id, .. } = &value.node else {
+                    return;
+                };
+    if id != "os" {
+        return;
+    }
+    checker.add_check(Check::new(
+        CheckKind::AssignmentToOsEnviron,
+        Range::from_located(target),
+    ));
 }

--- a/src/flake8_bugbear/plugins/cached_instance_method.rs
+++ b/src/flake8_bugbear/plugins/cached_instance_method.rs
@@ -13,29 +13,30 @@ fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
 
 /// B019
 pub fn cached_instance_method(checker: &mut Checker, decorator_list: &[Expr]) {
-    if matches!(checker.current_scope().kind, ScopeKind::Class(_)) {
-        for decorator in decorator_list {
-            // TODO(charlie): This should take into account `classmethod-decorators` and
-            // `staticmethod-decorators`.
-            if let ExprKind::Name { id, .. } = &decorator.node {
-                if id == "classmethod" || id == "staticmethod" {
-                    return;
-                }
+    if !matches!(checker.current_scope().kind, ScopeKind::Class(_)) {
+        return;
+    }
+    for decorator in decorator_list {
+        // TODO(charlie): This should take into account `classmethod-decorators` and
+        // `staticmethod-decorators`.
+        if let ExprKind::Name { id, .. } = &decorator.node {
+            if id == "classmethod" || id == "staticmethod" {
+                return;
             }
         }
-        for decorator in decorator_list {
-            if is_cache_func(
-                checker,
-                match &decorator.node {
-                    ExprKind::Call { func, .. } => func,
-                    _ => decorator,
-                },
-            ) {
-                checker.add_check(Check::new(
-                    CheckKind::CachedInstanceMethod,
-                    Range::from_located(decorator),
-                ));
-            }
+    }
+    for decorator in decorator_list {
+        if is_cache_func(
+            checker,
+            match &decorator.node {
+                ExprKind::Call { func, .. } => func,
+                _ => decorator,
+            },
+        ) {
+            checker.add_check(Check::new(
+                CheckKind::CachedInstanceMethod,
+                Range::from_located(decorator),
+            ));
         }
     }
 }

--- a/src/flake8_bugbear/plugins/cannot_raise_literal.rs
+++ b/src/flake8_bugbear/plugins/cannot_raise_literal.rs
@@ -6,10 +6,11 @@ use crate::checks::{Check, CheckKind};
 
 /// B016
 pub fn cannot_raise_literal(checker: &mut Checker, expr: &Expr) {
-    if let ExprKind::Constant { .. } = &expr.node {
-        checker.add_check(Check::new(
-            CheckKind::CannotRaiseLiteral,
-            Range::from_located(expr),
-        ));
-    }
+    let ExprKind::Constant { .. } = &expr.node else {
+        return;
+    };
+    checker.add_check(Check::new(
+        CheckKind::CannotRaiseLiteral,
+        Range::from_located(expr),
+    ));
 }

--- a/src/flake8_bugbear/plugins/f_string_docstring.rs
+++ b/src/flake8_bugbear/plugins/f_string_docstring.rs
@@ -6,14 +6,17 @@ use crate::checks::{Check, CheckKind};
 
 /// B021
 pub fn f_string_docstring(checker: &mut Checker, body: &[Stmt]) {
-    if let Some(stmt) = body.first() {
-        if let StmtKind::Expr { value } = &stmt.node {
-            if let ExprKind::JoinedStr { .. } = value.node {
-                checker.add_check(Check::new(
-                    CheckKind::FStringDocstring,
-                    Range::from_located(stmt),
-                ));
-            }
-        }
-    }
+    let Some(stmt) = body.first() else {
+        return;
+    };
+    let StmtKind::Expr { value } = &stmt.node else {
+        return;
+    };
+    let ExprKind::JoinedStr { .. } = value.node else {
+        return;
+    };
+    checker.add_check(Check::new(
+        CheckKind::FStringDocstring,
+        Range::from_located(stmt),
+    ));
 }

--- a/src/flake8_bugbear/plugins/function_call_argument_default.rs
+++ b/src/flake8_bugbear/plugins/function_call_argument_default.rs
@@ -71,29 +71,26 @@ where
 }
 
 fn is_nan_or_infinity(expr: &Expr, args: &[Expr]) -> bool {
-    if let ExprKind::Name { id, .. } = &expr.node {
-        if id == "float" {
-            if let Some(arg) = args.first() {
-                if let ExprKind::Constant {
-                    value: Constant::Str(value),
-                    ..
-                } = &arg.node
-                {
-                    let lowercased = value.to_lowercase();
-                    return lowercased == "nan"
-                        || lowercased == "+nan"
-                        || lowercased == "-nan"
-                        || lowercased == "inf"
-                        || lowercased == "+inf"
-                        || lowercased == "-inf"
-                        || lowercased == "infinity"
-                        || lowercased == "+infinity"
-                        || lowercased == "-infinity";
-                }
-            }
-        }
+    let ExprKind::Name { id, .. } = &expr.node else {
+        return false;
+    };
+    if id != "float" {
+        return false;
     }
-    false
+    let Some(arg) = args.first() else {
+        return false;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(value),
+        ..
+    } = &arg.node else {
+        return false;
+    };
+    let lowercased = value.to_lowercase();
+    matches!(
+        lowercased.as_str(),
+        "nan" | "+nan" | "-nan" | "inf" | "+inf" | "-inf" | "infinity" | "+infinity" | "-infinity"
+    )
 }
 
 /// B008

--- a/src/flake8_bugbear/plugins/getattr_with_constant.rs
+++ b/src/flake8_bugbear/plugins/getattr_with_constant.rs
@@ -22,32 +22,39 @@ fn attribute(value: &Expr, attr: &str) -> Expr {
 
 /// B009
 pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {
-    if let ExprKind::Name { id, .. } = &func.node {
-        if id == "getattr" {
-            if let [obj, arg] = args {
-                if let ExprKind::Constant {
-                    value: Constant::Str(value),
-                    ..
-                } = &arg.node
-                {
-                    if IDENTIFIER_REGEX.is_match(value) && !KWLIST.contains(&value.as_str()) {
-                        let mut check =
-                            Check::new(CheckKind::GetAttrWithConstant, Range::from_located(expr));
-                        if checker.patch(check.kind.code()) {
-                            let mut generator = SourceGenerator::new();
-                            generator.unparse_expr(&attribute(obj, value), 0);
-                            if let Ok(content) = generator.generate() {
-                                check.amend(Fix::replacement(
-                                    content,
-                                    expr.location,
-                                    expr.end_location.unwrap(),
-                                ));
-                            }
-                        }
-                        checker.add_check(check);
-                    }
-                }
-            }
+    let ExprKind::Name { id, .. } = &func.node else {
+        return;
+    };
+    if id != "getattr" {
+        return;
+    }
+    let [obj, arg] = args else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(value),
+        ..
+    } = &arg.node else {
+        return;
+    };
+    if !IDENTIFIER_REGEX.is_match(value) {
+        return;
+    }
+    if KWLIST.contains(&value.as_str()) {
+        return;
+    }
+
+    let mut check = Check::new(CheckKind::GetAttrWithConstant, Range::from_located(expr));
+    if checker.patch(check.kind.code()) {
+        let mut generator = SourceGenerator::new();
+        generator.unparse_expr(&attribute(obj, value), 0);
+        if let Ok(content) = generator.generate() {
+            check.amend(Fix::replacement(
+                content,
+                expr.location,
+                expr.end_location.unwrap(),
+            ));
         }
     }
+    checker.add_check(check);
 }

--- a/src/flake8_bugbear/plugins/raise_without_from_inside_except.rs
+++ b/src/flake8_bugbear/plugins/raise_without_from_inside_except.rs
@@ -13,21 +13,18 @@ struct RaiseVisitor {
 impl<'a> Visitor<'a> for RaiseVisitor {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match &stmt.node {
-            StmtKind::Raise { exc, cause } => {
-                if cause.is_none() {
-                    if let Some(exc) = exc {
-                        match &exc.node {
-                            ExprKind::Name { id, .. } if is_lower(id) => {}
-                            _ => {
-                                self.checks.push(Check::new(
-                                    CheckKind::RaiseWithoutFromInsideExcept,
-                                    Range::from_located(stmt),
-                                ));
-                            }
-                        }
-                    }
+            StmtKind::Raise {
+                exc: Some(exc),
+                cause: None,
+            } => match &exc.node {
+                ExprKind::Name { id, .. } if is_lower(id) => {}
+                _ => {
+                    self.checks.push(Check::new(
+                        CheckKind::RaiseWithoutFromInsideExcept,
+                        Range::from_located(stmt),
+                    ));
                 }
-            }
+            },
             StmtKind::ClassDef { .. }
             | StmtKind::FunctionDef { .. }
             | StmtKind::AsyncFunctionDef { .. }

--- a/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
+++ b/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
@@ -39,46 +39,47 @@ fn match_tuple_range<T>(located: &Located<T>, locator: &SourceCodeLocator) -> Re
             }
         }
     }
-    if let (Some(location), Some(end_location)) = (location, end_location) {
-        Ok(Range {
-            location,
-            end_location,
-        })
-    } else {
+    let (Some(location), Some(end_location)) = (location, end_location) else {
         bail!("Unable to find left and right parentheses");
-    }
+    };
+    Ok(Range {
+        location,
+        end_location,
+    })
 }
 
 /// B013
 pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[Excepthandler]) {
     for handler in handlers {
-        let ExcepthandlerKind::ExceptHandler { type_, .. } = &handler.node;
-        if let Some(type_) = type_ {
-            if let ExprKind::Tuple { elts, .. } = &type_.node {
-                if let [elt] = &elts[..] {
-                    let mut check = Check::new(
-                        CheckKind::RedundantTupleInExceptionHandler(elt.to_string()),
-                        Range::from_located(type_),
-                    );
-                    if checker.patch(check.kind.code()) {
-                        let mut generator = SourceGenerator::new();
-                        generator.unparse_expr(elt, 0);
-                        if let Ok(content) = generator.generate() {
-                            match match_tuple_range(handler, checker.locator) {
-                                Ok(range) => {
-                                    check.amend(Fix::replacement(
-                                        content,
-                                        range.location,
-                                        range.end_location,
-                                    ));
-                                }
-                                Err(e) => error!("Failed to locate parentheses: {e}"),
-                            }
-                        }
+        let ExcepthandlerKind::ExceptHandler { type_: Some(type_), .. } = &handler.node else {
+            continue;
+        };
+        let ExprKind::Tuple { elts, .. } = &type_.node else {
+            continue;
+        };
+        let [elt] = &elts[..] else {
+            continue;
+        };
+        let mut check = Check::new(
+            CheckKind::RedundantTupleInExceptionHandler(elt.to_string()),
+            Range::from_located(type_),
+        );
+        if checker.patch(check.kind.code()) {
+            let mut generator = SourceGenerator::new();
+            generator.unparse_expr(elt, 0);
+            if let Ok(content) = generator.generate() {
+                match match_tuple_range(handler, checker.locator) {
+                    Ok(range) => {
+                        check.amend(Fix::replacement(
+                            content,
+                            range.location,
+                            range.end_location,
+                        ));
                     }
-                    checker.add_check(check);
+                    Err(e) => error!("Failed to locate parentheses: {e}"),
                 }
             }
         }
+        checker.add_check(check);
     }
 }

--- a/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
+++ b/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
@@ -72,7 +72,7 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
                                         range.end_location,
                                     ));
                                 }
-                                Err(e) => error!("Failed to locate parentheses: {}", e),
+                                Err(e) => error!("Failed to locate parentheses: {e}"),
                             }
                         }
                     }

--- a/src/flake8_bugbear/plugins/setattr_with_constant.rs
+++ b/src/flake8_bugbear/plugins/setattr_with_constant.rs
@@ -53,7 +53,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
                                     expr.location,
                                     expr.end_location.unwrap(),
                                 )),
-                                Err(e) => error!("Failed to fix invalid comparison: {}", e),
+                                Err(e) => error!("Failed to fix invalid comparison: {e}"),
                             };
                         }
                         checker.add_check(check);

--- a/src/flake8_bugbear/plugins/setattr_with_constant.rs
+++ b/src/flake8_bugbear/plugins/setattr_with_constant.rs
@@ -35,31 +35,37 @@ fn assignment(obj: &Expr, name: &str, value: &Expr) -> Result<String> {
 
 /// B010
 pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {
-    if let ExprKind::Name { id, .. } = &func.node {
-        if id == "setattr" {
-            if let [obj, name, value] = args {
-                if let ExprKind::Constant {
-                    value: Constant::Str(name),
-                    ..
-                } = &name.node
-                {
-                    if IDENTIFIER_REGEX.is_match(name) && !KWLIST.contains(&name.as_str()) {
-                        let mut check =
-                            Check::new(CheckKind::SetAttrWithConstant, Range::from_located(expr));
-                        if checker.patch(check.kind.code()) {
-                            match assignment(obj, name, value) {
-                                Ok(content) => check.amend(Fix::replacement(
-                                    content,
-                                    expr.location,
-                                    expr.end_location.unwrap(),
-                                )),
-                                Err(e) => error!("Failed to fix invalid comparison: {e}"),
-                            };
-                        }
-                        checker.add_check(check);
-                    }
-                }
-            }
-        }
+    let ExprKind::Name { id, .. } = &func.node else {
+        return;
+    };
+    if id != "setattr" {
+        return;
     }
+    let [obj, name, value] = args else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(name),
+        ..
+    } = &name.node else {
+        return;
+    };
+    if !IDENTIFIER_REGEX.is_match(name) {
+        return;
+    }
+    if KWLIST.contains(&name.as_str()) {
+        return;
+    }
+    let mut check = Check::new(CheckKind::SetAttrWithConstant, Range::from_located(expr));
+    if checker.patch(check.kind.code()) {
+        match assignment(obj, name, value) {
+            Ok(content) => check.amend(Fix::replacement(
+                content,
+                expr.location,
+                expr.end_location.unwrap(),
+            )),
+            Err(e) => error!("Failed to fix invalid comparison: {e}"),
+        };
+    }
+    checker.add_check(check);
 }

--- a/src/flake8_bugbear/plugins/star_arg_unpacking_after_keyword_arg.rs
+++ b/src/flake8_bugbear/plugins/star_arg_unpacking_after_keyword_arg.rs
@@ -10,16 +10,19 @@ pub fn star_arg_unpacking_after_keyword_arg(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if let Some(keyword) = keywords.first() {
-        for arg in args {
-            if let ExprKind::Starred { .. } = arg.node {
-                if arg.location > keyword.location {
-                    checker.add_check(Check::new(
-                        CheckKind::StarArgUnpackingAfterKeywordArg,
-                        Range::from_located(arg),
-                    ));
-                }
-            }
+    let Some(keyword) = keywords.first() else {
+        return;
+    };
+    for arg in args {
+        let ExprKind::Starred { .. } = arg.node else {
+            continue;
+        };
+        if arg.location <= keyword.location {
+            continue;
         }
+        checker.add_check(Check::new(
+            CheckKind::StarArgUnpackingAfterKeywordArg,
+            Range::from_located(arg),
+        ));
     }
 }

--- a/src/flake8_bugbear/plugins/strip_with_multi_characters.rs
+++ b/src/flake8_bugbear/plugins/strip_with_multi_characters.rs
@@ -7,22 +7,27 @@ use crate::checks::{Check, CheckKind};
 
 /// B005
 pub fn strip_with_multi_characters(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {
-    if let ExprKind::Attribute { attr, .. } = &func.node {
-        if attr == "strip" || attr == "lstrip" || attr == "rstrip" {
-            if args.len() == 1 {
-                if let ExprKind::Constant {
-                    value: Constant::Str(value),
-                    ..
-                } = &args[0].node
-                {
-                    if value.len() > 1 && value.chars().unique().count() != value.len() {
-                        checker.add_check(Check::new(
-                            CheckKind::StripWithMultiCharacters,
-                            Range::from_located(expr),
-                        ));
-                    }
-                }
-            }
-        }
+    let ExprKind::Attribute { attr, .. } = &func.node else {
+        return;
+    };
+    if !matches!(attr.as_str(), "strip" | "lstrip" | "rstrip") {
+        return;
+    }
+    if args.len() != 1 {
+        return;
+    }
+
+    let ExprKind::Constant {
+        value: Constant::Str(value),
+        ..
+    } = &args[0].node else {
+        return;
+    };
+
+    if value.len() > 1 && value.chars().unique().count() != value.len() {
+        checker.add_check(Check::new(
+            CheckKind::StripWithMultiCharacters,
+            Range::from_located(expr),
+        ));
     }
 }

--- a/src/flake8_bugbear/plugins/unary_prefix_increment.rs
+++ b/src/flake8_bugbear/plugins/unary_prefix_increment.rs
@@ -6,14 +6,17 @@ use crate::checks::{Check, CheckKind};
 
 /// B002
 pub fn unary_prefix_increment(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand: &Expr) {
-    if matches!(op, Unaryop::UAdd) {
-        if let ExprKind::UnaryOp { op, .. } = &operand.node {
-            if matches!(op, Unaryop::UAdd) {
-                checker.add_check(Check::new(
-                    CheckKind::UnaryPrefixIncrement,
-                    Range::from_located(expr),
-                ));
-            }
-        }
+    if !matches!(op, Unaryop::UAdd) {
+        return;
     }
+    let ExprKind::UnaryOp { op, .. } = &operand.node else {
+            return;
+        };
+    if !matches!(op, Unaryop::UAdd) {
+        return;
+    }
+    checker.add_check(Check::new(
+        CheckKind::UnaryPrefixIncrement,
+        Range::from_located(expr),
+    ));
 }

--- a/src/flake8_bugbear/plugins/unreliable_callable_check.rs
+++ b/src/flake8_bugbear/plugins/unreliable_callable_check.rs
@@ -6,22 +6,27 @@ use crate::checks::{Check, CheckKind};
 
 /// B004
 pub fn unreliable_callable_check(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {
-    if let ExprKind::Name { id, .. } = &func.node {
-        if id == "getattr" || id == "hasattr" {
-            if args.len() >= 2 {
-                if let ExprKind::Constant {
-                    value: Constant::Str(s),
-                    ..
-                } = &args[1].node
-                {
-                    if s == "__call__" {
-                        checker.add_check(Check::new(
-                            CheckKind::UnreliableCallableCheck,
-                            Range::from_located(expr),
-                        ));
-                    }
-                }
-            }
-        }
+    let ExprKind::Name { id, .. } = &func.node else {
+        return;
+    };
+    if id != "getattr" && id != "hasattr" {
+        return;
     }
+    if args.len() < 2 {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(s),
+        ..
+    } = &args[1].node else
+    {
+        return;
+    };
+    if s != "__call__" {
+        return;
+    }
+    checker.add_check(Check::new(
+        CheckKind::UnreliableCallableCheck,
+        Range::from_located(expr),
+    ));
 }

--- a/src/flake8_comprehensions/checks.rs
+++ b/src/flake8_comprehensions/checks.rs
@@ -62,7 +62,7 @@ pub fn unnecessary_generator_list(
         if fix {
             match fixes::fix_unnecessary_generator_list(locator, expr) {
                 Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to generate fix: {}", e),
+                Err(e) => error!("Failed to generate fix: {e}"),
             }
         }
         return Some(check);
@@ -86,7 +86,7 @@ pub fn unnecessary_generator_set(
         if fix {
             match fixes::fix_unnecessary_generator_set(locator, expr) {
                 Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to generate fix: {}", e),
+                Err(e) => error!("Failed to generate fix: {e}"),
             }
         }
         return Some(check);
@@ -112,7 +112,7 @@ pub fn unnecessary_generator_dict(
                 if fix {
                     match fixes::fix_unnecessary_generator_dict(locator, expr) {
                         Ok(fix) => check.amend(fix),
-                        Err(e) => error!("Failed to generate fix: {}", e),
+                        Err(e) => error!("Failed to generate fix: {e}"),
                     }
                 }
                 return Some(check);
@@ -139,7 +139,7 @@ pub fn unnecessary_list_comprehension_set(
         if fix {
             match fixes::fix_unnecessary_list_comprehension_set(locator, expr) {
                 Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to generate fix: {}", e),
+                Err(e) => error!("Failed to generate fix: {e}"),
             }
         }
         return Some(check);
@@ -165,7 +165,7 @@ pub fn unnecessary_list_comprehension_dict(
                 if fix {
                     match fixes::fix_unnecessary_list_comprehension_dict(locator, expr) {
                         Ok(fix) => check.amend(fix),
-                        Err(e) => error!("Failed to generate fix: {}", e),
+                        Err(e) => error!("Failed to generate fix: {e}"),
                     }
                 }
                 return Some(check);
@@ -196,7 +196,7 @@ pub fn unnecessary_literal_set(
     if fix {
         match fixes::fix_unnecessary_literal_set(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)
@@ -232,7 +232,7 @@ pub fn unnecessary_literal_dict(
     if fix {
         match fixes::fix_unnecessary_literal_dict(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)
@@ -268,7 +268,7 @@ pub fn unnecessary_collection_call(
     if fix {
         match fixes::fix_unnecessary_collection_call(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)
@@ -296,7 +296,7 @@ pub fn unnecessary_literal_within_tuple_call(
     if fix {
         match fixes::fix_unnecessary_literal_within_tuple_call(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)
@@ -324,7 +324,7 @@ pub fn unnecessary_literal_within_list_call(
     if fix {
         match fixes::fix_unnecessary_literal_within_list_call(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)
@@ -345,7 +345,7 @@ pub fn unnecessary_list_call(
         if fix {
             match fixes::fix_unnecessary_list_call(locator, expr) {
                 Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to generate fix: {}", e),
+                Err(e) => error!("Failed to generate fix: {e}"),
             }
         }
         return Some(check);
@@ -375,7 +375,7 @@ pub fn unnecessary_call_around_sorted(
             if fix {
                 match fixes::fix_unnecessary_call_around_sorted(locator, expr) {
                     Ok(fix) => check.amend(fix),
-                    Err(e) => error!("Failed to generate fix: {}", e),
+                    Err(e) => error!("Failed to generate fix: {e}"),
                 }
             }
             return Some(check);
@@ -497,7 +497,7 @@ pub fn unnecessary_comprehension(
     if fix {
         match fixes::fix_unnecessary_comprehension(locator, expr) {
             Ok(fix) => check.amend(fix),
-            Err(e) => error!("Failed to generate fix: {}", e),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
     Some(check)

--- a/src/flake8_comprehensions/checks.rs
+++ b/src/flake8_comprehensions/checks.rs
@@ -158,22 +158,23 @@ pub fn unnecessary_list_comprehension_dict(
     location: Range,
 ) -> Option<Check> {
     let argument = exactly_one_argument_with_matching_function("dict", func, args, keywords)?;
-    if let ExprKind::ListComp { elt, .. } = &argument {
-        match &elt.node {
-            ExprKind::Tuple { elts, .. } if elts.len() == 2 => {
-                let mut check = Check::new(CheckKind::UnnecessaryListComprehensionDict, location);
-                if fix {
-                    match fixes::fix_unnecessary_list_comprehension_dict(locator, expr) {
-                        Ok(fix) => check.amend(fix),
-                        Err(e) => error!("Failed to generate fix: {e}"),
-                    }
-                }
-                return Some(check);
-            }
-            _ => {}
+    let ExprKind::ListComp { elt, .. } = &argument else {
+        return None;
+    };
+    let ExprKind::Tuple { elts, .. } = &elt.node else {
+        return None;
+    };
+    if elts.len() != 2 {
+        return None;
+    }
+    let mut check = Check::new(CheckKind::UnnecessaryListComprehensionDict, location);
+    if fix {
+        match fixes::fix_unnecessary_list_comprehension_dict(locator, expr) {
+            Ok(fix) => check.amend(fix),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
-    None
+    Some(check)
 }
 
 /// C405 (`set([1, 2])`)
@@ -340,17 +341,17 @@ pub fn unnecessary_list_call(
     location: Range,
 ) -> Option<Check> {
     let argument = first_argument_with_matching_function("list", func, args)?;
-    if let ExprKind::ListComp { .. } = argument {
-        let mut check = Check::new(CheckKind::UnnecessaryListCall, location);
-        if fix {
-            match fixes::fix_unnecessary_list_call(locator, expr) {
-                Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to generate fix: {e}"),
-            }
-        }
-        return Some(check);
+    if !matches!(argument, ExprKind::ListComp { .. }) {
+        return None;
     }
-    None
+    let mut check = Check::new(CheckKind::UnnecessaryListCall, location);
+    if fix {
+        match fixes::fix_unnecessary_list_call(locator, expr) {
+            Ok(fix) => check.amend(fix),
+            Err(e) => error!("Failed to generate fix: {e}"),
+        }
+    }
+    Some(check)
 }
 
 /// C413
@@ -366,22 +367,24 @@ pub fn unnecessary_call_around_sorted(
     if !(outer == "list" || outer == "reversed") {
         return None;
     }
-    if let ExprKind::Call { func, .. } = &args.first()?.node {
-        if function_name(func)? == "sorted" {
-            let mut check = Check::new(
-                CheckKind::UnnecessaryCallAroundSorted(outer.to_string()),
-                location,
-            );
-            if fix {
-                match fixes::fix_unnecessary_call_around_sorted(locator, expr) {
-                    Ok(fix) => check.amend(fix),
-                    Err(e) => error!("Failed to generate fix: {e}"),
-                }
-            }
-            return Some(check);
+    let ExprKind::Call { func, .. } = &args.first()?.node else {
+        return None;
+    };
+    if function_name(func)? != "sorted" {
+        return None;
+    }
+
+    let mut check = Check::new(
+        CheckKind::UnnecessaryCallAroundSorted(outer.to_string()),
+        location,
+    );
+    if fix {
+        match fixes::fix_unnecessary_call_around_sorted(locator, expr) {
+            Ok(fix) => check.amend(fix),
+            Err(e) => error!("Failed to generate fix: {e}"),
         }
     }
-    None
+    Some(check)
 }
 
 /// C414
@@ -402,25 +405,28 @@ pub fn unnecessary_double_cast_or_process(
         return None;
     }
 
-    if let ExprKind::Call { func, .. } = &args.first()?.node {
-        let inner = function_name(func)?;
-        // Ex) set(tuple(...))
-        if (outer == "set" || outer == "sorted")
-            && (inner == "list" || inner == "tuple" || inner == "reversed" || inner == "sorted")
-        {
-            return Some(new_check(inner, outer, location));
-        }
+    let ExprKind::Call { func, .. } = &args.first()?.node else {
+        return None;
+    };
 
-        // Ex) list(tuple(...))
-        if (outer == "list" || outer == "tuple") && (inner == "list" || inner == "tuple") {
-            return Some(new_check(inner, outer, location));
-        }
-
-        // Ex) set(set(...))
-        if outer == "set" && inner == "set" {
-            return Some(new_check(inner, outer, location));
-        }
+    let inner = function_name(func)?;
+    // Ex) set(tuple(...))
+    if (outer == "set" || outer == "sorted")
+        && (inner == "list" || inner == "tuple" || inner == "reversed" || inner == "sorted")
+    {
+        return Some(new_check(inner, outer, location));
     }
+
+    // Ex) list(tuple(...))
+    if (outer == "list" || outer == "tuple") && (inner == "list" || inner == "tuple") {
+        return Some(new_check(inner, outer, location));
+    }
+
+    // Ex) set(set(...))
+    if outer == "set" && inner == "set" {
+        return Some(new_check(inner, outer, location));
+    }
+
     None
 }
 
@@ -435,33 +441,34 @@ pub fn unnecessary_subscript_reversal(
     if !["set", "sorted", "reversed"].contains(&id) {
         return None;
     }
-    if let ExprKind::Subscript { slice, .. } = &first_arg.node {
-        if let ExprKind::Slice { lower, upper, step } = &slice.node {
-            if lower.is_none() && upper.is_none() {
-                if let Some(step) = step {
-                    if let ExprKind::UnaryOp {
-                        op: Unaryop::USub,
-                        operand,
-                    } = &step.node
-                    {
-                        if let ExprKind::Constant {
-                            value: Constant::Int(val),
-                            ..
-                        } = &operand.node
-                        {
-                            if *val == BigInt::from(1) {
-                                return Some(Check::new(
-                                    CheckKind::UnnecessarySubscriptReversal(id.to_string()),
-                                    location,
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    let ExprKind::Subscript { slice, .. } = &first_arg.node else {
+        return None;
+    };
+    let ExprKind::Slice { lower, upper, step } = &slice.node else {
+            return None;
+        };
+    if lower.is_some() || upper.is_some() {
+        return None;
     }
-    None
+    let ExprKind::UnaryOp {
+        op: Unaryop::USub,
+        operand,
+    } = &step.as_ref()?.node else {
+        return None;
+    };
+    let ExprKind::Constant {
+        value: Constant::Int(val),
+        ..
+    } = &operand.node else {
+        return None;
+    };
+    if *val != BigInt::from(1) {
+        return None;
+    };
+    Some(Check::new(
+        CheckKind::UnnecessarySubscriptReversal(id.to_string()),
+        location,
+    ))
 }
 
 /// C416

--- a/src/flake8_print/plugins/print_call.rs
+++ b/src/flake8_print/plugins/print_call.rs
@@ -9,39 +9,41 @@ use crate::flake8_print::checks;
 
 /// T201, T203
 pub fn print_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
-    if let Some(mut check) = checks::print_call(
+    let Some(mut check) = checks::print_call(
         func,
         checker.settings.enabled.contains(&CheckCode::T201),
         checker.settings.enabled.contains(&CheckCode::T203),
         Range::from_located(expr),
-    ) {
-        if checker.patch(check.kind.code()) {
-            let context = checker.binding_context();
-            if matches!(
-                checker.parents[context.defined_by].node,
-                StmtKind::Expr { .. }
+    ) else {
+        return;
+    };
+
+    if checker.patch(check.kind.code()) {
+        let context = checker.binding_context();
+        if matches!(
+            checker.parents[context.defined_by].node,
+            StmtKind::Expr { .. }
+        ) {
+            let deleted: Vec<&Stmt> = checker
+                .deletions
+                .iter()
+                .map(|index| checker.parents[*index])
+                .collect();
+            match helpers::remove_stmt(
+                checker.parents[context.defined_by],
+                context.defined_in.map(|index| checker.parents[index]),
+                &deleted,
             ) {
-                let deleted: Vec<&Stmt> = checker
-                    .deletions
-                    .iter()
-                    .map(|index| checker.parents[*index])
-                    .collect();
-                match helpers::remove_stmt(
-                    checker.parents[context.defined_by],
-                    context.defined_in.map(|index| checker.parents[index]),
-                    &deleted,
-                ) {
-                    Ok(fix) => {
-                        if fix.content.is_empty() || fix.content == "pass" {
-                            checker.deletions.insert(context.defined_by);
-                        }
-                        check.amend(fix);
+                Ok(fix) => {
+                    if fix.content.is_empty() || fix.content == "pass" {
+                        checker.deletions.insert(context.defined_by);
                     }
-                    Err(e) => error!("Failed to remove print call: {e}"),
+                    check.amend(fix);
                 }
+                Err(e) => error!("Failed to remove print call: {e}"),
             }
         }
-
-        checker.add_check(check);
     }
+
+    checker.add_check(check);
 }

--- a/src/flake8_print/plugins/print_call.rs
+++ b/src/flake8_print/plugins/print_call.rs
@@ -37,7 +37,7 @@ pub fn print_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
                         }
                         check.amend(fix);
                     }
-                    Err(e) => error!("Failed to remove print call: {}", e),
+                    Err(e) => error!("Failed to remove print call: {e}"),
                 }
             }
         }

--- a/src/flake8_tidy_imports/checks.rs
+++ b/src/flake8_tidy_imports/checks.rs
@@ -9,18 +9,16 @@ pub fn banned_relative_import(
     level: Option<&usize>,
     strictness: &Strictness,
 ) -> Option<Check> {
-    if let Some(level) = level {
-        if level
-            > &match strictness {
-                Strictness::All => 0,
-                Strictness::Parents => 1,
-            }
-        {
-            return Some(Check::new(
-                CheckKind::BannedRelativeImport(strictness.clone()),
-                Range::from_located(stmt),
-            ));
-        }
+    let strictness_level = match strictness {
+        Strictness::All => 0,
+        Strictness::Parents => 1,
+    };
+    if level? > &strictness_level {
+        Some(Check::new(
+            CheckKind::BannedRelativeImport(strictness.clone()),
+            Range::from_located(stmt),
+        ))
+    } else {
+        None
     }
-    None
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -151,79 +151,17 @@ pub fn lint_path(
     }
 
     // Read the file from disk.
-    let mut contents = fs::read_file(path)?;
+    let contents = fs::read_file(path)?;
 
-    // Track the number of fixed errors across iterations.
-    let mut fixed = 0;
-
-    // As an escape hatch, bail after 100 iterations.
-    let mut iterations = 0;
-
-    // Continuously autofix until the source code stabilizes.
-    let messages = loop {
-        // Tokenize once.
-        let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);
-
-        // Initialize the SourceCodeLocator (which computes offsets lazily).
-        let locator = SourceCodeLocator::new(&contents);
-
-        // Determine the noqa and isort exclusions.
-        let directives = directives::extract_directives(
-            &tokens,
-            &locator,
-            directives::Flags::from_settings(settings),
-        );
-
-        // Generate checks.
-        let checks = check_path(
-            path,
-            &contents,
-            tokens,
-            &locator,
-            &directives,
-            settings,
-            autofix.into(),
-            false,
-        )?;
-
-        // Apply autofix.
-        if matches!(autofix, fixer::Mode::Apply) && iterations < MAX_ITERATIONS {
-            if let Some((fixed_contents, applied)) = fix_file(&checks, &locator) {
-                // Count the number of fixed errors.
-                fixed += applied;
-
-                // Store the fixed contents.
-                contents = fixed_contents.to_string();
-
-                // Increment the iteration count.
-                iterations += 1;
-
-                // Re-run the linter pass (by avoiding the break).
-                continue;
-            }
-        }
-
-        // Convert to messages.
-        let filename = path.to_string_lossy().to_string();
-        break checks
-            .into_iter()
-            .map(|check| {
-                let source = if settings.show_source {
-                    Some(Source::from_check(&check, &locator))
-                } else {
-                    None
-                };
-                Message::from_check(check, filename.clone(), source)
-            })
-            .collect::<Vec<_>>();
-    };
+    // Lint the file.
+    let (contents, fixed, messages) = lint(contents, path, settings, autofix)?;
 
     // Re-populate the cache.
     cache::set(path, &metadata, settings, autofix, &messages, mode);
 
     // If we applied any fixes, write the contents back to disk.
     if fixed > 0 {
-        write(path, &contents)?;
+        write(path, contents)?;
     }
 
     Ok(Diagnostics { messages, fixed })
@@ -297,14 +235,32 @@ pub fn lint_stdin(
     autofix: &fixer::Mode,
 ) -> Result<Diagnostics> {
     // Read the file from disk.
-    let mut contents = stdin.to_string();
+    let contents = stdin.to_string();
 
+    // Lint the file.
+    let (contents, fixed, messages) = lint(contents, path, settings, autofix)?;
+
+    // Write the fixed contents to stdout.
+    if matches!(autofix, fixer::Mode::Apply) {
+        io::stdout().write_all(contents.as_bytes())?;
+    }
+
+    Ok(Diagnostics { messages, fixed })
+}
+
+fn lint(
+    mut contents: String,
+    path: &Path,
+    settings: &Settings,
+    autofix: &fixer::Mode,
+) -> Result<(String, usize, Vec<Message>)> {
     // Track the number of fixed errors across iterations.
     let mut fixed = 0;
 
     // As an escape hatch, bail after 100 iterations.
     let mut iterations = 0;
 
+    // Continuously autofix until the source code stabilizes.
     let messages = loop {
         // Tokenize once.
         let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);
@@ -363,12 +319,7 @@ pub fn lint_stdin(
             .collect();
     };
 
-    // Write the fixed contents to stdout.
-    if matches!(autofix, fixer::Mode::Apply) {
-        io::stdout().write_all(contents.as_bytes())?;
-    }
-
-    Ok(Diagnostics { messages, fixed })
+    Ok((contents, fixed, messages))
 }
 
 #[cfg(test)]

--- a/src/pycodestyle/plugins.rs
+++ b/src/pycodestyle/plugins.rs
@@ -25,10 +25,7 @@ fn compare(left: &Expr, ops: &[Cmpop], comparators: &[Expr]) -> Option<String> {
     );
     let mut generator = SourceGenerator::new();
     generator.unparse_expr(&cmp, 0);
-    if let Ok(content) = generator.generate() {
-        return Some(content);
-    }
-    None
+    generator.generate().ok()
 }
 
 /// E711, E712

--- a/src/pycodestyle/plugins.rs
+++ b/src/pycodestyle/plugins.rs
@@ -322,7 +322,7 @@ pub fn do_not_assign_lambda(checker: &mut Checker, target: &Expr, value: &Expr, 
                                 stmt.end_location.unwrap(),
                             ));
                         }
-                        Err(e) => error!("Failed to generate fix: {}", e),
+                        Err(e) => error!("Failed to generate fix: {e}"),
                     }
                 }
             }

--- a/src/pydocstyle/plugins.rs
+++ b/src/pydocstyle/plugins.rs
@@ -119,31 +119,33 @@ pub fn not_missing(
 
 /// D200
 pub fn one_liner(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = &definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            let mut line_count = 0;
-            let mut non_empty_line_count = 0;
-            for line in LinesWithTrailingNewline::from(string) {
-                line_count += 1;
-                if !line.trim().is_empty() {
-                    non_empty_line_count += 1;
-                }
-                if non_empty_line_count > 1 {
-                    break;
-                }
-            }
+    let Some(docstring) = &definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
 
-            if non_empty_line_count == 1 && (line_count > 1) {
-                checker.add_check(Check::new(
-                    CheckKind::FitsOnOneLine,
-                    Range::from_located(docstring),
-                ));
-            }
+    let mut line_count = 0;
+    let mut non_empty_line_count = 0;
+    for line in LinesWithTrailingNewline::from(string) {
+        line_count += 1;
+        if !line.trim().is_empty() {
+            non_empty_line_count += 1;
         }
+        if non_empty_line_count > 1 {
+            break;
+        }
+    }
+
+    if non_empty_line_count == 1 && (line_count > 1) {
+        checker.add_check(Check::new(
+            CheckKind::FitsOnOneLine,
+            Range::from_located(docstring),
+        ));
     }
 }
 
@@ -154,237 +156,384 @@ static INNER_FUNCTION_OR_CLASS_REGEX: Lazy<Regex> =
 
 /// D201, D202
 pub fn blank_before_after_function(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let DefinitionKind::Function(parent)
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let (
+        DefinitionKind::Function(parent)
         | DefinitionKind::NestedFunction(parent)
-        | DefinitionKind::Method(parent) = &definition.kind
-        {
-            if let ExprKind::Constant {
-                value: Constant::Str(_),
-                ..
-            } = &docstring.node
-            {
-                if checker.settings.enabled.contains(&CheckCode::D201) {
-                    let (before, ..) = checker.locator.partition_source_code_at(
-                        &Range::from_located(parent),
-                        &Range::from_located(docstring),
-                    );
+        | DefinitionKind::Method(parent)
+    ) = &definition.kind else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(_),
+        ..
+    } = &docstring.node else {
+        return;
+    };
 
-                    let blank_lines_before = before
-                        .lines()
-                        .rev()
-                        .skip(1)
-                        .take_while(|line| line.trim().is_empty())
-                        .count();
-                    if blank_lines_before != 0 {
-                        let mut check = Check::new(
-                            CheckKind::NoBlankLineBeforeFunction(blank_lines_before),
-                            Range::from_located(docstring),
-                        );
-                        if checker.patch(check.kind.code()) {
-                            // Delete the blank line before the docstring.
-                            check.amend(Fix::deletion(
-                                Location::new(docstring.location.row() - blank_lines_before, 0),
-                                Location::new(docstring.location.row(), 0),
-                            ));
-                        }
-                        checker.add_check(check);
-                    }
-                }
+    if checker.settings.enabled.contains(&CheckCode::D201) {
+        let (before, ..) = checker.locator.partition_source_code_at(
+            &Range::from_located(parent),
+            &Range::from_located(docstring),
+        );
 
-                if checker.settings.enabled.contains(&CheckCode::D202) {
-                    let (_, _, after) = checker.locator.partition_source_code_at(
-                        &Range::from_located(parent),
-                        &Range::from_located(docstring),
-                    );
-
-                    let all_blank_after = after
-                        .lines()
-                        .skip(1)
-                        .all(|line| line.trim().is_empty() || COMMENT_REGEX.is_match(line));
-                    if all_blank_after {
-                        return;
-                    }
-
-                    let blank_lines_after = after
-                        .lines()
-                        .skip(1)
-                        .take_while(|line| line.trim().is_empty())
-                        .count();
-
-                    // Avoid D202 violations for blank lines followed by inner functions or classes.
-                    if blank_lines_after == 1 && INNER_FUNCTION_OR_CLASS_REGEX.is_match(&after) {
-                        return;
-                    }
-
-                    if blank_lines_after != 0 {
-                        let mut check = Check::new(
-                            CheckKind::NoBlankLineAfterFunction(blank_lines_after),
-                            Range::from_located(docstring),
-                        );
-                        if checker.patch(check.kind.code()) {
-                            // Delete the blank line after the docstring.
-                            check.amend(Fix::deletion(
-                                Location::new(docstring.end_location.unwrap().row() + 1, 0),
-                                Location::new(
-                                    docstring.end_location.unwrap().row() + 1 + blank_lines_after,
-                                    0,
-                                ),
-                            ));
-                        }
-                        checker.add_check(check);
-                    }
-                }
+        let blank_lines_before = before
+            .lines()
+            .rev()
+            .skip(1)
+            .take_while(|line| line.trim().is_empty())
+            .count();
+        if blank_lines_before != 0 {
+            let mut check = Check::new(
+                CheckKind::NoBlankLineBeforeFunction(blank_lines_before),
+                Range::from_located(docstring),
+            );
+            if checker.patch(check.kind.code()) {
+                // Delete the blank line before the docstring.
+                check.amend(Fix::deletion(
+                    Location::new(docstring.location.row() - blank_lines_before, 0),
+                    Location::new(docstring.location.row(), 0),
+                ));
             }
+            checker.add_check(check);
+        }
+    }
+
+    if checker.settings.enabled.contains(&CheckCode::D202) {
+        let (_, _, after) = checker.locator.partition_source_code_at(
+            &Range::from_located(parent),
+            &Range::from_located(docstring),
+        );
+
+        let all_blank_after = after
+            .lines()
+            .skip(1)
+            .all(|line| line.trim().is_empty() || COMMENT_REGEX.is_match(line));
+        if all_blank_after {
+            return;
+        }
+
+        let blank_lines_after = after
+            .lines()
+            .skip(1)
+            .take_while(|line| line.trim().is_empty())
+            .count();
+
+        // Avoid D202 violations for blank lines followed by inner functions or classes.
+        if blank_lines_after == 1 && INNER_FUNCTION_OR_CLASS_REGEX.is_match(&after) {
+            return;
+        }
+
+        if blank_lines_after != 0 {
+            let mut check = Check::new(
+                CheckKind::NoBlankLineAfterFunction(blank_lines_after),
+                Range::from_located(docstring),
+            );
+            if checker.patch(check.kind.code()) {
+                // Delete the blank line after the docstring.
+                check.amend(Fix::deletion(
+                    Location::new(docstring.end_location.unwrap().row() + 1, 0),
+                    Location::new(
+                        docstring.end_location.unwrap().row() + 1 + blank_lines_after,
+                        0,
+                    ),
+                ));
+            }
+            checker.add_check(check);
         }
     }
 }
 
 /// D203, D204, D211
 pub fn blank_before_after_class(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = &definition.docstring {
-        if let DefinitionKind::Class(parent) | DefinitionKind::NestedClass(parent) =
-            &definition.kind
-        {
-            if let ExprKind::Constant {
-                value: Constant::Str(_),
-                ..
-            } = &docstring.node
-            {
-                if checker.settings.enabled.contains(&CheckCode::D203)
-                    || checker.settings.enabled.contains(&CheckCode::D211)
-                {
-                    let (before, ..) = checker.locator.partition_source_code_at(
-                        &Range::from_located(parent),
-                        &Range::from_located(docstring),
-                    );
+    let Some(docstring) = &definition.docstring else {
+        return;
+    };
+    let (DefinitionKind::Class(parent) | DefinitionKind::NestedClass(parent)) = &definition.kind else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(_),
+        ..
+    } = &docstring.node else {
+        return;
+    };
 
-                    let blank_lines_before = before
-                        .lines()
-                        .rev()
-                        .skip(1)
-                        .take_while(|line| line.trim().is_empty())
-                        .count();
-                    if checker.settings.enabled.contains(&CheckCode::D211) {
-                        if blank_lines_before != 0 {
-                            let mut check = Check::new(
-                                CheckKind::NoBlankLineBeforeClass(blank_lines_before),
-                                Range::from_located(docstring),
-                            );
-                            if checker.patch(check.kind.code()) {
-                                // Delete the blank line before the class.
-                                check.amend(Fix::deletion(
-                                    Location::new(docstring.location.row() - blank_lines_before, 0),
-                                    Location::new(docstring.location.row(), 0),
-                                ));
-                            }
-                            checker.add_check(check);
-                        }
-                    }
-                    if checker.settings.enabled.contains(&CheckCode::D203) {
-                        if blank_lines_before != 1 {
-                            let mut check = Check::new(
-                                CheckKind::OneBlankLineBeforeClass(blank_lines_before),
-                                Range::from_located(docstring),
-                            );
-                            if checker.patch(check.kind.code()) {
-                                // Insert one blank line before the class.
-                                check.amend(Fix::replacement(
-                                    "\n".to_string(),
-                                    Location::new(docstring.location.row() - blank_lines_before, 0),
-                                    Location::new(docstring.location.row(), 0),
-                                ));
-                            }
-                            checker.add_check(check);
-                        }
-                    }
+    if checker.settings.enabled.contains(&CheckCode::D203)
+        || checker.settings.enabled.contains(&CheckCode::D211)
+    {
+        let (before, ..) = checker.locator.partition_source_code_at(
+            &Range::from_located(parent),
+            &Range::from_located(docstring),
+        );
+
+        let blank_lines_before = before
+            .lines()
+            .rev()
+            .skip(1)
+            .take_while(|line| line.trim().is_empty())
+            .count();
+        if checker.settings.enabled.contains(&CheckCode::D211) {
+            if blank_lines_before != 0 {
+                let mut check = Check::new(
+                    CheckKind::NoBlankLineBeforeClass(blank_lines_before),
+                    Range::from_located(docstring),
+                );
+                if checker.patch(check.kind.code()) {
+                    // Delete the blank line before the class.
+                    check.amend(Fix::deletion(
+                        Location::new(docstring.location.row() - blank_lines_before, 0),
+                        Location::new(docstring.location.row(), 0),
+                    ));
                 }
-
-                if checker.settings.enabled.contains(&CheckCode::D204) {
-                    let (_, _, after) = checker.locator.partition_source_code_at(
-                        &Range::from_located(parent),
-                        &Range::from_located(docstring),
-                    );
-
-                    let all_blank_after = after
-                        .lines()
-                        .skip(1)
-                        .all(|line| line.trim().is_empty() || COMMENT_REGEX.is_match(line));
-                    if all_blank_after {
-                        return;
-                    }
-
-                    let blank_lines_after = after
-                        .lines()
-                        .skip(1)
-                        .take_while(|line| line.trim().is_empty())
-                        .count();
-                    if blank_lines_after != 1 {
-                        let mut check = Check::new(
-                            CheckKind::OneBlankLineAfterClass(blank_lines_after),
-                            Range::from_located(docstring),
-                        );
-                        if checker.patch(check.kind.code()) {
-                            // Insert a blank line before the class (replacing any existing lines).
-                            check.amend(Fix::replacement(
-                                "\n".to_string(),
-                                Location::new(docstring.end_location.unwrap().row() + 1, 0),
-                                Location::new(
-                                    docstring.end_location.unwrap().row() + 1 + blank_lines_after,
-                                    0,
-                                ),
-                            ));
-                        }
-                        checker.add_check(check);
-                    }
-                }
+                checker.add_check(check);
             }
+        }
+        if checker.settings.enabled.contains(&CheckCode::D203) {
+            if blank_lines_before != 1 {
+                let mut check = Check::new(
+                    CheckKind::OneBlankLineBeforeClass(blank_lines_before),
+                    Range::from_located(docstring),
+                );
+                if checker.patch(check.kind.code()) {
+                    // Insert one blank line before the class.
+                    check.amend(Fix::replacement(
+                        "\n".to_string(),
+                        Location::new(docstring.location.row() - blank_lines_before, 0),
+                        Location::new(docstring.location.row(), 0),
+                    ));
+                }
+                checker.add_check(check);
+            }
+        }
+    }
+
+    if checker.settings.enabled.contains(&CheckCode::D204) {
+        let (_, _, after) = checker.locator.partition_source_code_at(
+            &Range::from_located(parent),
+            &Range::from_located(docstring),
+        );
+
+        let all_blank_after = after
+            .lines()
+            .skip(1)
+            .all(|line| line.trim().is_empty() || COMMENT_REGEX.is_match(line));
+        if all_blank_after {
+            return;
+        }
+
+        let blank_lines_after = after
+            .lines()
+            .skip(1)
+            .take_while(|line| line.trim().is_empty())
+            .count();
+        if blank_lines_after != 1 {
+            let mut check = Check::new(
+                CheckKind::OneBlankLineAfterClass(blank_lines_after),
+                Range::from_located(docstring),
+            );
+            if checker.patch(check.kind.code()) {
+                // Insert a blank line before the class (replacing any existing lines).
+                check.amend(Fix::replacement(
+                    "\n".to_string(),
+                    Location::new(docstring.end_location.unwrap().row() + 1, 0),
+                    Location::new(
+                        docstring.end_location.unwrap().row() + 1 + blank_lines_after,
+                        0,
+                    ),
+                ));
+            }
+            checker.add_check(check);
         }
     }
 }
 
 /// D205
 pub fn blank_after_summary(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            let mut lines_count = 1;
-            let mut blanks_count = 0;
-            for line in string.trim().lines().skip(1) {
-                lines_count += 1;
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+
+    let mut lines_count = 1;
+    let mut blanks_count = 0;
+    for line in string.trim().lines().skip(1) {
+        lines_count += 1;
+        if line.trim().is_empty() {
+            blanks_count += 1;
+        } else {
+            break;
+        }
+    }
+    if lines_count > 1 && blanks_count != 1 {
+        let mut check = Check::new(
+            CheckKind::BlankLineAfterSummary,
+            Range::from_located(docstring),
+        );
+        if checker.patch(check.kind.code()) {
+            // Find the "summary" line (defined as the first non-blank line).
+            let mut summary_line = 0;
+            for line in string.lines() {
                 if line.trim().is_empty() {
-                    blanks_count += 1;
+                    summary_line += 1;
                 } else {
                     break;
                 }
             }
-            if lines_count > 1 && blanks_count != 1 {
+
+            // Insert one blank line after the summary (replacing any existing lines).
+            check.amend(Fix::replacement(
+                "\n".to_string(),
+                Location::new(docstring.location.row() + summary_line + 1, 0),
+                Location::new(
+                    docstring.location.row() + summary_line + 1 + blanks_count,
+                    0,
+                ),
+            ));
+        }
+        checker.add_check(check);
+    }
+}
+
+/// D206, D207, D208
+pub fn indent(checker: &mut Checker, definition: &Definition) {
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+
+    // Split the docstring into lines.
+    let lines: Vec<&str> = LinesWithTrailingNewline::from(string).collect();
+    if lines.len() <= 1 {
+        return;
+    }
+
+    let docstring_indent = whitespace::indentation(checker, docstring);
+
+    let mut has_seen_tab = docstring_indent.contains('\t');
+    let mut is_over_indented = true;
+    let mut over_indented_lines = vec![];
+    for i in 0..lines.len() {
+        // First lines and continuations doesn't need any indentation.
+        if i == 0 || lines[i - 1].ends_with('\\') {
+            continue;
+        }
+
+        // Omit empty lines, except for the last line, which is non-empty by way of
+        // containing the closing quotation marks.
+        let is_blank = lines[i].trim().is_empty();
+        if i < lines.len() - 1 && is_blank {
+            continue;
+        }
+
+        let line_indent = whitespace::leading_space(lines[i]);
+
+        // We only report tab indentation once, so only check if we haven't seen a tab
+        // yet.
+        has_seen_tab = has_seen_tab || line_indent.contains('\t');
+
+        if checker.settings.enabled.contains(&CheckCode::D207) {
+            // We report under-indentation on every line. This isn't great, but enables
+            // autofix.
+            if (i == lines.len() - 1 || !is_blank) && line_indent.len() < docstring_indent.len() {
                 let mut check = Check::new(
-                    CheckKind::BlankLineAfterSummary,
-                    Range::from_located(docstring),
+                    CheckKind::NoUnderIndentation,
+                    Range {
+                        location: Location::new(docstring.location.row() + i, 0),
+                        end_location: Location::new(docstring.location.row() + i, 0),
+                    },
                 );
                 if checker.patch(check.kind.code()) {
-                    // Find the "summary" line (defined as the first non-blank line).
-                    let mut summary_line = 0;
-                    for line in string.lines() {
-                        if line.trim().is_empty() {
-                            summary_line += 1;
-                        } else {
-                            break;
-                        }
-                    }
-
-                    // Insert one blank line after the summary (replacing any existing lines).
                     check.amend(Fix::replacement(
-                        "\n".to_string(),
-                        Location::new(docstring.location.row() + summary_line + 1, 0),
-                        Location::new(
-                            docstring.location.row() + summary_line + 1 + blanks_count,
-                            0,
-                        ),
+                        whitespace::clean(&docstring_indent),
+                        Location::new(docstring.location.row() + i, 0),
+                        Location::new(docstring.location.row() + i, line_indent.len()),
+                    ));
+                }
+                checker.add_check(check);
+            }
+        }
+
+        // Like pydocstyle, we only report over-indentation if either: (1) every line
+        // (except, optionally, the last line) is over-indented, or (2) the last line
+        // (which contains the closing quotation marks) is
+        // over-indented. We can't know if we've achieved that condition
+        // until we've viewed all the lines, so for now, just track
+        // the over-indentation status of every line.
+        if i < lines.len() - 1 {
+            if line_indent.len() > docstring_indent.len() {
+                over_indented_lines.push(i);
+            } else {
+                is_over_indented = false;
+            }
+        }
+    }
+
+    if checker.settings.enabled.contains(&CheckCode::D206) {
+        if has_seen_tab {
+            checker.add_check(Check::new(
+                CheckKind::IndentWithSpaces,
+                Range::from_located(docstring),
+            ));
+        }
+    }
+
+    if checker.settings.enabled.contains(&CheckCode::D208) {
+        // If every line (except the last) is over-indented...
+        if is_over_indented {
+            for i in over_indented_lines {
+                let line_indent = whitespace::leading_space(lines[i]);
+                if line_indent.len() > docstring_indent.len() {
+                    // We report over-indentation on every line. This isn't great, but
+                    // enables autofix.
+                    let mut check = Check::new(
+                        CheckKind::NoOverIndentation,
+                        Range {
+                            location: Location::new(docstring.location.row() + i, 0),
+                            end_location: Location::new(docstring.location.row() + i, 0),
+                        },
+                    );
+                    if checker.patch(check.kind.code()) {
+                        check.amend(Fix::replacement(
+                            whitespace::clean(&docstring_indent),
+                            Location::new(docstring.location.row() + i, 0),
+                            Location::new(docstring.location.row() + i, line_indent.len()),
+                        ));
+                    }
+                    checker.add_check(check);
+                }
+            }
+        }
+
+        // If the last line is over-indented...
+        if !lines.is_empty() {
+            let i = lines.len() - 1;
+            let line_indent = whitespace::leading_space(lines[i]);
+            if line_indent.len() > docstring_indent.len() {
+                let mut check = Check::new(
+                    CheckKind::NoOverIndentation,
+                    Range {
+                        location: Location::new(docstring.location.row() + i, 0),
+                        end_location: Location::new(docstring.location.row() + i, 0),
+                    },
+                );
+                if checker.patch(check.kind.code()) {
+                    check.amend(Fix::replacement(
+                        whitespace::clean(&docstring_indent),
+                        Location::new(docstring.location.row() + i, 0),
+                        Location::new(docstring.location.row() + i, line_indent.len()),
                     ));
                 }
                 checker.add_check(check);
@@ -393,369 +542,248 @@ pub fn blank_after_summary(checker: &mut Checker, definition: &Definition) {
     }
 }
 
-/// D206, D207, D208
-pub fn indent(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            // Split the docstring into lines.
-            let lines: Vec<&str> = LinesWithTrailingNewline::from(string).collect();
-            if lines.len() <= 1 {
-                return;
-            }
-
-            let docstring_indent = whitespace::indentation(checker, docstring);
-
-            let mut has_seen_tab = docstring_indent.contains('\t');
-            let mut is_over_indented = true;
-            let mut over_indented_lines = vec![];
-            for i in 0..lines.len() {
-                // First lines and continuations doesn't need any indentation.
-                if i == 0 || lines[i - 1].ends_with('\\') {
-                    continue;
-                }
-
-                // Omit empty lines, except for the last line, which is non-empty by way of
-                // containing the closing quotation marks.
-                let is_blank = lines[i].trim().is_empty();
-                if i < lines.len() - 1 && is_blank {
-                    continue;
-                }
-
-                let line_indent = whitespace::leading_space(lines[i]);
-
-                // We only report tab indentation once, so only check if we haven't seen a tab
-                // yet.
-                has_seen_tab = has_seen_tab || line_indent.contains('\t');
-
-                if checker.settings.enabled.contains(&CheckCode::D207) {
-                    // We report under-indentation on every line. This isn't great, but enables
-                    // autofix.
-                    if (i == lines.len() - 1 || !is_blank)
-                        && line_indent.len() < docstring_indent.len()
-                    {
-                        let mut check = Check::new(
-                            CheckKind::NoUnderIndentation,
-                            Range {
-                                location: Location::new(docstring.location.row() + i, 0),
-                                end_location: Location::new(docstring.location.row() + i, 0),
-                            },
-                        );
-                        if checker.patch(check.kind.code()) {
-                            check.amend(Fix::replacement(
-                                whitespace::clean(&docstring_indent),
-                                Location::new(docstring.location.row() + i, 0),
-                                Location::new(docstring.location.row() + i, line_indent.len()),
-                            ));
-                        }
-                        checker.add_check(check);
-                    }
-                }
-
-                // Like pydocstyle, we only report over-indentation if either: (1) every line
-                // (except, optionally, the last line) is over-indented, or (2) the last line
-                // (which contains the closing quotation marks) is
-                // over-indented. We can't know if we've achieved that condition
-                // until we've viewed all the lines, so for now, just track
-                // the over-indentation status of every line.
-                if i < lines.len() - 1 {
-                    if line_indent.len() > docstring_indent.len() {
-                        over_indented_lines.push(i);
-                    } else {
-                        is_over_indented = false;
-                    }
-                }
-            }
-
-            if checker.settings.enabled.contains(&CheckCode::D206) {
-                if has_seen_tab {
-                    checker.add_check(Check::new(
-                        CheckKind::IndentWithSpaces,
-                        Range::from_located(docstring),
-                    ));
-                }
-            }
-
-            if checker.settings.enabled.contains(&CheckCode::D208) {
-                // If every line (except the last) is over-indented...
-                if is_over_indented {
-                    for i in over_indented_lines {
-                        let line_indent = whitespace::leading_space(lines[i]);
-                        if line_indent.len() > docstring_indent.len() {
-                            // We report over-indentation on every line. This isn't great, but
-                            // enables autofix.
-                            let mut check = Check::new(
-                                CheckKind::NoOverIndentation,
-                                Range {
-                                    location: Location::new(docstring.location.row() + i, 0),
-                                    end_location: Location::new(docstring.location.row() + i, 0),
-                                },
-                            );
-                            if checker.patch(check.kind.code()) {
-                                check.amend(Fix::replacement(
-                                    whitespace::clean(&docstring_indent),
-                                    Location::new(docstring.location.row() + i, 0),
-                                    Location::new(docstring.location.row() + i, line_indent.len()),
-                                ));
-                            }
-                            checker.add_check(check);
-                        }
-                    }
-                }
-
-                // If the last line is over-indented...
-                if !lines.is_empty() {
-                    let i = lines.len() - 1;
-                    let line_indent = whitespace::leading_space(lines[i]);
-                    if line_indent.len() > docstring_indent.len() {
-                        let mut check = Check::new(
-                            CheckKind::NoOverIndentation,
-                            Range {
-                                location: Location::new(docstring.location.row() + i, 0),
-                                end_location: Location::new(docstring.location.row() + i, 0),
-                            },
-                        );
-                        if checker.patch(check.kind.code()) {
-                            check.amend(Fix::replacement(
-                                whitespace::clean(&docstring_indent),
-                                Location::new(docstring.location.row() + i, 0),
-                                Location::new(docstring.location.row() + i, line_indent.len()),
-                            ));
-                        }
-                        checker.add_check(check);
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// D209
 pub fn newline_after_last_paragraph(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            let mut line_count = 0;
-            for line in LinesWithTrailingNewline::from(string) {
-                if !line.trim().is_empty() {
-                    line_count += 1;
-                }
-                if line_count > 1 {
-                    let content = checker
-                        .locator
-                        .slice_source_code_range(&Range::from_located(docstring));
-                    if let Some(last_line) = content.lines().last().map(str::trim) {
-                        if last_line != "\"\"\"" && last_line != "'''" {
-                            let mut check = Check::new(
-                                CheckKind::NewLineAfterLastParagraph,
-                                Range::from_located(docstring),
-                            );
-                            if checker.patch(check.kind.code()) {
-                                // Insert a newline just before the end-quote(s).
-                                let content = format!(
-                                    "\n{}",
-                                    whitespace::clean(&whitespace::indentation(checker, docstring))
-                                );
-                                check.amend(Fix::insertion(
-                                    content,
-                                    Location::new(
-                                        docstring.end_location.unwrap().row(),
-                                        docstring.end_location.unwrap().column() - "\"\"\"".len(),
-                                    ),
-                                ));
-                            }
-                            checker.add_check(check);
-                        }
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+
+    let mut line_count = 0;
+    for line in LinesWithTrailingNewline::from(string) {
+        if !line.trim().is_empty() {
+            line_count += 1;
+        }
+        if line_count > 1 {
+            let content = checker
+                .locator
+                .slice_source_code_range(&Range::from_located(docstring));
+            if let Some(last_line) = content.lines().last().map(str::trim) {
+                if last_line != "\"\"\"" && last_line != "'''" {
+                    let mut check = Check::new(
+                        CheckKind::NewLineAfterLastParagraph,
+                        Range::from_located(docstring),
+                    );
+                    if checker.patch(check.kind.code()) {
+                        // Insert a newline just before the end-quote(s).
+                        let content = format!(
+                            "\n{}",
+                            whitespace::clean(&whitespace::indentation(checker, docstring))
+                        );
+                        check.amend(Fix::insertion(
+                            content,
+                            Location::new(
+                                docstring.end_location.unwrap().row(),
+                                docstring.end_location.unwrap().column() - "\"\"\"".len(),
+                            ),
+                        ));
                     }
-                    return;
+                    checker.add_check(check);
                 }
             }
+            return;
         }
     }
 }
 
 /// D210
 pub fn no_surrounding_whitespace(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+
+    let mut lines = LinesWithTrailingNewline::from(string);
+    let Some(line) = lines.next() else {
+        return;
+    };
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if line == trimmed {
+        return;
+    }
+    let mut check = Check::new(
+        CheckKind::NoSurroundingWhitespace,
+        Range::from_located(docstring),
+    );
+    if checker.patch(check.kind.code()) {
+        if let Some(first_line) = checker
+            .locator
+            .slice_source_code_range(&Range::from_located(docstring))
+            .lines()
+            .next()
+            .map(str::to_lowercase)
         {
-            let mut lines = LinesWithTrailingNewline::from(string);
-            if let Some(line) = lines.next() {
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    return;
-                }
-                if line != trimmed {
-                    let mut check = Check::new(
-                        CheckKind::NoSurroundingWhitespace,
-                        Range::from_located(docstring),
-                    );
-                    if checker.patch(check.kind.code()) {
-                        if let Some(first_line) = checker
-                            .locator
-                            .slice_source_code_range(&Range::from_located(docstring))
-                            .lines()
-                            .next()
-                            .map(str::to_lowercase)
-                        {
-                            for pattern in constants::TRIPLE_QUOTE_PREFIXES
-                                .iter()
-                                .chain(constants::SINGLE_QUOTE_PREFIXES)
-                            {
-                                if first_line.starts_with(pattern) {
-                                    check.amend(Fix::replacement(
-                                        trimmed.to_string(),
-                                        Location::new(
-                                            docstring.location.row(),
-                                            docstring.location.column() + pattern.len(),
-                                        ),
-                                        Location::new(
-                                            docstring.location.row(),
-                                            docstring.location.column()
-                                                + pattern.len()
-                                                + line.chars().count(),
-                                        ),
-                                    ));
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    checker.add_check(check);
+            for pattern in constants::TRIPLE_QUOTE_PREFIXES
+                .iter()
+                .chain(constants::SINGLE_QUOTE_PREFIXES)
+            {
+                if first_line.starts_with(pattern) {
+                    check.amend(Fix::replacement(
+                        trimmed.to_string(),
+                        Location::new(
+                            docstring.location.row(),
+                            docstring.location.column() + pattern.len(),
+                        ),
+                        Location::new(
+                            docstring.location.row(),
+                            docstring.location.column() + pattern.len() + line.chars().count(),
+                        ),
+                    ));
+                    break;
                 }
             }
         }
     }
+    checker.add_check(check);
 }
 
 /// D212, D213
 pub fn multi_line_summary_start(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
             value: Constant::Str(string),
             ..
-        } = &docstring.node
+        } = &docstring.node else
         {
-            if LinesWithTrailingNewline::from(string).nth(1).is_some() {
-                if let Some(first_line) = checker
-                    .locator
-                    .slice_source_code_range(&Range::from_located(docstring))
-                    .lines()
-                    .next()
-                    .map(str::to_lowercase)
-                {
-                    if constants::TRIPLE_QUOTE_PREFIXES.contains(&first_line.as_str()) {
-                        if checker.settings.enabled.contains(&CheckCode::D212) {
-                            checker.add_check(Check::new(
-                                CheckKind::MultiLineSummaryFirstLine,
-                                Range::from_located(docstring),
-                            ));
-                        }
-                    } else {
-                        if checker.settings.enabled.contains(&CheckCode::D213) {
-                            checker.add_check(Check::new(
-                                CheckKind::MultiLineSummarySecondLine,
-                                Range::from_located(docstring),
-                            ));
-                        }
-                    }
-                }
-            }
+            return;
+        };
+    if LinesWithTrailingNewline::from(string).nth(1).is_none() {
+        return;
+    };
+    let Some(first_line) = checker
+        .locator
+        .slice_source_code_range(&Range::from_located(docstring))
+        .lines()
+        .next()
+        .map(str::to_lowercase) else
+    {
+        return;
+    };
+    if constants::TRIPLE_QUOTE_PREFIXES.contains(&first_line.as_str()) {
+        if checker.settings.enabled.contains(&CheckCode::D212) {
+            checker.add_check(Check::new(
+                CheckKind::MultiLineSummaryFirstLine,
+                Range::from_located(docstring),
+            ));
+        }
+    } else {
+        if checker.settings.enabled.contains(&CheckCode::D213) {
+            checker.add_check(Check::new(
+                CheckKind::MultiLineSummarySecondLine,
+                Range::from_located(docstring),
+            ));
         }
     }
 }
 
 /// D300
 pub fn triple_quotes(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            if let Some(first_line) = checker
-                .locator
-                .slice_source_code_range(&Range::from_located(docstring))
-                .lines()
-                .next()
-                .map(str::to_lowercase)
-            {
-                let starts_with_triple = if string.contains("\"\"\"") {
-                    first_line.starts_with("'''")
-                        || first_line.starts_with("u'''")
-                        || first_line.starts_with("r'''")
-                        || first_line.starts_with("ur'''")
-                } else {
-                    first_line.starts_with("\"\"\"")
-                        || first_line.starts_with("u\"\"\"")
-                        || first_line.starts_with("r\"\"\"")
-                        || first_line.starts_with("ur\"\"\"")
-                };
-                if !starts_with_triple {
-                    checker.add_check(Check::new(
-                        CheckKind::UsesTripleQuotes,
-                        Range::from_located(docstring),
-                    ));
-                }
-            }
-        }
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+    let Some(first_line) = checker
+        .locator
+        .slice_source_code_range(&Range::from_located(docstring))
+        .lines()
+        .next()
+        .map(str::to_lowercase) else
+    {
+        return;
+    };
+    let starts_with_triple = if string.contains("\"\"\"") {
+        first_line.starts_with("'''")
+            || first_line.starts_with("u'''")
+            || first_line.starts_with("r'''")
+            || first_line.starts_with("ur'''")
+    } else {
+        first_line.starts_with("\"\"\"")
+            || first_line.starts_with("u\"\"\"")
+            || first_line.starts_with("r\"\"\"")
+            || first_line.starts_with("ur\"\"\"")
+    };
+    if !starts_with_triple {
+        checker.add_check(Check::new(
+            CheckKind::UsesTripleQuotes,
+            Range::from_located(docstring),
+        ));
     }
 }
 
 /// D400
 pub fn ends_with_period(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            if let Some(string) = string.trim().lines().next() {
-                if !string.ends_with('.') {
-                    checker.add_check(Check::new(
-                        CheckKind::EndsInPeriod,
-                        Range::from_located(docstring),
-                    ));
-                }
-            }
-        }
-    }
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+    let Some(string) = string.trim().lines().next() else {
+        return;
+    };
+    if string.ends_with('.') {
+        return;
+    };
+    checker.add_check(Check::new(
+        CheckKind::EndsInPeriod,
+        Range::from_located(docstring),
+    ));
 }
 
 /// D402
 pub fn no_signature(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let DefinitionKind::Function(parent)
+    let Some(docstring) = definition.docstring else {
+        return;
+    };
+    let (
+        DefinitionKind::Function(parent)
         | DefinitionKind::NestedFunction(parent)
-        | DefinitionKind::Method(parent) = definition.kind
-        {
-            if let StmtKind::FunctionDef { name, .. } = &parent.node {
-                if let ExprKind::Constant {
-                    value: Constant::Str(string),
-                    ..
-                } = &docstring.node
-                {
-                    if let Some(first_line) = string.lines().next() {
-                        if first_line.contains(&format!("{name}(")) {
-                            checker.add_check(Check::new(
-                                CheckKind::NoSignature,
-                                Range::from_located(docstring),
-                            ));
-                        }
-                    }
-                }
-            }
-        }
-    }
+        | DefinitionKind::Method(parent)
+    ) = definition.kind else {
+        return;
+    };
+    let StmtKind::FunctionDef { name, .. } = &parent.node else {
+        return;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
+    let Some(first_line) = string.lines().next() else {
+        return;
+    };
+    if !first_line.contains(&format!("{name}(")) {
+        return;
+    };
+    checker.add_check(Check::new(
+        CheckKind::NoSignature,
+        Range::from_located(docstring),
+    ));
 }
 
 /// D403
@@ -764,149 +792,168 @@ pub fn capitalized(checker: &mut Checker, definition: &Definition) {
         return;
     }
 
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            if let Some(first_word) = string.split(' ').next() {
-                if first_word == first_word.to_uppercase() {
-                    return;
-                }
-                for char in first_word.chars() {
-                    if !char.is_ascii_alphabetic() && char != '\'' {
-                        return;
-                    }
-                }
-                if let Some(first_char) = first_word.chars().next() {
-                    if !first_char.is_uppercase() {
-                        checker.add_check(Check::new(
-                            CheckKind::FirstLineCapitalized,
-                            Range::from_located(docstring),
-                        ));
-                    }
-                }
-            }
+    let Some(docstring) = definition.docstring else {
+        return
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return
+    };
+    let Some(first_word) = string.split(' ').next() else {
+        return
+    };
+    if first_word == first_word.to_uppercase() {
+        return;
+    }
+    for char in first_word.chars() {
+        if !char.is_ascii_alphabetic() && char != '\'' {
+            return;
         }
     }
+    let Some(first_char) = first_word.chars().next() else {
+        return;
+    };
+    if first_char.is_uppercase() {
+        return;
+    };
+    checker.add_check(Check::new(
+        CheckKind::FirstLineCapitalized,
+        Range::from_located(docstring),
+    ));
 }
 
 /// D404
 pub fn starts_with_this(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            let trimmed = string.trim();
-            if trimmed.is_empty() {
-                return;
-            }
+    let Some(docstring) = definition.docstring else {
+        return
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return
+    };
 
-            if let Some(first_word) = string.split(' ').next() {
-                if first_word
-                    .replace(|c: char| !c.is_alphanumeric(), "")
-                    .to_lowercase()
-                    == "this"
-                {
-                    checker.add_check(Check::new(
-                        CheckKind::NoThisPrefix,
-                        Range::from_located(docstring),
-                    ));
-                }
-            }
-        }
+    let trimmed = string.trim();
+    if trimmed.is_empty() {
+        return;
     }
+
+    let Some(first_word) = string.split(' ').next() else {
+        return
+    };
+    if first_word
+        .replace(|c: char| !c.is_alphanumeric(), "")
+        .to_lowercase()
+        != "this"
+    {
+        return;
+    }
+    checker.add_check(Check::new(
+        CheckKind::NoThisPrefix,
+        Range::from_located(docstring),
+    ));
 }
 
 /// D415
 pub fn ends_with_punctuation(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            if let Some(string) = string.trim().lines().next() {
-                if !(string.ends_with('.') || string.ends_with('!') || string.ends_with('?')) {
-                    checker.add_check(Check::new(
-                        CheckKind::EndsInPunctuation,
-                        Range::from_located(docstring),
-                    ));
-                }
-            }
-        }
+    let Some(docstring) = definition.docstring else {
+        return
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return
+    };
+    let Some(string) = string.trim().lines().next() else {
+        return
+    };
+    if string.ends_with('.') || string.ends_with('!') || string.ends_with('?') {
+        return;
     }
+    checker.add_check(Check::new(
+        CheckKind::EndsInPunctuation,
+        Range::from_located(docstring),
+    ));
 }
 
 /// D418
 pub fn if_needed(checker: &mut Checker, definition: &Definition) {
-    if definition.docstring.is_some() {
-        if let DefinitionKind::Function(stmt)
-        | DefinitionKind::NestedFunction(stmt)
-        | DefinitionKind::Method(stmt) = definition.kind
-        {
-            if is_overload(checker, stmt) {
-                checker.add_check(Check::new(
-                    CheckKind::SkipDocstring,
-                    Range::from_located(stmt),
-                ));
-            }
-        }
+    if definition.docstring.is_none() {
+        return;
     }
+    let (
+        DefinitionKind::Function(stmt)
+        | DefinitionKind::NestedFunction(stmt)
+        | DefinitionKind::Method(stmt)
+    ) = definition.kind else {
+        return
+    };
+    if !is_overload(checker, stmt) {
+        return;
+    }
+    checker.add_check(Check::new(
+        CheckKind::SkipDocstring,
+        Range::from_located(stmt),
+    ));
 }
 
 /// D419
 pub fn not_empty(checker: &mut Checker, definition: &Definition) -> bool {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            if string.trim().is_empty() {
-                if checker.settings.enabled.contains(&CheckCode::D419) {
-                    checker.add_check(Check::new(
-                        CheckKind::NonEmpty,
-                        Range::from_located(docstring),
-                    ));
-                }
-                return false;
-            }
-        }
+    let Some(docstring) = definition.docstring else {
+        return true;
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return true;
+    };
+    if !string.trim().is_empty() {
+        return true;
     }
-    true
+
+    if checker.settings.enabled.contains(&CheckCode::D419) {
+        checker.add_check(Check::new(
+            CheckKind::NonEmpty,
+            Range::from_located(docstring),
+        ));
+    }
+    false
 }
 
 /// D212, D214, D215, D405, D406, D407, D408, D409, D410, D411, D412, D413,
 /// D414, D416, D417
 pub fn sections(checker: &mut Checker, definition: &Definition) {
-    if let Some(docstring) = definition.docstring {
-        if let ExprKind::Constant {
-            value: Constant::Str(string),
-            ..
-        } = &docstring.node
-        {
-            let lines: Vec<&str> = LinesWithTrailingNewline::from(string).collect();
-            if lines.len() < 2 {
-                return;
-            }
+    let Some(docstring) = definition.docstring else {
+        return
+    };
+    let ExprKind::Constant {
+        value: Constant::Str(string),
+        ..
+    } = &docstring.node else {
+        return;
+    };
 
-            // First, interpret as NumPy-style sections.
-            let mut found_numpy_section = false;
-            for context in &section_contexts(&lines, &SectionStyle::NumPy) {
-                found_numpy_section = true;
-                numpy_section(checker, definition, context);
-            }
+    let lines: Vec<&str> = LinesWithTrailingNewline::from(string).collect();
+    if lines.len() < 2 {
+        return;
+    }
 
-            // If no such sections were identified, interpret as Google-style sections.
-            if !found_numpy_section {
-                for context in &section_contexts(&lines, &SectionStyle::Google) {
-                    google_section(checker, definition, context);
-                }
-            }
+    // First, interpret as NumPy-style sections.
+    let mut found_numpy_section = false;
+    for context in &section_contexts(&lines, &SectionStyle::NumPy) {
+        found_numpy_section = true;
+        numpy_section(checker, definition, context);
+    }
+
+    // If no such sections were identified, interpret as Google-style sections.
+    if !found_numpy_section {
+        for context in &section_contexts(&lines, &SectionStyle::Google) {
+            google_section(checker, definition, context);
         }
     }
 }
@@ -1310,69 +1357,74 @@ fn common_section(
 }
 
 fn missing_args(checker: &mut Checker, definition: &Definition, docstrings_args: &FxHashSet<&str>) {
-    if let DefinitionKind::Function(parent)
-    | DefinitionKind::NestedFunction(parent)
-    | DefinitionKind::Method(parent) = definition.kind
-    {
-        if let StmtKind::FunctionDef {
+    let (
+        DefinitionKind::Function(parent)
+        | DefinitionKind::NestedFunction(parent)
+        | DefinitionKind::Method(parent)
+    ) = definition.kind else {
+        return
+    };
+    let (
+        StmtKind::FunctionDef {
             args: arguments, ..
         }
         | StmtKind::AsyncFunctionDef {
             args: arguments, ..
-        } = &parent.node
-        {
-            // Look for arguments that weren't included in the docstring.
-            let mut missing_arg_names: BTreeSet<String> = BTreeSet::default();
-            for arg in arguments
-                .args
-                .iter()
-                .chain(arguments.posonlyargs.iter())
-                .chain(arguments.kwonlyargs.iter())
-                .skip(
-                    // If this is a non-static method, skip `cls` or `self`.
-                    usize::from(
-                        matches!(definition.kind, DefinitionKind::Method(_))
-                            && !is_staticmethod(checker, parent),
-                    ),
-                )
-            {
-                let arg_name = arg.node.arg.as_str();
-                if !arg_name.starts_with('_') && !docstrings_args.contains(&arg_name) {
-                    missing_arg_names.insert(arg_name.to_string());
-                }
-            }
-
-            // Check specifically for `vararg` and `kwarg`, which can be prefixed with a
-            // single or double star, respectively.
-            if let Some(arg) = &arguments.vararg {
-                let arg_name = arg.node.arg.as_str();
-                let starred_arg_name = format!("*{arg_name}");
-                if !arg_name.starts_with('_')
-                    && !docstrings_args.contains(&arg_name)
-                    && !docstrings_args.contains(&starred_arg_name.as_str())
-                {
-                    missing_arg_names.insert(starred_arg_name);
-                }
-            }
-            if let Some(arg) = &arguments.kwarg {
-                let arg_name = arg.node.arg.as_str();
-                let starred_arg_name = format!("**{arg_name}");
-                if !arg_name.starts_with('_')
-                    && !docstrings_args.contains(&arg_name)
-                    && !docstrings_args.contains(&starred_arg_name.as_str())
-                {
-                    missing_arg_names.insert(starred_arg_name);
-                }
-            }
-
-            if !missing_arg_names.is_empty() {
-                let names = missing_arg_names.into_iter().sorted().collect();
-                checker.add_check(Check::new(
-                    CheckKind::DocumentAllArguments(names),
-                    Range::from_located(parent),
-                ));
-            }
         }
+    ) = &parent.node else {
+        return
+    };
+
+    // Look for arguments that weren't included in the docstring.
+    let mut missing_arg_names: BTreeSet<String> = BTreeSet::default();
+    for arg in arguments
+        .args
+        .iter()
+        .chain(arguments.posonlyargs.iter())
+        .chain(arguments.kwonlyargs.iter())
+        .skip(
+            // If this is a non-static method, skip `cls` or `self`.
+            usize::from(
+                matches!(definition.kind, DefinitionKind::Method(_))
+                    && !is_staticmethod(checker, parent),
+            ),
+        )
+    {
+        let arg_name = arg.node.arg.as_str();
+        if !arg_name.starts_with('_') && !docstrings_args.contains(&arg_name) {
+            missing_arg_names.insert(arg_name.to_string());
+        }
+    }
+
+    // Check specifically for `vararg` and `kwarg`, which can be prefixed with a
+    // single or double star, respectively.
+    if let Some(arg) = &arguments.vararg {
+        let arg_name = arg.node.arg.as_str();
+        let starred_arg_name = format!("*{arg_name}");
+        if !arg_name.starts_with('_')
+            && !docstrings_args.contains(&arg_name)
+            && !docstrings_args.contains(&starred_arg_name.as_str())
+        {
+            missing_arg_names.insert(starred_arg_name);
+        }
+    }
+    if let Some(arg) = &arguments.kwarg {
+        let arg_name = arg.node.arg.as_str();
+        let starred_arg_name = format!("**{arg_name}");
+        if !arg_name.starts_with('_')
+            && !docstrings_args.contains(&arg_name)
+            && !docstrings_args.contains(&starred_arg_name.as_str())
+        {
+            missing_arg_names.insert(starred_arg_name);
+        }
+    }
+
+    if !missing_arg_names.is_empty() {
+        let names = missing_arg_names.into_iter().sorted().collect();
+        checker.add_check(Check::new(
+            CheckKind::DocumentAllArguments(names),
+            Range::from_located(parent),
+        ));
     }
 }
 

--- a/src/pyflakes/plugins/invalid_literal_comparisons.rs
+++ b/src/pyflakes/plugins/invalid_literal_comparisons.rs
@@ -52,7 +52,7 @@ pub fn invalid_literal_comparison(
                     },
                 ) {
                     Ok(fix) => check.amend(fix),
-                    Err(e) => error!("Failed to fix invalid comparison: {}", e),
+                    Err(e) => error!("Failed to fix invalid comparison: {e}"),
                 }
             }
             checker.add_check(check);

--- a/src/pyupgrade/checks.rs
+++ b/src/pyupgrade/checks.rs
@@ -30,45 +30,51 @@ pub fn super_args(
     // For a `super` invocation to be unnecessary, the first argument needs to match
     // the enclosing class, and the second argument needs to match the first
     // argument to the enclosing function.
-    if let [first_arg, second_arg] = args {
-        // Find the enclosing function definition (if any).
-        if let Some(StmtKind::FunctionDef {
-            args: parent_args, ..
-        }) = parents
-            .find(|stmt| matches!(stmt.node, StmtKind::FunctionDef { .. }))
-            .map(|stmt| &stmt.node)
-        {
-            // Extract the name of the first argument to the enclosing function.
-            if let Some(ArgData {
-                arg: parent_arg, ..
-            }) = parent_args.args.first().map(|expr| &expr.node)
-            {
-                // Find the enclosing class definition (if any).
-                if let Some(StmtKind::ClassDef {
-                    name: parent_name, ..
-                }) = parents
-                    .find(|stmt| matches!(stmt.node, StmtKind::ClassDef { .. }))
-                    .map(|stmt| &stmt.node)
-                {
-                    if let (
-                        ExprKind::Name {
-                            id: first_arg_id, ..
-                        },
-                        ExprKind::Name {
-                            id: second_arg_id, ..
-                        },
-                    ) = (&first_arg.node, &second_arg.node)
-                    {
-                        if first_arg_id == parent_name && second_arg_id == parent_arg {
-                            return Some(Check::new(
-                                CheckKind::SuperCallWithParameters,
-                                Range::from_located(expr),
-                            ));
-                        }
-                    }
-                }
-            }
-        }
+    let [first_arg, second_arg] = args else {
+        return None;
+    };
+
+    // Find the enclosing function definition (if any).
+    let Some(StmtKind::FunctionDef {
+        args: parent_args, ..
+    }) = parents
+        .find(|stmt| matches!(stmt.node, StmtKind::FunctionDef { .. }))
+        .map(|stmt| &stmt.node) else {
+        return None;
+    };
+
+    // Extract the name of the first argument to the enclosing function.
+    let Some(ArgData {
+        arg: parent_arg, ..
+    }) = parent_args.args.first().map(|expr| &expr.node) else {
+        return None;
+    };
+
+    // Find the enclosing class definition (if any).
+    let Some(StmtKind::ClassDef {
+        name: parent_name, ..
+    }) = parents
+        .find(|stmt| matches!(stmt.node, StmtKind::ClassDef { .. }))
+        .map(|stmt| &stmt.node) else {
+        return None;
+    };
+
+    let (
+        ExprKind::Name {
+            id: first_arg_id, ..
+        },
+        ExprKind::Name {
+            id: second_arg_id, ..
+        },
+    ) = (&first_arg.node, &second_arg.node) else {
+        return None;
+    };
+
+    if first_arg_id == parent_name && second_arg_id == parent_arg {
+        return Some(Check::new(
+            CheckKind::SuperCallWithParameters,
+            Range::from_located(expr),
+        ));
     }
 
     None
@@ -76,40 +82,46 @@ pub fn super_args(
 
 /// UP001
 pub fn useless_metaclass_type(targets: &[Expr], value: &Expr, location: Range) -> Option<Check> {
-    if targets.len() == 1 {
-        if let ExprKind::Name { id, .. } = targets.first().map(|expr| &expr.node).unwrap() {
-            if id == "__metaclass__" {
-                if let ExprKind::Name { id, .. } = &value.node {
-                    if id == "type" {
-                        return Some(Check::new(CheckKind::UselessMetaclassType, location));
-                    }
-                }
-            }
-        }
+    if targets.len() != 1 {
+        return None;
     }
-    None
+    let ExprKind::Name { id, .. } = targets.first().map(|expr| &expr.node).unwrap() else {
+        return None;
+    };
+    if id != "__metaclass__" {
+        return None;
+    }
+    let ExprKind::Name { id, .. } = &value.node else {
+        return None;
+    };
+    if id != "type" {
+        return None;
+    }
+    Some(Check::new(CheckKind::UselessMetaclassType, location))
 }
 
 /// UP004
 pub fn useless_object_inheritance(name: &str, bases: &[Expr], scope: &Scope) -> Option<Check> {
     for expr in bases {
-        if let ExprKind::Name { id, .. } = &expr.node {
-            if id == "object" {
-                match scope.values.get(&id.as_str()) {
-                    None
-                    | Some(Binding {
-                        kind: BindingKind::Builtin,
-                        ..
-                    }) => {
-                        return Some(Check::new(
-                            CheckKind::UselessObjectInheritance(name.to_string()),
-                            Range::from_located(expr),
-                        ));
-                    }
-                    _ => {}
-                }
-            }
+        let ExprKind::Name { id, .. } = &expr.node else {
+            continue;
+        };
+        if id != "object" {
+            continue;
         }
+        if !matches!(
+            scope.values.get(&id.as_str()),
+            None | Some(Binding {
+                kind: BindingKind::Builtin,
+                ..
+            })
+        ) {
+            continue;
+        }
+        return Some(Check::new(
+            CheckKind::UselessObjectInheritance(name.to_string()),
+            Range::from_located(expr),
+        ));
     }
 
     None
@@ -118,25 +130,23 @@ pub fn useless_object_inheritance(name: &str, bases: &[Expr], scope: &Scope) -> 
 /// UP003
 pub fn type_of_primitive(func: &Expr, args: &[Expr], location: Range) -> Option<Check> {
     // Validate the arguments.
-    if args.len() == 1 {
-        match &func.node {
-            ExprKind::Attribute { attr: id, .. } | ExprKind::Name { id, .. } => {
-                if id == "type" {
-                    if let ExprKind::Constant { value, .. } = &args[0].node {
-                        if let Some(primitive) = Primitive::from_constant(value) {
-                            return Some(Check::new(
-                                CheckKind::TypeOfPrimitive(primitive),
-                                location,
-                            ));
-                        }
-                    }
-                }
-            }
-            _ => {}
-        }
+    if args.len() != 1 {
+        return None;
     }
 
-    None
+    let (ExprKind::Attribute { attr: id, .. } | ExprKind::Name { id, .. }) = &func.node else {
+        return None;
+    };
+    if id != "type" {
+        return None;
+    }
+
+    let ExprKind::Constant { value, .. } = &args[0].node else {
+        return None;
+    };
+
+    let primitive = Primitive::from_constant(value)?;
+    Some(Check::new(CheckKind::TypeOfPrimitive(primitive), location))
 }
 
 /// UP011
@@ -147,46 +157,53 @@ pub fn unnecessary_lru_cache_params(
     import_aliases: &FxHashMap<&str, &str>,
 ) -> Option<Check> {
     for expr in decorator_list.iter() {
-        if let ExprKind::Call {
+        let ExprKind::Call {
             func,
             args,
             keywords,
         } = &expr.node
+        else {
+            continue;
+        };
+
+        if !(args.is_empty()
+            && helpers::match_module_member(
+                func,
+                "functools",
+                "lru_cache",
+                from_imports,
+                import_aliases,
+            ))
         {
-            if args.is_empty()
-                && helpers::match_module_member(
-                    func,
-                    "functools",
-                    "lru_cache",
-                    from_imports,
-                    import_aliases,
-                )
-            {
-                let range = Range {
-                    location: func.end_location.unwrap(),
-                    end_location: expr.end_location.unwrap(),
-                };
-                // Ex) `functools.lru_cache()`
-                if keywords.is_empty() {
-                    return Some(Check::new(CheckKind::UnnecessaryLRUCacheParams, range));
-                }
-                // Ex) `functools.lru_cache(maxsize=None)`
-                if target_version >= PythonVersion::Py39 && keywords.len() == 1 {
-                    let KeywordData { arg, value } = &keywords[0].node;
-                    if arg.as_ref().map(|arg| arg == "maxsize").unwrap_or_default()
-                        && matches!(
-                            value.node,
-                            ExprKind::Constant {
-                                value: Constant::None,
-                                kind: None,
-                            }
-                        )
-                    {
-                        return Some(Check::new(CheckKind::UnnecessaryLRUCacheParams, range));
-                    }
-                }
-            }
+            continue;
         }
+
+        let range = Range {
+            location: func.end_location.unwrap(),
+            end_location: expr.end_location.unwrap(),
+        };
+        // Ex) `functools.lru_cache()`
+        if keywords.is_empty() {
+            return Some(Check::new(CheckKind::UnnecessaryLRUCacheParams, range));
+        }
+        // Ex) `functools.lru_cache(maxsize=None)`
+        if !(target_version >= PythonVersion::Py39 && keywords.len() == 1) {
+            continue;
+        }
+
+        let KeywordData { arg, value } = &keywords[0].node;
+        if !(arg.as_ref().map(|arg| arg == "maxsize").unwrap_or_default()
+            && matches!(
+                value.node,
+                ExprKind::Constant {
+                    value: Constant::None,
+                    kind: None,
+                }
+            ))
+        {
+            continue;
+        }
+        return Some(Check::new(CheckKind::UnnecessaryLRUCacheParams, range));
     }
     None
 }

--- a/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
@@ -201,13 +201,13 @@ pub fn convert_named_tuple_functional_to_class(
                     if checker.patch(check.kind.code()) {
                         match convert_to_class(stmt, typename, properties, base_class) {
                             Ok(fix) => check.amend(fix),
-                            Err(err) => error!("Failed to convert `NamedTuple`: {}", err),
+                            Err(err) => error!("Failed to convert `NamedTuple`: {err}"),
                         }
                     }
                     checker.add_check(check);
                 }
             }
-            Err(err) => error!("Failed to parse defaults: {}", err),
+            Err(err) => error!("Failed to parse defaults: {err}"),
         }
     }
 }

--- a/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
@@ -229,7 +229,7 @@ pub fn convert_typed_dict_functional_to_class(
         match_typed_dict_assign(checker, targets, value)
     {
         match get_properties_and_total(args, keywords) {
-            Err(err) => error!("Failed to parse TypedDict: {}", err),
+            Err(err) => error!("Failed to parse TypedDict: {err}"),
             Ok((body, total_keyword)) => {
                 let mut check = Check::new(
                     CheckKind::ConvertTypedDictFunctionalToClass(class_name.to_string()),
@@ -238,7 +238,7 @@ pub fn convert_typed_dict_functional_to_class(
                 if checker.patch(check.kind.code()) {
                     match convert_to_class(stmt, class_name, body, total_keyword, base_class) {
                         Ok(fix) => check.amend(fix),
-                        Err(err) => error!("Failed to convert TypedDict: {}", err),
+                        Err(err) => error!("Failed to convert TypedDict: {err}"),
                     };
                 }
                 checker.add_check(check);

--- a/src/pyupgrade/plugins/redundant_open_modes.rs
+++ b/src/pyupgrade/plugins/redundant_open_modes.rs
@@ -90,7 +90,7 @@ fn create_check(
         } else {
             match create_remove_param_fix(locator, expr, mode_param) {
                 Ok(fix) => check.amend(fix),
-                Err(e) => error!("Failed to remove parameter: {}", e),
+                Err(e) => error!("Failed to remove parameter: {e}"),
             }
         }
     }

--- a/src/pyupgrade/plugins/unnecessary_future_import.rs
+++ b/src/pyupgrade/plugins/unnecessary_future_import.rs
@@ -76,7 +76,7 @@ pub fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, names: &[Lo
                     }
                     check.amend(fix);
                 }
-                Err(e) => error!("Failed to remove __future__ import: {}", e),
+                Err(e) => error!("Failed to remove __future__ import: {e}"),
             }
         }
         checker.add_check(check);

--- a/src/pyupgrade/plugins/useless_metaclass_type.rs
+++ b/src/pyupgrade/plugins/useless_metaclass_type.rs
@@ -30,7 +30,7 @@ pub fn useless_metaclass_type(checker: &mut Checker, stmt: &Stmt, value: &Expr, 
                     }
                     check.amend(fix);
                 }
-                Err(e) => error!("Failed to fix remove metaclass type: {}", e),
+                Err(e) => error!("Failed to fix remove metaclass type: {e}"),
             }
         }
         checker.add_check(check);

--- a/src/rules/checks.rs
+++ b/src/rules/checks.rs
@@ -1624,11 +1624,12 @@ pub fn ambiguous_unicode_character(
         // Search for confusing characters.
         if let Some(representant) = CONFUSABLES.get(&(current_char as u32)) {
             if let Some(representant) = char::from_u32(*representant) {
-                let location = if row_offset == 0 {
-                    Location::new(start.row() + row_offset, start.column() + col_offset)
+                let col = if row_offset == 0 {
+                    start.column() + col_offset
                 } else {
-                    Location::new(start.row() + row_offset, col_offset)
+                    col_offset
                 };
+                let location = Location::new(start.row() + row_offset, col);
                 let end_location = Location::new(location.row(), location.column() + 1);
                 let mut check = Check::new(
                     match context {

--- a/src/vendored/cformat.rs
+++ b/src/vendored/cformat.rs
@@ -406,8 +406,7 @@ mod tests {
         let result = fmt.parse::<CFormatString>();
         assert_eq!(
             result, expected,
-            "left = {:#?} \n\n\n right = {:#?}",
-            result, expected
+            "left = {result:#?} \n\n\n right = {expected:#?}"
         );
     }
 }


### PR DESCRIPTION
To check whitespace-less changes: https://github.com/charliermarsh/ruff/pull/1049/files?w=1

`ruff` is full of check-and-(return|continue) patterns. `?` and the new `let-else` expression matches them really well and prevent logic fix add indents or dedents