### PR TITLE
Infer package roots when running via stdin

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -114,16 +114,19 @@ fn read_from_stdin() -> Result<String> {
 
 /// Run the linter over a single file, read from `stdin`.
 pub fn run_stdin(
+    filename: Option<&Path>,
     strategy: &PyprojectDiscovery,
-    filename: &Path,
     autofix: fixer::Mode,
 ) -> Result<Diagnostics> {
+    let package_root = filename
+        .and_then(std::path::Path::parent)
+        .and_then(packages::detect_package_root);
     let stdin = read_from_stdin()?;
     let settings = match strategy {
         PyprojectDiscovery::Fixed(settings) => settings,
         PyprojectDiscovery::Hierarchical(settings) => settings,
     };
-    let mut diagnostics = lint_stdin(filename, &stdin, settings, autofix)?;
+    let mut diagnostics = lint_stdin(filename, package_root, &stdin, settings, autofix)?;
     diagnostics.messages.sort_unstable();
     Ok(diagnostics)
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -260,7 +260,8 @@ pub fn autoformat_path(path: &Path, _settings: &Settings) -> Result<()> {
 /// Generate a list of `Check` violations from source code content derived from
 /// stdin.
 pub fn lint_stdin(
-    path: &Path,
+    path: Option<&Path>,
+    package: Option<&Path>,
     stdin: &str,
     settings: &Settings,
     autofix: fixer::Mode,
@@ -269,7 +270,13 @@ pub fn lint_stdin(
     let contents = stdin.to_string();
 
     // Lint the file.
-    let (contents, fixed, messages) = lint(contents, path, None, settings, autofix)?;
+    let (contents, fixed, messages) = lint(
+        contents,
+        path.unwrap_or_else(|| Path::new("-")),
+        package,
+        settings,
+        autofix,
+    )?;
 
     // Write the fixed contents to stdout.
     if matches!(autofix, fixer::Mode::Apply) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,8 +224,7 @@ fn inner_main() -> Result<ExitCode> {
 
         // Generate lint violations.
         let diagnostics = if is_stdin {
-            let path = cli.stdin_filename.unwrap_or_else(|| PathBuf::from("-"));
-            commands::run_stdin(&pyproject_strategy, &path, autofix)?
+            commands::run_stdin(cli.stdin_filename.as_deref(), &pyproject_strategy, autofix)?
         } else {
             commands::run(
                 &cli.files,


### PR DESCRIPTION
Resolves: #1319.

## Test Plan

Ran `cat python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py | ../ruff/target/debug/ruff --select=I001 --stdin-filename python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py --fix -` from `sean/ruff` in the Dagster repo.

Verified that `dagster_aws` was classified as first-party:

![Screen Shot 2022-12-21 at 8 28 29 PM](https://user-images.githubusercontent.com/1309177/209035028-78b1e547-d2b5-4523-a41e-1803be69b6e5.png)

Omitted the filename, by running `cat python_modules/libraries/dagster-aws/dagster_aws/emr/emr.py | ../ruff/target/debug/ruff --select=I001 --fix -` from `sean/ruff` in the Dagster repo.

Verified that `dagster_aws` was classified as third-party:

![Screen Shot 2022-12-21 at 8 29 54 PM](https://user-images.githubusercontent.com/1309177/209035106-fd358305-1001-4bf9-bf8c-095dd7fd6d27.png)
