### PR TITLE
📝 Update readme example for adding isort required imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -3034,7 +3034,7 @@ Add the specified import line to all files.
 
 ```toml
 [tool.ruff.isort]
-add-import = ["from __future__ import annotations"]
+required-imports = ["from __future__ import annotations"]
 ```
 
 ---

--- a/src/isort/settings.rs
+++ b/src/isort/settings.rs
@@ -133,7 +133,7 @@ pub struct Options {
         default = r#"[]"#,
         value_type = "Vec<String>",
         example = r#"
-            add-import = ["from __future__ import annotations"]
+            required-imports = ["from __future__ import annotations"]
         "#
     )]
     /// Add the specified import line to all files.


### PR DESCRIPTION
Fixes use of  isort name to the ruff name.