### PR TITLE
Implement doc line length enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ For more, see [pycodestyle](https://pypi.org/project/pycodestyle/2.9.1/) on PyPI
 | E902 | IOError | IOError: `...` |  |
 | E999 | SyntaxError | SyntaxError: `...` |  |
 | W292 | NoNewLineAtEndOfFile | No newline at end of file | 🛠 |
+| W505 | DocLineTooLong | Doc line too long (89 > 88 characters) |  |
 | W605 | InvalidEscapeSequence | Invalid escape sequence: '\c' | 🛠 |
 
 ### mccabe (C90)
@@ -3157,6 +3158,24 @@ and "XXX"]).
 ```toml
 [tool.ruff.pycodestyle]
 ignore-overlong-task-comments = true
+```
+
+---
+
+#### [`max-doc-length`](#max-doc-length)
+
+The maximum line length to allow for line-length violations within
+documentation (`W505`), including standalone comments.
+
+**Default value**: `None`
+
+**Type**: `usize`
+
+**Example usage**:
+
+```toml
+[tool.ruff.pycodestyle]
+max-doc-length = 88
 ```
 
 ---

--- a/resources/test/fixtures/pycodestyle/W505.py
+++ b/resources/test/fixtures/pycodestyle/W505.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Here's a top-level docstring that's over the limit."""
+
+
+def f():
+    """Here's a docstring that's also over the limit."""
+
+    x = 1  # Here's a comment that's over the limit, but it's not standalone.
+
+    # Here's a standalone comment that's over the limit.
+
+    print("Here's a string that's over the limit, but it's not a docstring.")
+
+
+"This is also considered a docstring, and is over the limit."

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -945,6 +945,15 @@
             "boolean",
             "null"
           ]
+        },
+        "max-doc-length": {
+          "description": "The maximum line length to allow for line-length violations within documentation (`W505`), including standalone comments.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false
@@ -1616,6 +1625,9 @@
         "W2",
         "W29",
         "W292",
+        "W5",
+        "W50",
+        "W505",
         "W6",
         "W60",
         "W605",

--- a/src/doc_lines.rs
+++ b/src/doc_lines.rs
@@ -1,0 +1,58 @@
+//! Doc line extraction. In this context, a doc line is a line consisting of a
+//! standalone comment or a constant string statement.
+
+use rustpython_ast::{Constant, ExprKind, Stmt, StmtKind, Suite};
+use rustpython_parser::lexer::{LexResult, Tok};
+
+use crate::ast::visitor;
+use crate::ast::visitor::Visitor;
+
+/// Extract doc lines (standalone comments) from a token sequence.
+pub fn doc_lines_from_tokens(lxr: &[LexResult]) -> Vec<usize> {
+    let mut doc_lines: Vec<usize> = Vec::default();
+    let mut prev: Option<usize> = None;
+    for (start, tok, end) in lxr.iter().flatten() {
+        if matches!(tok, Tok::Indent | Tok::Dedent | Tok::Newline) {
+            continue;
+        }
+        if matches!(tok, Tok::Comment(..)) {
+            if let Some(prev) = prev {
+                if start.row() > prev {
+                    doc_lines.push(start.row());
+                }
+            } else {
+                doc_lines.push(start.row());
+            }
+        }
+        prev = Some(end.row());
+    }
+    doc_lines
+}
+
+#[derive(Default)]
+struct StringLinesVisitor {
+    string_lines: Vec<usize>,
+}
+
+impl Visitor<'_> for StringLinesVisitor {
+    fn visit_stmt(&mut self, stmt: &Stmt) {
+        if let StmtKind::Expr { value } = &stmt.node {
+            if let ExprKind::Constant {
+                value: Constant::Str(..),
+                ..
+            } = &value.node
+            {
+                self.string_lines
+                    .extend(value.location.row()..=value.end_location.unwrap().row());
+            }
+        }
+        visitor::walk_stmt(self, stmt);
+    }
+}
+
+/// Extract doc lines (standalone strings) from an AST.
+pub fn doc_lines_from_ast(python_ast: &Suite) -> Vec<usize> {
+    let mut visitor = StringLinesVisitor::default();
+    visitor.visit_body(python_ast);
+    visitor.string_lines
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,4 +93,5 @@ cfg_if! {
         pub use lib_wasm::check;
     }
 }
+pub mod doc_lines;
 pub mod flake8_pie;

--- a/src/pycodestyle/mod.rs
+++ b/src/pycodestyle/mod.rs
@@ -67,11 +67,28 @@ mod tests {
             &settings::Settings {
                 pycodestyle: Settings {
                     ignore_overlong_task_comments,
+                    ..Settings::default()
                 },
                 ..settings::Settings::for_rule(RuleCode::E501)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn max_doc_length() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("./resources/test/fixtures/pycodestyle/W505.py"),
+            &settings::Settings {
+                pycodestyle: Settings {
+                    max_doc_length: Some(50),
+                    ..Settings::default()
+                },
+                ..settings::Settings::for_rule(RuleCode::W505)
+            },
+        )?;
+        insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
     }
 }

--- a/src/pycodestyle/settings.rs
+++ b/src/pycodestyle/settings.rs
@@ -10,6 +10,16 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields, rename_all = "kebab-case", rename = "Pycodestyle")]
 pub struct Options {
     #[option(
+        default = "None",
+        value_type = "usize",
+        example = r#"
+            max-doc-length = 88
+        "#
+    )]
+    /// The maximum line length to allow for line-length violations within
+    /// documentation (`W505`), including standalone comments.
+    pub max_doc_length: Option<usize>,
+    #[option(
         default = "false",
         value_type = "bool",
         example = r#"
@@ -24,12 +34,14 @@ pub struct Options {
 
 #[derive(Debug, Default, Hash)]
 pub struct Settings {
+    pub max_doc_length: Option<usize>,
     pub ignore_overlong_task_comments: bool,
 }
 
 impl From<Options> for Settings {
     fn from(options: Options) -> Self {
         Self {
+            max_doc_length: options.max_doc_length,
             ignore_overlong_task_comments: options
                 .ignore_overlong_task_comments
                 .unwrap_or_default(),
@@ -40,6 +52,7 @@ impl From<Options> for Settings {
 impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
+            max_doc_length: settings.max_doc_length,
             ignore_overlong_task_comments: Some(settings.ignore_overlong_task_comments),
         }
     }

--- a/src/pycodestyle/snapshots/ruff__pycodestyle__tests__max_doc_length.snap
+++ b/src/pycodestyle/snapshots/ruff__pycodestyle__tests__max_doc_length.snap
@@ -1,0 +1,53 @@
+---
+source: src/pycodestyle/mod.rs
+expression: diagnostics
+---
+- kind:
+    DocLineTooLong:
+      - 57
+      - 50
+  location:
+    row: 2
+    column: 50
+  end_location:
+    row: 2
+    column: 57
+  fix: ~
+  parent: ~
+- kind:
+    DocLineTooLong:
+      - 56
+      - 50
+  location:
+    row: 6
+    column: 50
+  end_location:
+    row: 6
+    column: 56
+  fix: ~
+  parent: ~
+- kind:
+    DocLineTooLong:
+      - 56
+      - 50
+  location:
+    row: 10
+    column: 50
+  end_location:
+    row: 10
+    column: 56
+  fix: ~
+  parent: ~
+- kind:
+    DocLineTooLong:
+      - 61
+      - 50
+  location:
+    row: 15
+    column: 50
+  end_location:
+    row: 15
+    column: 61
+  fix: ~
+  parent: ~
+

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -132,6 +132,7 @@ define_rule_mapping!(
     E999 => violations::SyntaxError,
     // pycodestyle warnings
     W292 => violations::NoNewLineAtEndOfFile,
+    W505 => violations::DocLineTooLong,
     W605 => violations::InvalidEscapeSequence,
     // pyflakes
     F401 => violations::UnusedImport,
@@ -786,6 +787,7 @@ impl RuleCode {
             RuleCode::RUF100 => &LintSource::NoQA,
             RuleCode::E501
             | RuleCode::W292
+            | RuleCode::W505
             | RuleCode::UP009
             | RuleCode::PGH003
             | RuleCode::PGH004 => &LintSource::Lines,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -458,7 +458,7 @@ mod tests {
             }]
             .into_iter(),
         );
-        let expected = FxHashSet::from_iter([RuleCode::W292, RuleCode::W605]);
+        let expected = FxHashSet::from_iter([RuleCode::W292, RuleCode::W505, RuleCode::W605]);
         assert_eq!(actual, expected);
 
         let actual = resolve_codes(
@@ -478,7 +478,7 @@ mod tests {
             }]
             .into_iter(),
         );
-        let expected = FxHashSet::from_iter([RuleCode::W605]);
+        let expected = FxHashSet::from_iter([RuleCode::W505, RuleCode::W605]);
         assert_eq!(actual, expected);
 
         let actual = resolve_codes(
@@ -504,7 +504,7 @@ mod tests {
             ]
             .into_iter(),
         );
-        let expected = FxHashSet::from_iter([RuleCode::W292, RuleCode::W605]);
+        let expected = FxHashSet::from_iter([RuleCode::W292, RuleCode::W505, RuleCode::W605]);
         assert_eq!(actual, expected);
 
         let actual = resolve_codes(

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -315,6 +315,20 @@ impl AlwaysAutofixableViolation for InvalidEscapeSequence {
     }
 }
 
+define_violation!(
+    pub struct DocLineTooLong(pub usize, pub usize);
+);
+impl Violation for DocLineTooLong {
+    fn message(&self) -> String {
+        let DocLineTooLong(length, limit) = self;
+        format!("Doc line too long ({length} > {limit} characters)")
+    }
+
+    fn placeholder() -> Self {
+        DocLineTooLong(89, 88)
+    }
+}
+
 // pyflakes
 
 define_violation!(


### PR DESCRIPTION
This PR implements `W505` (`DocLineTooLong`), which is similar to `E501` (`LineTooLong`) but confined to doc lines.

I based the "doc line" definition on pycodestyle, which defines a doc line as a standalone comment or string statement. Our definition is a bit more liberal, since we consider any string statement a doc line (even if it's part of a multi-line statement) -- but that seems fine to me.

Note that, unusually, this rule requires custom extraction from both the token stream (to find standalone comments) and the AST (to find string statements).

Closes #1784.
