### PR TITLE
Make banned-api config setting optional

### DIFF
--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1095,9 +1095,6 @@
     },
     "Flake8TidyImportsOptions": {
       "type": "object",
-      "required": [
-        "banned-api"
-      ],
       "properties": {
         "ban-relative-imports": {
           "description": "Whether to ban all relative imports (`\"all\"`), or only those imports that extend into the parent module or beyond (`\"parents\"`).",
@@ -1112,7 +1109,10 @@
         },
         "banned-api": {
           "description": "Specific modules or module members that may not be imported or accessed. Note that this check is only meant to flag accidental uses, and can be circumvented via `eval` or `importlib`.",
-          "type": "object",
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": {
             "$ref": "#/definitions/BannedApi"
           }

--- a/src/flake8_tidy_imports/settings.rs
+++ b/src/flake8_tidy_imports/settings.rs
@@ -56,7 +56,7 @@ pub struct Options {
     /// Specific modules or module members that may not be imported or accessed.
     /// Note that this check is only meant to flag accidental uses,
     /// and can be circumvented via `eval` or `importlib`.
-    pub banned_api: FxHashMap<String, BannedApi>,
+    pub banned_api: Option<FxHashMap<String, BannedApi>>,
 }
 
 #[derive(Debug)]
@@ -78,7 +78,7 @@ impl From<Options> for Settings {
     fn from(options: Options) -> Self {
         Self {
             ban_relative_imports: options.ban_relative_imports.unwrap_or(Strictness::Parents),
-            banned_api: options.banned_api,
+            banned_api: options.banned_api.unwrap_or_default(),
         }
     }
 }
@@ -87,7 +87,7 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             ban_relative_imports: Some(settings.ban_relative_imports),
-            banned_api: settings.banned_api,
+            banned_api: Some(settings.banned_api),
         }
     }
 }

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -515,7 +515,7 @@ other-attribute = 1
                 }),
                 flake8_tidy_imports: Some(flake8_tidy_imports::settings::Options {
                     ban_relative_imports: Some(Strictness::Parents),
-                    banned_api: FxHashMap::from_iter([
+                    banned_api: Some(FxHashMap::from_iter([
                         (
                             "cgi".to_string(),
                             BannedApi {
@@ -528,7 +528,7 @@ other-attribute = 1
                                 msg: "Use typing_extensions.TypedDict instead.".to_string()
                             }
                         )
-                    ])
+                    ]))
                 }),
                 flake8_import_conventions: Some(flake8_import_conventions::settings::Options {
                     aliases: Some(FxHashMap::from_iter([(


### PR DESCRIPTION
In 9d34da23bde9c0788c654627373940ebf6f626f2
I introduced the [tool.ruff.flake8-tidy-imports.banned-api] config section but accidentally made it required, resulting in the following error if your pyproject.toml didn't specify the new section:

    error missing field `banned-api` for key `tool.ruff.flake8-tidy-imports`

This commit remedies that oversight.

Fixes #1464.