### PR TITLE
Improve F811 range for function and class definitions

### DIFF
--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -532,7 +532,7 @@ where
                     Binding {
                         kind: BindingKind::FunctionDefinition,
                         used: None,
-                        range: Range::from_located(stmt),
+                        range: helpers::identifier_range(stmt, self.locator),
                         source: Some(self.current_stmt().clone()),
                     },
                 );
@@ -1412,7 +1412,7 @@ where
                     Binding {
                         kind: BindingKind::ClassDefinition,
                         used: None,
-                        range: Range::from_located(stmt),
+                        range: helpers::identifier_range(stmt, self.locator),
                         source: Some(self.current_stmt().clone()),
                     },
                 );

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_0.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - 6
   location:
     row: 10
-    column: 0
+    column: 4
   end_location:
-    row: 11
-    column: 8
+    row: 10
+    column: 7
   fix: ~
   parent: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_15.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_15.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - 1
   location:
     row: 4
-    column: 0
+    column: 4
   end_location:
-    row: 5
-    column: 8
+    row: 4
+    column: 6
   fix: ~
   parent: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_16.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_16.py.snap
@@ -8,10 +8,10 @@ expression: checks
       - 3
   location:
     row: 8
-    column: 8
+    column: 12
   end_location:
-    row: 9
-    column: 16
+    row: 8
+    column: 14
   fix: ~
   parent: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_17.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F811_F811_17.py.snap
@@ -20,10 +20,10 @@ expression: checks
       - 6
   location:
     row: 9
-    column: 8
+    column: 12
   end_location:
-    row: 10
-    column: 16
+    row: 9
+    column: 14
   fix: ~
   parent: ~
 


### PR DESCRIPTION
This PR improves F811 range for function and class definitions using `helpers::identifier_range`.


### Current

```
> cargo run -- --select F811 --show-source resources/test/fixtures/pylint/used_prior_global_declaration.py
resources/test/fixtures/pylint/used_prior_global_declaration.py:156:1: F811 Redefinition of unused `f` from line 150
    |
156 | / def f():
157 | |     global x
158 | |     print(f"{x=}")
    | |__________________^ F811
    |
```

### Improved

```
> cargo run -- --select F811 --show-source resources/test/fixtures/pylint/used_prior_global_declaration.py
resources/test/fixtures/pylint/used_prior_global_declaration.py:156:5: F811 Redefinition of unused `f` from line 150
    |
156 | def f():
    |     ^ F811
    |
```

