### PR TITLE
Treat `extend-*` configuration options as "always extended"

### DIFF
--- a/resources/test/project/README.md
+++ b/resources/test/project/README.md
@@ -9,14 +9,13 @@ Running from the repo root should pick up and enforce the appropriate settings f
 
 ```
 ∴ cargo run resources/test/project/
-Found 8 error(s).
+Found 7 error(s).
 resources/test/project/examples/.dotfiles/script.py:1:1: I001 Import block is un-sorted or un-formatted
 resources/test/project/examples/.dotfiles/script.py:1:8: F401 `numpy` imported but unused
 resources/test/project/examples/.dotfiles/script.py:2:17: F401 `app.app_file` imported but unused
 resources/test/project/examples/docs/docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 resources/test/project/examples/docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/src/file.py:1:8: F401 `os` imported but unused
-resources/test/project/src/file.py:5:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/src/import_file.py:1:1: I001 Import block is un-sorted or un-formatted
 6 potentially fixable with the --fix option.
 ```
@@ -25,14 +24,13 @@ Running from the project directory itself should exhibit the same behavior:
 
 ```
 ∴ (cd resources/test/project/ && cargo run .)
-Found 8 error(s).
+Found 7 error(s).
 examples/.dotfiles/script.py:1:1: I001 Import block is un-sorted or un-formatted
 examples/.dotfiles/script.py:1:8: F401 `numpy` imported but unused
 examples/.dotfiles/script.py:2:17: F401 `app.app_file` imported but unused
 examples/docs/docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 examples/docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 src/file.py:1:8: F401 `os` imported but unused
-src/file.py:5:5: F841 Local variable `x` is assigned to but never used
 src/import_file.py:1:1: I001 Import block is un-sorted or un-formatted
 6 potentially fixable with the --fix option.
 ```
@@ -53,22 +51,19 @@ file paths from the current working directory:
 
 ```
 ∴ (cargo run -- --config=resources/test/project/pyproject.toml resources/test/project/)
-Found 14 error(s).
+Found 11 error(s).
 resources/test/project/examples/.dotfiles/script.py:1:1: I001 Import block is un-sorted or un-formatted
 resources/test/project/examples/.dotfiles/script.py:1:8: F401 `numpy` imported but unused
 resources/test/project/examples/.dotfiles/script.py:2:17: F401 `app.app_file` imported but unused
 resources/test/project/examples/docs/docs/concepts/file.py:1:8: F401 `os` imported but unused
-resources/test/project/examples/docs/docs/concepts/file.py:5:5: F841 Local variable `x` is assigned to but never used
+resources/test/project/examples/docs/docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 resources/test/project/examples/docs/docs/file.py:1:8: F401 `os` imported but unused
 resources/test/project/examples/docs/docs/file.py:3:8: F401 `numpy` imported but unused
 resources/test/project/examples/docs/docs/file.py:4:27: F401 `docs.concepts.file` imported but unused
-resources/test/project/examples/docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/examples/excluded/script.py:1:8: F401 `os` imported but unused
-resources/test/project/examples/excluded/script.py:5:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/src/file.py:1:8: F401 `os` imported but unused
-resources/test/project/src/file.py:5:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/src/import_file.py:1:1: I001 Import block is un-sorted or un-formatted
-10 potentially fixable with the --fix option.
+11 potentially fixable with the --fix option.
 ```
 
 Running from a parent directory should this "ignore" the `exclude` (hence, `concepts/file.py` gets
@@ -88,8 +83,7 @@ Passing an excluded directory directly should report errors in the contained fil
 
 ```
 ∴ cargo run resources/test/project/examples/excluded/
-Found 2 error(s).
+Found 1 error(s).
 resources/test/project/examples/excluded/script.py:1:8: F401 `os` imported but unused
-resources/test/project/examples/excluded/script.py:5:5: F841 Local variable `x` is assigned to but never used
 1 potentially fixable with the --fix option.
 ```

--- a/resources/test/project/examples/docs/pyproject.toml
+++ b/resources/test/project/examples/docs/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.ruff]
 extend = "../../pyproject.toml"
 src = ["."]
-extend-select = ["I001"]
+# Enable I001, and re-enable F841, to test extension priority.
+extend-select = ["I001", "F841"]
 extend-ignore = ["F401"]
 extend-exclude = ["./docs/concepts/file.py"]

--- a/resources/test/project/pyproject.toml
+++ b/resources/test/project/pyproject.toml
@@ -2,3 +2,4 @@
 src = [".", "python_modules/*"]
 exclude = ["examples/excluded"]
 extend-select = ["I001"]
+extend-ignore = ["F841"]


### PR DESCRIPTION
Now, every `--extend-ignore` and `--extend-select` pair is applied iteratively (rather than "overriding" the `--extend-ignore` and `--extend-select` of something else).

This sounds complicated, but I think the semantics are more intuitive.

As an example, say you have this in your `pyproject.toml`:

```toml
[tool.ruff]
select = ["F"]
ignore = ["F401"]
```

Today, if you run `ruff /path/to/file.py --extend-select F401`, we won't actually detect `F401`, because _today_, it's treated as equivalent to:

```toml
[tool.ruff]
select = ["F", "F401"]
ignore = ["F401"]
```

And ignores "beat" selects.

As of this PR, the same setup _would_ trigger `F401`, since we now resolve the first (select, ignore) pair, then apply the next (select, ignore) pair to the resolved codes, and so on.

This is particularly useful with configuration extension via `extend`, as the child `pyproject.toml` can _always_ enable and disable codes (whereas before, if a parent disabled a _specific_ code, it was impossible for the child to re-enable it).

Resolves #1216.