### PR TITLE
Fix E722 and F707 ranges

### DIFF
--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1168,7 +1168,9 @@ where
             }
             StmtKind::Try { handlers, .. } => {
                 if self.settings.enabled.contains(&CheckCode::F707) {
-                    if let Some(check) = pyflakes::checks::default_except_not_last(handlers) {
+                    if let Some(check) =
+                        pyflakes::checks::default_except_not_last(handlers, self.locator)
+                    {
                         self.add_check(check);
                     }
                 }
@@ -2679,7 +2681,8 @@ where
                     if let Some(check) = pycodestyle::checks::do_not_use_bare_except(
                         type_.as_deref(),
                         body,
-                        Range::from_located(excepthandler),
+                        excepthandler,
+                        self.locator,
                     ) {
                         self.add_check(check);
                     }

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E722_E722.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E722_E722.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 4
     column: 0
   end_location:
-    row: 5
-    column: 8
+    row: 4
+    column: 6
   fix: ~
   parent: ~
 - kind: DoNotUseBareExcept
@@ -16,8 +16,8 @@ expression: checks
     row: 11
     column: 0
   end_location:
-    row: 12
-    column: 8
+    row: 11
+    column: 6
   fix: ~
   parent: ~
 - kind: DoNotUseBareExcept
@@ -25,8 +25,8 @@ expression: checks
     row: 16
     column: 0
   end_location:
-    row: 17
-    column: 8
+    row: 16
+    column: 6
   fix: ~
   parent: ~
 

--- a/src/pyflakes/checks.rs
+++ b/src/pyflakes/checks.rs
@@ -5,8 +5,10 @@ use rustpython_parser::ast::{
     Constant, Excepthandler, ExcepthandlerKind, Expr, ExprKind, Stmt, StmtKind,
 };
 
+use crate::ast::helpers::except_range;
 use crate::ast::types::{Binding, BindingKind, Range, Scope, ScopeKind};
 use crate::checks::{Check, CheckKind};
+use crate::source_code_locator::SourceCodeLocator;
 
 /// F631
 pub fn assert_tuple(test: &Expr, location: Range) -> Option<Check> {
@@ -110,13 +112,16 @@ pub fn unused_annotation(
 }
 
 /// F707
-pub fn default_except_not_last(handlers: &[Excepthandler]) -> Option<Check> {
+pub fn default_except_not_last(
+    handlers: &[Excepthandler],
+    locator: &SourceCodeLocator,
+) -> Option<Check> {
     for (idx, handler) in handlers.iter().enumerate() {
         let ExcepthandlerKind::ExceptHandler { type_, .. } = &handler.node;
         if type_.is_none() && idx < handlers.len() - 1 {
             return Some(Check::new(
                 CheckKind::DefaultExceptNotLast,
-                Range::from_located(handler),
+                except_range(handler, locator),
             ));
         }
     }

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F707_F707.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F707_F707.py.snap
@@ -7,8 +7,8 @@ expression: checks
     row: 3
     column: 0
   end_location:
-    row: 4
-    column: 8
+    row: 3
+    column: 6
   fix: ~
   parent: ~
 - kind: DefaultExceptNotLast
@@ -16,8 +16,8 @@ expression: checks
     row: 10
     column: 0
   end_location:
-    row: 11
-    column: 8
+    row: 10
+    column: 6
   fix: ~
   parent: ~
 - kind: DefaultExceptNotLast
@@ -25,8 +25,8 @@ expression: checks
     row: 19
     column: 0
   end_location:
-    row: 20
-    column: 8
+    row: 19
+    column: 6
   fix: ~
   parent: ~
 


### PR DESCRIPTION
This PR fixes E722 and F707 ranges.

### Current

```
resources/test/fixtures/pycodestyle/E722.py:16:1: E722 Do not use bare `except`
   |
16 | / except:
17 | |     pass
   | |________^ E722
   |
```

### Fixed

```
resources/test/fixtures/pycodestyle/E722.py:16:1: E722 Do not use bare `except`
   |
16 | except:
   | ^^^^^^ E722
   |
```