### PR TITLE
Improve `excepthandler_name_range`

### DIFF
--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -402,21 +402,29 @@ pub fn excepthandler_name_range(
     handler: &Excepthandler,
     locator: &SourceCodeLocator,
 ) -> Option<Range> {
-    if let ExcepthandlerKind::ExceptHandler { name: None, .. } = &handler.node {
-        None
-    } else {
-        let contents = locator.slice_source_code_range(&Range::from_located(handler));
-        let range = lexer::make_tokenizer(&contents)
-            .flatten()
-            .tuple_windows()
-            .find(|(tok, next_tok)| {
-                matches!(tok.1, Tok::As) && matches!(next_tok.1, Tok::Name { .. })
-            })
-            .map(|((..), (start, _, end))| Range {
-                location: to_absolute(start, handler.location),
-                end_location: to_absolute(end, handler.location),
+    let ExcepthandlerKind::ExceptHandler {
+        name, type_, body, ..
+    } = &handler.node;
+    match (name, type_) {
+        (Some(_), Some(type_)) => {
+            let type_end_location = type_.end_location.unwrap();
+            let contents = locator.slice_source_code_range(&Range {
+                location: type_end_location,
+                end_location: body[0].location,
             });
-        range
+            let range = lexer::make_tokenizer(&contents)
+                .flatten()
+                .tuple_windows()
+                .find(|(tok, next_tok)| {
+                    matches!(tok.1, Tok::As) && matches!(next_tok.1, Tok::Name { .. })
+                })
+                .map(|((..), (start, _, end))| Range {
+                    location: to_absolute(start, type_end_location),
+                    end_location: to_absolute(end, type_end_location),
+                });
+            range
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
Follow-up for #1367. Improves `excepthandler_name_range` to only tokenize the `as name` part.