### PR TITLE
Include fix commit message when showing violations together with source

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -336,15 +336,15 @@ fn print_message(message: &Message) {
     );
     println!("{label}");
     if let Some(source) = &message.source {
-        let commit = message.kind.commit().unwrap_or_default();
-        let footer = if commit.is_empty() {
-            vec![]
-        } else {
+        let commit = message.kind.commit();
+        let footer = if commit.is_some() {
             vec![Annotation {
                 id: None,
-                label: Some(commit.as_str()),
+                label: commit.as_deref(),
                 annotation_type: AnnotationType::Help,
             }]
+        } else {
+            vec![]
         };
 
         let snippet = Snippet {
@@ -395,6 +395,17 @@ fn print_grouped_message(message: &Message, row_length: usize, column_length: us
     );
     println!("{label}");
     if let Some(source) = &message.source {
+        let commit = message.kind.commit();
+        let footer = if commit.is_some() {
+            vec![Annotation {
+                id: None,
+                label: commit.as_deref(),
+                annotation_type: AnnotationType::Help,
+            }]
+        } else {
+            vec![]
+        };
+
         let snippet = Snippet {
             title: Some(Annotation {
                 label: None,
@@ -402,7 +413,7 @@ fn print_grouped_message(message: &Message, row_length: usize, column_length: us
                 // The ID (error number) is already encoded in the `label`.
                 id: None,
             }),
-            footer: vec![],
+            footer,
             slices: vec![Slice {
                 source: &source.contents,
                 line_start: message.location.row(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -336,6 +336,17 @@ fn print_message(message: &Message) {
     );
     println!("{label}");
     if let Some(source) = &message.source {
+        let commit = message.kind.commit().unwrap_or_default();
+        let footer = if commit.is_empty() {
+            vec![]
+        } else {
+            vec![Annotation {
+                id: None,
+                label: Some(commit.as_str()),
+                annotation_type: AnnotationType::Help,
+            }]
+        };
+
         let snippet = Snippet {
             title: Some(Annotation {
                 label: None,
@@ -343,7 +354,7 @@ fn print_message(message: &Message) {
                 // The ID (error number) is already encoded in the `label`.
                 id: None,
             }),
-            footer: vec![],
+            footer,
             slices: vec![Slice {
                 source: &source.contents,
                 line_start: message.location.row(),
@@ -365,7 +376,7 @@ fn print_message(message: &Message) {
         // Skip the first line, since we format the `label` ourselves.
         let message = DisplayList::from(snippet).to_string();
         let (_, message) = message.split_once('\n').unwrap();
-        println!("{message}");
+        println!("{message}\n");
     }
 }
 


### PR DESCRIPTION
This change doesn't have a lot of impact right now, as in many cases the commit message is similar to the error message itself. However, it is more actionable and makes it more obvious in what places we can improve.

Refs: #218

![image](https://user-images.githubusercontent.com/50333/210131029-d6439963-a7ab-4b1f-8efc-4acbc2f599ad.png)

---

I think having this new commit message is a good first step, but long term I imagine it's more useful to the user if those messages were created by the check itself. We'd have much more context there and could generate much more actionable messages, e.g. 

```
= help: replace with `x.bar`
```