### PR TITLE
Fix range of SIM201, 202, and 208

### DIFF
--- a/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -40,7 +40,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
             unparse_expr(left, checker.style),
             unparse_expr(&comparators[0], checker.style),
         ),
-        Range::from_located(operand),
+        Range::from_located(expr),
     );
     if checker.patch(diagnostic.kind.code()) {
         diagnostic.amend(Fix::replacement(
@@ -84,7 +84,7 @@ pub fn negation_with_not_equal_op(
             unparse_expr(left, checker.style),
             unparse_expr(&comparators[0], checker.style),
         ),
-        Range::from_located(operand),
+        Range::from_located(expr),
     );
     if checker.patch(diagnostic.kind.code()) {
         diagnostic.amend(Fix::replacement(
@@ -117,7 +117,7 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
 
     let mut diagnostic = Diagnostic::new(
         violations::DoubleNegation(operand.to_string()),
-        Range::from_located(operand),
+        Range::from_located(expr),
     );
     if checker.patch(diagnostic.kind.code()) {
         diagnostic.amend(Fix::replacement(

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM201_SIM201.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM201_SIM201.py.snap
@@ -8,7 +8,7 @@ expression: diagnostics
       - b
   location:
     row: 1
-    column: 7
+    column: 3
   end_location:
     row: 1
     column: 13
@@ -27,7 +27,7 @@ expression: diagnostics
       - b + c
   location:
     row: 4
-    column: 7
+    column: 3
   end_location:
     row: 4
     column: 19
@@ -46,7 +46,7 @@ expression: diagnostics
       - c
   location:
     row: 7
-    column: 7
+    column: 3
   end_location:
     row: 7
     column: 19

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
@@ -8,7 +8,7 @@ expression: diagnostics
       - b
   location:
     row: 1
-    column: 7
+    column: 3
   end_location:
     row: 1
     column: 13
@@ -27,7 +27,7 @@ expression: diagnostics
       - b + c
   location:
     row: 4
-    column: 7
+    column: 3
   end_location:
     row: 4
     column: 19
@@ -46,7 +46,7 @@ expression: diagnostics
       - c
   location:
     row: 7
-    column: 7
+    column: 3
   end_location:
     row: 7
     column: 19

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
@@ -6,10 +6,10 @@ expression: diagnostics
     DoubleNegation: a
   location:
     row: 1
-    column: 12
+    column: 3
   end_location:
     row: 1
-    column: 13
+    column: 14
   fix:
     content: a
     location:
@@ -23,10 +23,10 @@ expression: diagnostics
     DoubleNegation: a == b
   location:
     row: 4
-    column: 13
+    column: 3
   end_location:
     row: 4
-    column: 19
+    column: 21
   fix:
     content: a == b
     location:


### PR DESCRIPTION
Before

```
resources/test/fixtures/flake8_simplify/SIM208.py:1:13: SIM208 Use `a` instead of `not (not a)`
  |
1 | if not (not a):  # SIM208
  |             ^ SIM208
  |
  = help: Replace with `a`

resources/test/fixtures/flake8_simplify/SIM208.py:4:14: SIM208 Use `a == b` instead of `not (not a == b)`
  |
4 | if not (not (a == b)):  # SIM208
  |              ^^^^^^ SIM208
  |
  = help: Replace with `a == b`
```

After

```
resources/test/fixtures/flake8_simplify/SIM208.py:1:4: SIM208 Use `a` instead of `not (not a)`
  |
1 | if not (not a):  # SIM208
  |    ^^^^^^^^^^^ SIM208
  |
  = help: Replace with `a`

resources/test/fixtures/flake8_simplify/SIM208.py:4:4: SIM208 Use `a == b` instead of `not (not a == b)`
  |
4 | if not (not (a == b)):  # SIM208
  |    ^^^^^^^^^^^^^^^^^^ SIM208
  |
  = help: Replace with `a == b`
```