### PR TITLE
Use multi-column layout for packaging status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Ruff is available as [`ruff`](https://pypi.org/project/ruff/) on PyPI:
 pip install ruff
 ```
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1)](https://repology.org/project/ruff-python-linter/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/ruff-python-linter.svg?exclude_unsupported=1&columns=4)](https://repology.org/project/ruff-python-linter/versions)
 
 For **macOS Homebrew** and **Linuxbrew** users, Ruff is also available as [`ruff`](https://formulae.brew.sh/formula/ruff) on Homebrew:
 


### PR DESCRIPTION
So it takes less space, demo: https://github.com/messense/ruff/tree/repology-multi-column#installation