### PR TITLE
Support shell expansion in `extend` paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "rustpython-parser",
  "serde",
  "serde_json",
+ "shellexpand",
  "strum",
  "strum_macros",
  "test-case",
@@ -2114,6 +2115,15 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+dependencies = [
+ "dirs 4.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev 
 rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
+shellexpand = { version = "3.0.0" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }

--- a/README.md
+++ b/README.md
@@ -1632,7 +1632,8 @@ exclude = [".venv"]
 
 #### [`extend`](#extend)
 
-A path to a local `pyproject.toml` file to merge into this configuration.
+A path to a local `pyproject.toml` file to merge into this configuration. User home
+directory and environment variables will be expanded.
 
 To resolve the current `pyproject.toml` file, Ruff will first resolve this base
 configuration file, then merge in any properties defined in the current configuration

--- a/src/settings/configuration.rs
+++ b/src/settings/configuration.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use glob::{glob, GlobError, Paths, PatternError};
 use regex::Regex;
+use shellexpand;
 
 use crate::checks_gen::CheckCodePrefix;
 use crate::cli::{collect_per_file_ignores, Overrides};
@@ -78,7 +79,14 @@ impl Configuration {
                     })
                     .collect()
             }),
-            extend: options.extend.map(PathBuf::from),
+            extend: options
+                .extend
+                .map(|extend| {
+                    let extend = shellexpand::full(&extend);
+                    extend.map(|extend| PathBuf::from(extend.as_ref()))
+                })
+                .transpose()
+                .map_err(|e| anyhow!("Invalid `extend` value: {e}"))?,
             extend_exclude: options
                 .extend_exclude
                 .map(|paths| {

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -67,7 +67,8 @@ pub struct Options {
     pub exclude: Option<Vec<String>>,
     #[option(
         doc = r#"
-            A path to a local `pyproject.toml` file to merge into this configuration.
+            A path to a local `pyproject.toml` file to merge into this configuration. User home
+            directory and environment variables will be expanded.
 
             To resolve the current `pyproject.toml` file, Ruff will first resolve this base
             configuration file, then merge in any properties defined in the current configuration


### PR DESCRIPTION
This allows things like:

```toml
[tool.ruff]
extend = "$FOO/pyproject.toml"
```

```toml
[tool.ruff]
extend = "~/pyproject.toml"
```

Raises an error in the event that an environment variable is undefined.

Resolves #1316.
