### PR TITLE
Allow duplicate enum values for enum.auto()

### DIFF
--- a/resources/test/fixtures/flake8_pie/PIE796.py
+++ b/resources/test/fixtures/flake8_pie/PIE796.py
@@ -2,7 +2,7 @@ import enum
 from enum import Enum, unique
 
 
-class FakeEnum(enum.Enum):
+class FakeEnum1(enum.Enum):
     A = "A"
     B = "B"
     C = "B"  # PIE796
@@ -58,3 +58,9 @@ class FakeEnum9(enum.Enum):
     A = "A"
     B = "B"
     C = "C"
+
+
+class FakeEnum10(enum.Enum):
+    A = enum.auto()
+    B = enum.auto()
+    C = enum.auto()

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -131,6 +131,15 @@ where
             continue;
         };
 
+        if let ExprKind::Call { func, .. } = &value.node {
+            if checker
+                .resolve_call_path(func)
+                .map_or(false, |call_path| call_path == ["enum", "auto"])
+            {
+                continue;
+            }
+        }
+
         if !seen_targets.insert(ComparableExpr::from(value)) {
             let diagnostic = Diagnostic::new(
                 violations::PreferUniqueEnums {


### PR DESCRIPTION
Closes #1932.