### PR TITLE
Only re-associate inline comments during normalization when necessary

### DIFF
--- a/resources/test/fixtures/isort/comments.py
+++ b/resources/test/fixtures/isort/comments.py
@@ -23,3 +23,6 @@ from A import (
     b,  # Comment 10
     c,  # Comment 11
 )
+
+from D import a_long_name_to_force_multiple_lines # Comment 12
+from D import another_long_name_to_force_multiple_lines # Comment 13

--- a/src/isort/mod.rs
+++ b/src/isort/mod.rs
@@ -191,6 +191,8 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                 atop,
                 inline,
             } => {
+                let single_import = names.len() == 1;
+
                 // Associate the comments with the first alias (best effort).
                 if let Some(alias) = names.first() {
                     let entry = if alias.name == "*" {
@@ -220,8 +222,13 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                     for comment in atop {
                         entry.atop.push(comment.value);
                     }
-                    for comment in inline {
-                        entry.inline.push(comment.value);
+
+                    // Only associate inline comments with first alias if multiple names have been
+                    // imported, i.e. the comment applies to all names
+                    if !single_import {
+                        for comment in &inline {
+                            entry.inline.push(comment.value.clone());
+                        }
                     }
                 }
 
@@ -255,6 +262,14 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                             ))
                             .or_default()
                     };
+
+                    // We only have one name imported, inline comments stay associated with that
+                    // entry.
+                    if single_import {
+                        for comment in &inline {
+                            entry.inline.push(comment.value.clone());
+                        }
+                    }
 
                     for comment in alias.atop {
                         entry.atop.push(comment.value);

--- a/src/isort/mod.rs
+++ b/src/isort/mod.rs
@@ -193,31 +193,19 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
             } => {
                 // Associate the comments with the first alias (best effort).
                 if let Some(alias) = names.first() {
-                    if alias.name == "*" {
-                        let entry = block
+                    let entry = if alias.name == "*" {
+                        block
                             .import_from_star
                             .entry(ImportFromData { module, level })
-                            .or_default();
-                        for comment in atop {
-                            entry.atop.push(comment.value);
-                        }
-                        for comment in inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .or_default()
                     } else if alias.asname.is_none() || combine_as_imports {
-                        let entry = &mut block
+                        &mut block
                             .import_from
                             .entry(ImportFromData { module, level })
                             .or_default()
-                            .0;
-                        for comment in atop {
-                            entry.atop.push(comment.value);
-                        }
-                        for comment in inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .0
                     } else {
-                        let entry = block
+                        block
                             .import_from_as
                             .entry((
                                 ImportFromData { module, level },
@@ -226,31 +214,26 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                                     asname: alias.asname,
                                 },
                             ))
-                            .or_default();
-                        for comment in atop {
-                            entry.atop.push(comment.value);
-                        }
-                        for comment in inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .or_default()
+                    };
+
+                    for comment in atop {
+                        entry.atop.push(comment.value);
+                    }
+                    for comment in inline {
+                        entry.inline.push(comment.value);
                     }
                 }
 
                 // Create an entry for every alias.
                 for alias in names {
-                    if alias.name == "*" {
-                        let entry = block
+                    let entry = if alias.name == "*" {
+                        block
                             .import_from_star
                             .entry(ImportFromData { module, level })
-                            .or_default();
-                        for comment in alias.atop {
-                            entry.atop.push(comment.value);
-                        }
-                        for comment in alias.inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .or_default()
                     } else if alias.asname.is_none() || combine_as_imports {
-                        let entry = block
+                        block
                             .import_from
                             .entry(ImportFromData { module, level })
                             .or_default()
@@ -259,15 +242,9 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                                 name: alias.name,
                                 asname: alias.asname,
                             })
-                            .or_default();
-                        for comment in alias.atop {
-                            entry.atop.push(comment.value);
-                        }
-                        for comment in alias.inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .or_default()
                     } else {
-                        let entry = block
+                        block
                             .import_from_as
                             .entry((
                                 ImportFromData { module, level },
@@ -276,13 +253,14 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                                     asname: alias.asname,
                                 },
                             ))
-                            .or_default();
-                        entry
-                            .atop
-                            .extend(alias.atop.into_iter().map(|comment| comment.value));
-                        for comment in alias.inline {
-                            entry.inline.push(comment.value);
-                        }
+                            .or_default()
+                    };
+
+                    for comment in alias.atop {
+                        entry.atop.push(comment.value);
+                    }
+                    for comment in alias.inline {
+                        entry.inline.push(comment.value);
                     }
                 }
             }

