### PR TITLE
Generate source code with detected line ending

### DIFF
--- a/ruff_dev/src/round_trip.rs
+++ b/ruff_dev/src/round_trip.rs
@@ -22,7 +22,11 @@ pub fn main(cli: &Cli) -> Result<()> {
     let python_ast = parser::parse_program(&contents, &cli.file.to_string_lossy())?;
     let locator = SourceCodeLocator::new(&contents);
     let stylist = SourceCodeStyleDetector::from_contents(&contents, &locator);
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_suite(&python_ast);
     println!("{}", generator.generate()?);
     Ok(())

--- a/src/flake8_bugbear/plugins/assert_false.rs
+++ b/src/flake8_bugbear/plugins/assert_false.rs
@@ -47,8 +47,11 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
 
     let mut check = Check::new(CheckKind::DoNotAssertFalse, Range::from_located(test));
     if checker.patch(check.kind.code()) {
-        let mut generator =
-            SourceCodeGenerator::new(checker.style.indentation(), checker.style.quote());
+        let mut generator = SourceCodeGenerator::new(
+            checker.style.indentation(),
+            checker.style.quote(),
+            checker.style.line_ending(),
+        );
         generator.unparse_stmt(&assertion_error(msg));
         if let Ok(content) = generator.generate() {
             check.amend(Fix::replacement(

--- a/src/flake8_bugbear/plugins/duplicate_exceptions.rs
+++ b/src/flake8_bugbear/plugins/duplicate_exceptions.rs
@@ -54,8 +54,11 @@ fn duplicate_handler_exceptions<'a>(
                 Range::from_located(expr),
             );
             if checker.patch(check.kind.code()) {
-                let mut generator =
-                    SourceCodeGenerator::new(checker.style.indentation(), checker.style.quote());
+                let mut generator = SourceCodeGenerator::new(
+                    checker.style.indentation(),
+                    checker.style.quote(),
+                    checker.style.line_ending(),
+                );
                 if unique_elts.len() == 1 {
                     generator.unparse_expr(unique_elts[0], 0);
                 } else {

--- a/src/flake8_bugbear/plugins/getattr_with_constant.rs
+++ b/src/flake8_bugbear/plugins/getattr_with_constant.rs
@@ -46,8 +46,11 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
 
     let mut check = Check::new(CheckKind::GetAttrWithConstant, Range::from_located(expr));
     if checker.patch(check.kind.code()) {
-        let mut generator =
-            SourceCodeGenerator::new(checker.style.indentation(), checker.style.quote());
+        let mut generator = SourceCodeGenerator::new(
+            checker.style.indentation(),
+            checker.style.quote(),
+            checker.style.line_ending(),
+        );
         generator.unparse_expr(&attribute(obj, value), 0);
         if let Ok(content) = generator.generate() {
             check.amend(Fix::replacement(

--- a/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
+++ b/src/flake8_bugbear/plugins/redundant_tuple_in_exception_handler.rs
@@ -23,8 +23,11 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             Range::from_located(type_),
         );
         if checker.patch(check.kind.code()) {
-            let mut generator =
-                SourceCodeGenerator::new(checker.style.indentation(), checker.style.quote());
+            let mut generator = SourceCodeGenerator::new(
+                checker.style.indentation(),
+                checker.style.quote(),
+                checker.style.line_ending(),
+            );
             generator.unparse_expr(elt, 0);
             if let Ok(content) = generator.generate() {
                 check.amend(Fix::replacement(

--- a/src/flake8_bugbear/plugins/setattr_with_constant.rs
+++ b/src/flake8_bugbear/plugins/setattr_with_constant.rs
@@ -34,7 +34,11 @@ fn assignment(
             type_comment: None,
         },
     );
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_stmt(&stmt);
     generator.generate().map_err(std::convert::Into::into)
 }

--- a/src/pycodestyle/plugins.rs
+++ b/src/pycodestyle/plugins.rs
@@ -30,7 +30,11 @@ fn compare(
             comparators: comparators.to_vec(),
         },
     );
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_expr(&cmp, 0);
     generator.generate().ok()
 }
@@ -302,7 +306,11 @@ fn function(
             type_comment: None,
         },
     );
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_stmt(&func);
     Ok(generator.generate()?)
 }

--- a/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
@@ -166,7 +166,11 @@ fn convert_to_class(
     base_class: &ExprKind,
     stylist: &SourceCodeStyleDetector,
 ) -> Result<Fix> {
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_stmt(&create_class_def_stmt(typename, body, base_class));
     let content = generator.generate()?;
     Ok(Fix::replacement(

--- a/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
@@ -199,7 +199,11 @@ fn convert_to_class(
     base_class: &ExprKind,
     stylist: &SourceCodeStyleDetector,
 ) -> Result<Fix> {
-    let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+    let mut generator = SourceCodeGenerator::new(
+        stylist.indentation(),
+        stylist.quote(),
+        stylist.line_ending(),
+    );
     generator.unparse_stmt(&create_class_def_stmt(
         class_name,
         body,

--- a/src/pyupgrade/plugins/remove_six_compat.rs
+++ b/src/pyupgrade/plugins/remove_six_compat.rs
@@ -138,7 +138,11 @@ fn replace_by_expr_kind(
 ) -> Result<Check> {
     let mut check = Check::new(CheckKind::RemoveSixCompat, Range::from_located(expr));
     if patch {
-        let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+        let mut generator = SourceCodeGenerator::new(
+            stylist.indentation(),
+            stylist.quote(),
+            stylist.line_ending(),
+        );
         generator.unparse_expr(&create_expr(node), 0);
         let content = generator.generate()?;
         check.amend(Fix::replacement(
@@ -158,7 +162,11 @@ fn replace_by_stmt_kind(
 ) -> Result<Check> {
     let mut check = Check::new(CheckKind::RemoveSixCompat, Range::from_located(expr));
     if patch {
-        let mut generator = SourceCodeGenerator::new(stylist.indentation(), stylist.quote());
+        let mut generator = SourceCodeGenerator::new(
+            stylist.indentation(),
+            stylist.quote(),
+            stylist.line_ending(),
+        );
         generator.unparse_stmt(&create_stmt(node));
         let content = generator.generate()?;
         check.amend(Fix::replacement(

--- a/src/pyupgrade/plugins/use_pep604_annotation.rs
+++ b/src/pyupgrade/plugins/use_pep604_annotation.rs
@@ -65,8 +65,11 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
     if checker.match_typing_call_path(&call_path, "Optional") {
         let mut check = Check::new(CheckKind::UsePEP604Annotation, Range::from_located(expr));
         if checker.patch(check.kind.code()) {
-            let mut generator =
-                SourceCodeGenerator::new(checker.style.indentation(), checker.style.quote());
+            let mut generator = SourceCodeGenerator::new(
+                checker.style.indentation(),
+                checker.style.quote(),
+                checker.style.line_ending(),
+            );
             generator.unparse_expr(&optional(slice), 0);
             if let Ok(content) = generator.generate() {
                 check.amend(Fix::replacement(
@@ -88,6 +91,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                     let mut generator = SourceCodeGenerator::new(
                         checker.style.indentation(),
                         checker.style.quote(),
+                        checker.style.line_ending(),
                     );
                     generator.unparse_expr(&union(elts), 0);
                     if let Ok(content) = generator.generate() {
@@ -103,6 +107,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                     let mut generator = SourceCodeGenerator::new(
                         checker.style.indentation(),
                         checker.style.quote(),
+                        checker.style.line_ending(),
                     );
                     generator.unparse_expr(slice, 0);
                     if let Ok(content) = generator.generate() {


### PR DESCRIPTION
Refs: #1477

I was considering to adjust `SourceCodeGenerator` to accept a `SourceCodeStyleDetector` (instead of passing in a third argument), but I don't see us adding many more options there.