### PR TITLE
Upgrade RustPython to support parenthesized context managers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -1952,7 +1952,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "bincode",
  "bitflags",
@@ -1992,7 +1992,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ regex = { version = "1.6.0" }
 ropey = { version = "1.5.0", features = ["cr_lines", "simd"], default-features = false }
 ruff_macros = { version = "0.0.178", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/README.md
+++ b/README.md
@@ -1073,8 +1073,7 @@ conflicts with the `isort` rules, like `I001`).
 
 Beyond the rule set, Ruff suffers from the following limitations vis-à-vis Flake8:
 
-1. Ruff does not yet support a few Python 3.9 and 3.10 language features, including structural
-   pattern matching and parenthesized context managers.
+1. Ruff does not yet support structural pattern matching.
 2. Flake8 has a plugin architecture and supports writing custom lint rules. (Instead, popular Flake8
    plugins are re-implemented in Rust as part of Ruff itself.)
 

--- a/flake8_to_ruff/Cargo.lock
+++ b/flake8_to_ruff/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=2edd0d264c50c7807bcff03a52a6509e8b7f187f#2edd0d264c50c7807bcff03a52a6509e8b7f187f"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
 dependencies = [
  "ahash",
  "anyhow",

--- a/resources/test/fixtures/pyflakes/F841_0.py
+++ b/resources/test/fixtures/pyflakes/F841_0.py
@@ -10,13 +10,13 @@ except ValueError as e:
     print(e)
 
 
-def f1():
+def f():
     x = 1
     y = 2
     z = x + y
 
 
-def f2():
+def f():
     foo = (1, 2)
     (a, b) = (1, 2)
 
@@ -26,12 +26,12 @@ def f2():
     (x, y) = baz = bar
 
 
-def f3():
+def f():
     locals()
     x = 1
 
 
-def f4():
+def f():
     _ = 1
     __ = 1
     _discarded = 1
@@ -40,26 +40,26 @@ def f4():
 a = 1
 
 
-def f5():
+def f():
     global a
 
-    # Used in `f7` via `nonlocal`.
+    # Used in `c` via `nonlocal`.
     b = 1
 
-    def f6():
+    def c():
         # F841
         b = 1
 
-    def f7():
+    def d():
         nonlocal b
 
 
-def f6():
+def f():
     annotations = []
     assert len([annotations for annotations in annotations])
 
 
-def f7():
+def f():
     def connect():
         return None, None
 
@@ -67,6 +67,22 @@ def f7():
         cursor.execute("SELECT * FROM users")
 
 
-def f8():
-    with open("file") as f, open("") as ((a, b)):
+def f():
+    def connect():
+        return None, None
+
+    with (connect() as (connection, cursor)):
+        cursor.execute("SELECT * FROM users")
+
+
+def f():
+    with open("file") as my_file, open("") as ((this, that)):
+        print("hello")
+
+
+def f():
+    with (
+        open("file") as my_file,
+        open("") as ((this, that)),
+    ):
         print("hello")

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,8 +11,8 @@ itertools = { version = "0.10.5" }
 libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "2edd0d264c50c7807bcff03a52a6509e8b7f187f" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__allow_overload.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__allow_overload.snap
@@ -8,7 +8,7 @@ expression: checks
     row: 29
     column: 4
   end_location:
-    row: 35
-    column: 0
+    row: 30
+    column: 16
   fix: ~
 

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__defaults.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__defaults.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 5
+    column: 8
   fix: ~
 - kind:
     MissingTypeFunctionArgument: a
@@ -35,8 +35,8 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 14
-    column: 0
+    row: 10
+    column: 8
   fix: ~
 - kind:
     MissingTypeFunctionArgument: b
@@ -62,8 +62,8 @@ expression: checks
     row: 19
     column: 0
   end_location:
-    row: 24
-    column: 0
+    row: 20
+    column: 8
   fix: ~
 - kind:
     MissingReturnTypePublicFunction: foo
@@ -71,8 +71,8 @@ expression: checks
     row: 24
     column: 0
   end_location:
-    row: 29
-    column: 0
+    row: 25
+    column: 8
   fix: ~
 - kind:
     DynamicallyTypedExpression: a

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__mypy_init_return.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__mypy_init_return.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 5
     column: 4
   end_location:
-    row: 10
-    column: 0
+    row: 6
+    column: 11
   fix: ~
 - kind:
     MissingReturnTypeMagicMethod: __init__
@@ -17,8 +17,8 @@ expression: checks
     row: 11
     column: 4
   end_location:
-    row: 16
-    column: 0
+    row: 12
+    column: 11
   fix: ~
 - kind:
     MissingReturnTypePrivateFunction: __init__
@@ -26,7 +26,7 @@ expression: checks
     row: 40
     column: 0
   end_location:
-    row: 42
-    column: 0
+    row: 41
+    column: 7
   fix: ~
 

--- a/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__suppress_none_returning.snap
+++ b/src/flake8_annotations/snapshots/ruff__flake8_annotations__tests__suppress_none_returning.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 45
     column: 0
   end_location:
-    row: 50
-    column: 0
+    row: 46
+    column: 15
   fix: ~
 - kind:
     MissingReturnTypePublicFunction: foo
@@ -17,7 +17,7 @@ expression: checks
     row: 50
     column: 0
   end_location:
-    row: 56
-    column: 0
+    row: 55
+    column: 14
   fix: ~
 

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B017_B017.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B017_B017.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 22
     column: 8
   end_location:
-    row: 25
-    column: 4
+    row: 23
+    column: 42
   fix: ~
 

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B024_B024.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B024_B024.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 17
     column: 0
   end_location:
-    row: 22
-    column: 0
+    row: 19
+    column: 13
   fix: ~
 - kind:
     AbstractBaseClassWithoutAbstractMethod: MetaBase_1
@@ -17,8 +17,8 @@ expression: checks
     row: 58
     column: 0
   end_location:
-    row: 63
-    column: 0
+    row: 60
+    column: 13
   fix: ~
 - kind:
     AbstractBaseClassWithoutAbstractMethod: abc_Base_1
@@ -26,8 +26,8 @@ expression: checks
     row: 69
     column: 0
   end_location:
-    row: 74
-    column: 0
+    row: 71
+    column: 13
   fix: ~
 - kind:
     AbstractBaseClassWithoutAbstractMethod: abc_Base_2
@@ -35,8 +35,8 @@ expression: checks
     row: 74
     column: 0
   end_location:
-    row: 79
-    column: 0
+    row: 76
+    column: 13
   fix: ~
 - kind:
     AbstractBaseClassWithoutAbstractMethod: notabc_Base_1
@@ -44,8 +44,8 @@ expression: checks
     row: 79
     column: 0
   end_location:
-    row: 84
-    column: 0
+    row: 81
+    column: 13
   fix: ~
 - kind:
     AbstractBaseClassWithoutAbstractMethod: abc_set_class_variable_4
@@ -53,7 +53,7 @@ expression: checks
     row: 128
     column: 0
   end_location:
-    row: 130
-    column: 0
+    row: 129
+    column: 7
   fix: ~
 

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B025_B025.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B025_B025.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 15
     column: 0
   end_location:
-    row: 22
-    column: 0
+    row: 20
+    column: 9
   fix: ~
 - kind:
     DuplicateTryBlockException: pickle.PickleError
@@ -17,8 +17,8 @@ expression: checks
     row: 22
     column: 0
   end_location:
-    row: 31
-    column: 0
+    row: 29
+    column: 9
   fix: ~
 - kind:
     DuplicateTryBlockException: TypeError
@@ -26,8 +26,8 @@ expression: checks
     row: 31
     column: 0
   end_location:
-    row: 39
-    column: 0
+    row: 38
+    column: 9
   fix: ~
 - kind:
     DuplicateTryBlockException: ValueError
@@ -35,7 +35,7 @@ expression: checks
     row: 31
     column: 0
   end_location:
-    row: 39
-    column: 0
+    row: 38
+    column: 9
   fix: ~
 

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B027_B027.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B027_B027.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 12
     column: 4
   end_location:
-    row: 15
-    column: 4
+    row: 13
+    column: 11
   fix: ~
 - kind:
     EmptyMethodWithoutAbstractDecorator: AbstractClass
@@ -17,8 +17,8 @@ expression: checks
     row: 15
     column: 4
   end_location:
-    row: 18
-    column: 4
+    row: 16
+    column: 12
   fix: ~
 - kind:
     EmptyMethodWithoutAbstractDecorator: AbstractClass
@@ -26,8 +26,8 @@ expression: checks
     row: 18
     column: 4
   end_location:
-    row: 22
-    column: 4
+    row: 20
+    column: 11
   fix: ~
 - kind:
     EmptyMethodWithoutAbstractDecorator: AbstractClass
@@ -35,7 +35,7 @@ expression: checks
     row: 22
     column: 4
   end_location:
-    row: 29
-    column: 4
+    row: 27
+    column: 12
   fix: ~
 

--- a/src/flake8_builtins/snapshots/ruff__flake8_builtins__tests__A001_A001.py.snap
+++ b/src/flake8_builtins/snapshots/ruff__flake8_builtins__tests__A001_A001.py.snap
@@ -89,8 +89,8 @@ expression: checks
     row: 10
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 11
+    column: 8
   fix: ~
 - kind:
     BuiltinVariableShadowing: slice
@@ -98,8 +98,8 @@ expression: checks
     row: 13
     column: 0
   end_location:
-    row: 16
-    column: 0
+    row: 14
+    column: 8
   fix: ~
 - kind:
     BuiltinVariableShadowing: ValueError
@@ -107,8 +107,8 @@ expression: checks
     row: 18
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 19
+    column: 7
   fix: ~
 - kind:
     BuiltinVariableShadowing: memoryview

--- a/src/flake8_builtins/snapshots/ruff__flake8_builtins__tests__A003_A003.py.snap
+++ b/src/flake8_builtins/snapshots/ruff__flake8_builtins__tests__A003_A003.py.snap
@@ -17,7 +17,7 @@ expression: checks
     row: 7
     column: 4
   end_location:
-    row: 9
-    column: 0
+    row: 8
+    column: 12
   fix: ~
 

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET503_RET503.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET503_RET503.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 7
     column: 4
   end_location:
-    row: 12
-    column: 0
+    row: 8
+    column: 16
   fix: ~
 - kind: ImplicitReturn
   location:
@@ -45,8 +45,8 @@ expression: checks
     row: 29
     column: 8
   end_location:
-    row: 34
-    column: 0
+    row: 30
+    column: 20
   fix: ~
 - kind: ImplicitReturn
   location:

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET505_RET505.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET505_RET505.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 5
     column: 4
   end_location:
-    row: 16
-    column: 0
+    row: 13
+    column: 16
   fix: ~
 - kind:
     SuperfluousElseReturn: Elif
@@ -17,8 +17,8 @@ expression: checks
     row: 17
     column: 4
   end_location:
-    row: 27
-    column: 4
+    row: 26
+    column: 13
   fix: ~
 - kind:
     SuperfluousElseReturn: Elif
@@ -26,8 +26,8 @@ expression: checks
     row: 38
     column: 4
   end_location:
-    row: 49
-    column: 0
+    row: 46
+    column: 16
   fix: ~
 - kind:
     SuperfluousElseReturn: Else
@@ -35,8 +35,8 @@ expression: checks
     row: 50
     column: 4
   end_location:
-    row: 58
-    column: 0
+    row: 55
+    column: 16
   fix: ~
 - kind:
     SuperfluousElseReturn: Else
@@ -44,8 +44,8 @@ expression: checks
     row: 61
     column: 8
   end_location:
-    row: 67
-    column: 4
+    row: 66
+    column: 20
   fix: ~
 - kind:
     SuperfluousElseReturn: Else
@@ -53,8 +53,8 @@ expression: checks
     row: 73
     column: 4
   end_location:
-    row: 81
-    column: 4
+    row: 80
+    column: 13
   fix: ~
 - kind:
     SuperfluousElseReturn: Else
@@ -62,8 +62,8 @@ expression: checks
     row: 86
     column: 8
   end_location:
-    row: 91
-    column: 4
+    row: 90
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseReturn: Else
@@ -71,7 +71,7 @@ expression: checks
     row: 97
     column: 4
   end_location:
-    row: 109
-    column: 0
+    row: 103
+    column: 23
   fix: ~
 

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET506_RET506.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET506_RET506.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 5
     column: 4
   end_location:
-    row: 16
-    column: 0
+    row: 13
+    column: 26
   fix: ~
 - kind:
     SuperfluousElseRaise: Elif
@@ -17,8 +17,8 @@ expression: checks
     row: 17
     column: 4
   end_location:
-    row: 27
-    column: 4
+    row: 26
+    column: 13
   fix: ~
 - kind:
     SuperfluousElseRaise: Else
@@ -26,8 +26,8 @@ expression: checks
     row: 31
     column: 4
   end_location:
-    row: 39
-    column: 0
+    row: 36
+    column: 26
   fix: ~
 - kind:
     SuperfluousElseRaise: Else
@@ -35,8 +35,8 @@ expression: checks
     row: 42
     column: 8
   end_location:
-    row: 48
-    column: 4
+    row: 47
+    column: 30
   fix: ~
 - kind:
     SuperfluousElseRaise: Else
@@ -44,8 +44,8 @@ expression: checks
     row: 54
     column: 4
   end_location:
-    row: 62
-    column: 4
+    row: 61
+    column: 13
   fix: ~
 - kind:
     SuperfluousElseRaise: Else
@@ -53,8 +53,8 @@ expression: checks
     row: 67
     column: 8
   end_location:
-    row: 72
-    column: 4
+    row: 71
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseRaise: Else
@@ -62,7 +62,7 @@ expression: checks
     row: 78
     column: 4
   end_location:
-    row: 90
-    column: 0
+    row: 84
+    column: 33
   fix: ~
 

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET507_RET507.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET507_RET507.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 6
     column: 8
   end_location:
-    row: 14
-    column: 0
+    row: 11
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseContinue: Elif
@@ -17,8 +17,8 @@ expression: checks
     row: 16
     column: 8
   end_location:
-    row: 26
-    column: 8
+    row: 25
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseContinue: Else
@@ -26,8 +26,8 @@ expression: checks
     row: 34
     column: 8
   end_location:
-    row: 40
-    column: 0
+    row: 37
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseContinue: Else
@@ -35,8 +35,8 @@ expression: checks
     row: 44
     column: 12
   end_location:
-    row: 50
-    column: 8
+    row: 49
+    column: 24
   fix: ~
 - kind:
     SuperfluousElseContinue: Else
@@ -44,8 +44,8 @@ expression: checks
     row: 57
     column: 8
   end_location:
-    row: 65
-    column: 8
+    row: 64
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseContinue: Else
@@ -53,8 +53,8 @@ expression: checks
     row: 71
     column: 12
   end_location:
-    row: 76
-    column: 8
+    row: 75
+    column: 21
   fix: ~
 - kind:
     SuperfluousElseContinue: Else
@@ -62,7 +62,7 @@ expression: checks
     row: 83
     column: 8
   end_location:
-    row: 92
-    column: 0
+    row: 89
+    column: 24
   fix: ~
 

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET508_RET508.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET508_RET508.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 6
     column: 8
   end_location:
-    row: 14
-    column: 0
+    row: 11
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseBreak: Elif
@@ -17,8 +17,8 @@ expression: checks
     row: 16
     column: 8
   end_location:
-    row: 26
-    column: 8
+    row: 25
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseBreak: Else
@@ -26,8 +26,8 @@ expression: checks
     row: 31
     column: 8
   end_location:
-    row: 37
-    column: 0
+    row: 34
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseBreak: Else
@@ -35,8 +35,8 @@ expression: checks
     row: 41
     column: 12
   end_location:
-    row: 47
-    column: 8
+    row: 46
+    column: 21
   fix: ~
 - kind:
     SuperfluousElseBreak: Else
@@ -44,8 +44,8 @@ expression: checks
     row: 54
     column: 8
   end_location:
-    row: 62
-    column: 8
+    row: 61
+    column: 17
   fix: ~
 - kind:
     SuperfluousElseBreak: Else
@@ -53,8 +53,8 @@ expression: checks
     row: 68
     column: 12
   end_location:
-    row: 73
-    column: 8
+    row: 72
+    column: 21
   fix: ~
 - kind:
     SuperfluousElseBreak: Else
@@ -62,7 +62,7 @@ expression: checks
     row: 80
     column: 8
   end_location:
-    row: 92
-    column: 0
+    row: 86
+    column: 21
   fix: ~
 

--- a/src/mccabe/snapshots/ruff__mccabe__tests__max_complexity_0.snap
+++ b/src/mccabe/snapshots/ruff__mccabe__tests__max_complexity_0.snap
@@ -10,8 +10,8 @@ expression: checks
     row: 2
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 3
+    column: 8
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -21,8 +21,8 @@ expression: checks
     row: 7
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 8
+    column: 10
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -32,8 +32,8 @@ expression: checks
     row: 12
     column: 0
   end_location:
-    row: 19
-    column: 0
+    row: 15
+    column: 12
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -43,8 +43,8 @@ expression: checks
     row: 19
     column: 0
   end_location:
-    row: 29
-    column: 0
+    row: 25
+    column: 47
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -54,8 +54,8 @@ expression: checks
     row: 29
     column: 0
   end_location:
-    row: 40
-    column: 0
+    row: 36
+    column: 47
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -65,8 +65,8 @@ expression: checks
     row: 40
     column: 0
   end_location:
-    row: 46
-    column: 0
+    row: 42
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -76,8 +76,8 @@ expression: checks
     row: 46
     column: 0
   end_location:
-    row: 54
-    column: 0
+    row: 50
+    column: 19
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -87,8 +87,8 @@ expression: checks
     row: 54
     column: 0
   end_location:
-    row: 62
-    column: 0
+    row: 58
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -98,8 +98,8 @@ expression: checks
     row: 62
     column: 0
   end_location:
-    row: 73
-    column: 0
+    row: 69
+    column: 7
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -109,8 +109,8 @@ expression: checks
     row: 63
     column: 4
   end_location:
-    row: 69
-    column: 4
+    row: 67
+    column: 11
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -120,8 +120,8 @@ expression: checks
     row: 64
     column: 8
   end_location:
-    row: 67
-    column: 8
+    row: 65
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -131,8 +131,8 @@ expression: checks
     row: 73
     column: 0
   end_location:
-    row: 85
-    column: 0
+    row: 81
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -142,8 +142,8 @@ expression: checks
     row: 85
     column: 0
   end_location:
-    row: 96
-    column: 0
+    row: 92
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -153,8 +153,8 @@ expression: checks
     row: 96
     column: 0
   end_location:
-    row: 107
-    column: 0
+    row: 103
+    column: 12
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -164,8 +164,8 @@ expression: checks
     row: 107
     column: 0
   end_location:
-    row: 112
-    column: 0
+    row: 108
+    column: 17
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -175,8 +175,8 @@ expression: checks
     row: 113
     column: 4
   end_location:
-    row: 139
-    column: 0
+    row: 138
+    column: 40
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -186,8 +186,8 @@ expression: checks
     row: 118
     column: 12
   end_location:
-    row: 121
-    column: 12
+    row: 119
+    column: 20
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -197,8 +197,8 @@ expression: checks
     row: 121
     column: 12
   end_location:
-    row: 125
-    column: 8
+    row: 123
+    column: 24
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -208,8 +208,8 @@ expression: checks
     row: 126
     column: 12
   end_location:
-    row: 129
-    column: 12
+    row: 127
+    column: 20
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -219,8 +219,8 @@ expression: checks
     row: 129
     column: 12
   end_location:
-    row: 132
-    column: 12
+    row: 130
+    column: 20
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -230,8 +230,8 @@ expression: checks
     row: 132
     column: 12
   end_location:
-    row: 135
-    column: 12
+    row: 133
+    column: 20
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -241,7 +241,7 @@ expression: checks
     row: 135
     column: 12
   end_location:
-    row: 138
-    column: 8
+    row: 136
+    column: 20
   fix: ~
 

--- a/src/mccabe/snapshots/ruff__mccabe__tests__max_complexity_3.snap
+++ b/src/mccabe/snapshots/ruff__mccabe__tests__max_complexity_3.snap
@@ -10,8 +10,8 @@ expression: checks
     row: 73
     column: 0
   end_location:
-    row: 85
-    column: 0
+    row: 81
+    column: 16
   fix: ~
 - kind:
     FunctionIsTooComplex:
@@ -21,7 +21,7 @@ expression: checks
     row: 113
     column: 4
   end_location:
-    row: 139
-    column: 0
+    row: 138
+    column: 40
   fix: ~
 

--- a/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N801_N801.py.snap
+++ b/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N801_N801.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 8
   fix: ~
 - kind:
     InvalidClassName: _bad
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 8
   fix: ~
 - kind:
     InvalidClassName: bad_class
@@ -26,8 +26,8 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 10
+    column: 8
   fix: ~
 - kind:
     InvalidClassName: Bad_Class
@@ -35,8 +35,8 @@ expression: checks
     row: 13
     column: 0
   end_location:
-    row: 17
-    column: 0
+    row: 14
+    column: 8
   fix: ~
 - kind:
     InvalidClassName: BAD_CLASS
@@ -44,7 +44,7 @@ expression: checks
     row: 17
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 18
+    column: 8
   fix: ~
 

--- a/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N802_N802.py.snap
+++ b/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N802_N802.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 8
-    column: 0
+    row: 5
+    column: 8
   fix: ~
 - kind:
     InvalidFunctionName: _Bad
@@ -17,8 +17,8 @@ expression: checks
     row: 8
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 9
+    column: 8
   fix: ~
 - kind:
     InvalidFunctionName: BAD
@@ -26,8 +26,8 @@ expression: checks
     row: 12
     column: 0
   end_location:
-    row: 16
-    column: 0
+    row: 13
+    column: 8
   fix: ~
 - kind:
     InvalidFunctionName: BAD_FUNC
@@ -35,8 +35,8 @@ expression: checks
     row: 16
     column: 0
   end_location:
-    row: 20
-    column: 0
+    row: 17
+    column: 8
   fix: ~
 - kind:
     InvalidFunctionName: testTest
@@ -44,7 +44,7 @@ expression: checks
     row: 40
     column: 4
   end_location:
-    row: 42
-    column: 0
+    row: 41
+    column: 19
   fix: ~
 

--- a/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N807_N807.py.snap
+++ b/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N807_N807.py.snap
@@ -7,15 +7,15 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 8
   fix: ~
 - kind: DunderFunctionName
   location:
     row: 14
     column: 4
   end_location:
-    row: 17
-    column: 4
+    row: 15
+    column: 12
   fix: ~
 

--- a/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N818_N818.py.snap
+++ b/src/pep8_naming/snapshots/ruff__pep8_naming__tests__N818_N818.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 10
+    column: 8
   fix: ~
 - kind:
     ErrorSuffixOnExceptionName: E
@@ -17,7 +17,7 @@ expression: checks
     row: 17
     column: 0
   end_location:
-    row: 19
-    column: 0
+    row: 18
+    column: 8
   fix: ~
 

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E722_E722.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E722_E722.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 5
+    column: 8
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 11
     column: 0
   end_location:
-    row: 14
-    column: 0
+    row: 12
+    column: 8
   fix: ~
 - kind: DoNotUseBareExcept
   location:
     row: 16
     column: 0
   end_location:
-    row: 19
-    column: 0
+    row: 17
+    column: 8
   fix: ~
 

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E741_E741.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E741_E741.py.snap
@@ -215,8 +215,8 @@ expression: checks
     row: 71
     column: 0
   end_location:
-    row: 74
-    column: 0
+    row: 72
+    column: 8
   fix: ~
 - kind:
     AmbiguousVariableName: l

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E742_E742.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E742_E742.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 8
   fix: ~
 - kind:
     AmbiguousClassName: I
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 8
   fix: ~
 - kind:
     AmbiguousClassName: O
@@ -26,7 +26,7 @@ expression: checks
     row: 9
     column: 0
   end_location:
-    row: 13
-    column: 0
+    row: 10
+    column: 8
   fix: ~
 

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E743_E743.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E743_E743.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 2
+    column: 8
   fix: ~
 - kind:
     AmbiguousFunctionName: I
@@ -17,8 +17,8 @@ expression: checks
     row: 5
     column: 0
   end_location:
-    row: 9
-    column: 0
+    row: 6
+    column: 8
   fix: ~
 - kind:
     AmbiguousFunctionName: O
@@ -26,7 +26,7 @@ expression: checks
     row: 10
     column: 4
   end_location:
-    row: 14
-    column: 0
+    row: 11
+    column: 12
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D101_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D101_D.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 15
     column: 0
   end_location:
-    row: 72
-    column: 0
+    row: 69
+    column: 12
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D102_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D102_D.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 23
     column: 4
   end_location:
-    row: 26
-    column: 4
+    row: 24
+    column: 12
   fix: ~
 - kind: PublicMethod
   location:
     row: 56
     column: 4
   end_location:
-    row: 59
-    column: 4
+    row: 57
+    column: 12
   fix: ~
 - kind: PublicMethod
   location:
     row: 68
     column: 4
   end_location:
-    row: 72
-    column: 0
+    row: 69
+    column: 12
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D103_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D103_D.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 400
     column: 0
   end_location:
-    row: 401
-    column: 0
+    row: 400
+    column: 27
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D105_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D105_D.py.snap
@@ -7,7 +7,7 @@ expression: checks
     row: 64
     column: 4
   end_location:
-    row: 67
-    column: 4
+    row: 65
+    column: 12
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D107_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D107_D.py.snap
@@ -7,15 +7,15 @@ expression: checks
     row: 60
     column: 4
   end_location:
-    row: 63
-    column: 4
+    row: 61
+    column: 12
   fix: ~
 - kind: PublicInit
   location:
     row: 534
     column: 4
   end_location:
-    row: 538
-    column: 0
+    row: 535
+    column: 12
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D417_sections.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D417_sections.py.snap
@@ -9,8 +9,8 @@ expression: checks
     row: 283
     column: 4
   end_location:
-    row: 296
-    column: 0
+    row: 293
+    column: 16
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -19,8 +19,8 @@ expression: checks
     row: 300
     column: 0
   end_location:
-    row: 309
-    column: 0
+    row: 306
+    column: 7
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -31,8 +31,8 @@ expression: checks
     row: 324
     column: 4
   end_location:
-    row: 332
-    column: 4
+    row: 330
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -43,8 +43,8 @@ expression: checks
     row: 336
     column: 4
   end_location:
-    row: 345
-    column: 4
+    row: 343
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -55,8 +55,8 @@ expression: checks
     row: 349
     column: 4
   end_location:
-    row: 357
-    column: 4
+    row: 355
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -66,8 +66,8 @@ expression: checks
     row: 361
     column: 4
   end_location:
-    row: 369
-    column: 4
+    row: 367
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -76,8 +76,8 @@ expression: checks
     row: 389
     column: 0
   end_location:
-    row: 401
-    column: 0
+    row: 398
+    column: 7
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -88,8 +88,8 @@ expression: checks
     row: 425
     column: 4
   end_location:
-    row: 436
-    column: 4
+    row: 434
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -100,8 +100,8 @@ expression: checks
     row: 440
     column: 4
   end_location:
-    row: 455
-    column: 4
+    row: 453
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -111,8 +111,8 @@ expression: checks
     row: 459
     column: 4
   end_location:
-    row: 471
-    column: 4
+    row: 469
+    column: 11
   fix: ~
 - kind:
     DocumentAllArguments:
@@ -121,7 +121,7 @@ expression: checks
     row: 489
     column: 4
   end_location:
-    row: 498
-    column: 0
+    row: 497
+    column: 11
   fix: ~
 

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D418_D.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D418_D.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 34
     column: 4
   end_location:
-    row: 38
-    column: 4
+    row: 36
+    column: 11
   fix: ~
 - kind: SkipDocstring
   location:
     row: 90
     column: 4
   end_location:
-    row: 94
-    column: 4
+    row: 92
+    column: 11
   fix: ~
 - kind: SkipDocstring
   location:
     row: 110
     column: 0
   end_location:
-    row: 115
-    column: 0
+    row: 112
+    column: 7
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F634_F634.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F634_F634.py.snap
@@ -7,15 +7,15 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 4
-    column: 0
+    row: 2
+    column: 8
   fix: ~
 - kind: IfTuple
   location:
     row: 7
     column: 4
   end_location:
-    row: 9
-    column: 4
+    row: 8
+    column: 12
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F707_F707.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F707_F707.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 5
-    column: 0
+    row: 4
+    column: 8
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 10
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 11
+    column: 8
   fix: ~
 - kind: DefaultExceptNotLast
   location:
     row: 19
     column: 0
   end_location:
-    row: 21
-    column: 0
+    row: 20
+    column: 8
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_0.py.snap
@@ -10,7 +10,7 @@ expression: checks
     row: 10
     column: 0
   end_location:
-    row: 12
-    column: 0
+    row: 11
+    column: 8
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_15.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_15.py.snap
@@ -10,7 +10,7 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 6
-    column: 0
+    row: 5
+    column: 8
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_16.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_16.py.snap
@@ -10,7 +10,7 @@ expression: checks
     row: 8
     column: 8
   end_location:
-    row: 10
-    column: 0
+    row: 9
+    column: 16
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_17.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_17.py.snap
@@ -21,7 +21,7 @@ expression: checks
     row: 9
     column: 8
   end_location:
-    row: 11
-    column: 0
+    row: 10
+    column: 16
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F841_F841_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F841_F841_0.py.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 4
+    column: 8
   fix: ~
 - kind:
     UnusedVariable: z
@@ -66,12 +66,21 @@ expression: checks
     column: 9
   fix: ~
 - kind:
-    UnusedVariable: f
+    UnusedVariable: my_file
   location:
-    row: 71
+    row: 79
     column: 25
   end_location:
-    row: 71
-    column: 26
+    row: 79
+    column: 32
+  fix: ~
+- kind:
+    UnusedVariable: my_file
+  location:
+    row: 85
+    column: 24
+  end_location:
+    row: 85
+    column: 31
   fix: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -8,8 +8,8 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 7
-    column: 0
+    row: 4
+    column: 8
   fix: ~
 - kind:
     UnusedVariable: foo
@@ -84,12 +84,21 @@ expression: checks
     column: 9
   fix: ~
 - kind:
-    UnusedVariable: f
+    UnusedVariable: my_file
   location:
-    row: 71
+    row: 79
     column: 25
   end_location:
-    row: 71
-    column: 26
+    row: 79
+    column: 32
+  fix: ~
+- kind:
+    UnusedVariable: my_file
+  location:
+    row: 85
+    column: 24
+  end_location:
+    row: 85
+    column: 31
   fix: ~
 

--- a/src/pylint/snapshots/ruff__pylint__tests__PLR0206_property_with_parameters.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__PLR0206_property_with_parameters.py.snap
@@ -7,23 +7,23 @@ expression: checks
     row: 7
     column: 4
   end_location:
-    row: 10
-    column: 4
+    row: 8
+    column: 29
   fix: ~
 - kind: PropertyWithParameters
   location:
     row: 11
     column: 4
   end_location:
-    row: 14
-    column: 4
+    row: 12
+    column: 29
   fix: ~
 - kind: PropertyWithParameters
   location:
     row: 15
     column: 4
   end_location:
-    row: 19
-    column: 0
+    row: 16
+    column: 29
   fix: ~
 

--- a/src/pylint/snapshots/ruff__pylint__tests__PLW0120_useless_else_on_loop.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__PLW0120_useless_else_on_loop.py.snap
@@ -7,55 +7,55 @@ expression: checks
     row: 6
     column: 4
   end_location:
-    row: 11
-    column: 4
+    row: 10
+    column: 31
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 16
     column: 4
   end_location:
-    row: 20
-    column: 4
+    row: 19
+    column: 31
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 23
     column: 0
   end_location:
-    row: 34
-    column: 0
+    row: 31
+    column: 21
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 34
     column: 0
   end_location:
-    row: 40
-    column: 0
+    row: 38
+    column: 21
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 40
     column: 0
   end_location:
-    row: 48
-    column: 0
+    row: 45
+    column: 13
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 81
     column: 4
   end_location:
-    row: 90
-    column: 4
+    row: 89
+    column: 19
   fix: ~
 - kind: UselessElseOnLoop
   location:
     row: 96
     column: 8
   end_location:
-    row: 101
-    column: 4
+    row: 100
+    column: 21
   fix: ~
 


### PR DESCRIPTION
Thanks to @andersk for the fix upstream. We also get much-improved end-locations for functions and classes and other compound statements based on @harupy's work.

Closes #54.
Closes #847.
Closes #680.
