### PR TITLE
Lazily compute ranges for class and function bindings

### DIFF
--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -11,7 +11,7 @@ use rustpython_parser::lexer;
 use rustpython_parser::lexer::Tok;
 use rustpython_parser::token::StringKind;
 
-use crate::ast::types::Range;
+use crate::ast::types::{Binding, BindingKind, Range};
 use crate::source_code_generator::SourceCodeGenerator;
 use crate::source_code_style::SourceCodeStyleDetector;
 use crate::SourceCodeLocator;
@@ -404,6 +404,22 @@ pub fn identifier_range(stmt: &Stmt, locator: &SourceCodeLocator) -> Range {
         error!("Failed to find identifier for {:?}", stmt);
     }
     Range::from_located(stmt)
+}
+
+/// Like `identifier_range`, but accepts a `Binding`.
+pub fn binding_range(binding: &Binding, locator: &SourceCodeLocator) -> Range {
+    if matches!(
+        binding.kind,
+        BindingKind::ClassDefinition | BindingKind::FunctionDefinition
+    ) {
+        if let Some(source) = &binding.source {
+            identifier_range(source, locator)
+        } else {
+            binding.range
+        }
+    } else {
+        binding.range
+    }
 }
 
 // Return the ranges of `Name` tokens within a specified node.

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -15,7 +15,7 @@ use rustpython_parser::ast::{
 use rustpython_parser::parser;
 
 use crate::ast::helpers::{
-    collect_call_paths, dealias_call_path, extract_handler_names, match_call_path,
+    binding_range, collect_call_paths, dealias_call_path, extract_handler_names, match_call_path,
 };
 use crate::ast::operations::extract_all_names;
 use crate::ast::relocate::relocate_expr;
@@ -560,7 +560,7 @@ where
                     Binding {
                         kind: BindingKind::FunctionDefinition,
                         used: None,
-                        range: helpers::identifier_range(stmt, self.locator),
+                        range: Range::from_located(stmt),
                         source: Some(self.current_stmt().clone()),
                     },
                 );
@@ -1544,7 +1544,7 @@ where
                     Binding {
                         kind: BindingKind::ClassDefinition,
                         used: None,
-                        range: helpers::identifier_range(stmt, self.locator),
+                        range: Range::from_located(stmt),
                         source: Some(self.current_stmt().clone()),
                     },
                 );
@@ -3373,7 +3373,7 @@ impl<'a> Checker<'a> {
                                     name.to_string(),
                                     existing.range.location.row(),
                                 ),
-                                binding.range,
+                                binding_range(&binding, self.locator),
                             ));
                         }
                     }
@@ -3935,7 +3935,7 @@ impl<'a> Checker<'a> {
                                         (*name).to_string(),
                                         binding.range.location.row(),
                                     ),
-                                    self.bindings[*index].range,
+                                    binding_range(&self.bindings[*index], self.locator),
                                 ));
                             }
                         }


### PR DESCRIPTION
This has a fairly significant performance impact (~320ms to ~307ms on the CPython benchmark).