### PR TITLE
Apply CLI options even when no pyproject.toml is found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,10 @@ fn resolve(config: Option<PathBuf>, overrides: &Overrides) -> Result<Strategy> {
         // current working directory. (With `Strategy::Hierarchical`, we'll end up the
         // "closest" `pyproject.toml` file for every Python file later on, so these act
         // as the "default" settings.)
-        let settings = Settings::from_configuration(Configuration::default(), &path_dedot::CWD)?;
+        let mut config = Configuration::default();
+        // Apply command-line options that override defaults
+        config.apply(overrides.clone());
+        let settings = Settings::from_configuration(config, &path_dedot::CWD)?;
         Ok(Strategy::Hierarchical(settings))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn resolve(config: Option<PathBuf>, overrides: &Overrides) -> Result<Strategy> {
         // "closest" `pyproject.toml` file for every Python file later on, so these act
         // as the "default" settings.)
         let mut config = Configuration::default();
-        // Apply command-line options that override defaults
+        // Apply command-line options that override defaults.
         config.apply(overrides.clone());
         let settings = Settings::from_configuration(config, &path_dedot::CWD)?;
         Ok(Strategy::Hierarchical(settings))


### PR DESCRIPTION
Thanks for all your fantastic work on this remarkable tool! 

I've been having an issue that when there is no `pyproject.toml` found, command line options are ignored in lieu of the hard-coded defaults. For example, `foo.py` produces two F401 errors by default (good!), but when I try to specify `ruff` options via the CLI (`--select`, `--ignore`, etc.) they're not respected (bad!).

```python
# foo.py
import os
import sys
```

```console
$ ruff --ignore=F401 foo.py
Found 2 error(s).
foo.py:1:8: F401 `os` imported but unused
foo.py:2:8: F401 `sys` imported but unused
2 potentially fixable with the --fix option.
```

I can make these command line options work if I put a `pyproject.toml` anywhere on the path, regardless of its content. I imagine the intended behavior is that options on the CLI should override defaults regardless of whether or not a `pyproject.toml` is found. 

From what I can tell, when a `pyproject.toml` is found, `ruff::resolve()` calls `Resolver::resolve_settings()`, which ultimately calls `Configuration::apply()`, which is responsible for joining the command line options: 

https://github.com/charliermarsh/ruff/blob/765d21c7b06e780fb91cbcc79909836883faf0dd/src/resolver.rs#L131-L133

However, `Configuration::apply()` is not called unless a `pyproject.toml` is found. It looks like 9853b0728ba9289753cb3be984de75677a4713c6 removed the following lines which had been responsible for merging command line options with the default configuration:

https://github.com/charliermarsh/ruff/blob/4bb6b4851a639d1855c7fb5d02ea53a074c9a178/src/main.rs#L93-L98

This PR adds back this functionality, although my solution is a bit inelegant given the recent removal of this sort of logic from `main.rs`. Maybe a better fix would be to break the call to `Configuration::apply()` above out into a separate method that is called in all cases? Happy to work more on it if so.

Either way, figured I'd offer the PR instead of just opening an issue. :) (Sorry for any silly issues; I'm a baby rustacean.)