### PR TITLE
Bump RustPython

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +1640,17 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -2027,8 +2059,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-ast"
-version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d532160333ffeb6dbeca2c2728c2391cd1e53b7f#d532160333ffeb6dbeca2c2728c2391cd1e53b7f"
+version = "0.2.0"
+source = "git+https://github.com/RustPython/RustPython.git?rev=acbc517b55406c76da83d7b2711941d8d3f65b87#acbc517b55406c76da83d7b2711941d8d3f65b87"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2037,8 +2069,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-common"
-version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d532160333ffeb6dbeca2c2728c2391cd1e53b7f#d532160333ffeb6dbeca2c2728c2391cd1e53b7f"
+version = "0.2.0"
+source = "git+https://github.com/RustPython/RustPython.git?rev=acbc517b55406c76da83d7b2711941d8d3f65b87#acbc517b55406c76da83d7b2711941d8d3f65b87"
 dependencies = [
  "ascii",
  "bitflags",
@@ -2062,8 +2094,8 @@ dependencies = [
 
 [[package]]
 name = "rustpython-compiler-core"
-version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d532160333ffeb6dbeca2c2728c2391cd1e53b7f#d532160333ffeb6dbeca2c2728c2391cd1e53b7f"
+version = "0.2.0"
+source = "git+https://github.com/RustPython/RustPython.git?rev=acbc517b55406c76da83d7b2711941d8d3f65b87#acbc517b55406c76da83d7b2711941d8d3f65b87"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2072,15 +2104,15 @@ dependencies = [
  "lz4_flex",
  "num-bigint",
  "num-complex",
+ "num_enum",
  "serde",
- "static_assertions",
  "thiserror",
 ]
 
 [[package]]
 name = "rustpython-parser"
-version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d532160333ffeb6dbeca2c2728c2391cd1e53b7f#d532160333ffeb6dbeca2c2728c2391cd1e53b7f"
+version = "0.2.0"
+source = "git+https://github.com/RustPython/RustPython.git?rev=acbc517b55406c76da83d7b2711941d8d3f65b87#acbc517b55406c76da83d7b2711941d8d3f65b87"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2516,6 +2548,15 @@ dependencies = [
  "joinery",
  "lazy_static",
  "regex",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ regex = { version = "1.6.0" }
 ropey = { version = "1.5.0", features = ["cr_lines", "simd"], default-features = false }
 ruff_macros = { version = "0.0.221", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
 schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -15,9 +15,9 @@ libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a87
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
 ruff_cli = { path = "../ruff_cli" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "d532160333ffeb6dbeca2c2728c2391cd1e53b7f" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "acbc517b55406c76da83d7b2711941d8d3f65b87" }
 schemars = { version = "0.8.11" }
 serde_json = {version="1.0.91"}
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/src/checkers/tokens.rs
+++ b/src/checkers/tokens.rs
@@ -105,7 +105,7 @@ pub fn check_tokens(
     // ISC001, ISC002
     if enforce_implicit_string_concatenation {
         diagnostics.extend(
-            flake8_implicit_str_concat::rules::implicit(tokens, locator)
+            flake8_implicit_str_concat::rules::implicit(tokens)
                 .into_iter()
                 .filter(|diagnostic| settings.enabled.contains(diagnostic.kind.code())),
         );

--- a/src/isort/helpers.rs
+++ b/src/isort/helpers.rs
@@ -23,7 +23,7 @@ pub fn trailing_comma(stmt: &Stmt, locator: &Locator) -> TrailingComma {
         if count == 1 {
             if matches!(
                 tok,
-                Tok::Newline | Tok::Indent | Tok::Dedent | Tok::Comment(_)
+                Tok::NonLogicalNewline | Tok::Indent | Tok::Dedent | Tok::Comment(_)
             ) {
                 continue;
             } else if matches!(tok, Tok::Comma) {

--- a/src/lex/docstring_detection.rs
+++ b/src/lex/docstring_detection.rs
@@ -43,7 +43,10 @@ impl StateMachine {
     }
 
     pub fn consume(&mut self, tok: &Tok) -> bool {
-        if matches!(tok, Tok::Newline | Tok::Indent | Tok::Dedent) {
+        if matches!(
+            tok,
+            Tok::NonLogicalNewline | Tok::Newline | Tok::Indent | Tok::Dedent | Tok::Comment(..)
+        ) {
             return false;
         }
 

--- a/src/pyupgrade/fixes.rs
+++ b/src/pyupgrade/fixes.rs
@@ -59,6 +59,10 @@ pub fn remove_class_def_base(
         let mut seen_comma = false;
         for (start, tok, end) in lexer::make_tokenizer_located(&contents, stmt_at).flatten() {
             if seen_comma {
+                if matches!(tok, Tok::NonLogicalNewline) {
+                    // Also delete any non-logical newlines after the comma.
+                    continue;
+                }
                 if matches!(tok, Tok::Newline) {
                     fix_end = Some(end);
                 } else {


### PR DESCRIPTION
~~Draft pending merge of https://github.com/RustPython/RustPython/pull/4443, currently pointing at my fork.~~

This bumps RustPython so we can use the new `NonLogicalNewline` token.
A couple of rules needed a fix due to the new token. There might be more that are not caught by tests (anything working with tokens directly with lookaheads), I hope not.