### PR TITLE
Disable doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ license = "MIT"
 [lib]
 name = "ruff"
 crate-type = ["cdylib", "rlib"]
+doctest = false
 
 [dependencies]
 annotate-snippets = { version = "0.9.1", features = ["color"] }

--- a/flake8_to_ruff/Cargo.toml
+++ b/flake8_to_ruff/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 name = "flake8_to_ruff"
+doctest = false
 
 [dependencies]
 anyhow = { version = "1.0.66" }

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -3,6 +3,10 @@ name = "ruff_dev"
 version = "0.0.217"
 edition = "2021"
 
+[lib]
+name = "ruff_dev"
+doctest = false
+
 [dependencies]
 anyhow = { version = "1.0.66" }
 clap = { version = "4.0.1", features = ["derive"] }

--- a/ruff_macros/Cargo.toml
+++ b/ruff_macros/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 once_cell = { version = "1.17.0" }


### PR DESCRIPTION
We don't have any doctests, but `cargo test --all` spends more than half the time on doctests? A little confusing, but this brings the test time from > 4s to < 2s on my machine.
