### PR TITLE
Fix PT006 autofix of parametrize name strings like `'   first, ,  second  '`

### DIFF
--- a/resources/test/fixtures/flake8_pytest_style/PT006.py
+++ b/resources/test/fixtures/flake8_pytest_style/PT006.py
@@ -11,6 +11,11 @@ def test_csv(param1, param2):
     ...
 
 
+@pytest.mark.parametrize("   param1,   ,    param2   , ", [(1, 2), (3, 4)])
+def test_csv_with_whitespace(param1, param2):
+    ...
+
+
 @pytest.mark.parametrize(("param1", "param2"), [(1, 2), (3, 4)])
 def test_tuple(param1, param2):
     ...

--- a/src/flake8_pytest_style/plugins/parametrize.rs
+++ b/src/flake8_pytest_style/plugins/parametrize.rs
@@ -22,7 +22,19 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
             value: Constant::Str(string),
             ..
         } => {
-            let names = string.split(',').collect::<Vec<&str>>();
+            // Match the following pytest code:
+            //    [x.strip() for x in argnames.split(",") if x.strip()]
+            let names = string
+                .split(',')
+                .filter_map(|s| {
+                    let trimmed = s.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed)
+                    }
+                })
+                .collect::<Vec<&str>>();
 
             if names.len() > 1 {
                 match names_type {

--- a/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_csv.snap
+++ b/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_csv.snap
@@ -5,55 +5,55 @@ expression: checks
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 14
+    row: 19
     column: 25
   end_location:
-    row: 14
+    row: 19
     column: 45
   fix: ~
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 19
+    row: 24
     column: 25
   end_location:
-    row: 19
+    row: 24
     column: 36
   fix:
     content: "\"param1\""
     location:
-      row: 19
+      row: 24
       column: 25
     end_location:
-      row: 19
+      row: 24
       column: 36
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 24
+    row: 29
     column: 25
   end_location:
-    row: 24
+    row: 29
     column: 45
   fix: ~
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 29
+    row: 34
     column: 25
   end_location:
-    row: 29
+    row: 34
     column: 35
   fix:
     content: "\"param1\""
     location:
-      row: 29
+      row: 34
       column: 25
     end_location:
-      row: 29
+      row: 34
       column: 35
   parent: ~
 

--- a/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_default.snap
+++ b/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_default.snap
@@ -20,47 +20,64 @@ expression: checks
       column: 40
   parent: ~
 - kind:
-    ParametrizeNamesWrongType: csv
+    ParametrizeNamesWrongType: tuple
   location:
-    row: 19
+    row: 14
     column: 25
   end_location:
-    row: 19
+    row: 14
+    column: 56
+  fix:
+    content: "(\"param1\", \"param2\")"
+    location:
+      row: 14
+      column: 25
+    end_location:
+      row: 14
+      column: 56
+  parent: ~
+- kind:
+    ParametrizeNamesWrongType: csv
+  location:
+    row: 24
+    column: 25
+  end_location:
+    row: 24
     column: 36
   fix:
     content: "\"param1\""
     location:
-      row: 19
+      row: 24
       column: 25
     end_location:
-      row: 19
+      row: 24
       column: 36
   parent: ~
 - kind:
     ParametrizeNamesWrongType: tuple
   location:
-    row: 24
+    row: 29
     column: 25
   end_location:
-    row: 24
+    row: 29
     column: 45
   fix: ~
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 29
+    row: 34
     column: 25
   end_location:
-    row: 29
+    row: 34
     column: 35
   fix:
     content: "\"param1\""
     location:
-      row: 29
+      row: 34
       column: 25
     end_location:
-      row: 29
+      row: 34
       column: 35
   parent: ~
 

--- a/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_list.snap
+++ b/src/flake8_pytest_style/snapshots/ruff__flake8_pytest_style__tests__PT006_list.snap
@@ -26,41 +26,58 @@ expression: checks
     column: 25
   end_location:
     row: 14
+    column: 56
+  fix:
+    content: "[\"param1\", \"param2\"]"
+    location:
+      row: 14
+      column: 25
+    end_location:
+      row: 14
+      column: 56
+  parent: ~
+- kind:
+    ParametrizeNamesWrongType: list
+  location:
+    row: 19
+    column: 25
+  end_location:
+    row: 19
     column: 45
   fix: ~
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 19
+    row: 24
     column: 25
   end_location:
-    row: 19
+    row: 24
     column: 36
   fix:
     content: "\"param1\""
     location:
-      row: 19
+      row: 24
       column: 25
     end_location:
-      row: 19
+      row: 24
       column: 36
   parent: ~
 - kind:
     ParametrizeNamesWrongType: csv
   location:
-    row: 29
+    row: 34
     column: 25
   end_location:
-    row: 29
+    row: 34
     column: 35
   fix:
     content: "\"param1\""
     location:
-      row: 29
+      row: 34
       column: 25
     end_location:
-      row: 29
+      row: 34
       column: 35
   parent: ~
 


### PR DESCRIPTION
pytest trims and ignores empty names.

Previously the autofix would be to `('   first', ' ', '    second  ')`.

Now it's `('first', 'second')`.