### PR TITLE
Remove redundant #![allow()] from main_native

### DIFF
--- a/src/main_native.rs
+++ b/src/main_native.rs
@@ -1,16 +1,3 @@
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::implicit_hasher,
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::similar_names,
-    clippy::too_many_lines
-)]
-
 use std::io::{self};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;


### PR DESCRIPTION
`main_native.rs` is a module of `main.rs`, so the `#![allow()]`s in the latter apply to the former automatically.