--- a/src/isort/mod.rs
+++ b/src/isort/mod.rs
@@ -229,7 +229,7 @@ fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) ->
                     // imported, i.e., the comment applies to all names; otherwise, associate
                     // with the alias.
                     if single_import
-                        && (alias.name != "*" && alias.asname.is_none() || combine_as_imports)
+                        && (alias.name != "*" && (alias.asname.is_none() || combine_as_imports))
                     {
                         let entry = block
                             .import_from

--- a/src/isort/snapshots/ruff__isort__tests__comments.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__comments.py.snap
@@ -7,14 +7,14 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 26
+    row: 29
     column: 0
   fix:
-    content: "import B  # Comment 4\n\n# Comment 3a\n# Comment 3b\nimport C\nimport D\n\n# Comment 5\n# Comment 6\nfrom A import (\n    a,  # Comment 7  # Comment 9\n    b,  # Comment 10\n    c,  # Comment 8  # Comment 11\n)\n"
+    content: "import B  # Comment 4\n\n# Comment 3a\n# Comment 3b\nimport C\nimport D\n\n# Comment 5\n# Comment 6\nfrom A import (\n    a,  # Comment 7  # Comment 9\n    b,  # Comment 10\n    c,  # Comment 8  # Comment 11\n)\nfrom D import (\n    a_long_name_to_force_multiple_lines,  # Comment 12\n    another_long_name_to_force_multiple_lines,  # Comment 13\n)\n"
     location:
       row: 3
       column: 0
     end_location:
-      row: 26
+      row: 29
       column: 0
 

--- a/src/isort/snapshots/ruff__isort__tests__fit_line_length_comment.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__fit_line_length_comment.py.snap
@@ -10,7 +10,7 @@ expression: checks
     row: 5
     column: 0
   fix:
-    content: "import a\n\n# Don't take this comment into account when determining whether the next import can fit on one line.\nfrom b import c\nfrom d import (  # Do take this comment into account when determining whether the next import can fit on one line.\n    e,\n)\n"
+    content: "import a\n\n# Don't take this comment into account when determining whether the next import can fit on one line.\nfrom b import c\nfrom d import (\n    e,  # Do take this comment into account when determining whether the next import can fit on one line.\n)\n"
     location:
       row: 1
       column: 0


### PR DESCRIPTION
This is in preparation for the force-single-line isort setting. We need
to keep inline comments associated to the import itself, if possible.

This is the case when an `import from` statement only imports a single
name, there is no ambiguity as to where that comment belongs.

Input:

```python
from D import a_long_name_to_force_multiple_lines # Comment 12
from D import another_long_name_to_force_multiple_lines # Comment 13
```

Before:
```python
from D import (  # Comment 12  # Comment 13
    a_long_name_to_force_multiple_lines,
    another_long_name_to_force_multiple_lines,
)
```

After:
```python
from D import (
    a_long_name_to_force_multiple_lines,  # Comment 12
    another_long_name_to_force_multiple_lines,  # Comment 13
)
```

---

Note to reviewers:

I'm currently cloning the comment values not because I want to, but because I couldn't find a way to convince the compiler that it's fine (at least right now). Would appreciate any help here on how to express that better.