### PR TITLE
Support for-else loops in `SIM110` and `SIM111`

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM110.py
+++ b/resources/test/fixtures/flake8_simplify/SIM110.py
@@ -51,6 +51,44 @@ def f():
 
 
 def f():
+    # SIM110
+    for x in iterable:
+        if check(x):
+            return True
+    else:
+        return False
+
+
+def f():
+    # SIM111
+    for x in iterable:
+        if check(x):
+            return False
+    else:
+        return True
+
+
+def f():
+    # SIM110
+    for x in iterable:
+        if check(x):
+            return True
+    else:
+        return False
+    return True
+
+
+def f():
+    # SIM111
+    for x in iterable:
+        if check(x):
+            return False
+    else:
+        return True
+    return False
+
+
+def f():
     for x in iterable:
         if check(x):
             return True

--- a/resources/test/fixtures/flake8_simplify/SIM111.py
+++ b/resources/test/fixtures/flake8_simplify/SIM111.py
@@ -51,6 +51,44 @@ def f():
 
 
 def f():
+    # SIM110
+    for x in iterable:
+        if check(x):
+            return True
+    else:
+        return False
+
+
+def f():
+    # SIM111
+    for x in iterable:
+        if check(x):
+            return False
+    else:
+        return True
+
+
+def f():
+    # SIM110
+    for x in iterable:
+        if check(x):
+            return True
+    else:
+        return False
+    return True
+
+
+def f():
+    # SIM111
+    for x in iterable:
+        if check(x):
+            return False
+    else:
+        return True
+    return False
+
+
+def f():
     for x in iterable:
         if check(x):
             return True

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1310,8 +1310,15 @@ where
                 if self.settings.enabled.contains(&RuleCode::PLW0120) {
                     pylint::rules::useless_else_on_loop(self, stmt, body, orelse);
                 }
-                if self.settings.enabled.contains(&RuleCode::SIM118) {
-                    flake8_simplify::rules::key_in_dict_for(self, target, iter);
+                if matches!(stmt.node, StmtKind::For { .. }) {
+                    if self.settings.enabled.contains(&RuleCode::SIM110)
+                        || self.settings.enabled.contains(&RuleCode::SIM111)
+                    {
+                        flake8_simplify::rules::convert_for_loop_to_any_all(self, stmt, None);
+                    }
+                    if self.settings.enabled.contains(&RuleCode::SIM118) {
+                        flake8_simplify::rules::key_in_dict_for(self, target, iter);
+                    }
                 }
             }
             StmtKind::Try {
@@ -3168,7 +3175,7 @@ where
                 if matches!(stmt.node, StmtKind::For { .. })
                     && matches!(sibling.node, StmtKind::Return { .. })
                 {
-                    flake8_simplify::rules::convert_loop_to_any_all(self, stmt, sibling);
+                    flake8_simplify::rules::convert_for_loop_to_any_all(self, stmt, Some(sibling));
                 }
             }
         }

--- a/src/flake8_simplify/rules/mod.rs
+++ b/src/flake8_simplify/rules/mod.rs
@@ -2,7 +2,7 @@ pub use ast_bool_op::{
     a_and_not_a, a_or_not_a, and_false, compare_with_tuple, duplicate_isinstance_call, or_true,
 };
 pub use ast_expr::use_capital_environment_variables;
-pub use ast_for::convert_loop_to_any_all;
+pub use ast_for::convert_for_loop_to_any_all;
 pub use ast_if::{
     nested_if_statements, return_bool_condition_directly, use_dict_get_with_default,
     use_ternary_operator,

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM110_SIM110.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM110_SIM110.py.snap
@@ -19,4 +19,38 @@ expression: diagnostics
       row: 6
       column: 16
   parent: ~
+- kind:
+    ConvertLoopToAny: return any(check(x) for x in iterable)
+  location:
+    row: 55
+    column: 4
+  end_location:
+    row: 59
+    column: 20
+  fix:
+    content: return any(check(x) for x in iterable)
+    location:
+      row: 55
+      column: 4
+    end_location:
+      row: 59
+      column: 20
+  parent: ~
+- kind:
+    ConvertLoopToAny: return any(check(x) for x in iterable)
+  location:
+    row: 73
+    column: 4
+  end_location:
+    row: 77
+    column: 20
+  fix:
+    content: return any(check(x) for x in iterable)
+    location:
+      row: 73
+      column: 4
+    end_location:
+      row: 77
+      column: 20
+  parent: ~
 

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM111_SIM111.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM111_SIM111.py.snap
@@ -36,4 +36,38 @@ expression: diagnostics
       row: 36
       column: 15
   parent: ~
+- kind:
+    ConvertLoopToAll: return all(not check(x) for x in iterable)
+  location:
+    row: 64
+    column: 4
+  end_location:
+    row: 68
+    column: 19
+  fix:
+    content: return all(not check(x) for x in iterable)
+    location:
+      row: 64
+      column: 4
+    end_location:
+      row: 68
+      column: 19
+  parent: ~
+- kind:
+    ConvertLoopToAll: return all(not check(x) for x in iterable)
+  location:
+    row: 83
+    column: 4
+  end_location:
+    row: 87
+    column: 19
+  fix:
+    content: return all(not check(x) for x in iterable)
+    location:
+      row: 83
+      column: 4
+    end_location:
+      row: 87
+      column: 19
+  parent: ~
 


### PR DESCRIPTION
This PR adds support for `SIM110` and `SIM111` simplifications of the form:

```py
def f():
    # SIM110
    for x in iterable:
        if check(x):
            return True
    else:
        return False
```