### PR TITLE
Omit `sys.version_info` and `sys.platform` checks from ternary rule

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM108.py
+++ b/resources/test/fixtures/flake8_simplify/SIM108.py
@@ -29,3 +29,20 @@ else:
         b = 1
     else:
         b = 2
+
+import sys
+
+if sys.version_info >= (3, 9):
+    randbytes = random.randbytes
+else:
+    randbytes = _get_random_bytes
+
+if sys.platform == "darwin":
+    randbytes = random.randbytes
+else:
+    randbytes = _get_random_bytes
+
+if sys.platform.startswith("linux"):
+    randbytes = random.randbytes
+else:
+    randbytes = _get_random_bytes


### PR DESCRIPTION
Resolves #1753.