### PR TITLE
Add a command to clear the Ruff cache

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -15,8 +15,9 @@ use serde::{Deserialize, Serialize};
 use crate::message::Message;
 use crate::settings::{flags, Settings};
 
-static CACHE_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("RUFF_CACHE_DIR").ok());
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+static CACHE_DIR: Lazy<Option<String>> = Lazy::new(|| std::env::var("RUFF_CACHE_DIR").ok());
+pub const DEFAULT_CACHE_DIR_NAME: &str = ".ruff_cache";
 
 #[derive(Serialize, Deserialize)]
 struct CacheMetadata {
@@ -40,7 +41,7 @@ struct CheckResult {
 pub fn cache_dir(project_root: &Path) -> PathBuf {
     CACHE_DIR
         .as_ref()
-        .map_or_else(|| project_root.join(".ruff_cache"), PathBuf::from)
+        .map_or_else(|| project_root.join(DEFAULT_CACHE_DIR_NAME), PathBuf::from)
 }
 
 fn content_dir() -> &'static Path {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use crate::settings::types::{
 #[command(version)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cli {
-    #[arg(required_unless_present_any = ["explain", "generate_shell_completion"])]
+    #[arg(required_unless_present_any = ["clean", "explain", "generate_shell_completion"])]
     pub files: Vec<PathBuf>,
     /// Path to the `pyproject.toml` or `ruff.toml` file to use for
     /// configuration.
@@ -150,6 +150,9 @@ pub struct Cli {
     /// Generate shell completion
     #[arg(long, hide = true, value_name = "SHELL")]
     pub generate_shell_completion: Option<clap_complete_command::Shell>,
+    /// Clear any caches in the current directory or any subdirectories.
+    #[arg(long)]
+    pub clean: bool,
     /// Path to the cache directory.
     #[arg(long)]
     pub cache_dir: Option<PathBuf>,
@@ -163,6 +166,7 @@ impl Cli {
             Arguments {
                 add_noqa: self.add_noqa,
                 autoformat: self.autoformat,
+                clean: self.clean,
                 config: self.config,
                 diff: self.diff,
                 exit_zero: self.exit_zero,
@@ -224,6 +228,7 @@ fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {
 pub struct Arguments {
     pub add_noqa: bool,
     pub autoformat: bool,
+    pub clean: bool,
     pub config: Option<PathBuf>,
     pub diff: bool,
     pub exit_zero: bool,

--- a/src/main_native.rs
+++ b/src/main_native.rs
@@ -83,12 +83,18 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
     let log_level = extract_log_level(&cli);
     set_up_logging(&log_level)?;
 
-    if cli.show_settings && cli.show_files {
-        anyhow::bail!("specify --show-settings or show-files (not both)")
-    }
     if let Some(shell) = cli.generate_shell_completion {
         shell.generate(&mut Cli::command(), &mut io::stdout());
         return Ok(ExitCode::SUCCESS);
+    }
+    if cli.show_settings && cli.show_files {
+        anyhow::bail!("specify --show-settings or show-files (not both)")
+    }
+    if cli.clean {
+        commands::clean(&log_level)?;
+        if cli.files.is_empty() {
+            return Ok(ExitCode::SUCCESS);
+        }
     }
 
     // Construct the "default" settings. These are used when no `pyproject.toml`


### PR DESCRIPTION
You can now run: `ruff --clean`.