### PR TITLE
Remove redundant __name__ == "__main__"

### DIFF
--- a/ruff/__main__.py
+++ b/ruff/__main__.py
@@ -2,6 +2,5 @@ import os
 import sys
 import sysconfig
 
-if __name__ == "__main__":
-    ruff = os.path.join(sysconfig.get_path("scripts"), "ruff")
-    sys.exit(os.spawnv(os.P_WAIT, ruff, [ruff, *sys.argv[1:]]))
+ruff = os.path.join(sysconfig.get_path("scripts"), "ruff")
+sys.exit(os.spawnv(os.P_WAIT, ruff, [ruff, *sys.argv[1:]]))


### PR DESCRIPTION
The name of the module is `__main__` anyway.