### PR TITLE
Set editor background on top-level component

### DIFF
--- a/playground/src/Editor/Editor.tsx
+++ b/playground/src/Editor/Editor.tsx
@@ -98,7 +98,11 @@ export default function Editor() {
   }, []);
 
   return (
-    <main className={"h-full w-full flex flex-auto"}>
+    <main
+      className={
+        "h-full w-full flex flex-auto bg-ayu-background dark:bg-ayu-background-dark"
+      }
+    >
       <Header
         edit={edit}
         tab={tab}

--- a/playground/src/Editor/Header.tsx
+++ b/playground/src/Editor/Header.tsx
@@ -44,8 +44,6 @@ export default function Header({
         "border-b",
         "border-gray-200",
         "dark:border-gray-800",
-        "bg-ayu-background",
-        "dark:bg-ayu-background-dark",
       )}
     >
       <div className="flex space-x-5">


### PR DESCRIPTION
This avoids a flash of unstyled content when loading the WASM bundle.