### PR TITLE
Use absolute paths for --stdin-filename matching

### DIFF
--- a/src/main_native.rs
+++ b/src/main_native.rs
@@ -14,7 +14,7 @@ use ::ruff::settings::types::SerializationFormat;
 use ::ruff::settings::{pyproject, Settings};
 #[cfg(feature = "update-informer")]
 use ::ruff::updates;
-use ::ruff::{commands, fix, warn_user_once};
+use ::ruff::{commands, fix, fs, warn_user_once};
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
@@ -244,7 +244,7 @@ pub(crate) fn inner_main() -> Result<ExitCode> {
         // Generate lint violations.
         let diagnostics = if is_stdin {
             commands::run_stdin(
-                cli.stdin_filename.as_deref(),
+                cli.stdin_filename.map(fs::normalize_path).as_deref(),
                 &pyproject_strategy,
                 &file_strategy,
                 &overrides,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,6 +4,7 @@ use std::str;
 
 use anyhow::Result;
 use assert_cmd::{crate_name, Command};
+use path_absolutize::path_dedot;
 
 #[test]
 fn test_stdin_success() -> Result<()> {
@@ -57,34 +58,37 @@ fn test_stdin_json() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        r#"[
-  {
+        format!(
+            r#"[
+  {{
     "code": "F401",
     "message": "`os` imported but unused",
-    "fix": {
+    "fix": {{
       "content": "",
       "message": "Remove unused import: `os`",
-      "location": {
+      "location": {{
         "row": 1,
         "column": 0
-      },
-      "end_location": {
+      }},
+      "end_location": {{
         "row": 2,
         "column": 0
-      }
-    },
-    "location": {
+      }}
+    }},
+    "location": {{
       "row": 1,
       "column": 8
-    },
-    "end_location": {
+    }},
+    "end_location": {{
       "row": 1,
       "column": 10
-    },
-    "filename": "F401.py"
-  }
+    }},
+    "filename": "{}/F401.py"
+  }}
 ]
-"#
+"#,
+            path_dedot::CWD.to_str().unwrap()
+        )
     );
     Ok(())
 }


### PR DESCRIPTION
Non-basename glob matches (e.g., for `--per-file-ignores`) assume that the path has been converted to an absolute path. (We do this for filenames as part of the directory traversal.) For filenames passed via stdin, though, we're missing this conversion. So `--per-file-ignores` that rely on the _basename_ worked as expected, but directory paths did not.

Closes #1840.