### PR TITLE
Avoid flagging nested f-strings

### DIFF
--- a/resources/test/fixtures/pyflakes/F541.py
+++ b/resources/test/fixtures/pyflakes/F541.py
@@ -1,6 +1,8 @@
+# OK
 a = "abc"
 b = f"ghi{'jkl'}"
 
+# Errors
 c = f"def"
 d = f"def" + "ghi"
 e = (
@@ -8,5 +10,17 @@ e = (
     "ghi"
 )
 
+# OK
 g = f"ghi{123:{45}}"
+
+# Error
 h = "x" "y" f"z"
+
+v = 23.234234
+
+# OK
+f"{v:0.2f}"
+
+# OK (false negatives)
+f"{v:{f'0.2f'}}"
+f"{f''}"

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
@@ -4,19 +4,10 @@ expression: checks
 ---
 - kind: FStringMissingPlaceholders
   location:
-    row: 4
+    row: 6
     column: 4
   end_location:
-    row: 4
-    column: 10
-  fix: ~
-  parent: ~
-- kind: FStringMissingPlaceholders
-  location:
-    row: 5
-    column: 4
-  end_location:
-    row: 5
+    row: 6
     column: 10
   fix: ~
   parent: ~
@@ -31,10 +22,19 @@ expression: checks
   parent: ~
 - kind: FStringMissingPlaceholders
   location:
-    row: 12
+    row: 9
     column: 4
   end_location:
-    row: 12
+    row: 9
+    column: 10
+  fix: ~
+  parent: ~
+- kind: FStringMissingPlaceholders
+  location:
+    row: 17
+    column: 4
+  end_location:
+    row: 17
     column: 16
   fix: ~
   parent: ~


### PR DESCRIPTION
We're currently flagging cases like this:

```py
v = 23.234234
f"{v:0.2f}"  # error
```

Because the `0.2f` is represented as an "empty" `JoinedStr`. However, this is consistent with CPython. Pyflakes just skips these, which leads to some false negatives... but it definitely outweighs the false positives, which would be common.

Resolves #1514.