### PR TITLE
Support isort's force-single-line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2467,6 +2467,23 @@ extra-standard-library = ["path"]
 
 ---
 
+#### [`force-single-line`](#force-single-line)
+
+Forces all from imports to appear on their own line.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+force-single-line = true
+```
+
+---
+
 #### [`force-wrap-aliases`](#force-wrap-aliases)
 
 Force `import from` statements with multiple members and at least one

--- a/README.md
+++ b/README.md
@@ -2553,6 +2553,23 @@ known-third-party = ["src"]
 
 ---
 
+#### [`single-line-exclusions`](#single-line-exclusions)
+
+One or more modules to exclude from the single line rule.
+
+**Default value**: `[]`
+
+**Type**: `Vec<String>`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+single-line-exclusions = ["os", "json"]
+```
+
+---
+
 #### [`split-on-trailing-comma`](#split-on-trailing-comma)
 
 If a comma is placed after the last member in a multi-line import, then

--- a/playground/src/ruff_options.ts
+++ b/playground/src/ruff_options.ts
@@ -188,6 +188,11 @@ export const AVAILABLE_OPTIONS: OptionGroup[] = [
             "type": 'Vec<String>',
         },
         {
+            "name": "single-line-exclusions",
+            "default": '[]',
+            "type": 'Vec<String>',
+        },
+        {
             "name": "split-on-trailing-comma",
             "default": 'true',
             "type": 'bool',

--- a/playground/src/ruff_options.ts
+++ b/playground/src/ruff_options.ts
@@ -168,6 +168,11 @@ export const AVAILABLE_OPTIONS: OptionGroup[] = [
             "type": 'Vec<String>',
         },
         {
+            "name": "force-single-line",
+            "default": 'false',
+            "type": 'bool',
+        },
+        {
             "name": "force-wrap-aliases",
             "default": 'false',
             "type": 'bool',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ strip = true
 [tool.ruff.isort]
 force-wrap-aliases = true
 combine-as-imports = true
+force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,4 @@ strip = true
 force-wrap-aliases = true
 combine-as-imports = true
 force-single-line = true
+single-line-exclusions = ["os", "logging.handlers"]

--- a/resources/test/fixtures/isort/force_single_line.py
+++ b/resources/test/fixtures/isort/force_single_line.py
@@ -1,5 +1,6 @@
 import sys, math
 from os import path, uname
+from logging.handlers import StreamHandler, FileHandler
 
 # comment 1
 from third_party import lib1, lib2, \

--- a/resources/test/fixtures/isort/force_single_line.py
+++ b/resources/test/fixtures/isort/force_single_line.py
@@ -1,0 +1,17 @@
+import sys, math
+from os import path, uname
+
+# comment 1
+from third_party import lib1, lib2, \
+     lib3, lib7, lib5, lib6
+# comment 2
+from third_party import lib4
+
+from foo import bar  # comment 3
+from foo2 import bar2  # comment 4
+
+# comment 5
+from bar import (
+     a, # comment 6
+     b, # comment 7
+)

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1078,6 +1078,13 @@
             "type": "string"
           }
         },
+        "force-single-line": {
+          "description": "Forces all from imports to appear on their own line.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "force-wrap-aliases": {
           "description": "Force `import from` statements with multiple members and at least one alias (e.g., `import A as B`) to wrap such that every line contains exactly one member. For example, this formatting would be retained, rather than condensing to a single line:\n\n```py from .utils import ( test_directory as test_directory, test_id as test_id ) ```\n\nNote that this setting is only effective when combined with `combine-as-imports = true`. When `combine-as-imports` isn't enabled, every aliased `import from` will be given its own line, in which case, wrapping is not necessary.",
           "type": [

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1112,6 +1112,16 @@
             "type": "string"
           }
         },
