### PR TITLE
Use more precise error ranges for names

### DIFF
--- a/src/pycodestyle/checks.rs
+++ b/src/pycodestyle/checks.rs
@@ -1,7 +1,7 @@
 use itertools::izip;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rustpython_ast::{Constant, Excepthandler, Located, Location, Stmt, StmtKind};
+use rustpython_ast::{Constant, Excepthandler, Location, Stmt, StmtKind};
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
 use crate::ast::helpers::except_range;
@@ -111,11 +111,11 @@ fn is_ambiguous_name(name: &str) -> bool {
 }
 
 /// E741
-pub fn ambiguous_variable_name<T>(name: &str, located: &Located<T>) -> Option<Check> {
+pub fn ambiguous_variable_name(name: &str, range: Range) -> Option<Check> {
     if is_ambiguous_name(name) {
         Some(Check::new(
             CheckKind::AmbiguousVariableName(name.to_string()),
-            Range::from_located(located),
+            range,
         ))
     } else {
         None

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E741_E741.py.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__E741_E741.py.snap
@@ -106,7 +106,7 @@ expression: checks
     AmbiguousVariableName: l
   location:
     row: 25
-    column: 4
+    column: 11
   end_location:
     row: 25
     column: 12
@@ -136,7 +136,7 @@ expression: checks
     AmbiguousVariableName: l
   location:
     row: 33
-    column: 8
+    column: 17
   end_location:
     row: 33
     column: 18
@@ -236,10 +236,10 @@ expression: checks
     AmbiguousVariableName: l
   location:
     row: 71
-    column: 0
+    column: 21
   end_location:
-    row: 72
-    column: 8
+    row: 71
+    column: 22
   fix: ~
   parent: ~
 - kind:

--- a/src/pylint/snapshots/ruff__pylint__tests__PLE0117_nonlocal_without_binding.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__PLE0117_nonlocal_without_binding.py.snap
@@ -6,7 +6,7 @@ expression: checks
     NonlocalWithoutBinding: x
   location:
     row: 5
-    column: 4
+    column: 13
   end_location:
     row: 5
     column: 14
@@ -16,7 +16,7 @@ expression: checks
     NonlocalWithoutBinding: y
   location:
     row: 9
-    column: 4
+    column: 13
   end_location:
     row: 9
     column: 14
@@ -26,7 +26,7 @@ expression: checks
     NonlocalWithoutBinding: y
   location:
     row: 19
-    column: 8
+    column: 17
   end_location:
     row: 19
     column: 18

--- a/src/pylint/snapshots/ruff__pylint__tests__PLW0602_global_variable_not_assigned.py.snap
+++ b/src/pylint/snapshots/ruff__pylint__tests__PLW0602_global_variable_not_assigned.py.snap
@@ -6,7 +6,7 @@ expression: checks
     GlobalVariableNotAssigned: x
   location:
     row: 5
-    column: 4
+    column: 11
   end_location:
     row: 5
     column: 12
@@ -16,7 +16,7 @@ expression: checks
     GlobalVariableNotAssigned: x
   location:
     row: 9
-    column: 4
+    column: 11
   end_location:
     row: 9
     column: 12


### PR DESCRIPTION
Improves error ranges for the following rules:

- E741
- PLW0602
- PLE0117


### Current

```
> cargo run -- --select PLW --no-cache --show-source resources/test/fixtures/pylint/global_variable_not_assigned.py --show-source
resources/test/fixtures/pylint/global_variable_not_assigned.py:5:5: PLW0602 Using global for `x` but no assignment is done
  |
5 |     global x
  |     ^^^^^^^^ PLW0602
  |

resources/test/fixtures/pylint/global_variable_not_assigned.py:9:5: PLW0602 Using global for `x` but no assignment is done
  |
9 |     global x
  |     ^^^^^^^^ PLW0602
  |

Found 2 error(s).
```

### Fixed

```
> cargo run -- --select PLW --no-cache resources/test/fixtures/pylint/global_variable_not_assigned.py --show-source
resources/test/fixtures/pylint/global_variable_not_assigned.py:5:12: PLW0602 Using global for `x` but no assignment is done
  |
5 |     global x
  |            ^ PLW0602
  |

resources/test/fixtures/pylint/global_variable_not_assigned.py:9:12: PLW0602 Using global for `x` but no assignment is done
  |
9 |     global x
  |            ^ PLW0602
  |

Found 2 error(s).
```
