### PR TITLE
Stop highlighting --help output in README as shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ ruff path/to/code/ --select F401 --select F403
 See `ruff --help` for more:
 
 <!-- Begin auto-generated cli help. -->
-```shell
+```
 Ruff: An extremely fast Python linter.
 
 Usage: ruff [OPTIONS] [FILES]...

--- a/ruff_dev/src/generate_cli_help.rs
+++ b/ruff_dev/src/generate_cli_help.rs
@@ -28,7 +28,7 @@ pub fn main(cli: &Cli) -> Result<()> {
         print!("{output}");
     } else {
         replace_readme_section(
-            &format!("```shell\n{output}\n```\n"),
+            &format!("```\n{output}\n```\n"),
             HELP_BEGIN_PRAGMA,
             HELP_END_PRAGMA,
         )?;


### PR DESCRIPTION
This PR is meant to address the following obviously unintended GitHub rendering:

![image](https://user-images.githubusercontent.com/73739153/210713719-7fb465b1-db91-4074-8a0c-4efa3c47c2f4.png)
