### PR TITLE
Use more precise error ranges for RET505~508

### DIFF
--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -3,6 +3,7 @@ use rustpython_ast::{Constant, Expr, ExprKind, Location, Stmt, StmtKind};
 
 use super::helpers::result_exists;
 use super::visitor::{ReturnVisitor, Stack};
+use crate::ast::helpers::elif_else_range;
 use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
 use crate::ast::whitespace::indentation;
@@ -228,7 +229,8 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
             if checker.settings.enabled.contains(&RuleCode::RET505) {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::SuperfluousElseReturn(branch),
-                    Range::from_located(stmt),
+                    elif_else_range(stmt, checker.locator)
+                        .unwrap_or_else(|| Range::from_located(stmt)),
                 ));
             }
             return true;
@@ -237,7 +239,8 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
             if checker.settings.enabled.contains(&RuleCode::RET508) {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::SuperfluousElseBreak(branch),
-                    Range::from_located(stmt),
+                    elif_else_range(stmt, checker.locator)
+                        .unwrap_or_else(|| Range::from_located(stmt)),
                 ));
             }
             return true;
@@ -246,7 +249,8 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
             if checker.settings.enabled.contains(&RuleCode::RET506) {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::SuperfluousElseRaise(branch),
-                    Range::from_located(stmt),
+                    elif_else_range(stmt, checker.locator)
+                        .unwrap_or_else(|| Range::from_located(stmt)),
                 ));
             }
             return true;
@@ -255,7 +259,8 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
             if checker.settings.enabled.contains(&RuleCode::RET507) {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::SuperfluousElseContinue(branch),
-                    Range::from_located(stmt),
+                    elif_else_range(stmt, checker.locator)
+                        .unwrap_or_else(|| Range::from_located(stmt)),
                 ));
             }
             return true;

--- a/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET505_RET505.py.snap
+++ b/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET505_RET505.py.snap
@@ -5,81 +5,81 @@ expression: diagnostics
 - kind:
     SuperfluousElseReturn: Elif
   location:
-    row: 5
+    row: 8
     column: 4
   end_location:
-    row: 13
-    column: 16
+    row: 8
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Elif
   location:
-    row: 17
+    row: 23
     column: 4
   end_location:
-    row: 26
-    column: 13
+    row: 23
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Elif
   location:
-    row: 38
+    row: 41
     column: 4
   end_location:
-    row: 46
-    column: 16
+    row: 41
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Else
   location:
-    row: 50
+    row: 53
     column: 4
   end_location:
-    row: 55
-    column: 16
+    row: 53
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Else
   location:
-    row: 61
+    row: 64
     column: 8
   end_location:
-    row: 66
-    column: 20
+    row: 64
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Else
   location:
-    row: 73
+    row: 79
     column: 4
   end_location:
-    row: 80
-    column: 13
+    row: 79
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Else
   location:
-    row: 86
+    row: 89
     column: 8
   end_location:
-    row: 90
-    column: 17
+    row: 89
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseReturn: Else
   location:
-    row: 97
+    row: 99
     column: 4
   end_location:
-    row: 103
-    column: 23
+    row: 99
+    column: 8
   fix: ~
   parent: ~
 

--- a/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET506_RET506.py.snap
+++ b/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET506_RET506.py.snap
@@ -5,71 +5,71 @@ expression: diagnostics
 - kind:
     SuperfluousElseRaise: Elif
   location:
-    row: 5
+    row: 8
     column: 4
   end_location:
-    row: 13
-    column: 26
+    row: 8
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Elif
   location:
-    row: 17
+    row: 23
     column: 4
   end_location:
-    row: 26
-    column: 13
+    row: 23
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Else
   location:
-    row: 31
+    row: 34
     column: 4
   end_location:
-    row: 36
-    column: 26
+    row: 34
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Else
   location:
-    row: 42
+    row: 45
     column: 8
   end_location:
