### PR TITLE
Add autofix for SIM300

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ For more, see [flake8-simplify](https://pypi.org/project/flake8-simplify/0.19.3/
 | SIM118 | KeyInDict | Use `key in dict` instead of `key in dict.keys()` | 🛠 |
 | SIM222 | OrTrue | Use `True` instead of `... or True` | 🛠 |
 | SIM223 | AndFalse | Use `False` instead of `... and False` | 🛠 |
-| SIM300 | YodaConditions | Use `left == right` instead of `right == left (Yoda-conditions)` |  |
+| SIM300 | YodaConditions | Use `left == right` instead of `right == left (Yoda-conditions)` | 🛠 |
 
 ### flake8-tidy-imports (TID)
 

--- a/src/flake8_simplify/plugins/yoda_conditions.rs
+++ b/src/flake8_simplify/plugins/yoda_conditions.rs
@@ -1,8 +1,10 @@
-use rustpython_ast::{Cmpop, Expr, ExprKind};
+use rustpython_ast::{Cmpop, Expr, ExprKind, Location};
 
 use crate::ast::types::Range;
+use crate::autofix::Fix;
 use crate::checkers::ast::Checker;
 use crate::registry::{Check, CheckKind};
+use crate::source_code_generator::SourceCodeGenerator;
 
 /// SIM300
 pub fn yoda_conditions(
@@ -31,10 +33,36 @@ pub fn yoda_conditions(
         return;
     }
 
-    let check = Check::new(
+    let mut check = Check::new(
         CheckKind::YodaConditions(left.to_string(), right.to_string()),
         Range::from_located(expr),
     );
+
+    if checker.patch(check.kind.code()) {
+        let cmp = Expr::new(
+            Location::default(),
+            Location::default(),
+            ExprKind::Compare {
+                left: Box::new(right.clone()),
+                ops: vec![Cmpop::Eq],
+                comparators: vec![left.clone()],
+            },
+        );
+        let mut generator = SourceCodeGenerator::new(
+            checker.style.indentation(),
+            checker.style.quote(),
+            checker.style.line_ending(),
+        );
+        generator.unparse_expr(&cmp, 0);
+
+        if let Ok(content) = generator.generate() {
+            check.amend(Fix::replacement(
+                content,
+                left.location,
+                right.end_location.unwrap(),
+            ));
+        };
+    }
 
     checker.add_check(check);
 }

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM300_SIM300.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM300_SIM300.py.snap
@@ -12,7 +12,14 @@ expression: checks
   end_location:
     row: 2
     column: 17
-  fix: ~
+  fix:
+    content: "compare == \"yoda\""
+    location:
+      row: 2
+      column: 0
+    end_location:
+      row: 2
+      column: 17
   parent: ~
 - kind:
     YodaConditions:
@@ -24,6 +31,13 @@ expression: checks
   end_location:
     row: 3
     column: 9
-  fix: ~
+  fix:
+    content: age == 42
+    location:
+      row: 3
+      column: 0
+    end_location:
+      row: 3
+      column: 9
   parent: ~
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3594,6 +3594,7 @@ impl CheckKind {
                 | CheckKind::UselessImportAlias
                 | CheckKind::UselessMetaclassType
                 | CheckKind::UselessObjectInheritance(..)
+                | CheckKind::YodaConditions(..)
         )
     }
 
@@ -3856,6 +3857,9 @@ impl CheckKind {
             CheckKind::UselessObjectInheritance(..) => {
                 Some("Remove `object` inheritance".to_string())
             }
+            CheckKind::YodaConditions(left, right) => Some(format!(
+                "Replace with `{left} == {right}` (Yoda-conditions)`"
+            )),
             _ => None,
         }
     }


### PR DESCRIPTION
I think this is right! I ran it locally on the test cases and it worked, but admittedly I wasn't really sure what I was doing when creating an Expr instance or even the values I used for SourceCodeGenerator.

Here's an example of it working:

```python
> cat test.py
...
# Line 9
42 == x
'foo' == yoda
print('foo' == yoda)
print(42 == x)

def main():
    print("hello world")
    print('foo' == yoda)
```

One thing I can't figure out is why it doesn't show here that there are fixes possible. I'm expecting something like 
`4 potentially fixable with the --fix option.`

```
cargo run test.py --no-cache --select SIM300
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/ruff test.py --no-cache --select SIM300`
test.py:9:1: SIM300 Use `42 == x` instead of `x == 42 (Yoda-conditions)`
test.py:10:1: SIM300 Use `'foo' == yoda` instead of `yoda == 'foo' (Yoda-conditions)`
test.py:11:7: SIM300 Use `'foo' == yoda` instead of `yoda == 'foo' (Yoda-conditions)`
test.py:12:7: SIM300 Use `42 == x` instead of `x == 42 (Yoda-conditions)`
test.py:16:11: SIM300 Use `'foo' == yoda` instead of `yoda == 'foo' (Yoda-conditions)`
Found 5 error(s).
```

but when I run this
```
cargo run test.py --no-cache --select SIM300 --fix
   
Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/ruff test.py --no-cache --select SIM300 --fix`
Found 5 error(s) (5 fixed, 0 remaining).
```

It does fix the file. 

```
...
# Line 9
x == 42
yoda == 'foo'
print(yoda == 'foo')
print(x == 42)

def main():
    print("hello world")
    print(yoda == 'foo')
```

