### PR TITLE
Avoid PEP 604 rewrites for runtime annotations

### DIFF
--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1499,12 +1499,12 @@ where
             ExprKind::Subscript { value, slice, .. } => {
                 // Ex) Optional[...]
                 if !self.in_deferred_string_type_definition
+                    && self.in_annotation
                     && self.settings.enabled.contains(&CheckCode::UP007)
                     && (self.settings.target_version >= PythonVersion::Py310
                         || (self.settings.target_version >= PythonVersion::Py37
                             && !self.settings.pyupgrade.keep_runtime_typing
-                            && self.annotations_future_enabled
-                            && self.in_annotation))
+                            && self.annotations_future_enabled))
                 {
                     pyupgrade::plugins::use_pep604_annotation(self, expr, value, slice);
                 }

--- a/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_604_py310.snap
+++ b/src/pyupgrade/snapshots/ruff__pyupgrade__tests__future_annotations_pep_604_py310.snap
@@ -18,20 +18,4 @@ expression: checks
       row: 40
       column: 16
   parent: ~
-- kind: UsePEP604Annotation
-  location:
-    row: 42
-    column: 20
-  end_location:
-    row: 42
-    column: 47
-  fix:
-    content: "List[int] | List[str]"
-    location:
-      row: 42
-      column: 20
-    end_location:
-      row: 42
-      column: 47
-  parent: ~
 


### PR DESCRIPTION
Resolves #1560.