### PR TITLE
Include list of fixed files in `stderr` output

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,6 +36,7 @@ pub fn run(
     overrides: &Overrides,
     cache: flags::Cache,
     autofix: fixer::Mode,
+    level: LogLevel,
 ) -> Result<Diagnostics> {
     // Collect all the Python files to check.
     let start = Instant::now();
@@ -101,7 +102,7 @@ pub fn run(
                         .and_then(|parent| package_roots.get(parent))
                         .and_then(|package| *package);
                     let settings = resolver.resolve(path, pyproject_strategy);
-                    lint_path(path, package, settings, cache, autofix)
+                    lint_path(path, package, settings, cache, autofix, level)
                         .map_err(|e| (Some(path.to_owned()), e.to_string()))
                 }
                 Err(e) => Err((

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -19,6 +19,7 @@ use crate::checkers::lines::check_lines;
 use crate::checkers::noqa::check_noqa;
 use crate::checkers::tokens::check_tokens;
 use crate::directives::Directives;
+use crate::logging::LogLevel;
 use crate::message::{Message, Source};
 use crate::noqa::add_noqa;
 use crate::registry::{Check, CheckCode, CheckKind, LintSource};
@@ -181,6 +182,7 @@ pub fn lint_path(
     settings: &Settings,
     cache: flags::Cache,
     autofix: fixer::Mode,
+    level: LogLevel,
 ) -> Result<Diagnostics> {
     // Validate the `Settings` and return any errors.
     settings.validate()?;
@@ -212,6 +214,9 @@ pub fn lint_path(
         let (transformed, fixed, messages) = lint_fix(&contents, path, package, settings)?;
         if fixed > 0 {
             if matches!(autofix, fixer::Mode::Apply) {
+                if level >= LogLevel::Default {
+                    eprintln!("Fixing {fixed} error(s) in {}", fs::relativize_path(path));
+                }
                 write(path, transformed)?;
             } else if matches!(autofix, fixer::Mode::Diff) {
                 let mut stdout = io::stdout().lock();

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -25,7 +25,7 @@ macro_rules! tell_user {
     }
 }
 
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub enum LogLevel {
     // No output (+ `log::LevelFilter::Off`).
     Silent,
@@ -38,7 +38,7 @@ pub enum LogLevel {
 }
 
 impl LogLevel {
-    fn level_filter(&self) -> log::LevelFilter {
+    fn level_filter(self) -> log::LevelFilter {
         match self {
             LogLevel::Default => log::LevelFilter::Info,
             LogLevel::Verbose => log::LevelFilter::Debug,

--- a/src/main_native.rs
+++ b/src/main_native.rs
@@ -18,7 +18,6 @@ use std::sync::mpsc::channel;
 
 use ::ruff::autofix::fixer;
 use ::ruff::cli::{extract_log_level, Cli, Overrides};
-use ::ruff::commands;
 use ::ruff::logging::{set_up_logging, LogLevel};
 use ::ruff::printer::{Printer, Violations};
 use ::ruff::resolver::{resolve_settings, FileDiscovery, PyprojectDiscovery, Relativity};
@@ -27,12 +26,12 @@ use ::ruff::settings::types::SerializationFormat;
 use ::ruff::settings::{pyproject, Settings};
 #[cfg(feature = "update-informer")]
 use ::ruff::updates;
+use ::ruff::{commands, one_time_warning};
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 use path_absolutize::path_dedot;
-use ruff::one_time_warning;
 
 /// Resolve the relevant settings strategy and defaults for the current
 /// invocation.
@@ -216,6 +215,7 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
             &overrides,
             cache.into(),
             fixer::Mode::None,
+            log_level,
         )?;
         printer.write_continuously(&messages)?;
 
@@ -246,6 +246,7 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
                             &overrides,
                             cache.into(),
                             fixer::Mode::None,
+                            log_level,
                         )?;
                         printer.write_continuously(&messages)?;
                     }
@@ -257,7 +258,7 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
         let modifications =
             commands::add_noqa(&cli.files, &pyproject_strategy, &file_strategy, &overrides)?;
         if modifications > 0 && log_level >= LogLevel::Default {
-            println!("Added {modifications} noqa directives.");
+            eprintln!("Added {modifications} noqa directives.");
         }
     } else {
         let is_stdin = cli.files == vec![PathBuf::from("-")];
@@ -279,6 +280,7 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
                 &overrides,
                 cache.into(),
                 autofix,
+                log_level,
             )?
         };
 


### PR DESCRIPTION
This PR adds the list of fixed files to Ruff's output (send to `stderr`, and omitted for `--silent` and `--quiet` settings):

![Screen Shot 2023-01-06 at 7 07 57 PM](https://user-images.githubusercontent.com/1309177/211120323-6203e624-b38d-47ae-a544-8d13e2410396.png)

Closes #1667.