### PR TITLE
Autofix SIM102 (NestedIfStatements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ For more, see [flake8-simplify](https://pypi.org/project/flake8-simplify/0.19.3/
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
 | SIM101 | DuplicateIsinstanceCall | Multiple `isinstance` calls for `...`, merge into a single call | 🛠 |
-| SIM102 | NestedIfStatements | Use a single `if` statement instead of nested `if` statements |  |
+| SIM102 | NestedIfStatements | Use a single `if` statement instead of nested `if` statements | 🛠 |
 | SIM103 | ReturnBoolConditionDirectly | Return the condition `...` directly | 🛠 |
 | SIM105 | UseContextlibSuppress | Use `contextlib.suppress(...)` instead of try-except-pass |  |
 | SIM107 | ReturnInTryExceptFinally | Don't use `return` in `try`/`except` and `finally` |  |

--- a/resources/test/fixtures/flake8_simplify/SIM102.py
+++ b/resources/test/fixtures/flake8_simplify/SIM102.py
@@ -1,25 +1,88 @@
-if a:  # SIM102
+# SIM102
+if a:
     if b:
         c
 
-
+# SIM102
 if a:
     pass
-elif b:  # SIM102
+elif b:
     if c:
         d
 
+# SIM102
+if a:
+    # Unfixable due to placement of this comment.
+    if b:
+        c
+
+# SIM102
+if a:
+    if b:
+        # Fixable due to placement of this comment.
+        c
+
+# OK
 if a:
     if b:
         c
     else:
         d
 
+# OK
 if __name__ == "__main__":
     if foo():
         ...
 
+# OK
 if a:
     d
     if b:
         c
+
+while True:
+    # SIM102
+    if True:
+        if True:
+            """this
+is valid"""
+
+            """the indentation on
+            this line is significant"""
+
+            "this is" \
+"allowed too"
+
+            ("so is"
+"this for some reason")
+
+
+# SIM102
+if True:
+    if True:
+        """this
+is valid"""
+
+        """the indentation on
+        this line is significant"""
+
+        "this is" \
+"allowed too"
+
+        ("so is"
+"this for some reason")
+
+while True:
+    # SIM102
+    if node.module:
+        if node.module == "multiprocessing" or node.module.startswith(
+            "multiprocessing."
+        ):
+            print("Bad module!")
+
+# SIM102
+if node.module:
+    if node.module == "multiprocessing" or node.module.startswith(
+        "multiprocessing."
+    ):
+        print("Bad module!")

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -361,10 +361,9 @@ pub fn collect_arg_names<'a>(arguments: &'a Arguments) -> FxHashSet<&'a str> {
 }
 
 /// Returns `true` if a statement or expression includes at least one comment.
