### PR TITLE
Skip unused argument checks for magic methods

### DIFF
--- a/resources/test/fixtures/flake8_unused_arguments/ARG.py
+++ b/resources/test/fixtures/flake8_unused_arguments/ARG.py
@@ -181,3 +181,17 @@ def f(a: int, b: int) -> str:
 
 def f(a, b):
     return f"{a}{b}"
+
+
+###
+# Unused arguments on magic methods.
+###
+class C:
+    def __init__(self, x) -> None:
+        print("Hello, world!")
+
+    def __str__(self) -> str:
+        return "Hello, world!"
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        print("Hello, world!")

--- a/src/ast/cast.rs
+++ b/src/ast/cast.rs
@@ -1,5 +1,12 @@
 use rustpython_ast::{Expr, Stmt, StmtKind};
 
+pub fn name(stmt: &Stmt) -> &str {
+    match &stmt.node {
+        StmtKind::FunctionDef { name, .. } | StmtKind::AsyncFunctionDef { name, .. } => name,
+        _ => panic!("Expected StmtKind::FunctionDef | StmtKind::AsyncFunctionDef"),
+    }
+}
+
 pub fn decorator_list(stmt: &Stmt) -> &Vec<Expr> {
     match &stmt.node {
         StmtKind::FunctionDef { decorator_list, .. }

--- a/src/flake8_annotations/rules.rs
+++ b/src/flake8_annotations/rules.rs
@@ -319,7 +319,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                             helpers::identifier_range(stmt, checker.locator),
                         ));
                     }
-                } else if visibility::is_init(stmt) {
+                } else if visibility::is_init(cast::name(stmt)) {
                     // Allow omission of return annotation in `__init__` functions, as long as at
                     // least one argument is typed.
                     if checker.settings.enabled.contains(&RuleCode::ANN204) {
@@ -341,7 +341,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                             checker.diagnostics.push(diagnostic);
                         }
                     }
-                } else if visibility::is_magic(stmt) {
+                } else if visibility::is_magic(cast::name(stmt)) {
                     if checker.settings.enabled.contains(&RuleCode::ANN204) {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::MissingReturnTypeSpecialMethod(name.to_string()),

--- a/src/flake8_unused_arguments/rules.rs
+++ b/src/flake8_unused_arguments/rules.rs
@@ -153,6 +153,10 @@ pub fn unused_arguments(
                         .enabled
                         .contains(Argumentable::Method.rule_code())
                         && !helpers::is_empty(body)
+                        && (!visibility::is_magic(name)
+                            || visibility::is_init(name)
+                            || visibility::is_new(name)
+                            || visibility::is_call(name))
                         && !visibility::is_abstract(checker, decorator_list)
                         && !visibility::is_override(checker, decorator_list)
                         && !visibility::is_overload(checker, decorator_list)
@@ -178,6 +182,10 @@ pub fn unused_arguments(
                         .enabled
                         .contains(Argumentable::ClassMethod.rule_code())
                         && !helpers::is_empty(body)
+                        && (!visibility::is_magic(name)
+                            || visibility::is_init(name)
+                            || visibility::is_new(name)
+                            || visibility::is_call(name))
                         && !visibility::is_abstract(checker, decorator_list)
                         && !visibility::is_override(checker, decorator_list)
                         && !visibility::is_overload(checker, decorator_list)
@@ -203,6 +211,10 @@ pub fn unused_arguments(
                         .enabled
                         .contains(Argumentable::StaticMethod.rule_code())
                         && !helpers::is_empty(body)
+                        && (!visibility::is_magic(name)
+                            || visibility::is_init(name)
+                            || visibility::is_new(name)
+                            || visibility::is_call(name))
                         && !visibility::is_abstract(checker, decorator_list)
                         && !visibility::is_override(checker, decorator_list)
                         && !visibility::is_overload(checker, decorator_list)

--- a/src/flake8_unused_arguments/snapshots/ruff__flake8_unused_arguments__tests__ARG002_ARG.py.snap
+++ b/src/flake8_unused_arguments/snapshots/ruff__flake8_unused_arguments__tests__ARG002_ARG.py.snap
@@ -1,6 +1,6 @@
 ---
 source: src/flake8_unused_arguments/mod.rs
-expression: checks
+expression: diagnostics
 ---
 - kind:
     UnusedMethodArgument: x
@@ -30,6 +30,16 @@ expression: checks
   end_location:
     row: 41
     column: 16
+  fix: ~
+  parent: ~
+- kind:
+    UnusedMethodArgument: x
+  location:
+    row: 190
+    column: 23
+  end_location:
+    row: 190
+    column: 24
   fix: ~
   parent: ~
 

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -82,27 +82,23 @@ pub fn is_abstract(checker: &Checker, decorator_list: &[Expr]) -> bool {
 }
 
 /// Returns `true` if a function is a "magic method".
-pub fn is_magic(stmt: &Stmt) -> bool {
-    match &stmt.node {
-        StmtKind::FunctionDef { name, .. } | StmtKind::AsyncFunctionDef { name, .. } => {
-            name.starts_with("__")
-                && name.ends_with("__")
-                && name != "__init__"
-                && name != "__call__"
-                && name != "__new__"
-        }
-        _ => panic!("Found non-FunctionDef in is_magic"),
-    }
+pub fn is_magic(name: &str) -> bool {
+    name.starts_with("__") && name.ends_with("__")
 }
 
 /// Returns `true` if a function is an `__init__`.
-pub fn is_init(stmt: &Stmt) -> bool {
-    match &stmt.node {
-        StmtKind::FunctionDef { name, .. } | StmtKind::AsyncFunctionDef { name, .. } => {
-            name == "__init__"
-        }
-        _ => panic!("Found non-FunctionDef in is_init"),
-    }
+pub fn is_init(name: &str) -> bool {
+    name == "__init__"
+}
+
+/// Returns `true` if a function is an `__new__`.
+pub fn is_new(name: &str) -> bool {
+    name == "__new__"
+}
+
+/// Returns `true` if a function is an `__call__`.
+pub fn is_call(name: &str) -> bool {
+    name == "__call__"
 }
 
 /// Returns `true` if a module name indicates public visibility.


### PR DESCRIPTION
We still check `__init__`, `__call__`, and `__new__`.

Closes #1796.