-    row: 47
-    column: 30
+    row: 45
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Else
   location:
-    row: 54
+    row: 60
     column: 4
   end_location:
-    row: 61
-    column: 13
+    row: 60
+    column: 8
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Else
   location:
-    row: 67
+    row: 70
     column: 8
   end_location:
-    row: 71
-    column: 17
+    row: 70
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseRaise: Else
   location:
-    row: 78
+    row: 80
     column: 4
   end_location:
-    row: 84
-    column: 33
+    row: 80
+    column: 8
   fix: ~
   parent: ~
 

--- a/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET507_RET507.py.snap
+++ b/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET507_RET507.py.snap
@@ -5,71 +5,71 @@ expression: diagnostics
 - kind:
     SuperfluousElseContinue: Elif
   location:
-    row: 6
+    row: 8
     column: 8
   end_location:
-    row: 11
-    column: 17
+    row: 8
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Elif
   location:
-    row: 16
+    row: 22
     column: 8
   end_location:
-    row: 25
-    column: 17
+    row: 22
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Else
   location:
-    row: 34
+    row: 36
     column: 8
   end_location:
-    row: 37
-    column: 17
+    row: 36
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Else
   location:
-    row: 44
+    row: 47
     column: 12
   end_location:
-    row: 49
-    column: 24
+    row: 47
+    column: 16
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Else
   location:
-    row: 57
+    row: 63
     column: 8
   end_location:
-    row: 64
-    column: 17
+    row: 63
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Else
   location:
-    row: 71
+    row: 74
     column: 12
   end_location:
-    row: 75
-    column: 21
+    row: 74
+    column: 16
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseContinue: Else
   location:
-    row: 83
+    row: 85
     column: 8
   end_location:
-    row: 89
-    column: 24
+    row: 85
+    column: 12
   fix: ~
   parent: ~
 

--- a/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET508_RET508.py.snap
+++ b/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET508_RET508.py.snap
@@ -5,71 +5,71 @@ expression: diagnostics
 - kind:
     SuperfluousElseBreak: Elif
   location:
-    row: 6
+    row: 8
     column: 8
   end_location:
-    row: 11
-    column: 17
+    row: 8
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Elif
   location:
-    row: 16
+    row: 22
     column: 8
   end_location:
-    row: 25
-    column: 17
+    row: 22
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Else
   location:
-    row: 31
+    row: 33
     column: 8
   end_location:
-    row: 34
-    column: 17
+    row: 33
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Else
   location:
-    row: 41
+    row: 44
     column: 12
   end_location:
-    row: 46
-    column: 21
+    row: 44
+    column: 16
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Else
   location:
-    row: 54
+    row: 60
     column: 8
   end_location:
-    row: 61
-    column: 17
+    row: 60
+    column: 12
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Else
   location:
-    row: 68
+    row: 71
     column: 12
   end_location:
-    row: 72
-    column: 21
+    row: 71
+    column: 16
   fix: ~
   parent: ~
 - kind:
     SuperfluousElseBreak: Else
   location:
-    row: 80
+    row: 82
     column: 8
   end_location:
-    row: 86
-    column: 21
+    row: 82
+    column: 12
   fix: ~
   parent: ~
 


### PR DESCRIPTION
Fix:

```
resources/test/fixtures/flake8_return/RET505.py:5:5: RET505 Unnecessary `elif` after `return` statement
   |
 5 |       if x:  # [no-else-return]
   |  _____^
 6 | |         a = 1
 7 | |         return y
 8 | |     elif z:
 9 | |         b = 2
10 | |         return w
11 | |     else:
12 | |         c = 3
13 | |         return z
   | |________________^ RET505
```

to:

```
resources/test/fixtures/flake8_return/RET505.py:8:5: RET505 Unnecessary `elif` after `return` statement
  |
8 |     elif z:
  |     ^^^^ RET505
  |
```

so we can directly jump to `elif` or `else` that violates `RET50x` from the error message.