### PR TITLE
Fix `__init__.py` being private

### DIFF
--- a/src/pydocstyle/mod.rs
+++ b/src/pydocstyle/mod.rs
@@ -62,6 +62,7 @@ mod tests {
     #[test_case(CheckCode::D417, Path::new("sections.py"); "D417_0")]
     #[test_case(CheckCode::D418, Path::new("D.py"); "D418")]
     #[test_case(CheckCode::D419, Path::new("D.py"); "D419")]
+    #[test_case(CheckCode::D104, Path::new("D104/__init__.py"); "D104_1")]
     fn checks(check_code: CheckCode, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", check_code.as_ref(), path.to_string_lossy());
         let checks = test_path(

--- a/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D104_D104____init__.py.snap
+++ b/src/pydocstyle/snapshots/ruff__pydocstyle__tests__D104_D104____init__.py.snap
@@ -1,0 +1,14 @@
+---
+source: src/pydocstyle/mod.rs
+expression: checks
+---
+- kind: PublicPackage
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 1
+    column: 0
+  fix: ~
+  parent: ~
+

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -107,7 +107,7 @@ pub fn is_init(stmt: &Stmt) -> bool {
 
 /// Returns `true` if a module name indicates private visibility.
 fn is_private_module(module_name: &str) -> bool {
-    module_name.starts_with('_') || (module_name.starts_with("__") && module_name.ends_with("__"))
+    module_name.starts_with('_')
 }
 
 pub fn module_visibility(path: &Path) -> Visibility {

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -111,7 +111,18 @@ fn is_private_module(module_name: &str) -> bool {
 }
 
 pub fn module_visibility(path: &Path) -> Visibility {
-    for component in path.iter().rev() {
+    let mut components = path.iter().rev();
+    let filename = components.next().unwrap().to_string_lossy();
+    let mut module_name = filename.as_ref();
+    if let Some(idx) = filename.rfind('.') {
+        module_name = &filename[..idx];
+    }
+
+    if is_private_module(module_name) && module_name != "__init__" {
+        return Visibility::Private;
+    }
+
+    for component in components {
         if is_private_module(&component.to_string_lossy()) {
             return Visibility::Private;
         }


### PR DESCRIPTION
Previously `visibility::module_visibility()` returned `Private`
for any module name starting with an underscore, resulting in
`__init__.py` being categorized as private, which in turn resulted
in D104 (Missing docstring in public package) never being reported
for `__init__.py` files.

The commits implement separate changes, so I'd rather have you not squash them.