### PR TITLE
Tweak summary message to include total error counts

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -46,14 +46,13 @@ impl<'a> Printer<'a> {
 
     fn pre_text(&self, diagnostics: &Diagnostics) {
         if self.log_level >= &LogLevel::Default {
-            if diagnostics.fixed > 0 {
-                println!(
-                    "Found {} error(s) ({} fixed).",
-                    diagnostics.messages.len(),
-                    diagnostics.fixed,
-                );
-            } else if !diagnostics.messages.is_empty() {
-                println!("Found {} error(s).", diagnostics.messages.len());
+            let fixed = diagnostics.fixed;
+            let remaining = diagnostics.messages.len();
+            let total = fixed + remaining;
+            if fixed > 0 {
+                println!("Found {total} error(s) ({fixed} fixed, {remaining} remaining).");
+            } else if remaining > 0 {
+                println!("Found {remaining} error(s).");
             }
         }
     }


### PR DESCRIPTION
We now print, e.g., `Found 3 error(s) (3 fixed, 0 remaining).`.

Resolves: #1061.
