### PR TITLE
Add `visit_format_spec` to avoid false positives for F541 in f-string format specifier

### DIFF
--- a/resources/test/fixtures/pyflakes/F541.py
+++ b/resources/test/fixtures/pyflakes/F541.py
@@ -20,6 +20,7 @@ v = 23.234234
 
 # OK
 f"{v:0.2f}"
+f"{f'{v:0.2f}'}"
 
 # OK (false negatives)
 f"{v:{f'0.2f'}}"

--- a/resources/test/fixtures/pyflakes/F541.py
+++ b/resources/test/fixtures/pyflakes/F541.py
@@ -22,6 +22,6 @@ v = 23.234234
 f"{v:0.2f}"
 f"{f'{v:0.2f}'}"
 
-# OK (false negatives)
+# Errors
 f"{v:{f'0.2f'}}"
 f"{f''}"

--- a/resources/test/fixtures/pyflakes/F821_0.py
+++ b/resources/test/fixtures/pyflakes/F821_0.py
@@ -89,7 +89,8 @@ A = (
     f'B'
     f'{B}'
 )
-
+C = f'{A:{B}}'
+C = f'{A:{f"{B}"}}'
 
 from typing import Annotated, Literal
 

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -38,6 +38,9 @@ pub trait Visitor<'a> {
     fn visit_excepthandler(&mut self, excepthandler: &'a Excepthandler) {
         walk_excepthandler(self, excepthandler);
     }
+    fn visit_format_spec(&mut self, format_spec: &'a Expr) {
+        walk_expr(self, format_spec);
+    }
     fn visit_arguments(&mut self, arguments: &'a Arguments) {
         walk_arguments(self, arguments);
     }
@@ -387,7 +390,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         } => {
             visitor.visit_expr(value);
             if let Some(expr) = format_spec {
-                visitor.visit_expr(expr);
+                visitor.visit_format_spec(expr);
             }
         }
         ExprKind::JoinedStr { values } => {

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
@@ -40,19 +40,19 @@ expression: checks
   parent: ~
 - kind: FStringMissingPlaceholders
   location:
-    row: 25
+    row: 26
     column: 6
   end_location:
-    row: 25
+    row: 26
     column: 13
   fix: ~
   parent: ~
 - kind: FStringMissingPlaceholders
   location:
-    row: 26
+    row: 27
     column: 3
   end_location:
-    row: 26
+    row: 27
     column: 6
   fix: ~
   parent: ~

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F541_F541.py.snap
@@ -38,4 +38,22 @@ expression: checks
     column: 16
   fix: ~
   parent: ~
+- kind: FStringMissingPlaceholders
+  location:
+    row: 25
+    column: 6
+  end_location:
+    row: 25
+    column: 13
+  fix: ~
+  parent: ~
+- kind: FStringMissingPlaceholders
+  location:
+    row: 26
+    column: 3
+  end_location:
+    row: 26
+    column: 6
+  fix: ~
+  parent: ~
 

--- a/src/pyflakes/snapshots/ruff__pyflakes__tests__F821_F821_0.py.snap
+++ b/src/pyflakes/snapshots/ruff__pyflakes__tests__F821_F821_0.py.snap
@@ -83,32 +83,52 @@ expression: checks
   fix: ~
   parent: ~
 - kind:
+    UndefinedName: B
+  location:
+    row: 92
+    column: 10
+  end_location:
+    row: 92
+    column: 11
+  fix: ~
+  parent: ~
+- kind:
+    UndefinedName: B
+  location:
+    row: 93
+    column: 13
+  end_location:
+    row: 93
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
     UndefinedName: PEP593Test123
   location:
-    row: 114
+    row: 115
     column: 8
   end_location:
-    row: 114
+    row: 115
     column: 23
   fix: ~
   parent: ~
 - kind:
     UndefinedName: foo
   location:
-    row: 122
+    row: 123
     column: 13
   end_location:
-    row: 122
+    row: 123
     column: 18
   fix: ~
   parent: ~
 - kind:
     UndefinedName: bar
   location:
-    row: 122
+    row: 123
     column: 20
   end_location:
-    row: 122
+    row: 123
     column: 25
   fix: ~
   parent: ~


### PR DESCRIPTION
See #1514 for details.