### PR TITLE
Treat failures to fix TypedDict conversions as debug logs

### DIFF
--- a/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_named_tuple_functional_to_class.rs
@@ -1,24 +1,23 @@
 use anyhow::{bail, Result};
-use log::error;
-use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Location, Stmt, StmtKind};
+use log::debug;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use crate::ast::helpers::match_module_member;
+use crate::ast::helpers::{create_expr, create_stmt, match_module_member, unparse_stmt};
 use crate::ast::types::Range;
 use crate::autofix::Fix;
 use crate::checkers::ast::Checker;
 use crate::python::identifiers::IDENTIFIER_REGEX;
 use crate::python::keyword::KWLIST;
 use crate::registry::Check;
-use crate::source_code_generator::SourceCodeGenerator;
 use crate::source_code_style::SourceCodeStyleDetector;
 use crate::violations;
 
-/// Return the typename, args, keywords and mother class
+/// Return the typename, args, keywords, and base class.
 fn match_named_tuple_assign<'a>(
     checker: &Checker,
     targets: &'a [Expr],
     value: &'a Expr,
-) -> Option<(&'a str, &'a [Expr], &'a [Keyword], &'a ExprKind)> {
+) -> Option<(&'a str, &'a [Expr], &'a [Keyword], &'a Expr)> {
     let target = targets.get(0)?;
     let ExprKind::Name { id: typename, .. } = &target.node else {
         return None;
@@ -39,43 +38,25 @@ fn match_named_tuple_assign<'a>(
     ) {
         return None;
     }
-    Some((typename, args, keywords, &func.node))
+    Some((typename, args, keywords, func))
 }
 
 /// Generate a `StmtKind::AnnAssign` representing the provided property
 /// definition.
 fn create_property_assignment_stmt(
     property: &str,
-    annotation: &ExprKind,
-    value: Option<&ExprKind>,
+    annotation: &Expr,
+    value: Option<&Expr>,
 ) -> Stmt {
-    Stmt::new(
-        Location::default(),
-        Location::default(),
-        StmtKind::AnnAssign {
-            target: Box::new(Expr::new(
-                Location::default(),
-                Location::default(),
-                ExprKind::Name {
-                    id: property.to_string(),
-                    ctx: ExprContext::Load,
-                },
-            )),
-            annotation: Box::new(Expr::new(
-                Location::default(),
-                Location::default(),
-                annotation.clone(),
-            )),
-            value: value.map(|v| {
-                Box::new(Expr::new(
-                    Location::default(),
-                    Location::default(),
-                    v.clone(),
-                ))
-            }),
-            simple: 1,
-        },
-    )
+    create_stmt(StmtKind::AnnAssign {
+        target: Box::new(create_expr(ExprKind::Name {
+            id: property.to_string(),
+            ctx: ExprContext::Load,
+        })),
+        annotation: Box::new(annotation.clone()),
+        value: value.map(|value| Box::new(value.clone())),
+        simple: 1,
+    })
 }
 
 /// Match the `defaults` keyword in a `NamedTuple(...)` call.
@@ -105,7 +86,6 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
     let ExprKind::List { elts, .. } = &fields.node else {
         bail!("Expected argument to be `ExprKind::List`");
     };
-
     let padded_defaults = if elts.len() >= defaults.len() {
         std::iter::repeat(None)
             .take(elts.len() - defaults.len())
@@ -132,9 +112,7 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
                 bail!("Invalid property name: {}", property)
             }
             Ok(create_property_assignment_stmt(
-                property,
-                &annotation.node,
-                default.map(|d| &d.node),
+                property, annotation, default,
             ))
         })
         .collect()
@@ -142,35 +120,26 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
 
 /// Generate a `StmtKind:ClassDef` statement based on the provided body and
 /// keywords.
