### PR TITLE
Apply fix to all errors in E711 and E712 autofix

### DIFF
--- a/src/autofix/mod.rs
+++ b/src/autofix/mod.rs
@@ -35,12 +35,4 @@ impl Fix {
             end_location: at,
         }
     }
-
-    pub fn dummy(location: Location) -> Self {
-        Self {
-            content: String::new(),
-            location,
-            end_location: location,
-        }
-    }
 }

--- a/src/pycodestyle/plugins.rs
+++ b/src/pycodestyle/plugins.rs
@@ -59,24 +59,21 @@ pub fn literal_comparisons(
         )
     {
         if matches!(op, Cmpop::Eq) {
-            let mut check = Check::new(
+            let check = Check::new(
                 CheckKind::NoneComparison(RejectedCmpop::Eq),
                 Range::from_located(comparator),
             );
             if checker.patch(check.kind.code()) {
-                // Dummy replacement
-                check.amend(Fix::dummy(expr.location));
                 bad_ops.insert(0, Cmpop::Is);
             }
             checks.push(check);
         }
         if matches!(op, Cmpop::NotEq) {
-            let mut check = Check::new(
+            let check = Check::new(
                 CheckKind::NoneComparison(RejectedCmpop::NotEq),
                 Range::from_located(comparator),
             );
             if checker.patch(check.kind.code()) {
-                check.amend(Fix::dummy(expr.location));
                 bad_ops.insert(0, Cmpop::IsNot);
             }
             checks.push(check);
@@ -90,23 +87,21 @@ pub fn literal_comparisons(
         } = comparator.node
         {
             if matches!(op, Cmpop::Eq) {
-                let mut check = Check::new(
+                let check = Check::new(
                     CheckKind::TrueFalseComparison(value, RejectedCmpop::Eq),
                     Range::from_located(comparator),
                 );
                 if checker.patch(check.kind.code()) {
-                    check.amend(Fix::dummy(expr.location));
                     bad_ops.insert(0, Cmpop::Is);
                 }
                 checks.push(check);
             }
             if matches!(op, Cmpop::NotEq) {
-                let mut check = Check::new(
+                let check = Check::new(
                     CheckKind::TrueFalseComparison(value, RejectedCmpop::NotEq),
                     Range::from_located(comparator),
                 );
                 if checker.patch(check.kind.code()) {
-                    check.amend(Fix::dummy(expr.location));
                     bad_ops.insert(0, Cmpop::IsNot);
                 }
                 checks.push(check);
@@ -126,23 +121,21 @@ pub fn literal_comparisons(
             )
         {
             if matches!(op, Cmpop::Eq) {
-                let mut check = Check::new(
+                let check = Check::new(
                     CheckKind::NoneComparison(RejectedCmpop::Eq),
                     Range::from_located(comparator),
                 );
                 if checker.patch(check.kind.code()) {
-                    check.amend(Fix::dummy(expr.location));
                     bad_ops.insert(idx, Cmpop::Is);
                 }
                 checks.push(check);
             }
             if matches!(op, Cmpop::NotEq) {
-                let mut check = Check::new(
+                let check = Check::new(
                     CheckKind::NoneComparison(RejectedCmpop::NotEq),
                     Range::from_located(comparator),
                 );
                 if checker.patch(check.kind.code()) {
-                    check.amend(Fix::dummy(expr.location));
                     bad_ops.insert(idx, Cmpop::IsNot);
                 }
                 checks.push(check);
@@ -156,23 +149,21 @@ pub fn literal_comparisons(
             } = comparator.node
             {
                 if matches!(op, Cmpop::Eq) {
-                    let mut check = Check::new(
+                    let check = Check::new(
                         CheckKind::TrueFalseComparison(value, RejectedCmpop::Eq),
                         Range::from_located(comparator),
                     );
                     if checker.patch(check.kind.code()) {
-                        check.amend(Fix::dummy(expr.location));
                         bad_ops.insert(idx, Cmpop::Is);
                     }
                     checks.push(check);
                 }
                 if matches!(op, Cmpop::NotEq) {
-                    let mut check = Check::new(
+                    let check = Check::new(
                         CheckKind::TrueFalseComparison(value, RejectedCmpop::NotEq),
                         Range::from_located(comparator),
                     );
                     if checker.patch(check.kind.code()) {
-                        check.amend(Fix::dummy(expr.location));
                         bad_ops.insert(idx, Cmpop::IsNot);
                     }
                     checks.push(check);
@@ -190,9 +181,9 @@ pub fn literal_comparisons(
             .cloned()
             .collect::<Vec<_>>();
         if let Some(content) = compare(left, &ops, comparators) {
-            if let Some(check) = checks.last_mut() {
-                check.fix = Some(Fix::replacement(
-                    content,
+            for check in &mut checks {
+                check.amend(Fix::replacement(
+                    content.to_string(),
                     expr.location,
                     expr.end_location.unwrap(),
                 ));

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E711_E711.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E711_E711.py.snap
@@ -139,13 +139,13 @@ expression: checks
     row: 26
     column: 12
   fix:
-    content: ""
+    content: x is None is not None
     location:
       row: 26
       column: 3
     end_location:
       row: 26
-      column: 3
+      column: 20
 - kind:
     NoneComparison: NotEq
   location:

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E712_E712.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E712_E712.py.snap
@@ -175,13 +175,13 @@ expression: checks
     row: 25
     column: 14
   fix:
-    content: ""
+    content: res is True is not False
     location:
       row: 25
       column: 3
     end_location:
       row: 25
-      column: 3
+      column: 23
 - kind:
     TrueFalseComparison:
       - false


### PR DESCRIPTION
This is closer to what we do for unused imports, and means that every Quick Fix action fixes the entire expression.