### PR TITLE
Test to prevent continious reformatting when used together with black

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,9 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - run: pip install black[d]==22.12.0
       - run: cargo test --all
+      - run: cargo test --package ruff --test black_compatibility_test -- --ignored
 
   maturin_build:
     name: "maturin build"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,6 +1895,7 @@ dependencies = [
  "titlecase",
  "toml",
  "update-informer",
+ "ureq",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ textwrap = { version = "0.16.0" }
 titlecase = { version = "2.2.1" }
 toml = { version = "0.5.9" }
 update-informer = { version = "0.5.0", default-features = false, features = ["pypi"], optional = true }
-ureq = { version = "2.5.0", features = [] }
 walkdir = { version = "2.3.2" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -72,6 +71,7 @@ assert_cmd = { version = "2.0.4" }
 criterion = { version = "0.4.0" }
 insta = { version = "1.19.1", features = ["yaml"] }
 test-case = { version = "2.2.2" }
+ureq = { version = "2.5.0", features = [] }
 
 [features]
 default = ["update-informer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ textwrap = { version = "0.16.0" }
 titlecase = { version = "2.2.1" }
 toml = { version = "0.5.9" }
 update-informer = { version = "0.5.0", default-features = false, features = ["pypi"], optional = true }
+ureq = { version = "2.5.0", features = [] }
 walkdir = { version = "2.3.2" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/src/flake8_builtins/checks.rs
+++ b/src/flake8_builtins/checks.rs
@@ -1,4 +1,4 @@
-use rustpython_ast::{Located};
+use rustpython_ast::Located;
 
 use crate::ast::types::Range;
 use crate::checks::{Check, CheckKind};

--- a/src/mccabe/checks.rs
+++ b/src/mccabe/checks.rs
@@ -1,7 +1,6 @@
 use rustpython_ast::{ExcepthandlerKind, ExprKind, Stmt, StmtKind};
 
 use crate::ast::helpers::identifier_range;
-
 use crate::checks::{Check, CheckKind};
 use crate::source_code_locator::SourceCodeLocator;
 

--- a/tests/black_compatibility_test.rs
+++ b/tests/black_compatibility_test.rs
@@ -1,0 +1,186 @@
+use std::io::{ErrorKind, Read};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::thread::sleep;
+use std::time::Duration;
+use std::{fs, process, str};
+
+use anyhow::{anyhow, Context, Result};
+use assert_cmd::{crate_name, Command};
+use itertools::Itertools;
+use ruff::checks::CheckCategory;
+use strum::IntoEnumIterator;
+use walkdir::WalkDir;
+
+/// Handles blackd process and allows submitting code to it for formatting.
+struct Blackd {
+    address: SocketAddr,
+    server: process::Child,
+    client: ureq::Agent,
+}
+
+impl Blackd {
+    pub fn new() -> Result<Self> {
+        // Get free TCP port to run on
+        let address = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))?.local_addr()?;
+
+        let server = process::Command::new("blackd")
+            .args([
+                "--bind-host",
+                &address.ip().to_string(),
+                "--bind-port",
+                &address.port().to_string(),
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("Starting blackd")?;
+
+        // Wait for blackd to be ready
+        for _ in 0..20 {
+            match TcpStream::connect(address) {
+                Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+                    sleep(Duration::from_millis(50));
+                }
+                Err(e) => return Err(e.into()),
+                Ok(_) => break,
+            }
+        }
+
+        Ok(Self {
+            address,
+            server,
+            client: ureq::agent(),
+        })
+    }
+
+    /// Format given code with blackd.
+    pub fn check(&self, code: &[u8]) -> Result<Vec<u8>> {
+        match self
+            .client
+            .post(&format!("http://{}/", self.address))
+            .set("X-Line-Length", "88")
+            .send_bytes(code)
+        {
+            // 204 indicates the input wasn't changed during formatting, so
+            // we return the original.
+            Ok(response) => {
+                if response.status() == 204 {
+                    Ok(code.to_vec())
+                } else {
+                    let mut buf = vec![];
+                    response
+                        .into_reader()
+                        .take((1024 * 1024) as u64)
+                        .read_to_end(&mut buf)?;
+                    Ok(buf)
+                }
+            }
+            Err(ureq::Error::Status(_, response)) => Err(anyhow::anyhow!(
+                "Formatting with black failed: {}",
+                response.into_string()?
+            )),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+impl Drop for Blackd {
+    fn drop(&mut self) {
+        self.server.kill().expect("Couldn't end blackd process");
+    }
+}
+
+fn run_test(path: &Path, blackd: &Blackd, ruff_args: &[&str]) -> Result<()> {
+    let input = fs::read(path)?;
+
+    let step_1 = &Command::cargo_bin(crate_name!())?
+        .args(ruff_args)
+        .write_stdin(input)
+        .assert()
+        .append_context("step", "running input through ruff");
+    if !step_1.get_output().status.success() {
+        return Err(anyhow!(
+            "Running input through ruff failed:\n{}",
+            str::from_utf8(&step_1.get_output().stderr)?
+        ));
+    }
+    let step_1_output = step_1.get_output().stdout.clone();
+
+    let step_2_output = blackd.check(&step_1_output)?;
+
+    let step_3 = &Command::cargo_bin(crate_name!())?
+        .args(ruff_args)
+        .write_stdin(step_2_output.clone())
+        .assert();
+    if !step_3.get_output().status.success() {
+        return Err(anyhow!(
+            "Running input through ruff after black failed:\n{}",
+            str::from_utf8(&step_3.get_output().stderr)?
+        ));
+    }
+    let step_3_output = step_3.get_output().stdout.clone();
+
+    assert_eq!(
+        str::from_utf8(&step_2_output),
+        str::from_utf8(&step_3_output),
+        "Mismatch found for {}",
+        path.display()
+    );
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn test_ruff_black_compatibility() -> Result<()> {
+    let blackd = Blackd::new()?;
+
+    let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("test")
+        .join("fixtures");
+
+    // Ignore some fixtures that currently trigger errors. `E999.py` especially, as
+    // that is triggering a syntax error on purpose.
+    let excludes = ["E999.py", "B009_B010.py", "W605_1.py", "leading_prefix.py"];
+
+    let paths: Vec<walkdir::DirEntry> = WalkDir::new(fixtures_dir)
+        .into_iter()
+        .filter(|entry| {
+            entry.as_ref().map_or(true, |entry| {
+                let file_name = entry.path().file_name().unwrap().to_string_lossy();
+
+                (file_name.ends_with(".py") || file_name.ends_with(".pyi"))
+                    && !excludes.contains(&file_name.to_string().as_str())
+            })
+        })
+        .filter_map(std::result::Result::ok)
+        .collect();
+
+    let codes = CheckCategory::iter()
+        // Exclude ruff codes, specifically RUF100, because it causes differences that are not a
+        // problem. Ruff would add a `# noqa: W292`  after the first run, black introduces a
+        // newline, and ruff removes the `# noqa: W292` again.
+        .filter(|category| *category != CheckCategory::Ruff)
+        .map(|category| category.codes().iter().map(AsRef::as_ref).join(","))
+        .join(",");
+    let ruff_args = [
+        "-",
+        "--silent",
+        "--exit-zero",
+        "--fix",
+        "--line-length",
+        "88",
+        "--select",
+        &codes,
+    ];
+
+    for entry in paths {
+        let path = entry.path();
+        run_test(path, &blackd, &ruff_args).context(format!("Testing {}", path.display()))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Runs the sequence `ruff -> black -> ruff` against all test fixtures and fails when that sequence is not stable.

Pretty slow right now and it should probably run against a specific version of black. Would like to get some guidance here on how best to approach that.

- [x] run against specific version of black
- [x] skip test cases that (intentionally) trigger parser issues (E999.py)
- [x] make fast enough?
- [x] setup black to make CI work

---

This did turn up a bug:

When running ruff against 

```python
_ = lambda x: setattr(x, "bar", 1)
``` 
with everything enabled, this produces

```python
def _(x):
    return x.bar = 1
```

which is invalid syntax.