### PR TITLE
Fix detection of changed imports in isort plugin

### DIFF
--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -95,7 +95,7 @@ pub fn check_imports(
         end_location: Location::new(range.end_location.row() + 1 + num_trailing_lines, 0),
     };
     let actual = dedent(&locator.slice_source_code_range(&range));
-    if actual == expected {
+    if actual == dedent(&expected) {
         None
     } else {
         let mut check = Check::new(CheckKind::UnsortedImports, range);


### PR DESCRIPTION
With the correct handling of line endings recently introduced, the isort plugin got into an endless loop because the check whether something was changed made incorrect assumptions.

Specifically, `dedent` will rejoin the lines using LF. When compared to the source which may have CRLF or just CR, this condition will never be true, even if nothing visually actually changed.

An alternative solution would be to reimplement dedent and indent to be aware of the line endings. Something we eventually might have to do, as there are still some places that (incorrectly) assume line endings are always just LF.

Closes #1490

---

When applied to #1501 this fixes the test failures.