### PR TITLE
generate-check-code-prefix: Run `rustfmt` automatically; only write if changed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - run: ./target/release/ruff_dev generate-rules-table
       - run: ./target/release/ruff_dev generate-options
       - run: git diff --quiet README.md || echo "::error file=README.md::This file is outdated. You may have to rerun 'cargo dev generate-options' and/or 'cargo dev generate-rules-table'."
-      - run: ./target/release/ruff_dev generate-check-code-prefix && cargo fmt -- src/checks_gen.rs
+      - run: ./target/release/ruff_dev generate-check-code-prefix
       - run: git diff --quiet src/checks_gen.rs || echo "::error file=src/checks_gen.rs::This file is outdated. You may have to rerun 'cargo dev generate-check-code-prefix'."
       - run: git diff --exit-code -- README.md src/checks_gen.rs
 

--- a/ruff_dev/src/generate_check_code_prefix.rs
+++ b/ruff_dev/src/generate_check_code_prefix.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::OpenOptions;
 use std::io::Write;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
@@ -10,8 +11,6 @@ use codegen::{Scope, Type, Variant};
 use itertools::Itertools;
 use ruff::checks::{CheckCode, CODE_REDIRECTS, PREFIX_REDIRECTS};
 use strum::IntoEnumIterator;
-
-const FILE: &str = "src/checks_gen.rs";
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -208,7 +207,11 @@ pub fn main(cli: &Cli) -> Result<()> {
     if cli.dry_run {
         println!("{output}");
     } else {
-        let mut f = OpenOptions::new().write(true).truncate(true).open(FILE)?;
+        let file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("Failed to find root directory")
+            .join("src/checks_gen.rs");
+        let mut f = OpenOptions::new().write(true).truncate(true).open(file)?;
         write!(f, "{output}")?;
     }
 

--- a/ruff_dev/src/generate_check_code_prefix.rs
+++ b/ruff_dev/src/generate_check_code_prefix.rs
@@ -1,8 +1,7 @@
 //! Generate the `CheckCodePrefix` enum.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::OpenOptions;
-use std::io::Write;
+use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -211,8 +210,9 @@ pub fn main(cli: &Cli) -> Result<()> {
             .parent()
             .expect("Failed to find root directory")
             .join("src/checks_gen.rs");
-        let mut f = OpenOptions::new().write(true).truncate(true).open(file)?;
-        write!(f, "{output}")?;
+        if fs::read(&file).map_or(true, |old| old != output.as_bytes()) {
+            fs::write(&file, output.as_bytes())?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This avoids unnecessary recompilation when nothing changed.