-pub fn has_comments<T>(located: &Located<T>, locator: &Locator) -> bool {
-    lexer::make_tokenizer(&locator.slice_source_code_range(&Range::from_located(located)))
-        .flatten()
-        .any(|(_, tok, _)| matches!(tok, Tok::Comment(..)))
+pub fn has_comments_in(range: Range, locator: &Locator) -> bool {
+    lexer::make_tokenizer(&locator.slice_source_code_range(&range))
+        .any(|result| result.map_or(false, |(_, tok, _)| matches!(tok, Tok::Comment(..))))
 }
 
 /// Returns `true` if a call is an argumented `super` invocation.

--- a/src/ast/whitespace.rs
+++ b/src/ast/whitespace.rs
@@ -4,12 +4,12 @@ use std::str::Lines;
 use rustpython_ast::{Located, Location};
 
 use crate::ast::types::Range;
-use crate::checkers::ast::Checker;
+use crate::source_code::Locator;
 
 /// Extract the leading indentation from a line.
-pub fn indentation<'a, T>(checker: &'a Checker, located: &'a Located<T>) -> Cow<'a, str> {
+pub fn indentation<'a, T>(locator: &'a Locator, located: &'a Located<T>) -> Cow<'a, str> {
     let range = Range::from_located(located);
-    checker.locator.slice_source_code_range(&Range::new(
+    locator.slice_source_code_range(&Range::new(
         Location::new(range.location.row(), 0),
         Location::new(range.location.row(), range.location.column()),
     ))

--- a/src/ast/whitespace.rs
+++ b/src/ast/whitespace.rs
@@ -7,12 +7,17 @@ use crate::ast::types::Range;
 use crate::source_code::Locator;
 
 /// Extract the leading indentation from a line.
-pub fn indentation<'a, T>(locator: &'a Locator, located: &'a Located<T>) -> Cow<'a, str> {
+pub fn indentation<'a, T>(locator: &'a Locator, located: &'a Located<T>) -> Option<Cow<'a, str>> {
     let range = Range::from_located(located);
-    locator.slice_source_code_range(&Range::new(
+    let indentation = locator.slice_source_code_range(&Range::new(
         Location::new(range.location.row(), 0),
         Location::new(range.location.row(), range.location.column()),
-    ))
+    ));
+    if indentation.chars().all(char::is_whitespace) {
+        Some(indentation)
+    } else {
+        None
+    }
 }
 
 /// Extract the leading words from a line of text.

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -108,7 +108,7 @@ fn implicit_return(checker: &mut Checker, last_stmt: &Stmt) {
                 Diagnostic::new(violations::ImplicitReturn, Range::from_located(last_stmt));
             if checker.patch(&RuleCode::RET503) {
                 let mut content = String::new();
-                content.push_str(&indentation(checker, last_stmt));
+                content.push_str(&indentation(&checker.locator, last_stmt));
                 content.push_str("return None");
                 content.push('\n');
                 diagnostic.amend(Fix::insertion(

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -107,14 +107,16 @@ fn implicit_return(checker: &mut Checker, last_stmt: &Stmt) {
             let mut diagnostic =
                 Diagnostic::new(violations::ImplicitReturn, Range::from_located(last_stmt));
             if checker.patch(&RuleCode::RET503) {
-                let mut content = String::new();
-                content.push_str(&indentation(&checker.locator, last_stmt));
-                content.push_str("return None");
-                content.push('\n');
-                diagnostic.amend(Fix::insertion(
-                    content,
-                    Location::new(last_stmt.end_location.unwrap().row() + 1, 0),
-                ));
+                if let Some(indent) = indentation(checker.locator, last_stmt) {
+                    let mut content = String::new();
+                    content.push_str(&indent);
+                    content.push_str("return None");
+                    content.push('\n');
+                    diagnostic.amend(Fix::insertion(
+                        content,
+                        Location::new(last_stmt.end_location.unwrap().row() + 1, 0),
+                    ));
+                }
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -2,7 +2,7 @@ use rustpython_ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKin
 
 use crate::ast::comparable::ComparableExpr;
 use crate::ast::helpers::{
-    contains_call_path, contains_effect, create_expr, create_stmt, has_comments, unparse_expr,
+    contains_call_path, contains_effect, create_expr, create_stmt, has_comments_in, unparse_expr,
     unparse_stmt,
 };
 use crate::ast::types::Range;
@@ -97,7 +97,8 @@ pub fn return_bool_condition_directly(checker: &mut Checker, stmt: &Stmt) {
         Range::from_located(stmt),
     );
     if checker.patch(&RuleCode::SIM103)
-        && !(has_comments(stmt, checker.locator) || has_comments(&orelse[0], checker.locator))
+        && !(has_comments_in(Range::from_located(stmt), checker.locator)
+            || has_comments_in(Range::from_located(&orelse[0]), checker.locator))
     {
         let return_stmt = create_stmt(StmtKind::Return {
             value: Some(test.clone()),
@@ -201,7 +202,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
     }
 
     // Don't flag if the statement expression contains any comments.
-    if has_comments(stmt, checker.locator) {
+    if has_comments_in(Range::from_located(stmt), checker.locator) {
         return;
     }
 
@@ -304,7 +305,7 @@ pub fn use_dict_get_with_default(
     }
 
     // Don't flag if the statement expression contains any comments.
-    if has_comments(stmt, checker.locator) {
+    if has_comments_in(Range::from_located(stmt), checker.locator) {
         return;
     }
 

--- a/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/src/rules/flake8_simplify/rules/fix_if.rs
@@ -1,0 +1,137 @@
+use std::borrow::Cow;
+
+use anyhow::{bail, Result};
+use libcst_native::{
+    BooleanOp, BooleanOperation, Codegen, CodegenState, CompoundStatement, Expression, If,
+    LeftParen, ParenthesizableWhitespace, ParenthesizedNode, RightParen, SimpleWhitespace,
+    Statement, Suite,
+};
+use rustpython_ast::Location;
+
+use crate::ast::types::Range;
+use crate::ast::whitespace;
+use crate::cst::matchers::match_module;
+use crate::fix::Fix;
+use crate::source_code::Locator;
+
+fn parenthesize_and_operand(expr: Expression) -> Expression {
+    match &expr {
+        _ if !expr.lpar().is_empty() => expr,
+        Expression::BooleanOperation(boolean_operation)
+            if matches!(boolean_operation.operator, BooleanOp::Or { .. }) =>
+        {
+            expr.with_parens(LeftParen::default(), RightParen::default())
+        }
+        Expression::IfExp(_) | Expression::Lambda(_) | Expression::NamedExpr(_) => {
+            expr.with_parens(LeftParen::default(), RightParen::default())
+        }
+        _ => expr,
+    }
+}
+
+/// (SIM102) Convert `if a: if b:` to `if a and b:`.
+pub(crate) fn fix_nested_if_statements(
+    locator: &Locator,
+    stmt: &rustpython_ast::Stmt,
+) -> Result<Fix> {
+    // Infer the indentation of the outer block.
+    let Some(outer_indent) = whitespace::indentation(locator, stmt) else {
+        bail!("Unable to fix multiline statement");
+    };
+
+    // Extract the module text.
+    let contents = locator.slice_source_code_range(&Range::new(
+        Location::new(stmt.location.row(), 0),
+        Location::new(stmt.end_location.unwrap().row() + 1, 0),
+    ));
+
+    // Handle `elif` blocks differently; detect them upfront.
+    let is_elif = contents.trim_start().starts_with("elif");
+
+    // If this is an `elif`, we have to remove the `elif` keyword for now. (We'll
+    // restore the `el` later on.)
+    let module_text = if is_elif {
+        Cow::Owned(contents.replacen("elif", "if", 1))
+    } else {
+        contents
+    };
+
+    // If the block is indented, "embed" it in a function definition, to preserve
+    // indentation while retaining valid source code. (We'll strip the prefix later
+    // on.)
+    let module_text = if outer_indent.is_empty() {
+        module_text
+    } else {
+        Cow::Owned(format!("def f():\n{module_text}"))
+    };
+
+    // Parse the CST.
+    let mut tree = match_module(&module_text)?;
+
+    let statements = if outer_indent.is_empty() {
+        &mut *tree.body
+    } else {
+        let [Statement::Compound(CompoundStatement::FunctionDef(embedding))] = &mut *tree.body else {
+            bail!("Expected statement to be embedded in a function definition")
+        };
+
+        let Suite::IndentedBlock(indented_block) = &mut embedding.body else {
+            bail!("Expected indented block")
+        };
+        indented_block.indent = Some(&outer_indent);
+
+        &mut *indented_block.body
+    };
+
+    let [Statement::Compound(CompoundStatement::If(outer_if))] = statements else {
+        bail!("Expected one outer if statement")
+    };
+
+    let If {
+        body: Suite::IndentedBlock(ref mut outer_body),
+        orelse: None,
+        ..
+    } = outer_if else {
+        bail!("Expected outer if to have indented body and no else")
+    };
+
+    let [Statement::Compound(CompoundStatement::If(inner_if @ If { orelse: None, .. }))] =
+        &mut *outer_body.body
+    else {
+        bail!("Expected one inner if statement");
+    };
+
+    outer_if.test = Expression::BooleanOperation(Box::new(BooleanOperation {
+        left: Box::new(parenthesize_and_operand(outer_if.test.clone())),
+        operator: BooleanOp::And {
+            whitespace_before: ParenthesizableWhitespace::SimpleWhitespace(SimpleWhitespace(" ")),
+            whitespace_after: ParenthesizableWhitespace::SimpleWhitespace(SimpleWhitespace(" ")),
+        },
+        right: Box::new(parenthesize_and_operand(inner_if.test.clone())),
+        lpar: vec![],
+        rpar: vec![],
+    }));
+    outer_if.body = inner_if.body.clone();
+
+    let mut state = CodegenState::default();
+    tree.codegen(&mut state);
+
+    // Reconstruct and reformat the code.
+    let module_text = state.to_string();
+    let module_text = if outer_indent.is_empty() {
+        &module_text
+    } else {
+        module_text.strip_prefix("def f():\n").unwrap()
+    };
+    let contents = if is_elif {
+        module_text.replacen("if", "elif", 1)
+    } else {
+        module_text.to_string()
+    };
+
+    Ok(Fix::replacement(
+        contents,
+        Location::new(stmt.location.row(), 0),
+        Location::new(stmt.end_location.unwrap().row() + 1, 0),
+    ))
+}

--- a/src/rules/flake8_simplify/rules/mod.rs
+++ b/src/rules/flake8_simplify/rules/mod.rs
@@ -25,6 +25,7 @@ mod ast_if;
 mod ast_ifexp;
 mod ast_unary_op;
 mod ast_with;
+mod fix_if;
 mod key_in_dict;
 mod open_file_with_context_handler;
 mod return_in_try_except_finally;

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -5,21 +5,130 @@ expression: diagnostics
 - kind:
     NestedIfStatements: ~
   location:
-    row: 1
+    row: 2
     column: 0
   end_location:
-    row: 3
+    row: 4
+    column: 9
+  fix:
+    content: "if a and b:\n    c\n"
+    location:
+      row: 2
+      column: 0
+    end_location:
+      row: 5
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 9
+    column: 0
+  end_location:
+    row: 11
+    column: 9
+  fix:
+    content: "elif b and c:\n    d\n"
+    location:
+      row: 9
+      column: 0
+    end_location:
+      row: 12
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 14
+    column: 0
+  end_location:
+    row: 17
     column: 9
   fix: ~
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 8
+    row: 20
     column: 0
   end_location:
-    row: 10
+    row: 23
     column: 9
-  fix: ~
+  fix:
+    content: "if a and b:\n    # Fixable due to placement of this comment.\n    c\n"
+    location:
+      row: 20
+      column: 0
+    end_location:
+      row: 24
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 45
+    column: 4
+  end_location:
+    row: 57
+    column: 23
+  fix:
+    content: "    if True and True:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
+    location:
+      row: 45
+      column: 0
+    end_location:
+      row: 58
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 61
+    column: 0
+  end_location:
+    row: 73
+    column: 23
+  fix:
+    content: "if True and True:\n    \"\"\"this\nis valid\"\"\"\n\n    \"\"\"the indentation on\n        this line is significant\"\"\"\n\n    \"this is\" \\\n\"allowed too\"\n\n    (\"so is\"\n\"this for some reason\")\n"
+    location:
+      row: 61
+      column: 0
+    end_location:
+      row: 74
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 77
+    column: 4
+  end_location:
+    row: 81
+    column: 32
+  fix:
+    content: "    if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n        \"multiprocessing.\"\n    )):\n        print(\"Bad module!\")\n"
+    location:
+      row: 77
+      column: 0
+    end_location:
+      row: 82
+      column: 0
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 84
+    column: 0
+  end_location:
+    row: 88
+    column: 28
+  fix:
+    content: "if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n    \"multiprocessing.\"\n)):\n    print(\"Bad module!\")\n"
+    location:
+      row: 84
+      column: 0
+    end_location:
+      row: 89
+      column: 0
   parent: ~
 

--- a/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -89,7 +89,7 @@ pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keywo
                 if middle.multi_line {
                     contents.push(',');
                     contents.push('\n');
-                    contents.push_str(&indentation(checker, first));
+                    contents.push_str(&indentation(&checker.locator, first));
                 } else {
                     contents.push(',');
                     contents.push(' ');

--- a/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -6,6 +6,7 @@ use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::source_code::Locator;
 use crate::violations;
 
 #[derive(Debug)]
@@ -41,6 +42,42 @@ fn extract_middle(contents: &str) -> Option<MiddleContent> {
     })
 }
 
+/// Generate a [`Fix`] for a `stdout` and `stderr` [`Keyword`] pair.
+fn generate_fix(locator: &Locator, stdout: &Keyword, stderr: &Keyword) -> Option<Fix> {
+    let first = if stdout.location < stderr.location {
+        stdout
+    } else {
+        stderr
+    };
+    let last = if stdout.location > stderr.location {
+        stdout
+    } else {
+        stderr
+    };
+    let mut contents = String::from("capture_output=True");
+    if let Some(middle) = extract_middle(
+        &locator.slice_source_code_range(&Range::new(first.end_location.unwrap(), last.location)),
+    ) {
+        if middle.multi_line {
+            let Some(indent) = indentation(locator, first) else {
+                return None;
+            };
+            contents.push(',');
+            contents.push('\n');
+            contents.push_str(&indent);
+        } else {
+            contents.push(',');
+            contents.push(' ');
+        }
+        contents.push_str(middle.contents);
+    }
+    Some(Fix::replacement(
+        contents,
+        first.location,
+        last.end_location.unwrap(),
+    ))
+}
+
 /// UP022
 pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keyword]) {
     if checker
@@ -69,38 +106,9 @@ pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keywo
         let mut diagnostic =
             Diagnostic::new(violations::ReplaceStdoutStderr, Range::from_located(expr));
         if checker.patch(diagnostic.kind.code()) {
-            let first = if stdout.location < stderr.location {
-                stdout
-            } else {
-                stderr
+            if let Some(fix) = generate_fix(checker.locator, stdout, stderr) {
+                diagnostic.amend(fix);
             };
-            let last = if stdout.location > stderr.location {
-                stdout
-            } else {
-                stderr
-            };
-            let mut contents = String::from("capture_output=True");
-            if let Some(middle) =
-                extract_middle(&checker.locator.slice_source_code_range(&Range::new(
-                    first.end_location.unwrap(),
-                    last.location,
-                )))
-            {
-                if middle.multi_line {
-                    contents.push(',');
-                    contents.push('\n');
-                    contents.push_str(&indentation(&checker.locator, first));
-                } else {
-                    contents.push(',');
-                    contents.push(' ');
-                }
-                contents.push_str(middle.contents);
-            }
-            diagnostic.amend(Fix::replacement(
-                contents,
-                first.location,
-                last.end_location.unwrap(),
-            ));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -227,7 +227,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
             {
                 // Generate the fix, if needed, which is shared between all `mock` imports.
                 let content = if checker.patch(&RuleCode::UP026) {
-                    let indent = indentation(checker, stmt);
+                    let indent = indentation(&checker.locator, stmt);
                     match format_import(stmt, &indent, checker.locator, checker.stylist) {
                         Ok(content) => Some(content),
                         Err(e) => {
@@ -273,7 +273,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     Range::from_located(stmt),
                 );
                 if checker.patch(&RuleCode::UP026) {
-                    let indent = indentation(checker, stmt);
+                    let indent = indentation(&checker.locator, stmt);
                     match format_import_from(stmt, &indent, checker.locator, checker.stylist) {
                         Ok(content) => {
                             diagnostic.amend(Fix::replacement(

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -2829,9 +2829,13 @@ impl AlwaysAutofixableViolation for DuplicateIsinstanceCall {
 define_violation!(
     pub struct NestedIfStatements;
 );
-impl Violation for NestedIfStatements {
+impl AlwaysAutofixableViolation for NestedIfStatements {
     fn message(&self) -> String {
         "Use a single `if` statement instead of nested `if` statements".to_string()
+    }
+
+    fn autofix_title(&self) -> String {
+        "Combine `if` statements using `and`".to_string()
     }
 
     fn placeholder() -> Self {


### PR DESCRIPTION
I tried to write an autofixer for SIM102 (`NestedIfStatements`) using LibCST to preserve comments. But I ran into two issues that potentially point to general problems with the with the `SourceCodeLocator` API and/or the `Fix::replacement` API. So I’m opening this draft to discuss what the plan should be.

---

Firstly, if the input `if` statement is indented, the output `if` body will be misindented:

```diff
 while 1:
     while 2:
-        if 3:
-            if 4:
-                5
+        if 3 and 4:
+    5
```

In this case, `SourceCodeLocator::slice_source_code_range` fails to strip the indentation from the second and following lines:

```python
if 3:
            if 4:
                5
```

and `Fix::replacement` fails to add that indentation.

---

Secondly, if the input `if` statement is actually an `elif`, the fix fails:

```python
while 1:
    while 2:
        if 3:
            4
        elif 5:
            if 6:
                7
```

In this case, `SourceCodeLocator::slice_source_code_range` returns this invalid Python that LibCST can’t parse:

```python
elif 5:
            if 6:
                7
```