### PR TITLE
Replace `toml` with `toml_edit`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1283,6 +1283,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1922,7 +1931,7 @@ dependencies = [
  "test-case",
  "textwrap",
  "titlecase",
- "toml",
+ "toml_edit",
  "update-informer",
  "ureq",
  "walkdir",
@@ -2487,12 +2496,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.10"
+name = "toml_datetime"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
+dependencies = [
+ "indexmap",
+ "itertools",
+ "nom8",
+ "serde",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }
 titlecase = { version = "2.2.1" }
-toml = { version = "0.5.9" }
+toml_edit = { version = "0.17.1", features = ["easy"] }
 walkdir = { version = "2.3.2" }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/flake8_to_ruff/Cargo.toml
+++ b/flake8_to_ruff/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
-toml = { version = "0.5.9" }
+toml_edit = { version = "0.17.1", features = ["easy"] }
 
 [dev-dependencies]
 

--- a/flake8_to_ruff/src/black.rs
+++ b/flake8_to_ruff/src/black.rs
@@ -26,7 +26,7 @@ struct Pyproject {
 
 pub fn parse_black_options<P: AsRef<Path>>(path: P) -> Result<Option<Black>> {
     let contents = std::fs::read_to_string(path)?;
-    Ok(toml::from_str::<Pyproject>(&contents)?
+    Ok(toml_edit::easy::from_str::<Pyproject>(&contents)?
         .tool
         .and_then(|tool| tool.black))
 }

--- a/flake8_to_ruff/src/main.rs
+++ b/flake8_to_ruff/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
 
     // Create Ruff's pyproject.toml section.
     let pyproject = converter::convert(&config, black.as_ref(), cli.plugin)?;
-    println!("{}", toml::to_string_pretty(&pyproject)?);
+    println!("{}", toml_edit::easy::to_string_pretty(&pyproject)?);
 
     Ok(())
 }

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -31,13 +31,13 @@ impl Pyproject {
 /// Parse a `ruff.toml` file.
 fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
     let contents = fs::read_file(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    toml_edit::easy::from_str(&contents).map_err(Into::into)
 }
 
 /// Parse a `pyproject.toml` file.
 fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
     let contents = fs::read_file(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    toml_edit::easy::from_str(&contents).map_err(Into::into)
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.
@@ -143,17 +143,17 @@ mod tests {
 
     #[test]
     fn deserialize() -> Result<()> {
-        let pyproject: Pyproject = toml::from_str(r#""#)?;
+        let pyproject: Pyproject = toml_edit::easy::from_str(r#""#)?;
         assert_eq!(pyproject.tool, None);
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 "#,
         )?;
         assert_eq!(pyproject.tool, Some(Tools { ruff: None }));
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -209,7 +209,7 @@ mod tests {
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -266,7 +266,7 @@ line-length = 79
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -323,7 +323,7 @@ exclude = ["foo.py"]
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -380,7 +380,7 @@ select = ["E501"]
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -438,7 +438,7 @@ ignore = ["E501"]
             })
         );
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]
@@ -447,7 +447,7 @@ line_length = 79
         )
         .is_err());
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]
@@ -456,7 +456,7 @@ select = ["E123"]
         )
         .is_err());
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]


### PR DESCRIPTION
The `toml` crate doesn't support TOML 1.0, but `toml_edit` does. While there is a plan to [migrate `toml` to be on `toml_edit`](https://github.com/toml-rs/toml/issues/340), it's not ready yet and it's very easy to switch back to `toml` when it's ready.