### PR TITLE
Use `--stdin-filename` when resolving configuration files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,7 +120,7 @@ pub struct Cli {
     pub autoformat: bool,
     /// The name of the file when passing it through stdin.
     #[arg(long)]
-    pub stdin_filename: Option<String>,
+    pub stdin_filename: Option<PathBuf>,
     /// Explain a rule.
     #[arg(long)]
     pub explain: Option<CheckCode>,
@@ -203,7 +203,7 @@ pub struct Arguments {
     pub show_files: bool,
     pub show_settings: bool,
     pub silent: bool,
-    pub stdin_filename: Option<String>,
+    pub stdin_filename: Option<PathBuf>,
     pub verbose: bool,
     pub watch: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@
 )]
 
 use std::io::{self};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::mpsc::channel;
 
@@ -35,18 +35,25 @@ use path_absolutize::path_dedot;
 
 /// Resolve the relevant settings strategy and defaults for the current
 /// invocation.
-fn resolve(config: Option<PathBuf>, overrides: &Overrides) -> Result<PyprojectDiscovery> {
+fn resolve(
+    config: Option<PathBuf>,
+    overrides: &Overrides,
+    stdin_filename: &Option<PathBuf>,
+) -> Result<PyprojectDiscovery> {
     if let Some(pyproject) = config {
         // First priority: the user specified a `pyproject.toml` file. Use that
         // `pyproject.toml` for _all_ configuration, and resolve paths relative to the
         // current working directory. (This matches ESLint's behavior.)
         let settings = resolve_settings(&pyproject, &Relativity::Cwd, Some(overrides))?;
         Ok(PyprojectDiscovery::Fixed(settings))
-    } else if let Some(pyproject) = pyproject::find_pyproject_toml(path_dedot::CWD.as_path())? {
-        // Second priority: find a `pyproject.toml` file in the current working path,
-        // and resolve all paths relative to that directory. (With
-        // `Strategy::Hierarchical`, we'll end up finding the "closest" `pyproject.toml`
-        // file for every Python file later on, so these act as the "default" settings.)
+    } else if let Some(pyproject) =
+        pyproject::find_pyproject_toml(stdin_filename.as_ref().unwrap_or(&path_dedot::CWD))?
+    {
+        // Second priority: find a `pyproject.toml` file in either an ancestor of
+        // `stdin_filename` (if set) or the current working path all paths relative to
+        // that directory. (With `Strategy::Hierarchical`, we'll end up finding
+        // the "closest" `pyproject.toml` file for every Python file later on,
+        // so these act as the "default" settings.)
         let settings = resolve_settings(&pyproject, &Relativity::Parent, Some(overrides))?;
         Ok(PyprojectDiscovery::Hierarchical(settings))
     } else if let Some(pyproject) = pyproject::find_user_pyproject_toml() {
@@ -85,7 +92,7 @@ fn inner_main() -> Result<ExitCode> {
 
     // Construct the "default" settings. These are used when no `pyproject.toml`
     // files are present, or files are injected from outside of the hierarchy.
-    let pyproject_strategy = resolve(cli.config, &overrides)?;
+    let pyproject_strategy = resolve(cli.config, &overrides, &cli.stdin_filename)?;
 
     // Extract options that are included in `Settings`, but only apply at the top
     // level.
@@ -207,9 +214,8 @@ fn inner_main() -> Result<ExitCode> {
 
         // Generate lint violations.
         let diagnostics = if is_stdin {
-            let filename = cli.stdin_filename.unwrap_or_else(|| "-".to_string());
-            let path = Path::new(&filename);
-            commands::run_stdin(&pyproject_strategy, path, autofix)?
+            let path = cli.stdin_filename.unwrap_or_else(|| PathBuf::from("-"));
+            commands::run_stdin(&pyproject_strategy, &path, autofix)?
         } else {
             commands::run(
                 &cli.files,


### PR DESCRIPTION
Currently, when `ruff` is called with  `--stdin-filename`, it does not use this value when searching for a configuration file:

```console
user@host ~/ $ tree
.
├── foo
│   ├── bar.py
│   └── pyproject.toml
└── pyproject.toml
```

```console
user@host ~/ $ cat /home/user/foo/bar.py | ruff --stdin-filename=/home/user/foo/bar.py -
...
# Uses /home/user/pyproject.toml (based on cwd /home/user), not the expected /home/user/foo/pyproject.toml
```

This is a non-trivial issue when using `ruff` with, for example, something like [null-ls.nvim](https://github.com/Carlosiano/null-ls.nvim), which passes files via stdin and correctly sets `--stdin-filename`, but does not set the current directory to the project directory before executing `ruff`. 

By contrast, when `black` receives a `--stdin-filename` flag, it uses it in the resolution of the project root (see [here](https://github.com/psf/black/blob/cd9fef8bab3a39dfba494f1917e4158faba439f9/src/black/files.py#L43-L61)). So, `black` finds the expected project-local `pyproject.toml` in the example directory tree above:

```console
user@host ~/ $  cat /home/user/foo/bar.py | black --stdin-filename=/home/user/foo/bar.py -v -
Identified `/home/user/foo` as project root containing a pyproject.toml. 
...
```

This PR makes `ruff` find configuration files more like `black` does when `--stdin-filename` is passed. Apologies in advance if the current behavior of `ruff` is intended or if this PR is premature (and I won't be offended if this PR is rejected!). 
