### PR TITLE
Add isort.order-by-type boolean setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2851,6 +2851,24 @@ known-third-party = ["src"]
 
 ---
 
+#### [`order-by-type`](#order-by-type)
+
+Order imports by type, which is determined by case, in addition to
+alphabetically.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+order-by-type = true
+```
+
+---
+
 #### [`single-line-exclusions`](#single-line-exclusions)
 
 One or more modules to exclude from the single line rule.

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1324,6 +1324,13 @@
             "type": "string"
           }
         },
+        "order-by-type": {
+          "description": "Order imports by type, which is determined by case, in addition to alphabetically.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "single-line-exclusions": {
           "description": "One or more modules to exclude from the single line rule.",
           "type": [

--- a/src/isort/plugins.rs
+++ b/src/isort/plugins.rs
@@ -81,6 +81,7 @@ pub fn check_imports(
         settings.isort.split_on_trailing_comma,
         settings.isort.force_single_line,
         &settings.isort.single_line_exclusions,
+        settings.isort.order_by_type,
     );
 
     // Expand the span the entire range, including leading and trailing space.

--- a/src/isort/settings.rs
+++ b/src/isort/settings.rs
@@ -79,6 +79,16 @@ pub struct Options {
     /// See isort's [`split-on-trailing-comma`](https://pycqa.github.io/isort/docs/configuration/options.html#split-on-trailing-comma) option.
     pub split_on_trailing_comma: Option<bool>,
     #[option(
+        default = r#"true"#,
+        value_type = "bool",
+        example = r#"
+            order-by-type = true
+        "#
+    )]
+    /// Order imports by type, which is determined by case, in addition to
+    /// alphabetically.
+    pub order_by_type: Option<bool>,
+    #[option(
         default = r#"[]"#,
         value_type = "Vec<String>",
         example = r#"
@@ -120,6 +130,7 @@ pub struct Settings {
     pub single_line_exclusions: BTreeSet<String>,
     pub known_first_party: BTreeSet<String>,
     pub known_third_party: BTreeSet<String>,
+    pub order_by_type: bool,
     pub extra_standard_library: BTreeSet<String>,
 }
 
@@ -130,6 +141,7 @@ impl Default for Settings {
             force_wrap_aliases: false,
             split_on_trailing_comma: true,
             force_single_line: false,
+            order_by_type: true,
             single_line_exclusions: BTreeSet::new(),
             known_first_party: BTreeSet::new(),
             known_third_party: BTreeSet::new(),
@@ -145,6 +157,7 @@ impl From<Options> for Settings {
             force_wrap_aliases: options.force_wrap_aliases.unwrap_or(false),
             split_on_trailing_comma: options.split_on_trailing_comma.unwrap_or(true),
             force_single_line: options.force_single_line.unwrap_or(false),
+            order_by_type: options.order_by_type.unwrap_or(true),
             single_line_exclusions: BTreeSet::from_iter(
                 options.single_line_exclusions.unwrap_or_default(),
             ),
@@ -164,6 +177,7 @@ impl From<Settings> for Options {
             force_wrap_aliases: Some(settings.force_wrap_aliases),
             split_on_trailing_comma: Some(settings.split_on_trailing_comma),
             force_single_line: Some(settings.force_single_line),
+            order_by_type: Some(settings.order_by_type),
             single_line_exclusions: Some(settings.single_line_exclusions.into_iter().collect()),
             known_first_party: Some(settings.known_first_party.into_iter().collect()),
             known_third_party: Some(settings.known_third_party.into_iter().collect()),

--- a/src/isort/snapshots/ruff__isort__tests__order_by_type_false_order_by_type.py.snap
+++ b/src/isort/snapshots/ruff__isort__tests__order_by_type_false_order_by_type.py.snap
@@ -1,0 +1,21 @@
+---
+source: src/isort/mod.rs
+expression: checks
+---
+- kind: UnsortedImports
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 13
+    column: 0
+  fix:
+    content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, Popen, STDOUT\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import Apple, BASIC, Class, CONSTANT, function\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 13
+      column: 0
+  parent: ~
+

--- a/src/isort/sorting.rs
+++ b/src/isort/sorting.rs
@@ -11,8 +11,10 @@ pub enum Prefix {
     Variables,
 }
 
-fn prefix(name: &str) -> Prefix {
-    if name.len() > 1 && string::is_upper(name) {
+fn prefix(name: &str, order_by_type: bool) -> Prefix {
+    if !order_by_type {
+        Prefix::Variables
+    } else if name.len() > 1 && string::is_upper(name) {
         // Ex) `CONSTANT`
         Prefix::Constants
     } else if name.chars().next().map_or(false, char::is_uppercase) {
@@ -37,9 +39,9 @@ pub fn cmp_modules(alias1: &AliasData, alias2: &AliasData) -> Ordering {
 }
 
 /// Compare two member imports within `StmtKind::ImportFrom` blocks.
-pub fn cmp_members(alias1: &AliasData, alias2: &AliasData) -> Ordering {
-    prefix(alias1.name)
-        .cmp(&prefix(alias2.name))
+pub fn cmp_members(alias1: &AliasData, alias2: &AliasData, order_by_type: bool) -> Ordering {
+    prefix(alias1.name, order_by_type)
+        .cmp(&prefix(alias2.name, order_by_type))
         .then_with(|| cmp_modules(alias1, alias2))
 }
 

--- a/src/isort/sorting.rs
+++ b/src/isort/sorting.rs
@@ -11,10 +11,8 @@ pub enum Prefix {
     Variables,
 }
 
-fn prefix(name: &str, order_by_type: bool) -> Prefix {
-    if !order_by_type {
-        Prefix::Variables
-    } else if name.len() > 1 && string::is_upper(name) {
+fn prefix(name: &str) -> Prefix {
+    if name.len() > 1 && string::is_upper(name) {
         // Ex) `CONSTANT`
         Prefix::Constants
     } else if name.chars().next().map_or(false, char::is_uppercase) {
@@ -40,9 +38,13 @@ pub fn cmp_modules(alias1: &AliasData, alias2: &AliasData) -> Ordering {
 
 /// Compare two member imports within `StmtKind::ImportFrom` blocks.
 pub fn cmp_members(alias1: &AliasData, alias2: &AliasData, order_by_type: bool) -> Ordering {
-    prefix(alias1.name, order_by_type)
-        .cmp(&prefix(alias2.name, order_by_type))
-        .then_with(|| cmp_modules(alias1, alias2))
+    if order_by_type {
+        prefix(alias1.name)
+            .cmp(&prefix(alias2.name))
+            .then_with(|| cmp_modules(alias1, alias2))
+    } else {
+        cmp_modules(alias1, alias2)
+    }
 }
 
 /// Compare two relative import levels.


### PR DESCRIPTION
The default `isort` behavior is `order-by-type = true`. When imports are ordered by type:

1. `CONSTANT_VARIABLES` are first.
2. `CamelCaseClasses` are second.
3. `everything_else` is third.

- https://pycqa.github.io/isort/docs/configuration/options.html#order-by-type

When `order-by-type = false` imports are ordered alphabetically (case-insensitive).

eg.

`order-by-type = false`

```py
import BAR
import bar
import FOO
import foo
import StringIO
from module import Apple, BASIC, Class, CONSTANT, function
```

`order-by-type = true`

```py
import BAR
import bar
import FOO
import foo
import StringIO
from module import BASIC, CONSTANT, Apple, Class, function
```

---

This PR is what I could hobble together with my limited `rust`.
In particular, I couldn't get a default option value of `true` without `impl Default for Settings` and wasn't sure the best way to get `member_key` aware of the setting without quite a bit of argument passing.

Open to feedback on anything in the PR and if this is an `isort` feature that would have a home in `ruff`!