### PR TITLE
Actually fix wasm-pack build command

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -31,8 +31,7 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.4.0
       - uses: jetli/wasm-bindgen-action@v0.2.0
       - name: "Run wasm-pack"
-        run: ln -s . ruff  # HACK because `wasm-pack build` doesn't support our crate structure (see https://github.com/rustwasm/wasm-pack/issues/1211)
-        run: wasm-pack build --target web --out-dir playground/src/pkg -p ruff
+        run: wasm-pack build --target web --out-dir playground/src/pkg . -- -p ruff
       - name: "Install Node dependencies"
         run: npm ci
         working-directory: playground


### PR DESCRIPTION
I initially attempted to run `wasm-pack build -p ruff` which gave the error message:

    Error: crate directory is missing a `Cargo.toml` file; is `-p` the wrong directory?

I interpreted that as wasm-pack looking for the "ruff" directory because I specified -p ruff, however actually the wasm-pack build usage is:

    wasm-pack build [FLAGS] [OPTIONS] <path> <cargo-build-options>

And I was missing the `<path>` argument. So this actually wasn't at all a bug in wasm-pack but just a confusing error message. And the symlink hack I introduced in the previous commit didn't actually work ... I only accidentally omitted the `-p` when testing (which ended up as `ruff` being the <path> argument) ... CLIs are fun.