-fn create_class_def_stmt(typename: &str, body: Vec<Stmt>, base_class: &ExprKind) -> Stmt {
-    Stmt::new(
-        Location::default(),
-        Location::default(),
-        StmtKind::ClassDef {
-            name: typename.to_string(),
-            bases: vec![Expr::new(
-                Location::default(),
-                Location::default(),
-                base_class.clone(),
-            )],
-            keywords: vec![],
-            body,
-            decorator_list: vec![],
-        },
-    )
+fn create_class_def_stmt(typename: &str, body: Vec<Stmt>, base_class: &Expr) -> Stmt {
+    create_stmt(StmtKind::ClassDef {
+        name: typename.to_string(),
+        bases: vec![base_class.clone()],
+        keywords: vec![],
+        body,
+        decorator_list: vec![],
+    })
 }
 
+/// Generate a `Fix` to convert a `NamedTuple` assignment to a class definition.
 fn convert_to_class(
     stmt: &Stmt,
     typename: &str,
     body: Vec<Stmt>,
-    base_class: &ExprKind,
+    base_class: &Expr,
     stylist: &SourceCodeStyleDetector,
 ) -> Fix {
-    let mut generator: SourceCodeGenerator = stylist.into();
-    generator.unparse_stmt(&create_class_def_stmt(typename, body, base_class));
     Fix::replacement(
-        generator.generate(),
+        unparse_stmt(&create_class_def_stmt(typename, body, base_class), stylist),
         stmt.location,
         stmt.end_location.unwrap(),
     )
@@ -188,26 +157,25 @@ pub fn convert_named_tuple_functional_to_class(
     {
         return;
     };
-    match match_defaults(keywords) {
-        Ok(defaults) => match create_properties_from_args(args, defaults) {
+    let mut check = Check::new(
+        violations::ConvertNamedTupleFunctionalToClass(typename.to_string()),
+        Range::from_located(stmt),
+    );
+    if checker.patch(check.kind.code()) {
+        match match_defaults(keywords)
+            .and_then(|defaults| create_properties_from_args(args, defaults))
+        {
             Ok(properties) => {
-                let mut check = Check::new(
-                    violations::ConvertNamedTupleFunctionalToClass(typename.to_string()),
-                    Range::from_located(stmt),
-                );
-                if checker.patch(check.kind.code()) {
-                    check.amend(convert_to_class(
-                        stmt,
-                        typename,
-                        properties,
-                        base_class,
-                        checker.style,
-                    ));
-                }
-                checker.checks.push(check);
+                check.amend(convert_to_class(
+                    stmt,
+                    typename,
+                    properties,
+                    base_class,
+                    checker.style,
+                ));
             }
-            Err(err) => error!("Failed to create properties: {err}"),
-        },
-        Err(err) => error!("Failed to parse defaults: {err}"),
+            Err(err) => debug!("Skipping ineligible `NamedTuple` \"{typename}\": {err}"),
+        };
     }
+    checker.checks.push(check);
 }

--- a/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
+++ b/src/pyupgrade/plugins/convert_typed_dict_functional_to_class.rs
@@ -1,17 +1,14 @@
 use anyhow::{bail, Result};
-use log::error;
-use rustpython_ast::{
-    Constant, Expr, ExprContext, ExprKind, Keyword, KeywordData, Location, Stmt, StmtKind,
-};
+use log::debug;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use crate::ast::helpers::match_module_member;
+use crate::ast::helpers::{create_expr, create_stmt, match_module_member, unparse_stmt};
 use crate::ast::types::Range;
 use crate::autofix::Fix;
 use crate::checkers::ast::Checker;
 use crate::python::identifiers::IDENTIFIER_REGEX;
 use crate::python::keyword::KWLIST;
 use crate::registry::Check;
-use crate::source_code_generator::SourceCodeGenerator;
 use crate::source_code_style::SourceCodeStyleDetector;
 use crate::violations;
 
@@ -21,7 +18,7 @@ fn match_typed_dict_assign<'a>(
     checker: &Checker,
     targets: &'a [Expr],
     value: &'a Expr,
-) -> Option<(&'a str, &'a [Expr], &'a [Keyword], &'a ExprKind)> {
+) -> Option<(&'a str, &'a [Expr], &'a [Keyword], &'a Expr)> {
     let target = targets.get(0)?;
     let ExprKind::Name { id: class_name, .. } = &target.node else {
         return None;
@@ -42,38 +39,26 @@ fn match_typed_dict_assign<'a>(
     ) {
         return None;
     }
-    Some((class_name, args, keywords, &func.node))
+    Some((class_name, args, keywords, func))
 }
 
 /// Generate a `StmtKind::AnnAssign` representing the provided property
 /// definition.
 fn create_property_assignment_stmt(property: &str, annotation: &ExprKind) -> Stmt {
-    Stmt::new(
-        Location::default(),
-        Location::default(),
-        StmtKind::AnnAssign {
-            target: Box::new(Expr::new(
-                Location::default(),
-                Location::default(),
-                ExprKind::Name {
-                    id: property.to_string(),
-                    ctx: ExprContext::Load,
-                },
-            )),
-            annotation: Box::new(Expr::new(
-                Location::default(),
-                Location::default(),
-                annotation.clone(),
-            )),
-            value: None,
-            simple: 1,
-        },
-    )
+    create_stmt(StmtKind::AnnAssign {
+        target: Box::new(create_expr(ExprKind::Name {
+            id: property.to_string(),
+            ctx: ExprContext::Load,
+        })),
+        annotation: Box::new(create_expr(annotation.clone())),
+        value: None,
+        simple: 1,
+    })
 }
 
 /// Generate a `StmtKind::Pass` statement.
 fn create_pass_stmt() -> Stmt {
-    Stmt::new(Location::default(), Location::default(), StmtKind::Pass)
+    create_stmt(StmtKind::Pass)
 }
 
 /// Generate a `StmtKind:ClassDef` statement based on the provided body,
@@ -81,35 +66,23 @@ fn create_pass_stmt() -> Stmt {
 fn create_class_def_stmt(
     class_name: &str,
     body: Vec<Stmt>,
-    total_keyword: Option<KeywordData>,
-    base_class: &ExprKind,
+    total_keyword: Option<&Keyword>,
+    base_class: &Expr,
 ) -> Stmt {
     let keywords = match total_keyword {
-        Some(keyword) => vec![Keyword::new(
-            Location::default(),
-            Location::default(),
-            keyword,
-        )],
+        Some(keyword) => vec![keyword.clone()],
         None => vec![],
     };
-    Stmt::new(
-        Location::default(),
-        Location::default(),
-        StmtKind::ClassDef {
-            name: class_name.to_string(),
-            bases: vec![Expr::new(
-                Location::default(),
-                Location::default(),
-                base_class.clone(),
-            )],
-            keywords,
-            body,
-            decorator_list: vec![],
-        },
-    )
+    create_stmt(StmtKind::ClassDef {
+        name: class_name.to_string(),
+        bases: vec![base_class.clone()],
+        keywords,
+        body,
+        decorator_list: vec![],
+    })
 }
 
-fn get_properties_from_dict_literal(keys: &[Expr], values: &[Expr]) -> Result<Vec<Stmt>> {
+fn properties_from_dict_literal(keys: &[Expr], values: &[Expr]) -> Result<Vec<Stmt>> {
     keys.iter()
         .zip(values.iter())
         .map(|(key, value)| match &key.node {
@@ -120,7 +93,7 @@ fn get_properties_from_dict_literal(keys: &[Expr], values: &[Expr]) -> Result<Ve
                 if IDENTIFIER_REGEX.is_match(property) && !KWLIST.contains(&property.as_str()) {
                     Ok(create_property_assignment_stmt(property, &value.node))
                 } else {
-                    bail!("Invalid property name: {}", property)
+                    bail!("Property name is not valid identifier: {}", property)
                 }
             }
             _ => bail!("Expected `key` to be `Constant::Str`"),
@@ -128,18 +101,18 @@ fn get_properties_from_dict_literal(keys: &[Expr], values: &[Expr]) -> Result<Ve
         .collect()
 }
 
-fn get_properties_from_dict_call(func: &Expr, keywords: &[Keyword]) -> Result<Vec<Stmt>> {
+fn properties_from_dict_call(func: &Expr, keywords: &[Keyword]) -> Result<Vec<Stmt>> {
     let ExprKind::Name { id, .. } = &func.node else {
         bail!("Expected `func` to be `ExprKind::Name`")
     };
     if id != "dict" {
         bail!("Expected `id` to be `\"dict\"`")
     }
-    get_properties_from_keywords(keywords)
+    properties_from_keywords(keywords)
 }
 
 // Deprecated in Python 3.11, removed in Python 3.13.
-fn get_properties_from_keywords(keywords: &[Keyword]) -> Result<Vec<Stmt>> {
+fn properties_from_keywords(keywords: &[Keyword]) -> Result<Vec<Stmt>> {
     keywords
         .iter()
         .map(|keyword| {
@@ -156,36 +129,40 @@ fn get_properties_from_keywords(keywords: &[Keyword]) -> Result<Vec<Stmt>> {
 }
 
 // The only way to have the `total` keyword is to use the args version, like:
-// (`TypedDict('name', {'a': int}, total=True)`)
-fn get_total_from_only_keyword(keywords: &[Keyword]) -> Option<&KeywordData> {
+// ```
+// TypedDict('name', {'a': int}, total=True)
+// ```
+fn match_total_from_only_keyword(keywords: &[Keyword]) -> Option<&Keyword> {
     let keyword = keywords.get(0)?;
     let arg = &keyword.node.arg.as_ref()?;
     match arg.as_str() {
-        "total" => Some(&keyword.node),
+        "total" => Some(keyword),
         _ => None,
     }
 }
 
-fn get_properties_and_total(
-    args: &[Expr],
-    keywords: &[Keyword],
-) -> Result<(Vec<Stmt>, Option<KeywordData>)> {
+fn match_properties_and_total<'a>(
+    args: &'a [Expr],
+    keywords: &'a [Keyword],
+) -> Result<(Vec<Stmt>, Option<&'a Keyword>)> {
     // We don't have to manage the hybrid case because it's not possible to have a
     // dict and keywords. For example, the following is illegal:
-    //   MyType = TypedDict('MyType', {'a': int, 'b': str}, a=int, b=str)
+    // ```
+    // MyType = TypedDict('MyType', {'a': int, 'b': str}, a=int, b=str)
+    // ```
     if let Some(dict) = args.get(1) {
-        let total = get_total_from_only_keyword(keywords).cloned();
+        let total = match_total_from_only_keyword(keywords);
         match &dict.node {
             ExprKind::Dict { keys, values } => {
-                Ok((get_properties_from_dict_literal(keys, values)?, total))
+                Ok((properties_from_dict_literal(keys, values)?, total))
             }
             ExprKind::Call { func, keywords, .. } => {
-                Ok((get_properties_from_dict_call(func, keywords)?, total))
+                Ok((properties_from_dict_call(func, keywords)?, total))
             }
             _ => Ok((vec![create_pass_stmt()], total)),
         }
     } else if !keywords.is_empty() {
-        Ok((get_properties_from_keywords(keywords)?, None))
+        Ok((properties_from_keywords(keywords)?, None))
     } else {
         Ok((vec![create_pass_stmt()], None))
     }
@@ -196,19 +173,15 @@ fn convert_to_class(
     stmt: &Stmt,
     class_name: &str,
     body: Vec<Stmt>,
-    total_keyword: Option<KeywordData>,
-    base_class: &ExprKind,
+    total_keyword: Option<&Keyword>,
+    base_class: &Expr,
     stylist: &SourceCodeStyleDetector,
 ) -> Fix {
-    let mut generator: SourceCodeGenerator = stylist.into();
-    generator.unparse_stmt(&create_class_def_stmt(
-        class_name,
-        body,
-        total_keyword,
-        base_class,
-    ));
     Fix::replacement(
-        generator.generate(),
+        unparse_stmt(
+            &create_class_def_stmt(class_name, body, total_keyword, base_class),
+            stylist,
+        ),
         stmt.location,
         stmt.end_location.unwrap(),
     )
@@ -226,26 +199,25 @@ pub fn convert_typed_dict_functional_to_class(
     {
         return;
     };
-    let (body, total_keyword) = match get_properties_and_total(args, keywords) {
-        Err(err) => {
-            error!("Failed to parse TypedDict: {err}");
-            return;
-        }
-        Ok(args) => args,
-    };
+
     let mut check = Check::new(
         violations::ConvertTypedDictFunctionalToClass(class_name.to_string()),
         Range::from_located(stmt),
     );
     if checker.patch(check.kind.code()) {
-        check.amend(convert_to_class(
-            stmt,
-            class_name,
-            body,
-            total_keyword,
-            base_class,
-            checker.style,
-        ));
+        match match_properties_and_total(args, keywords) {
+            Ok((body, total_keyword)) => {
+                check.amend(convert_to_class(
+                    stmt,
+                    class_name,
+                    body,
+                    total_keyword,
+                    base_class,
+                    checker.style,
+                ));
+            }
+            Err(err) => debug!("Skipping ineligible `TypedDict` \"{class_name}\": {err}"),
+        };
     }
     checker.checks.push(check);
 }

--- a/src/pyupgrade/snapshots/ruff__pyupgrade__tests__UP013_UP013.py.snap
+++ b/src/pyupgrade/snapshots/ruff__pyupgrade__tests__UP013_UP013.py.snap
@@ -139,6 +139,16 @@ expression: checks
       column: 65
   parent: ~
 - kind:
+    ConvertTypedDictFunctionalToClass: MyType9
+  location:
+    row: 27
+    column: 0
+  end_location:
+    row: 27
+    column: 55
+  fix: ~
+  parent: ~
+- kind:
     ConvertTypedDictFunctionalToClass: MyType10
   location:
     row: 30

--- a/src/pyupgrade/snapshots/ruff__pyupgrade__tests__UP014_UP014.py.snap
+++ b/src/pyupgrade/snapshots/ruff__pyupgrade__tests__UP014_UP014.py.snap
@@ -53,4 +53,14 @@ expression: checks
       row: 15
       column: 56
   parent: ~
+- kind:
+    ConvertNamedTupleFunctionalToClass: NT4
+  location:
+    row: 18
+    column: 0
+  end_location:
+    row: 22
+    column: 1
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
This also allows us to flag the error, even if we can't fix it.

Closes #1212.