### PR TITLE
Avoid RET504 errors for intermediary function calls

### DIFF
--- a/resources/test/fixtures/flake8_return/RET504.py
+++ b/resources/test/fixtures/flake8_return/RET504.py
@@ -7,18 +7,6 @@ def x():
 
 
 def x():
-    b, a = 1, 2
-    print(b)
-    return a  # error
-
-
-def x():
-    a = 1
-    print()
-    return a  # error
-
-
-def x():
     a = 1
     print(a)
     a = 2
@@ -53,7 +41,6 @@ def x():
 
 # https://github.com/afonasev/flake8-return/issues/47#issue-641117366
 def user_agent_username(username=None):
-
     if not username:
         return ""
 
@@ -133,6 +120,20 @@ def x():
 def x():
     a = 1
     print(f"a={a}")
+    return a
+
+
+# Considered OK, since functions can have side effects.
+def x():
+    b, a = 1, 2
+    print(b)
+    return a
+
+
+# Considered OK, since functions can have side effects.
+def x():
+    a = 1
+    print()
     return a
 
 

--- a/src/flake8_return/snapshots/ruff__flake8_return__tests__RET504_RET504.py.snap
+++ b/src/flake8_return/snapshots/ruff__flake8_return__tests__RET504_RET504.py.snap
@@ -12,50 +12,34 @@ expression: checks
   fix: ~
 - kind: UnnecessaryAssign
   location:
-    row: 12
+    row: 13
     column: 11
   end_location:
-    row: 12
+    row: 13
     column: 12
   fix: ~
 - kind: UnnecessaryAssign
   location:
-    row: 18
-    column: 11
-  end_location:
-    row: 18
-    column: 12
-  fix: ~
-- kind: UnnecessaryAssign
-  location:
-    row: 25
-    column: 11
-  end_location:
-    row: 25
-    column: 12
-  fix: ~
-- kind: UnnecessaryAssign
-  location:
-    row: 31
+    row: 19
     column: 15
   end_location:
-    row: 31
+    row: 19
     column: 16
   fix: ~
 - kind: UnnecessaryAssign
   location:
-    row: 43
+    row: 31
     column: 11
   end_location:
-    row: 43
+    row: 31
     column: 17
   fix: ~
 - kind: UnnecessaryAssign
   location:
-    row: 51
+    row: 39
     column: 11
   end_location:
-    row: 51
+    row: 39
     column: 20
   fix: ~
 


### PR DESCRIPTION
This has led to enough false-positives that I want to at least avoid flagging it when we have function calls between the assignment and the return (which handles the filed cases).

Resolves #1290, #1233.