### PR TITLE
Don't require docstrings for setters and deleters

### DIFF
--- a/resources/test/fixtures/pydocstyle/setter.py
+++ b/resources/test/fixtures/pydocstyle/setter.py
@@ -1,0 +1,17 @@
+class PropertyWithSetter:
+    @property
+    def foo(self) -> str:
+        """Docstring for foo."""
+        return "foo"
+
+    @foo.setter
+    def foo(self, value: str) -> None:
+        pass
+
+    @foo.deleter
+    def foo(self):
+        pass
+
+    @foo
+    def foo(self, value: str) -> None:
+        pass

--- a/src/rules/pydocstyle/mod.rs
+++ b/src/rules/pydocstyle/mod.rs
@@ -17,7 +17,8 @@ mod tests {
 
     #[test_case(RuleCode::D100, Path::new("D.py"); "D100")]
     #[test_case(RuleCode::D101, Path::new("D.py"); "D101")]
-    #[test_case(RuleCode::D102, Path::new("D.py"); "D102")]
+    #[test_case(RuleCode::D102, Path::new("D.py"); "D102_0")]
+    #[test_case(RuleCode::D102, Path::new("setter.py"); "D102_1")]
     #[test_case(RuleCode::D103, Path::new("D.py"); "D103")]
     #[test_case(RuleCode::D104, Path::new("D.py"); "D104")]
     #[test_case(RuleCode::D105, Path::new("D.py"); "D105")]

--- a/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D102_setter.py.snap
+++ b/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D102_setter.py.snap
@@ -1,0 +1,15 @@
+---
+source: src/rules/pydocstyle/mod.rs
+expression: diagnostics
+---
+- kind:
+    PublicMethod: ~
+  location:
+    row: 16
+    column: 8
+  end_location:
+    row: 16
+    column: 11
+  fix: ~
+  parent: ~
+

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use rustpython_ast::{Expr, Stmt, StmtKind};
 
+use crate::ast::helpers::collect_call_path;
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Documentable;
 
@@ -148,7 +149,29 @@ fn function_visibility(stmt: &Stmt) -> Visibility {
 
 fn method_visibility(stmt: &Stmt) -> Visibility {
     match &stmt.node {
-        StmtKind::FunctionDef { name, .. } | StmtKind::AsyncFunctionDef { name, .. } => {
+        StmtKind::FunctionDef {
+            name,
+            decorator_list,
+            ..
+        }
+        | StmtKind::AsyncFunctionDef {
+            name,
+            decorator_list,
+            ..
+        } => {
+            // Is this a setter or deleter?
+            if decorator_list.iter().any(|expr| {
+                let call_path = collect_call_path(expr);
+                print!("{call_path:?}");
+                if call_path.len() > 1 {
+                    call_path[0] == name
+                } else {
+                    false
+                }
+            }) {
+                return Visibility::Private;
+            }
+
             // Is the method non-private?
             if !name.starts_with('_') {
                 return Visibility::Public;


### PR DESCRIPTION
Like `pydocstyle`, we require that, for `@foo.setter`, the method name is `foo`.

Closes #1873.