+        "single-line-exclusions": {
+          "description": "One or more modules to exclude from the single line rule.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "split-on-trailing-comma": {
           "description": "If a comma is placed after the last member in a multi-line import, then the imports will never be folded into one line.\n\nSee isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.",
           "type": [

--- a/src/isort/mod.rs
+++ b/src/isort/mod.rs
@@ -495,29 +495,38 @@ fn sort_imports(block: ImportBlock) -> OrderedImportBlock {
     ordered
 }
 
-fn force_single_line_imports(block: OrderedImportBlock) -> OrderedImportBlock {
+fn force_single_line_imports<'a>(
+    block: OrderedImportBlock<'a>,
+    single_line_exclusions: &BTreeSet<String>,
+) -> OrderedImportBlock<'a> {
     let mut import_from = vec![];
 
-    block
-        .import_from
-        .into_iter()
-        .for_each(|(from_data, comment_set, _, alias_data)| {
-            import_from.extend(alias_data.into_iter().enumerate().map(|(i, f)| {
-                (
-                    from_data.clone(),
-                    if i == 0 {
-                        comment_set.clone()
-                    } else {
-                        CommentSet {
-                            atop: vec![],
-                            inline: vec![],
-                        }
-                    },
-                    TrailingComma::Absent,
-                    vec![f],
-                )
-            }));
-        });
+    block.import_from.into_iter().for_each(
+        |(from_data, comment_set, trailing_comma, alias_data)| {
+            if from_data
+                .module
+                .map_or(false, |m| single_line_exclusions.contains(m))
+            {
+                import_from.push((from_data, comment_set, trailing_comma, alias_data));
+            } else {
+                import_from.extend(alias_data.into_iter().enumerate().map(|(i, f)| {
+                    (
+                        from_data.clone(),
+                        if i == 0 {
+                            comment_set.clone()
+                        } else {
+                            CommentSet {
+                                atop: vec![],
+                                inline: vec![],
+                            }
+                        },
+                        TrailingComma::Absent,
+                        vec![f],
+                    )
+                }));
+            }
+        },
+    );
 
     OrderedImportBlock {
         import: block.import,
@@ -540,6 +549,7 @@ pub fn format_imports(
     force_wrap_aliases: bool,
     split_on_trailing_comma: bool,
     force_single_line: bool,
+    single_line_exclusions: &BTreeSet<String>,
 ) -> String {
     let trailer = &block.trailer;
     let block = annotate_imports(&block.imports, comments, locator, split_on_trailing_comma);
@@ -564,7 +574,7 @@ pub fn format_imports(
     for import_block in block_by_type.into_values() {
         let mut import_block = sort_imports(import_block);
         if force_single_line {
-            import_block = force_single_line_imports(import_block);
+            import_block = force_single_line_imports(import_block, single_line_exclusions);
         }
 
         // Add a blank line between every section.
@@ -611,6 +621,7 @@ pub fn format_imports(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::path::Path;
 
     use anyhow::Result;
@@ -742,6 +753,9 @@ mod tests {
             &Settings {
                 isort: isort::settings::Settings {
                     force_single_line: true,
+                    single_line_exclusions: vec!["os".to_string(), "logging.handlers".to_string()]
+                        .into_iter()
+                        .collect::<BTreeSet<_>>(),
                     ..isort::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],

--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -82,6 +82,7 @@ pub fn check_imports(
         settings.isort.combine_as_imports,
         settings.isort.force_wrap_aliases,
         settings.isort.split_on_trailing_comma,
+        settings.isort.force_single_line,
     );
 
     // Expand the span the entire range, including leading and trailing space.

--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -83,6 +83,7 @@ pub fn check_imports(
         settings.isort.force_wrap_aliases,
         settings.isort.split_on_trailing_comma,
         settings.isort.force_single_line,
+        &settings.isort.single_line_exclusions,
     );
 
     // Expand the span the entire range, including leading and trailing space.

--- a/src/isort/settings.rs
+++ b/src/isort/settings.rs
@@ -48,6 +48,15 @@ pub struct Options {
     /// Forces all from imports to appear on their own line.
     pub force_single_line: Option<bool>,
     #[option(
+        default = r#"[]"#,
+        value_type = "Vec<String>",
+        example = r#"
+            single-line-exclusions = ["os", "json"]
+        "#
+    )]
+    /// One or more modules to exclude from the single line rule.
+    pub single_line_exclusions: Option<Vec<String>>,
+    #[option(
         default = r#"false"#,
         value_type = "bool",
         example = r#"
@@ -108,6 +117,7 @@ pub struct Settings {
     pub force_wrap_aliases: bool,
     pub split_on_trailing_comma: bool,
     pub force_single_line: bool,
+    pub single_line_exclusions: BTreeSet<String>,
     pub known_first_party: BTreeSet<String>,
     pub known_third_party: BTreeSet<String>,
     pub extra_standard_library: BTreeSet<String>,
@@ -120,6 +130,9 @@ impl Settings {
             force_wrap_aliases: options.force_wrap_aliases.unwrap_or(false),
             split_on_trailing_comma: options.split_on_trailing_comma.unwrap_or(true),
             force_single_line: options.force_single_line.unwrap_or(false),
+            single_line_exclusions: BTreeSet::from_iter(
+                options.single_line_exclusions.unwrap_or_default(),
+            ),
             known_first_party: BTreeSet::from_iter(options.known_first_party.unwrap_or_default()),
             known_third_party: BTreeSet::from_iter(options.known_third_party.unwrap_or_default()),
             extra_standard_library: BTreeSet::from_iter(
@@ -136,6 +149,7 @@ impl Default for Settings {
             force_wrap_aliases: false,
             split_on_trailing_comma: true,
             force_single_line: false,
+            single_line_exclusions: BTreeSet::new(),
             known_first_party: BTreeSet::new(),
             known_third_party: BTreeSet::new(),
             extra_standard_library: BTreeSet::new(),

--- a/src/isort/settings.rs
+++ b/src/isort/settings.rs
@@ -43,6 +43,13 @@ pub struct Options {
     #[option(
         default = r#"false"#,
         value_type = "bool",
+        example = r#"force-single-line = true"#
+    )]
+    /// Forces all from imports to appear on their own line.
+    pub force_single_line: Option<bool>,
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
         example = r#"
             combine-as-imports = true
         "#
@@ -95,10 +102,12 @@ pub struct Options {
 }
 
 #[derive(Debug, Hash)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub combine_as_imports: bool,
     pub force_wrap_aliases: bool,
     pub split_on_trailing_comma: bool,
+    pub force_single_line: bool,
     pub known_first_party: BTreeSet<String>,
     pub known_third_party: BTreeSet<String>,
     pub extra_standard_library: BTreeSet<String>,
@@ -110,6 +119,7 @@ impl Settings {
             combine_as_imports: options.combine_as_imports.unwrap_or(false),
             force_wrap_aliases: options.force_wrap_aliases.unwrap_or(false),
             split_on_trailing_comma: options.split_on_trailing_comma.unwrap_or(true),
+            force_single_line: options.force_single_line.unwrap_or(false),
             known_first_party: BTreeSet::from_iter(options.known_first_party.unwrap_or_default()),
             known_third_party: BTreeSet::from_iter(options.known_third_party.unwrap_or_default()),
             extra_standard_library: BTreeSet::from_iter(
@@ -125,6 +135,7 @@ impl Default for Settings {
             combine_as_imports: false,
             force_wrap_aliases: false,
             split_on_trailing_comma: true,
+            force_single_line: false,
             known_first_party: BTreeSet::new(),
             known_third_party: BTreeSet::new(),
             extra_standard_library: BTreeSet::new(),

--- a/src/isort/snapshots/ruff__isort__tests__force_single_line_force_single_line.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__force_single_line_force_single_line.py.snap
@@ -1,0 +1,20 @@
+---
+source: src/isort/mod.rs
+expression: checks
+---
+- kind: UnsortedImports
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 18
+    column: 0
+  fix:
+    content: "import math\nimport sys\nfrom os import path\nfrom os import uname\n\n# comment 5\nfrom bar import a  # comment 6\nfrom bar import b  # comment 7\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 18
+      column: 0
+

--- a/src/isort/snapshots/ruff__isort__tests__force_single_line_force_single_line.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__force_single_line_force_single_line.py.snap
@@ -7,14 +7,14 @@ expression: checks
     row: 1
     column: 0
   end_location:
-    row: 18
+    row: 19
     column: 0
   fix:
-    content: "import math\nimport sys\nfrom os import path\nfrom os import uname\n\n# comment 5\nfrom bar import a  # comment 6\nfrom bar import b  # comment 7\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
+    content: "import math\nimport sys\nfrom logging.handlers import FileHandler, StreamHandler\nfrom os import path, uname\n\n# comment 5\nfrom bar import a  # comment 6\nfrom bar import b  # comment 7\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
     location:
       row: 1
       column: 0
     end_location:
-      row: 18
+      row: 19
       column: 0
 

--- a/src/isort/types.rs
+++ b/src/isort/types.rs
@@ -16,7 +16,7 @@ impl Default for TrailingComma {
     }
 }
 
-#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Hash, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct ImportFromData<'a> {
     pub module: Option<&'a String>,
     pub level: Option<&'a usize>,
@@ -28,7 +28,7 @@ pub struct AliasData<'a> {
     pub asname: Option<&'a String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct CommentSet<'a> {
     pub atop: Vec<Cow<'a, str>>,
     pub inline: Vec<Cow<'a, str>>,


### PR DESCRIPTION
Forces all from imports to appear on their own line.

Closes #1252