### PR TITLE
Avoid false-positives for yields with non-identical references

### DIFF
--- a/resources/test/fixtures/pyupgrade/UP028_1.py
+++ b/resources/test/fixtures/pyupgrade/UP028_1.py
@@ -111,3 +111,13 @@ def f():
     class C:
         def __init__(self):
             print(x)
+
+
+def f():
+    for x in y:
+        yield x, x + 1
+
+
+def f():
+    for x, y in z:
+        yield x, y, x + y


### PR DESCRIPTION
Resolves #1663.