### PR TITLE
Update RustPython to use correct Tuple location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -1972,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ regex = { version = "1.6.0" }
 ropey = { version = "1.5.0", features = ["cr_lines", "simd"], default-features = false }
 ruff_macros = { version = "0.0.185", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/flake8_to_ruff/Cargo.lock
+++ b/flake8_to_ruff/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=8d879a53197f9c73062f6160410bdba796a71cbf#8d879a53197f9c73062f6160410bdba796a71cbf"
+source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
 dependencies = [
  "ahash",
  "anyhow",

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,8 +11,8 @@ itertools = { version = "0.10.5" }
 libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8d879a53197f9c73062f6160410bdba796a71cbf" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }

--- a/src/flake8_bugbear/plugins/duplicate_exceptions.rs
+++ b/src/flake8_bugbear/plugins/duplicate_exceptions.rs
@@ -58,7 +58,11 @@ fn duplicate_handler_exceptions<'a>(
             if checker.patch(check.kind.code()) {
                 // TODO(charlie): If we have a single element, remove the tuple.
                 let mut generator = SourceGenerator::new();
-                generator.unparse_expr(&type_pattern(unique_elts), 0);
+                if unique_elts.len() == 1 {
+                    generator.unparse_expr(unique_elts[0], 0);
+                } else {
+                    generator.unparse_expr(&type_pattern(unique_elts), 0);
+                }
                 if let Ok(content) = generator.generate() {
                     check.amend(Fix::replacement(
                         content,

--- a/src/flake8_bugbear/plugins/duplicate_exceptions.rs
+++ b/src/flake8_bugbear/plugins/duplicate_exceptions.rs
@@ -56,7 +56,6 @@ fn duplicate_handler_exceptions<'a>(
                 Range::from_located(expr),
             );
             if checker.patch(check.kind.code()) {
-                // TODO(charlie): If we have a single element, remove the tuple.
                 let mut generator = SourceGenerator::new();
                 if unique_elts.len() == 1 {
                     generator.unparse_expr(unique_elts[0], 0);

--- a/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
+++ b/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
@@ -1,52 +1,10 @@
-use anyhow::{bail, Result};
-use log::error;
-use rustpython_ast::{Excepthandler, ExcepthandlerKind, ExprKind, Located};
-use rustpython_parser::lexer;
-use rustpython_parser::lexer::Tok;
+use rustpython_ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
-use crate::ast::helpers;
 use crate::ast::types::Range;
 use crate::autofix::Fix;
 use crate::checkers::ast::Checker;
 use crate::checks::{Check, CheckKind};
 use crate::code_gen::SourceGenerator;
-use crate::SourceCodeLocator;
-
-/// Given a statement like `except (ValueError,)`, find the range of the
-/// parenthesized expression.
-fn match_tuple_range<T>(located: &Located<T>, locator: &SourceCodeLocator) -> Result<Range> {
-    // Extract contents from the source code.
-    let range = Range::from_located(located);
-    let contents = locator.slice_source_code_range(&range);
-
-    // Find the left (opening) and right (closing) parentheses.
-    let mut location = None;
-    let mut end_location = None;
-    let mut count: usize = 0;
-    for (start, tok, end) in lexer::make_tokenizer(&contents).flatten() {
-        if matches!(tok, Tok::Lpar) {
-            if count == 0 {
-                location = Some(helpers::to_absolute(start, range.location));
-            }
-            count += 1;
-        }
-
-        if matches!(tok, Tok::Rpar) {
-            count -= 1;
-            if count == 0 {
-                end_location = Some(helpers::to_absolute(end, range.location));
-                break;
-            }
-        }
-    }
-    let (Some(location), Some(end_location)) = (location, end_location) else {
-        bail!("Unable to find left and right parentheses");
-    };
-    Ok(Range {
-        location,
-        end_location,
-    })
-}
 
 /// B013
 pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[Excepthandler]) {
@@ -68,16 +26,11 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             let mut generator = SourceGenerator::new();
             generator.unparse_expr(elt, 0);
             if let Ok(content) = generator.generate() {
-                match match_tuple_range(handler, checker.locator) {
-                    Ok(range) => {
-                        check.amend(Fix::replacement(
-                            content,
-                            range.location,
-                            range.end_location,
-                        ));
-                    }
-                    Err(e) => error!("Failed to locate parentheses: {e}"),
-                }
+                check.amend(Fix::replacement(
+                    content,
+                    type_.location,
+                    type_.end_location.unwrap(),
+                ));
             }
         }
         checker.add_check(check);

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B013_B013.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B013_B013.py.snap
@@ -6,10 +6,10 @@ expression: checks
     RedundantTupleInExceptionHandler: ValueError
   location:
     row: 3
-    column: 8
+    column: 7
   end_location:
     row: 3
-    column: 19
+    column: 20
   fix:
     content: ValueError
     location:

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B014_B014.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B014_B014.py.snap
@@ -12,7 +12,7 @@ expression: checks
     row: 17
     column: 25
   fix:
-    content: "OSError,"
+    content: OSError
     location:
       row: 17
       column: 7
@@ -29,7 +29,7 @@ expression: checks
     row: 28
     column: 25
   fix:
-    content: "MyError,"
+    content: MyError
     location:
       row: 28
       column: 7
@@ -46,7 +46,7 @@ expression: checks
     row: 49
     column: 27
   fix:
-    content: "re.error,"
+    content: re.error
     location:
       row: 49
       column: 7

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B014_B014.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B014_B014.py.snap
@@ -7,50 +7,50 @@ expression: checks
       - OSError
   location:
     row: 17
-    column: 8
+    column: 7
   end_location:
     row: 17
-    column: 24
+    column: 25
   fix:
     content: "OSError,"
     location:
       row: 17
-      column: 8
+      column: 7
     end_location:
       row: 17
-      column: 24
+      column: 25
 - kind:
     DuplicateHandlerException:
       - MyError
   location:
     row: 28
-    column: 8
+    column: 7
   end_location:
     row: 28
-    column: 24
+    column: 25
   fix:
     content: "MyError,"
     location:
       row: 28
-      column: 8
+      column: 7
     end_location:
       row: 28
-      column: 24
+      column: 25
 - kind:
     DuplicateHandlerException:
       - re.error
   location:
     row: 49
-    column: 8
+    column: 7
   end_location:
     row: 49
-    column: 26
+    column: 27
   fix:
     content: "re.error,"
     location:
       row: 49
-      column: 8
+      column: 7
     end_location:
       row: 49
-      column: 26
+      column: 27
 


### PR DESCRIPTION
Update RustPython for https://github.com/RustPython/RustPython/pull/4340.

```
$ cargo run -- --no-cache --show-source --select B013 resources/test/fixtures/flake8_bugbear/B013.py
resources/test/fixtures/flake8_bugbear/B013.py:3:8: B013 A length-one tuple literal is redundant. Write `except ValueError` instead of `except (ValueError,)`.
  |
3 | except (ValueError,):
  |        ^^^^^^^^^^^^^ B013
  |
1 potentially fixable with the --fix option.
```

B013 now covers the correct range.