### PR TITLE
Update RustPython to use the correct `BinOp` location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -1975,7 +1975,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ regex = { version = "1.6.0" }
 ropey = { version = "1.5.0", features = ["cr_lines", "simd"], default-features = false }
 ruff_macros = { version = "0.0.192", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
 shellexpand = { version = "3.0.0" }

--- a/flake8_to_ruff/Cargo.lock
+++ b/flake8_to_ruff/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -2061,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=c01f014b1269eedcf4bdb45d5fbc62ae2beecf31#c01f014b1269eedcf4bdb45d5fbc62ae2beecf31"
+source = "git+https://github.com/RustPython/RustPython.git?rev=1b6cb170e925a43d605b3fed9f6b878e63e47744#1b6cb170e925a43d605b3fed9f6b878e63e47744"
 dependencies = [
  "ahash",
  "anyhow",

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,8 +11,8 @@ itertools = { version = "0.10.5" }
 libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "c01f014b1269eedcf4bdb45d5fbc62ae2beecf31" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "1b6cb170e925a43d605b3fed9f6b878e63e47744" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F501_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F501_F50x.py.snap
@@ -6,7 +6,7 @@ expression: checks
     PercentFormatInvalidFormat: incomplete format
   location:
     row: 1
-    column: 9
+    column: 0
   end_location:
     row: 1
     column: 25

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F502_F502.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F502_F502.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 6
-    column: 10
+    column: 0
   end_location:
     row: 6
     column: 19
@@ -13,7 +13,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 7
-    column: 10
+    column: 0
   end_location:
     row: 7
     column: 20
@@ -21,7 +21,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 8
-    column: 10
+    column: 0
   end_location:
     row: 8
     column: 19
@@ -29,7 +29,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 9
-    column: 10
+    column: 0
   end_location:
     row: 9
     column: 22
@@ -37,7 +37,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 11
-    column: 10
+    column: 0
   end_location:
     row: 11
     column: 37
@@ -45,7 +45,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 12
-    column: 10
+    column: 0
   end_location:
     row: 12
     column: 37
@@ -53,7 +53,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 13
-    column: 10
+    column: 0
   end_location:
     row: 13
     column: 37

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F502_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F502_F50x.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatExpectedMapping
   location:
     row: 9
-    column: 10
+    column: 0
   end_location:
     row: 9
     column: 21

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F503_F503.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F503_F503.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatExpectedSequence
   location:
     row: 17
-    column: 8
+    column: 0
   end_location:
     row: 17
     column: 24
@@ -13,7 +13,7 @@ expression: checks
 - kind: PercentFormatExpectedSequence
   location:
     row: 18
-    column: 8
+    column: 0
   end_location:
     row: 18
     column: 28
@@ -21,7 +21,7 @@ expression: checks
 - kind: PercentFormatExpectedSequence
   location:
     row: 23
-    column: 8
+    column: 0
   end_location:
     row: 23
     column: 42

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F503_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F503_F50x.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatExpectedSequence
   location:
     row: 10
-    column: 8
+    column: 0
   end_location:
     row: 10
     column: 20

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F504_F504.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F504_F504.py.snap
@@ -7,7 +7,7 @@ expression: checks
       - b
   location:
     row: 3
-    column: 14
+    column: 0
   end_location:
     row: 3
     column: 34
@@ -24,7 +24,7 @@ expression: checks
       - b
   location:
     row: 8
-    column: 8
+    column: 0
   end_location:
     row: 8
     column: 29
@@ -41,7 +41,7 @@ expression: checks
       - b
   location:
     row: 9
-    column: 8
+    column: 0
   end_location:
     row: 9
     column: 29

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F504_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F504_F50x.py.snap
@@ -7,7 +7,7 @@ expression: checks
       - baz
   location:
     row: 8
-    column: 10
+    column: 0
   end_location:
     row: 8
     column: 32

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F505_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F505_F50x.py.snap
@@ -7,7 +7,7 @@ expression: checks
       - bar
   location:
     row: 7
-    column: 10
+    column: 0
   end_location:
     row: 7
     column: 14

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F506_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F506_F50x.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatMixedPositionalAndNamed
   location:
     row: 2
-    column: 13
+    column: 0
   end_location:
     row: 2
     column: 29
@@ -13,7 +13,7 @@ expression: checks
 - kind: PercentFormatMixedPositionalAndNamed
   location:
     row: 3
-    column: 13
+    column: 0
   end_location:
     row: 3
     column: 29
@@ -21,7 +21,7 @@ expression: checks
 - kind: PercentFormatMixedPositionalAndNamed
   location:
     row: 11
-    column: 11
+    column: 0
   end_location:
     row: 11
     column: 27

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F507_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F507_F50x.py.snap
@@ -8,7 +8,7 @@ expression: checks
       - 1
   location:
     row: 5
-    column: 8
+    column: 0
   end_location:
     row: 5
     column: 14
@@ -19,7 +19,7 @@ expression: checks
       - 3
   location:
     row: 6
-    column: 8
+    column: 0
   end_location:
     row: 6
     column: 19

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F508_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F508_F50x.py.snap
@@ -5,7 +5,7 @@ expression: checks
 - kind: PercentFormatStarRequiresSequence
   location:
     row: 11
-    column: 11
+    column: 0
   end_location:
     row: 11
     column: 27

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F509_F50x.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F509_F50x.py.snap
@@ -6,7 +6,7 @@ expression: checks
     PercentFormatUnsupportedFormatCharacter: j
   location:
     row: 4
-    column: 5
+    column: 0
   end_location:
     row: 4
     column: 11


### PR DESCRIPTION
See https://github.com/RustPython/RustPython/pull/4348


```shell
# On main
> cargo run -- --show-source resources/test/fixtures/pyflakes/F504.py
...
resources/test/fixtures/pyflakes/F504.py:3:15: F504 '...' % ... has unused named argument(s): b
  |
3 | "%(a)s %(c)s" % {a: "?", "b": "!"}  # F504 ("b" not used)
  |               ^^^^^^^^^^^^^^^^^^^^ F504
  |
resources/test/fixtures/pyflakes/F504.py:8:9: F504 '...' % ... has unused named argument(s): b
  |
8 | "%(a)s" % {"a": 1, r"b": "!"}  # F504 ("b" not used)
  |         ^^^^^^^^^^^^^^^^^^^^^ F504
  |
resources/test/fixtures/pyflakes/F504.py:9:9: F504 '...' % ... has unused named argument(s): b
  |
9 | "%(a)s" % {'a': 1, u"b": "!"}  # F504 ("b" not used)
  |         ^^^^^^^^^^^^^^^^^^^^^ F504
  |
Found 3 error(s).
3 potentially fixable with the --fix option.
```

```shell
# On this PR branch
> cargo run -- --show-source resources/test/fixtures/pyflakes/F504.py
...
resources/test/fixtures/pyflakes/F504.py:3:1: F504 '...' % ... has unused named argument(s): b
  |
3 | "%(a)s %(c)s" % {a: "?", "b": "!"}  # F504 ("b" not used)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F504
  |
resources/test/fixtures/pyflakes/F504.py:8:1: F504 '...' % ... has unused named argument(s): b
  |
8 | "%(a)s" % {"a": 1, r"b": "!"}  # F504 ("b" not used)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F504
  |
resources/test/fixtures/pyflakes/F504.py:9:1: F504 '...' % ... has unused named argument(s): b
  |
9 | "%(a)s" % {'a': 1, u"b": "!"}  # F504 ("b" not used)
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F504
  |
Found 3 error(s).
3 potentially fixable with the --fix option.
```