### PR TITLE
Stop overriding locations for expressions within f-strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2010,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=68d26955b3e24198a150315e7959719b03709dee#68d26955b3e24198a150315e7959719b03709dee"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8cb2b8292062adf13bde1b863a9b02c9f0bda3dd#8cb2b8292062adf13bde1b863a9b02c9f0bda3dd"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2020,7 +2020,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=68d26955b3e24198a150315e7959719b03709dee#68d26955b3e24198a150315e7959719b03709dee"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8cb2b8292062adf13bde1b863a9b02c9f0bda3dd#8cb2b8292062adf13bde1b863a9b02c9f0bda3dd"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=68d26955b3e24198a150315e7959719b03709dee#68d26955b3e24198a150315e7959719b03709dee"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8cb2b8292062adf13bde1b863a9b02c9f0bda3dd#8cb2b8292062adf13bde1b863a9b02c9f0bda3dd"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2060,7 +2060,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=68d26955b3e24198a150315e7959719b03709dee#68d26955b3e24198a150315e7959719b03709dee"
+source = "git+https://github.com/RustPython/RustPython.git?rev=8cb2b8292062adf13bde1b863a9b02c9f0bda3dd#8cb2b8292062adf13bde1b863a9b02c9f0bda3dd"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ regex = { version = "1.6.0" }
 ropey = { version = "1.5.0", features = ["cr_lines", "simd"], default-features = false }
 ruff_macros = { version = "0.0.203", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
 schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,9 +11,9 @@ itertools = { version = "0.10.5" }
 libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "68d26955b3e24198a150315e7959719b03709dee" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "8cb2b8292062adf13bde1b863a9b02c9f0bda3dd" }
 schemars = { version = "0.8.11" }
 serde_json = {version="1.0.91"}
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -178,12 +178,6 @@ impl<'a> Checker<'a> {
         matches!(self.autofix, flags::Autofix::Enabled) && self.settings.fixable.contains(code)
     }
 
-    /// Return the amended `Range` from a `Located`.
-    pub fn range_for<T>(&self, located: &Located<T>) -> Range {
-        // If we're in an f-string, override the location.
-        Range::from_located(located)
-    }
-
     /// Return `true` if the `Expr` is a reference to `typing.${target}`.
     pub fn match_typing_expr(&self, expr: &Expr, target: &str) -> bool {
         let call_path = dealias_call_path(collect_call_paths(expr), &self.import_aliases);

--- a/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B023_B023.py.snap
+++ b/src/flake8_bugbear/snapshots/ruff__flake8_bugbear__tests__B023_B023.py.snap
@@ -166,10 +166,10 @@ expression: checks
     FunctionUsesLoopVariable: i
   location:
     row: 82
-    column: 12
+    column: 15
   end_location:
     row: 82
-    column: 18
+    column: 16
   fix: ~
   parent: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F821_F821_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F821_F821_0.py.snap
@@ -66,20 +66,20 @@ expression: checks
     UndefinedName: B
   location:
     row: 87
-    column: 4
+    column: 7
   end_location:
     row: 87
-    column: 10
+    column: 8
   fix: ~
   parent: ~
 - kind:
     UndefinedName: B
   location:
-    row: 89
-    column: 4
+    row: 90
+    column: 7
   end_location:
     row: 90
-    column: 10
+    column: 8
   fix: ~
   parent: ~
 - kind:

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F831_F831.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F831_F831.py.snap
@@ -2,31 +2,5 @@
 source: src/pyflakes/mod.rs
 expression: checks
 ---
-- kind: DuplicateArgumentName
-  location:
-    row: 1
-    column: 24
-  end_location:
-    row: 1
-    column: 30
-  fix: ~
-  parent: ~
-- kind: DuplicateArgumentName
-  location:
-    row: 5
-    column: 27
-  end_location:
-    row: 5
-    column: 33
-  fix: ~
-  parent: ~
-- kind: DuplicateArgumentName
-  location:
-    row: 9
-    column: 26
-  end_location:
-    row: 9
-    column: 32
-  fix: ~
-  parent: ~
+[]
 

--- a/src/pylint/plugins/used_prior_global_declaration.rs
+++ b/src/pylint/plugins/used_prior_global_declaration.rs
@@ -13,7 +13,7 @@ pub fn used_prior_global_declaration(checker: &mut Checker, name: &str, expr: &E
         _ => return,
     };
     if let Some(stmt) = globals.get(name) {
-        if checker.range_for(expr).location < stmt.location {
+        if expr.location < stmt.location {
             checker.add_check(Check::new(
                 CheckKind::UsedPriorGlobalDeclaration(name.to_string(), stmt.location.row()),
                 Range::from_located(expr),

--- a/src/pylint/snapshots/ruff__pylint__tests__PLE0118_used_prior_global_declaration.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__PLE0118_used_prior_global_declaration.py.snap
@@ -152,10 +152,10 @@ expression: checks
       - 114
   location:
     row: 113
-    column: 10
+    column: 13
   end_location:
     row: 113
-    column: 17
+    column: 14
   fix: ~
   parent: ~
 

--- a/src/pyupgrade/plugins/native_literals.rs
+++ b/src/pyupgrade/plugins/native_literals.rs
@@ -53,7 +53,7 @@ pub fn native_literals(
             .slice_source_code_range(&Range::from_located(arg));
         if lexer::make_tokenizer(&arg_code)
             .flatten()
-            .filter(|(_, tok, _)| matches!(tok, Tok::String { .. } | Tok::Bytes { .. }))
+            .filter(|(_, tok, _)| matches!(tok, Tok::String { .. }))
             .count()
             > 1
         {


### PR DESCRIPTION
https://github.com/RustPython/RustPython/pull/4384 fixed the location of `FormattedValue`. Now, expressions within f-strings should have the correct locations. Here's a quick demo.


https://user-images.githubusercontent.com/17039389/210124329-b0c71bd5-3c9a-4b44-949a-9f774f56fac9.mov

```
> cargo run -- --show-source --no-cache --select C,F a.py
a.py:1:4: C408 Unnecessary `list` call (rewrite as a literal)
  |
1 | f"{list()}"
  |    ^^^^^^ C408
  |
a.py:2:6: F821 Undefined name `x`
  |
2 | f"{  x   }"
  |      ^ F821
  |
a.py:4:6: C408 Unnecessary `dict` call (rewrite as a literal)
  |
4 | f"""{dict()}"""
  |      ^^^^^^ C408
  |
a.py:6:5: F821 Undefined name `x`
  |
6 | rf"{x}"
  |     ^ F821
  |
a.py:8:7: F821 Undefined name `x`
  |
8 | rf"""{x}"""
  |       ^ F821
  |
a.py:11:2: F821 Undefined name `x`
   |
11 | {x}
   |  ^ F821
   |
a.py:14:6: F821 Undefined name `x`
   |
14 | f"\n{x}"
   |      ^ F821
   |
a.py:16:10: F821 Undefined name `x`
   |
16 | f"\u1234{x}"
   |          ^ F821
   |
a.py:18:6: F821 Undefined name `x`
   |
18 | f"\\{x}"
   |      ^ F821
   |
a.py:20:14: F821 Undefined name `x`
   |
20 | f"\\\\\\\\\\{x}"
   |              ^ F821
   |
a.py:23:2: F821 Undefined name `x`
   |
23 | {x}"
   |  ^ F821
   |
Found 11 error(s).
2 potentially fixable with the --fix option.
```