### PR TITLE
Readme : Fix incorrect exmaple.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1573,7 +1573,7 @@ ignored when evaluating (e.g.) unused-variable checks. The default expression ma
 ```toml
 [tool.ruff]
 # Only ignore variables named "_".
-dummy_variable_rgx = "^_$"
+dummy-variable-rgx = "^_$"
 ```
 
 ---

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -38,7 +38,7 @@ pub struct Options {
         value_type = "Regex",
         example = r#"
             # Only ignore variables named "_".
-            dummy_variable_rgx = "^_$"
+            dummy-variable-rgx = "^_$"
         "#
     )]
     pub dummy_variable_rgx: Option<String>,


### PR DESCRIPTION
Updates incorrect usage example for "dummy-variable-rgx" 