### PR TITLE
Cancel outdated in-progress workflow automatically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/using-concurrency

No need to waste time on outdated workflow runs.