### PR TITLE
Avoid triggering SIM117 for async with statements

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM117.py
+++ b/resources/test/fixtures/flake8_simplify/SIM117.py
@@ -16,3 +16,15 @@ with A() as a:
     with B() as b:
         print("hello")
     a()
+
+async with A() as a:
+    with B() as b:
+        print("hello")
+
+with A() as a:
+    async with B() as b:
+        print("hello")
+
+async with A() as a:
+    async with B() as b:
+        print("hello")

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1279,7 +1279,7 @@ where
                     }
                 }
             }
-            StmtKind::With { items, body, .. } | StmtKind::AsyncWith { items, body, .. } => {
+            StmtKind::With { items, body, .. } => {
                 if self.settings.enabled.contains(&RuleCode::B017) {
                     flake8_bugbear::rules::assert_raises_exception(self, stmt, items);
                 }
@@ -1291,7 +1291,7 @@ where
                         self,
                         stmt,
                         body,
-                        self.current_stmt_parent().map(|parent| parent.0),
+                        self.current_stmt_parent().map(Into::into),
                     );
                 }
             }


### PR DESCRIPTION
Actually, it looks like _none_ of the existing rules should be triggered on async `with` statements.

Closes #1902.