### PR TITLE
Use `trim_end` when checking line continutation

### DIFF
--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -554,7 +554,7 @@ pub fn preceded_by_continuation(stmt: &Stmt, locator: &SourceCodeLocator) -> boo
             Location::new(stmt.location.row(), 0),
         );
         let line = locator.slice_source_code_range(&range);
-        if line.trim().ends_with('\\') {
+        if line.trim_end().ends_with('\\') {
             return true;
         }
     }

--- a/src/flake8_implicit_str_concat/checks.rs
+++ b/src/flake8_implicit_str_concat/checks.rs
@@ -28,7 +28,7 @@ pub fn implicit(tokens: &[LexResult], locator: &SourceCodeLocator) -> Vec<Check>
                     location: *a_end,
                     end_location: Location::new(a_end.row() + 1, 0),
                 });
-                if contents.trim().ends_with('\\') {
+                if contents.trim_end().ends_with('\\') {
                     checks.push(Check::new(
                         CheckKind::MultiLineImplicitStringConcatenation,
                         Range {


### PR DESCRIPTION
Just a minor optimization.