### PR TITLE
Improve `SIM117`

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -2,6 +2,11 @@ with A() as a:  # SIM117
     with B() as b:
         print("hello")
 
+with A() as a:  # SIM117
+    with B() as b:
+        with C() as c:
+            print("hello")
+
 with A() as a:
     a()
     with B() as b:

--- a/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -2,9 +2,9 @@ with A() as a:  # SIM117
     with B() as b:
         print("hello")
 
-with A() as a:  # SIM117
-    with B() as b:
-        with C() as c:
+with A():  # SIM117
+    with B():
+        with C():
             print("hello")
 
 with A() as a:

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -622,7 +622,7 @@ pub fn preceded_by_continuation(stmt: &Stmt, locator: &Locator) -> bool {
     false
 }
 
-// Return the `Range` of the first `Tok::Colon` token in a `Range`.
+/// Return the `Range` of the first `Tok::Colon` token in a `Range`.
 pub fn first_colon_range(range: Range, locator: &Locator) -> Option<Range> {
     let contents = locator.slice_source_code_range(&range);
     let range = lexer::make_tokenizer_located(&contents, range.location)

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -622,6 +622,19 @@ pub fn preceded_by_continuation(stmt: &Stmt, locator: &Locator) -> bool {
     false
 }
 
+// Return the `Range` of the first `Tok::Colon` token in a `Range`.
+pub fn first_colon_range(range: Range, locator: &Locator) -> Option<Range> {
+    let contents = locator.slice_source_code_range(&range);
+    let range = lexer::make_tokenizer_located(&contents, range.location)
+        .flatten()
+        .find(|(_, kind, _)| matches!(kind, Tok::Colon))
+        .map(|(location, _, end_location)| Range {
+            location,
+            end_location,
+        });
+    range
+}
+
 /// Return `true` if a `Stmt` appears to be part of a multi-statement line, with
 /// other statements preceding it.
 pub fn preceded_by_multi_statement_line(stmt: &Stmt, locator: &Locator) -> bool {

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -721,7 +721,9 @@ mod tests {
     use rustpython_ast::Location;
     use rustpython_parser::parser;
 
-    use crate::ast::helpers::{else_range, identifier_range, match_trailing_content};
+    use crate::ast::helpers::{
+        else_range, first_colon_range, identifier_range, match_trailing_content,
+    };
     use crate::ast::types::Range;
     use crate::source_code::Locator;
 
@@ -850,6 +852,22 @@ else:
         assert_eq!(range.location.column(), 0);
         assert_eq!(range.end_location.row(), 3);
         assert_eq!(range.end_location.column(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn test_first_colon_range() -> Result<()> {
+        let contents = "with a: pass";
+        let locator = Locator::new(contents);
+        let range = first_colon_range(
+            Range::new(Location::new(1, 0), Location::new(1, contents.len())),
+            &locator,
+        )
+        .unwrap();
+        assert_eq!(range.location.row(), 1);
+        assert_eq!(range.location.column(), 6);
+        assert_eq!(range.end_location.row(), 1);
+        assert_eq!(range.end_location.column(), 7);
         Ok(())
     }
 }

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -856,7 +856,7 @@ else:
     }
 
     #[test]
-    fn test_first_colon_range() -> Result<()> {
+    fn test_first_colon_range() {
         let contents = "with a: pass";
         let locator = Locator::new(contents);
         let range = first_colon_range(
@@ -868,6 +868,5 @@ else:
         assert_eq!(range.location.column(), 6);
         assert_eq!(range.end_location.row(), 1);
         assert_eq!(range.end_location.column(), 7);
-        Ok(())
     }
 }

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1270,7 +1270,11 @@ where
                     flake8_pytest_style::rules::complex_raises(self, stmt, items, body);
                 }
                 if self.settings.enabled.contains(&RuleCode::SIM117) {
-                    flake8_simplify::rules::multiple_with_statements(self, stmt);
+                    flake8_simplify::rules::multiple_with_statements(
+                        self,
+                        stmt,
+                        self.current_stmt_parent().map(|parent| parent.0),
+                    );
                 }
             }
             StmtKind::While { body, orelse, .. } => {

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1273,6 +1273,7 @@ where
                     flake8_simplify::rules::multiple_with_statements(
                         self,
                         stmt,
+                        body,
                         self.current_stmt_parent().map(|parent| parent.0),
                     );
                 }

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -13,7 +13,7 @@ fn find_nested_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
     let StmtKind::With { items, body, .. } = &body[0].node else {
         return None
     };
-    find_nested_with(body).or_else(|| Some((items, body)))
+    find_nested_with(body).or(Some((items, body)))
 }
 
 /// SIM117

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -19,8 +19,8 @@ fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
 /// SIM117
 pub fn multiple_with_statements(
     checker: &mut Checker,
-    stmt: &Stmt,
-    body: &[Stmt],
+    with_stmt: &Stmt,
+    with_body: &[Stmt],
     parent: Option<&Stmt>,
 ) {
     if let Some(parent) = parent {
@@ -30,7 +30,7 @@ pub fn multiple_with_statements(
             }
         }
     }
-    if let Some((items, body)) = find_last_with(body) {
+    if let Some((items, body)) = find_last_with(with_body) {
         let last_item = items.last().expect("Expected items to be non-empty");
         let colon = first_colon_range(
             Range::new(
@@ -48,8 +48,8 @@ pub fn multiple_with_statements(
         checker.diagnostics.push(Diagnostic::new(
             violations::MultipleWithStatements,
             colon.map_or_else(
-                || Range::from_located(stmt),
-                |colon| Range::new(stmt.location, colon.end_location),
+                || Range::from_located(with_stmt),
+                |colon| Range::new(with_stmt.location, colon.end_location),
             ),
         ));
     }

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -5,18 +5,29 @@ use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violations;
 
-/// SIM117
-pub fn multiple_with_statements(checker: &mut Checker, stmt: &Stmt) {
+fn find_nested_with(stmt: &Stmt) -> Option<&Stmt> {
     let StmtKind::With { body, .. } = &stmt.node else {
-        return;
+        return None
     };
-    if body.len() != 1 {
-        return;
+    if body.len() != 1 || !matches!(body[0].node, StmtKind::With { .. }) {
+        return None;
     }
-    if matches!(body[0].node, StmtKind::With { .. }) {
+    find_nested_with(&body[0]).or_else(|| Some(&body[0]))
+}
+
+/// SIM117
+pub fn multiple_with_statements(checker: &mut Checker, stmt: &Stmt, parent: Option<&Stmt>) {
+    if let Some(parent) = parent {
+        if let StmtKind::With { body, .. } = &parent.node {
+            if body.len() == 1 {
+                return;
+            }
+        }
+    }
+    if let Some(with_stmt) = find_nested_with(stmt) {
         checker.diagnostics.push(Diagnostic::new(
             violations::MultipleWithStatements,
-            Range::from_located(stmt),
+            Range::new(stmt.location, with_stmt.end_location.unwrap()),
         ));
     }
 }

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -35,8 +35,7 @@ pub fn multiple_with_statements(checker: &mut Checker, stmt: &Stmt, parent: Opti
                 last_item
                     .optional_vars
                     .as_ref()
-                    .map(|v| v.end_location)
-                    .unwrap_or(last_item.context_expr.end_location)
+                    .map_or(last_item.context_expr.end_location, |v| v.end_location)
                     .unwrap(),
                 body.first()
                     .expect("Expected body to be non-empty")
@@ -46,9 +45,10 @@ pub fn multiple_with_statements(checker: &mut Checker, stmt: &Stmt, parent: Opti
         );
         checker.diagnostics.push(Diagnostic::new(
             violations::MultipleWithStatements,
-            colon
-                .map(|colon| Range::new(stmt.location, colon.end_location))
-                .unwrap_or_else(|| Range::from_located(stmt)),
+            colon.map_or_else(
+                || Range::from_located(stmt),
+                |colon| Range::new(stmt.location, colon.end_location),
+            ),
         ));
     }
 }

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -6,14 +6,14 @@ use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violations;
 
-fn find_nested_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
+fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
     if body.len() != 1 {
         return None;
     }
     let StmtKind::With { items, body, .. } = &body[0].node else {
         return None
     };
-    find_nested_with(body).or(Some((items, body)))
+    find_last_with(body).or(Some((items, body)))
 }
 
 /// SIM117
@@ -30,7 +30,7 @@ pub fn multiple_with_statements(
             }
         }
     }
-    if let Some((items, body)) = find_nested_with(body) {
+    if let Some((items, body)) = find_last_with(body) {
         let last_item = items.last().expect("Expected items to be non-empty");
         let colon = first_colon_range(
             Range::new(

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -1,4 +1,4 @@
-use rustpython_ast::{Stmt, StmtKind, Withitem};
+use rustpython_ast::{Located, Stmt, StmtKind, Withitem};
 
 use crate::ast::helpers::first_colon_range;
 use crate::ast::types::Range;
@@ -7,12 +7,7 @@ use crate::registry::Diagnostic;
 use crate::violations;
 
 fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
-    if body.len() != 1 {
-        return None;
-    }
-    let StmtKind::With { items, body, .. } = &body[0].node else {
-        return None
-    };
+    let [Located { node: StmtKind::With { items, body, .. }, ..}] = body else { return None };
     find_last_with(body).or(Some((items, body)))
 }
 

--- a/src/flake8_simplify/rules/ast_with.rs
+++ b/src/flake8_simplify/rules/ast_with.rs
@@ -21,9 +21,9 @@ pub fn multiple_with_statements(
     checker: &mut Checker,
     with_stmt: &Stmt,
     with_body: &[Stmt],
-    parent: Option<&Stmt>,
+    with_parent: Option<&Stmt>,
 ) {
-    if let Some(parent) = parent {
+    if let Some(parent) = with_parent {
         if let StmtKind::With { body, .. } = &parent.node {
             if body.len() == 1 {
                 return;

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -19,7 +19,7 @@ expression: diagnostics
     column: 0
   end_location:
     row: 7
-    column: 22
+    column: 17
   fix: ~
   parent: ~
 

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -1,6 +1,6 @@
 ---
 source: src/flake8_simplify/mod.rs
-expression: checks
+expression: diagnostics
 ---
 - kind:
     MultipleWithStatements: ~
@@ -10,6 +10,26 @@ expression: checks
   end_location:
     row: 3
     column: 22
+  fix: ~
+  parent: ~
+- kind:
+    MultipleWithStatements: ~
+  location:
+    row: 5
+    column: 0
+  end_location:
+    row: 8
+    column: 26
+  fix: ~
+  parent: ~
+- kind:
+    MultipleWithStatements: ~
+  location:
+    row: 12
+    column: 4
+  end_location:
+    row: 14
+    column: 26
   fix: ~
   parent: ~
 

--- a/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/src/flake8_simplify/snapshots/ruff__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -8,8 +8,8 @@ expression: diagnostics
     row: 1
     column: 0
   end_location:
-    row: 3
-    column: 22
+    row: 2
+    column: 18
   fix: ~
   parent: ~
 - kind:
@@ -18,18 +18,8 @@ expression: diagnostics
     row: 5
     column: 0
   end_location:
-    row: 8
-    column: 26
-  fix: ~
-  parent: ~
-- kind:
-    MultipleWithStatements: ~
-  location:
-    row: 12
-    column: 4
-  end_location:
-    row: 14
-    column: 26
+    row: 7
+    column: 22
   fix: ~
   parent: ~
 


### PR DESCRIPTION
This PR makes the following changes to improve `SIM117`:

- Avoid emitting `SIM117` multiple times within the same `with` statement:
- Adjust the error range.  


## Example

```python
with A() as a:  # SIM117
    with B() as b:
        with C() as c:
            print("hello")
```

### Current

```
resources/test/fixtures/flake8_simplify/SIM117.py:5:1: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
  |
5 | / with A() as a:  # SIM117
6 | |     with B() as b:
7 | |         with C() as c:
8 | |             print("hello")
  | |__________________________^ SIM117
  |

resources/test/fixtures/flake8_simplify/SIM117.py:6:5: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
  |
6 |       with B() as b:
  |  _____^
7 | |         with C() as c:
8 | |             print("hello")
  | |__________________________^ SIM117
  |
```

### Improved

```
resources/test/fixtures/flake8_simplify/SIM117.py:5:1: SIM117 Use a single `with` statement with multiple contexts instead of nested `with` statements
  |
5 | / with A() as a:  # SIM117
6 | |     with B() as b:
7 | |         with C() as c:
  | |______________________^ SIM117
  |
```