### PR TITLE
[Stylistic/non-functional] Use an r# format string to make json easier to read

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -55,12 +55,33 @@ fn test_stdin_json() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        "[\n  {\n    \"code\": \"F401\",\n    \"message\": \"`os` imported but unused\",\n    \
-         \"fix\": {\n      \"content\": \"\",\n      \"location\": {\n        \"row\": 1,\n        \
-         \"column\": 0\n      },\n      \"end_location\": {\n        \"row\": 2,\n        \
-         \"column\": 0\n      }\n    },\n    \"location\": {\n      \"row\": 1,\n      \
-         \"column\": 8\n    },\n    \"end_location\": {\n      \"row\": 1,\n      \"column\": \
-         10\n    },\n    \"filename\": \"F401.py\"\n  }\n]\n"
+        r#"[
+  {
+    "code": "F401",
+    "message": "`os` imported but unused",
+    "fix": {
+      "content": "",
+      "location": {
+        "row": 1,
+        "column": 0
+      },
+      "end_location": {
+        "row": 2,
+        "column": 0
+      }
+    },
+    "location": {
+      "row": 1,
+      "column": 8
+    },
+    "end_location": {
+      "row": 1,
+      "column": 10
+    },
+    "filename": "F401.py"
+  }
+]
+"#
     );
     Ok(())
 }


### PR DESCRIPTION
I had trouble making sense of the expected json due to all the explicitly listed newlines. Converting this to a string that doesn't need those makes it easiert to read.