### PR TITLE
Treat nested classes and functions as "standard" siblings

### DIFF
--- a/resources/test/fixtures/isort/insert_empty_lines.py
+++ b/resources/test/fixtures/isort/insert_empty_lines.py
@@ -27,3 +27,15 @@ if True:
     import os
 def f():
     pass
+
+if True:
+    x = 1
+    import collections
+    import typing
+    class X: pass
+
+if True:
+    x = 1
+    import collections
+    import typing
+    def f(): pass

--- a/src/isort/snapshots/ruff__isort__tests__insert_empty_lines.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__insert_empty_lines.py.snap
@@ -47,4 +47,34 @@ expression: checks
     end_location:
       row: 16
       column: 0
+- kind: UnsortedImports
+  location:
+    row: 33
+    column: 0
+  end_location:
+    row: 35
+    column: 0
+  fix:
+    content: "    import collections\n    import typing\n\n"
+    location:
+      row: 33
+      column: 0
+    end_location:
+      row: 35
+      column: 0
+- kind: UnsortedImports
+  location:
+    row: 39
+    column: 0
+  end_location:
+    row: 41
+    column: 0
+  fix:
+    content: "    import collections\n    import typing\n\n"
+    location:
+      row: 39
+      column: 0
+    end_location:
+      row: 41
+      column: 0
 

--- a/src/isort/track.rs
+++ b/src/isort/track.rs
@@ -60,12 +60,17 @@ where
         // Track manual splits.
         while self.split_index < self.directives.splits.len() {
             if stmt.location.row() >= self.directives.splits[self.split_index] {
-                self.finalize(Some(match &stmt.node {
-                    StmtKind::FunctionDef { .. } | StmtKind::AsyncFunctionDef { .. } => {
-                        Trailer::FunctionDef
+                // TODO(charlie): Track nesting semantically, rather than via column index.
+                self.finalize(Some(if stmt.location.column() == 0 {
+                    match &stmt.node {
+                        StmtKind::FunctionDef { .. } | StmtKind::AsyncFunctionDef { .. } => {
+                            Trailer::FunctionDef
+                        }
+                        StmtKind::ClassDef { .. } => Trailer::ClassDef,
+                        _ => Trailer::Sibling,
                     }
-                    StmtKind::ClassDef { .. } => Trailer::ClassDef,
-                    _ => Trailer::Sibling,
+                } else {
+                    Trailer::Sibling
                 }));
                 self.split_index += 1;
             } else {
@@ -81,12 +86,17 @@ where
         {
             self.track_import(stmt);
         } else {
-            self.finalize(Some(match &stmt.node {
-                StmtKind::FunctionDef { .. } | StmtKind::AsyncFunctionDef { .. } => {
-                    Trailer::FunctionDef
+            // TODO(charlie): Track nesting semantically, rather than via column index.
+            self.finalize(Some(if stmt.location.column() == 0 {
+                match &stmt.node {
+                    StmtKind::FunctionDef { .. } | StmtKind::AsyncFunctionDef { .. } => {
+                        Trailer::FunctionDef
+                    }
+                    StmtKind::ClassDef { .. } => Trailer::ClassDef,
+                    _ => Trailer::Sibling,
                 }
-                StmtKind::ClassDef { .. } => Trailer::ClassDef,
-                _ => Trailer::Sibling,
+            } else {
+                Trailer::Sibling
             }));
         }
 


### PR DESCRIPTION
In these cases, we only want to insert one newline, to match Black's behavior.

(If it proves too difficulty to maintain compatibility here, we'll just stop with any newline insertions in nested blocks.)