### PR TITLE
Use absolute paths for GitHub and Gitlab annotations

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -240,7 +240,7 @@ impl<'a> Printer<'a> {
                         "::error title=Ruff \
                          ({}),file={},line={},col={},endLine={},endColumn={}::{}",
                         message.kind.code(),
-                        relativize_path(Path::new(&message.filename)),
+                        message.filename,
                         message.location.row(),
                         message.location.column(),
                         message.end_location.row(),
@@ -264,7 +264,7 @@ impl<'a> Printer<'a> {
                                     "severity": "major",
                                     "fingerprint": message.kind.code(),
                                     "location": {
-                                        "path": relativize_path(Path::new(&message.filename)),
+                                        "path": message.filename,
                                         "lines": {
                                             "begin": message.location.row(),
                                             "end": message.end_location.row()


### PR DESCRIPTION
Note that the _annotation path_ is absolute, while the path encoded in the message remains relative.

![Screen Shot 2023-01-12 at 5 54 11 PM](https://user-images.githubusercontent.com/1309177/212198531-63f15445-0f6a-471c-a64c-18ad2b6df0c7.png)

Closes #1835.
