### PR TITLE
Mark redefined-but-unused imports as unused regardless of scope

### DIFF
--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -73,7 +73,11 @@ pub struct Scope<'a> {
     pub kind: ScopeKind<'a>,
     pub import_starred: bool,
     pub uses_locals: bool,
+    /// A map from bound name to binding index.
     pub values: FxHashMap<&'a str, usize>,
+    /// A list of (name, index) pairs for bindings that were overridden in the
+    /// scope.
+    pub overridden: Vec<(&'a str, usize)>,
 }
 
 impl<'a> Scope<'a> {
@@ -84,6 +88,7 @@ impl<'a> Scope<'a> {
             import_starred: false,
             uses_locals: false,
             values: FxHashMap::default(),
+            overridden: Vec::new(),
         }
     }
 }
@@ -117,8 +122,6 @@ pub struct Binding<'a> {
     /// Tuple of (scope index, range) indicating the scope and range at which
     /// the binding was last used.
     pub used: Option<(usize, Range)>,
-    /// A list of pointers to `Binding` instances that redefined this binding.
-    pub redefined: Vec<usize>,
 }
 
 // Pyflakes defines the following binding hierarchy (via inheritance):

--- a/src/pyflakes/mod.rs
+++ b/src/pyflakes/mod.rs
@@ -1105,11 +1105,11 @@ mod tests {
     fn aliased_import() -> Result<()> {
         flakes(
             "import fu as FU, bar as FU",
-            &[CheckCode::F811, CheckCode::F401],
+            &[CheckCode::F401, CheckCode::F811, CheckCode::F401],
         )?;
         flakes(
             "from moo import fu as FU, bar as FU",
-            &[CheckCode::F811, CheckCode::F401],
+            &[CheckCode::F401, CheckCode::F811, CheckCode::F401],
         )?;
 
         Ok(())
@@ -1146,9 +1146,15 @@ mod tests {
 
     #[test]
     fn redefined_while_unused() -> Result<()> {
-        flakes("import fu; fu = 3", &[CheckCode::F811])?;
-        flakes("import fu; fu, bar = 3", &[CheckCode::F811])?;
-        flakes("import fu; [fu, bar] = 3", &[CheckCode::F811])?;
+        flakes("import fu; fu = 3", &[CheckCode::F401, CheckCode::F811])?;
+        flakes(
+            "import fu; fu, bar = 3",
+            &[CheckCode::F401, CheckCode::F811],
+        )?;
+        flakes(
+            "import fu; [fu, bar] = 3",
+            &[CheckCode::F401, CheckCode::F811],
+        )?;
 
         Ok(())
     }
@@ -1165,7 +1171,7 @@ mod tests {
             import os
         os.path
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -1203,7 +1209,7 @@ mod tests {
             pass
         os.path
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -1279,7 +1285,7 @@ mod tests {
             from bb import mixer
         mixer(123)
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -1345,14 +1351,13 @@ mod tests {
 
     #[test]
     fn redefined_by_function() -> Result<()> {
-        // TODO(charlie): Why does this differ from the next test assertion?
         flakes(
             r#"
         import fu
         def fu():
             pass
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -1430,7 +1435,7 @@ mod tests {
         class fu:
             pass
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -1694,7 +1699,7 @@ mod tests {
         for fu in range(2):
             pass
         "#,
-            &[CheckCode::F402],
+            &[CheckCode::F401, CheckCode::F402],
         )?;
 
         Ok(())
@@ -1851,7 +1856,7 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[CheckCode::F811, CheckCode::F841],
+            &[CheckCode::F401, CheckCode::F811, CheckCode::F841],
         )?;
 
         Ok(())
@@ -2161,7 +2166,7 @@ mod tests {
         import fu.bar, fu.bar
         fu.bar
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
         flakes(
             r#"
@@ -2169,7 +2174,7 @@ mod tests {
         import fu.bar
         fu.bar
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())
@@ -2325,7 +2330,7 @@ mod tests {
             fu
         fu
         "#,
-            &[CheckCode::F811],
+            &[CheckCode::F401, CheckCode::F811],
         )?;
 
         Ok(())


### PR DESCRIPTION
Right now, if an import is redefined-while-unused by a variable in the same scope, we lose that binding, and thus never report it as unused. This matches the current Pyflakes behavior, but... I think it can be improved?

For example, right now, these return different error combinations:

```py
# Only reports redefined-while-unused (not unused import).
import fu
def fu():
    pass

# Reports both redefined-while-unused _and_ unused import.
import fu
def bar():
    def baz():
        def fu():
            pass
```

The solution I opted for here was to preserve references to the "overridden" bindings, and include those when checking for unused imports.
