### PR TITLE
Drop `RuleCode` in favor of `Rule` enum with human-friendly names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "strum_macros",
  "test-case",
  "textwrap",
+ "thiserror",
  "titlecase",
  "toml_edit",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }
 titlecase = { version = "2.2.1" }
 toml_edit = { version = "0.17.1", features = ["easy"] }
+thiserror = { version = "1.0" }
 
 # https://docs.rs/getrandom/0.2.7/getrandom/#webassembly-support
 # For (future) wasm-pack support

--- a/ruff_cli/src/cli.rs
+++ b/ruff_cli/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{command, Parser};
 use regex::Regex;
 use ruff::fs;
 use ruff::logging::LogLevel;
-use ruff::registry::{RuleCode, RuleCodePrefix};
+use ruff::registry::{Rule, RuleCodePrefix};
 use ruff::resolver::ConfigProcessor;
 use ruff::settings::types::{
     FilePattern, PatternPrefixPair, PerFileIgnore, PythonVersion, SerializationFormat,
@@ -169,6 +169,7 @@ pub struct Cli {
     /// Explain a rule.
     #[arg(
         long,
+        value_parser=Rule::from_code,
         // Fake subcommands.
         conflicts_with = "add_noqa",
         conflicts_with = "clean",
@@ -180,7 +181,7 @@ pub struct Cli {
         conflicts_with = "stdin_filename",
         conflicts_with = "watch",
     )]
-    pub explain: Option<RuleCode>,
+    pub explain: Option<Rule>,
     /// Generate shell completion
     #[arg(
         long,
@@ -302,7 +303,7 @@ pub struct Arguments {
     pub config: Option<PathBuf>,
     pub diff: bool,
     pub exit_zero: bool,
-    pub explain: Option<RuleCode>,
+    pub explain: Option<Rule>,
     pub files: Vec<PathBuf>,
     pub generate_shell_completion: Option<clap_complete_command::Shell>,
     pub isolated: bool,

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -114,7 +114,7 @@ pub fn run(
             .unwrap_or_else(|(path, message)| {
                 if let Some(path) = &path {
                     let settings = resolver.resolve(path, pyproject_strategy);
-                    if settings.rules.enabled(&Rule::E902) {
+                    if settings.rules.enabled(&Rule::IOError) {
                         Diagnostics::new(vec![Message {
                             kind: IOError(message).into(),
                             location: Location::default(),

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -15,7 +15,7 @@ use ruff::cache::CACHE_DIR_NAME;
 use ruff::linter::add_noqa_to_path;
 use ruff::logging::LogLevel;
 use ruff::message::{Location, Message};
-use ruff::registry::RuleCode;
+use ruff::registry::Rule;
 use ruff::resolver::{FileDiscovery, PyprojectDiscovery};
 use ruff::settings::flags;
 use ruff::settings::types::SerializationFormat;
@@ -114,7 +114,7 @@ pub fn run(
             .unwrap_or_else(|(path, message)| {
                 if let Some(path) = &path {
                     let settings = resolver.resolve(path, pyproject_strategy);
-                    if settings.rules.enabled(&RuleCode::E902) {
+                    if settings.rules.enabled(&Rule::E902) {
                         Diagnostics::new(vec![Message {
                             kind: IOError(message).into(),
                             location: Location::default(),
@@ -289,24 +289,24 @@ struct Explanation<'a> {
     summary: &'a str,
 }
 
-/// Explain a `RuleCode` to the user.
-pub fn explain(code: &RuleCode, format: SerializationFormat) -> Result<()> {
+/// Explain a `Rule` to the user.
+pub fn explain(rule: &Rule, format: SerializationFormat) -> Result<()> {
     match format {
         SerializationFormat::Text | SerializationFormat::Grouped => {
             println!(
                 "{} ({}): {}",
-                code.as_ref(),
-                code.origin().name(),
-                code.kind().summary()
+                rule.code(),
+                rule.origin().name(),
+                rule.kind().summary()
             );
         }
         SerializationFormat::Json => {
             println!(
                 "{}",
                 serde_json::to_string_pretty(&Explanation {
-                    code: code.as_ref(),
-                    origin: code.origin().name(),
-                    summary: &code.kind().summary(),
+                    code: rule.code(),
+                    origin: rule.origin().name(),
+                    summary: &rule.kind().summary(),
                 })?
             );
         }

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -157,8 +157,8 @@ quoting the executed command, along with the relevant file contents and `pyproje
         PyprojectDiscovery::Hierarchical(settings) => settings.cli.clone(),
     };
 
-    if let Some(code) = cli.explain {
-        commands::explain(&code, format)?;
+    if let Some(rule) = cli.explain {
+        commands::explain(&rule, format)?;
         return Ok(ExitCode::SUCCESS);
     }
     if cli.show_settings {

--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -143,7 +143,7 @@ impl<'a> Printer<'a> {
                             .messages
                             .iter()
                             .map(|message| ExpandedMessage {
-                                code: message.kind.code(),
+                                code: message.kind.rule(),
                                 message: message.kind.body(),
                                 fix: message.fix.as_ref().map(|fix| ExpandedFix {
                                     content: &fix.content,
@@ -178,7 +178,7 @@ impl<'a> Printer<'a> {
                             message.kind.body()
                         ));
                         let mut case =
-                            TestCase::new(format!("org.ruff.{}", message.kind.code()), status);
+                            TestCase::new(format!("org.ruff.{}", message.kind.rule()), status);
                         let file_path = Path::new(filename);
                         let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
                         let classname = file_path.parent().unwrap().join(file_stem);
@@ -248,14 +248,14 @@ impl<'a> Printer<'a> {
                         ":",
                         message.location.column(),
                         ":",
-                        message.kind.code().as_ref(),
+                        message.kind.rule().as_ref(),
                         message.kind.body(),
                     );
                     writeln!(
                         stdout,
                         "::error title=Ruff \
                          ({}),file={},line={},col={},endLine={},endColumn={}::{}",
-                        message.kind.code(),
+                        message.kind.rule(),
                         message.filename,
                         message.location.row(),
                         message.location.column(),
@@ -276,9 +276,9 @@ impl<'a> Printer<'a> {
                             .iter()
                             .map(|message| {
                                 json!({
-                                    "description": format!("({}) {}", message.kind.code(), message.kind.body()),
+                                    "description": format!("({}) {}", message.kind.rule(), message.kind.body()),
                                     "severity": "major",
-                                    "fingerprint": message.kind.code(),
+                                    "fingerprint": message.kind.rule(),
                                     "location": {
                                         "path": message.filename,
                                         "lines": {
@@ -361,7 +361,7 @@ fn print_message<T: Write>(stdout: &mut T, message: &Message) -> Result<()> {
         ":".cyan(),
         message.location.column(),
         ":".cyan(),
-        message.kind.code().as_ref().red().bold(),
+        message.kind.rule().as_ref().red().bold(),
         message.kind.body(),
     );
     writeln!(stdout, "{label}")?;
@@ -388,7 +388,7 @@ fn print_message<T: Write>(stdout: &mut T, message: &Message) -> Result<()> {
                 source: &source.contents,
                 line_start: message.location.row(),
                 annotations: vec![SourceAnnotation {
-                    label: message.kind.code().as_ref(),
+                    label: message.kind.rule().as_ref(),
                     annotation_type: AnnotationType::Error,
                     range: source.range,
                 }],
@@ -425,7 +425,7 @@ fn print_grouped_message<T: Write>(
         ":".cyan(),
         message.location.column(),
         " ".repeat(column_length - num_digits(message.location.column())),
-        message.kind.code().as_ref().red().bold(),
+        message.kind.rule().as_ref().red().bold(),
         message.kind.body(),
     );
     writeln!(stdout, "{label}")?;
@@ -452,7 +452,7 @@ fn print_grouped_message<T: Write>(
                 source: &source.contents,
                 line_start: message.location.row(),
                 annotations: vec![SourceAnnotation {
-                    label: message.kind.code().as_ref(),
+                    label: message.kind.rule().as_ref(),
                     annotation_type: AnnotationType::Error,
                     range: source.range,
                 }],

--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -248,7 +248,7 @@ impl<'a> Printer<'a> {
                         ":",
                         message.location.column(),
                         ":",
-                        message.kind.rule().as_ref(),
+                        message.kind.rule().code(),
                         message.kind.body(),
                     );
                     writeln!(
@@ -361,7 +361,7 @@ fn print_message<T: Write>(stdout: &mut T, message: &Message) -> Result<()> {
         ":".cyan(),
         message.location.column(),
         ":".cyan(),
-        message.kind.rule().as_ref().red().bold(),
+        message.kind.rule().code().red().bold(),
         message.kind.body(),
     );
     writeln!(stdout, "{label}")?;
@@ -388,7 +388,7 @@ fn print_message<T: Write>(stdout: &mut T, message: &Message) -> Result<()> {
                 source: &source.contents,
                 line_start: message.location.row(),
                 annotations: vec![SourceAnnotation {
-                    label: message.kind.rule().as_ref(),
+                    label: message.kind.rule().code(),
                     annotation_type: AnnotationType::Error,
                     range: source.range,
                 }],
@@ -425,7 +425,7 @@ fn print_grouped_message<T: Write>(
         ":".cyan(),
         message.location.column(),
         " ".repeat(column_length - num_digits(message.location.column())),
-        message.kind.rule().as_ref().red().bold(),
+        message.kind.rule().code().red().bold(),
         message.kind.body(),
     );
     writeln!(stdout, "{label}")?;
@@ -452,7 +452,7 @@ fn print_grouped_message<T: Write>(
                 source: &source.contents,
                 line_start: message.location.row(),
                 annotations: vec![SourceAnnotation {
-                    label: message.kind.rule().as_ref(),
+                    label: message.kind.rule().code(),
                     annotation_type: AnnotationType::Error,
                     range: source.range,
                 }],

--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -177,8 +177,10 @@ impl<'a> Printer<'a> {
                             message.location.column(),
                             message.kind.body()
                         ));
-                        let mut case =
-                            TestCase::new(format!("org.ruff.{}", message.kind.rule()), status);
+                        let mut case = TestCase::new(
+                            format!("org.ruff.{}", message.kind.rule().code()),
+                            status,
+                        );
                         let file_path = Path::new(filename);
                         let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
                         let classname = file_path.parent().unwrap().join(file_stem);
@@ -255,7 +257,7 @@ impl<'a> Printer<'a> {
                         stdout,
                         "::error title=Ruff \
                          ({}),file={},line={},col={},endLine={},endColumn={}::{}",
-                        message.kind.rule(),
+                        message.kind.rule().code(),
                         message.filename,
                         message.location.row(),
                         message.location.column(),
@@ -276,7 +278,7 @@ impl<'a> Printer<'a> {
                             .iter()
                             .map(|message| {
                                 json!({
-                                    "description": format!("({}) {}", message.kind.rule(), message.kind.body()),
+                                    "description": format!("({}) {}", message.kind.rule().code(), message.kind.body()),
                                     "severity": "major",
                                     "fingerprint": message.kind.rule(),
                                     "location": {

--- a/ruff_dev/src/generate_rules_table.rs
+++ b/ruff_dev/src/generate_rules_table.rs
@@ -30,7 +30,7 @@ fn generate_table(table_out: &mut String, prefix: &RuleCodePrefix) {
         let fix_token = if kind.fixable() { "🛠" } else { "" };
         table_out.push_str(&format!(
             "| {} | {} | {} | {} |",
-            kind.rule().as_ref(),
+            kind.rule().code(),
             kind.as_ref(),
             kind.summary().replace('|', r"\|"),
             fix_token

--- a/ruff_dev/src/generate_rules_table.rs
+++ b/ruff_dev/src/generate_rules_table.rs
@@ -30,7 +30,7 @@ fn generate_table(table_out: &mut String, prefix: &RuleCodePrefix) {
         let fix_token = if kind.fixable() { "🛠" } else { "" };
         table_out.push_str(&format!(
             "| {} | {} | {} | {} |",
-            kind.code().as_ref(),
+            kind.rule().as_ref(),
             kind.as_ref(),
             kind.summary().replace('|', r"\|"),
             fix_token

--- a/ruff_macros/src/define_rule_mapping.rs
+++ b/ruff_macros/src/define_rule_mapping.rs
@@ -4,10 +4,10 @@ use syn::parse::Parse;
 use syn::{Ident, Path, Token};
 
 pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
-    let mut rulecode_variants = quote!();
+    let mut rule_variants = quote!();
     let mut diagkind_variants = quote!();
-    let mut rulecode_kind_match_arms = quote!();
-    let mut rulecode_origin_match_arms = quote!();
+    let mut rule_kind_match_arms = quote!();
+    let mut rule_origin_match_arms = quote!();
     let mut diagkind_code_match_arms = quote!();
     let mut diagkind_body_match_arms = quote!();
     let mut diagkind_fixable_match_arms = quote!();
@@ -15,13 +15,13 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
     let mut from_impls_for_diagkind = quote!();
 
     for (code, path, name) in &mapping.entries {
-        rulecode_variants.extend(quote! {#code,});
+        rule_variants.extend(quote! {#code,});
         diagkind_variants.extend(quote! {#name(#path),});
-        rulecode_kind_match_arms.extend(
+        rule_kind_match_arms.extend(
             quote! {Self::#code => DiagnosticKind::#name(<#path as Violation>::placeholder()),},
         );
         let origin = get_origin(code);
-        rulecode_origin_match_arms.extend(quote! {Self::#code => RuleOrigin::#origin,});
+        rule_origin_match_arms.extend(quote! {Self::#code => RuleOrigin::#origin,});
         diagkind_code_match_arms.extend(quote! {Self::#name(..) => &RuleCode::#code, });
         diagkind_body_match_arms.extend(quote! {Self::#name(x) => Violation::message(x), });
         diagkind_fixable_match_arms
@@ -45,34 +45,36 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
 
     quote! {
         #[derive(
-            AsRefStr,
+            AsRefStr,    // TODO(martin): Remove
             EnumIter,
-            EnumString,
+            EnumString,  // TODO(martin): Remove
             Debug,
-            Display,
+            Display,     // TODO(martin): Remove
             PartialEq,
             Eq,
             Clone,
-            Serialize,
-            Deserialize,
+            Serialize,   // TODO(martin): Remove
+            Deserialize, // TODO(martin): Remove
             Hash,
             PartialOrd,
             Ord,
         )]
-        pub enum RuleCode { #rulecode_variants }
+        pub enum Rule { #rule_variants }
+
+        pub use Rule as RuleCode; // TODO(martin): Remove
 
         #[derive(AsRefStr, Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub enum DiagnosticKind { #diagkind_variants }
 
 
-        impl RuleCode {
+        impl Rule {
             /// A placeholder representation of the `DiagnosticKind` for the diagnostic.
             pub fn kind(&self) -> DiagnosticKind {
-                match self { #rulecode_kind_match_arms }
+                match self { #rule_kind_match_arms }
             }
 
             pub fn origin(&self) -> RuleOrigin {
-                match self { #rulecode_origin_match_arms }
+                match self { #rule_origin_match_arms }
             }
         }
 

--- a/ruff_macros/src/define_rule_mapping.rs
+++ b/ruff_macros/src/define_rule_mapping.rs
@@ -80,8 +80,8 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
 
 
         impl DiagnosticKind {
-            /// A four-letter shorthand code for the diagnostic.
-            pub fn code(&self) -> &'static RuleCode {
+            /// The rule of the diagnostic.
+            pub fn rule(&self) -> &'static Rule {
                 match self { #diagkind_code_match_arms }
             }
 

--- a/ruff_macros/src/define_rule_mapping.rs
+++ b/ruff_macros/src/define_rule_mapping.rs
@@ -55,8 +55,6 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
             PartialEq,
             Eq,
             Clone,
-            Serialize,   // TODO(martin): Remove
-            Deserialize, // TODO(martin): Remove
             Hash,
             PartialOrd,
             Ord,

--- a/ruff_macros/src/define_rule_mapping.rs
+++ b/ruff_macros/src/define_rule_mapping.rs
@@ -51,7 +51,6 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
             EnumIter,
             EnumString,  // TODO(martin): Remove
             Debug,
-            Display,     // TODO(martin): Remove
             PartialEq,
             Eq,
             Clone,

--- a/ruff_macros/src/define_rule_mapping.rs
+++ b/ruff_macros/src/define_rule_mapping.rs
@@ -18,18 +18,16 @@ pub fn define_rule_mapping(mapping: &Mapping) -> proc_macro2::TokenStream {
         rulecode_variants.extend(quote! {#code,});
         diagkind_variants.extend(quote! {#name(#path),});
         rulecode_kind_match_arms.extend(
-            quote! {RuleCode::#code => DiagnosticKind::#name(<#path as Violation>::placeholder()),},
+            quote! {Self::#code => DiagnosticKind::#name(<#path as Violation>::placeholder()),},
         );
         let origin = get_origin(code);
-        rulecode_origin_match_arms.extend(quote! {RuleCode::#code => RuleOrigin::#origin,});
-        diagkind_code_match_arms.extend(quote! {DiagnosticKind::#name(..) => &RuleCode::#code, });
-        diagkind_body_match_arms
-            .extend(quote! {DiagnosticKind::#name(x) => Violation::message(x), });
+        rulecode_origin_match_arms.extend(quote! {Self::#code => RuleOrigin::#origin,});
+        diagkind_code_match_arms.extend(quote! {Self::#name(..) => &RuleCode::#code, });
+        diagkind_body_match_arms.extend(quote! {Self::#name(x) => Violation::message(x), });
         diagkind_fixable_match_arms
-            .extend(quote! {DiagnosticKind::#name(x) => x.autofix_title_formatter().is_some(),});
-        diagkind_commit_match_arms.extend(
-            quote! {DiagnosticKind::#name(x) => x.autofix_title_formatter().map(|f| f(x)), },
-        );
+            .extend(quote! {Self::#name(x) => x.autofix_title_formatter().is_some(),});
+        diagkind_commit_match_arms
+            .extend(quote! {Self::#name(x) => x.autofix_title_formatter().map(|f| f(x)), });
         from_impls_for_diagkind.extend(quote! {
             impl From<#path> for DiagnosticKind {
                 fn from(x: #path) -> Self {

--- a/ruff_macros/src/lib.rs
+++ b/ruff_macros/src/lib.rs
@@ -29,17 +29,8 @@ pub fn derive_config(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
         .into()
 }
 
-#[proc_macro_derive(RuleCodePrefix)]
-pub fn derive_rule_code_prefix(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-
-    rule_code_prefix::derive_impl(input)
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
-}
-
 #[proc_macro]
 pub fn define_rule_mapping(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mapping = parse_macro_input!(item as define_rule_mapping::Mapping);
-    define_rule_mapping::define_rule_mapping(mapping).into()
+    define_rule_mapping::define_rule_mapping(&mapping).into()
 }

--- a/scripts/add_plugin.py
+++ b/scripts/add_plugin.py
@@ -47,11 +47,11 @@ mod tests {
     use anyhow::Result;
     use test_case::test_case;
 
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::linter::test_path;
     use crate::settings;
 
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
         let diagnostics =test_path(
             Path::new("./resources/test/fixtures/%s")

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -44,9 +44,9 @@ def main(*, name: str, code: str, origin: str) -> None:
 
     with open(mod_rs, "w") as fp:
         for line in content.splitlines():
-            if line.strip() == "fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {":
-                indent = line.split("fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {")[0]
-                fp.write(f'{indent}#[test_case(RuleCode::{code}, Path::new("{code}.py"); "{code}")]')
+            if line.strip() == "fn rules(rule_code: Rule, path: &Path) -> Result<()> {":
+                indent = line.split("fn rules(rule_code: Rule, path: &Path) -> Result<()> {")[0]
+                fp.write(f'{indent}#[test_case(Rule::{code}, Path::new("{code}.py"); "{code}")]')
                 fp.write("\n")
 
             fp.write(line)

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -30,7 +30,7 @@ use crate::python::builtins::{BUILTINS, MAGIC_GLOBALS};
 use crate::python::future::ALL_FEATURE_NAMES;
 use crate::python::typing;
 use crate::python::typing::{Callable, SubscriptKind};
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::{
     flake8_2020, flake8_annotations, flake8_bandit, flake8_blind_except, flake8_boolean_trap,
     flake8_bugbear, flake8_builtins, flake8_comprehensions, flake8_datetimez, flake8_debugger,
@@ -160,7 +160,7 @@ impl<'a> Checker<'a> {
 
     /// Return `true` if a patch should be generated under the given autofix
     /// `Mode`.
-    pub fn patch(&self, code: &RuleCode) -> bool {
+    pub fn patch(&self, code: &Rule) -> bool {
         matches!(self.autofix, flags::Autofix::Enabled) && self.settings.rules.should_fix(code)
     }
 
@@ -256,8 +256,8 @@ impl<'a> Checker<'a> {
         None
     }
 
-    /// Return `true` if a `RuleCode` is disabled by a `noqa` directive.
-    pub fn is_ignored(&self, code: &RuleCode, lineno: usize) -> bool {
+    /// Return `true` if a `Rule` is disabled by a `noqa` directive.
+    pub fn is_ignored(&self, code: &Rule, lineno: usize) -> bool {
         // TODO(charlie): `noqa` directives are mostly enforced in `check_lines.rs`.
         // However, in rare cases, we need to check them here. For example, when
         // removing unused imports, we create a single fix that's applied to all
@@ -337,7 +337,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::E741) {
+                if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
                     self.diagnostics
                         .extend(names.iter().zip(ranges.iter()).filter_map(|(name, range)| {
                             pycodestyle::rules::ambiguous_variable_name(name, *range)
@@ -375,7 +375,7 @@ where
 
                         // Ensure that every nonlocal has an existing binding from a parent scope.
                         if !exists {
-                            if self.settings.rules.enabled(&RuleCode::PLE0117) {
+                            if self.settings.rules.enabled(&Rule::NonlocalWithoutBinding) {
                                 self.diagnostics.push(Diagnostic::new(
                                     violations::NonlocalWithoutBinding(name.to_string()),
                                     *range,
@@ -385,7 +385,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::E741) {
+                if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
                     self.diagnostics
                         .extend(names.iter().zip(ranges.iter()).filter_map(|(name, range)| {
                             pycodestyle::rules::ambiguous_variable_name(name, *range)
@@ -393,7 +393,7 @@ where
                 }
             }
             StmtKind::Break => {
-                if self.settings.rules.enabled(&RuleCode::F701) {
+                if self.settings.rules.enabled(&Rule::BreakOutsideLoop) {
                     if let Some(diagnostic) = pyflakes::rules::break_outside_loop(
                         stmt,
                         &mut self
@@ -408,7 +408,7 @@ where
                 }
             }
             StmtKind::Continue => {
-                if self.settings.rules.enabled(&RuleCode::F702) {
+                if self.settings.rules.enabled(&Rule::ContinueOutsideLoop) {
                     if let Some(diagnostic) = pyflakes::rules::continue_outside_loop(
                         stmt,
                         &mut self
@@ -438,7 +438,7 @@ where
                 body,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::E743) {
+                if self.settings.rules.enabled(&Rule::AmbiguousFunctionName) {
                     if let Some(diagnostic) =
                         pycodestyle::rules::ambiguous_function_name(name, || {
                             helpers::identifier_range(stmt, self.locator)
@@ -448,7 +448,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N802) {
+                if self.settings.rules.enabled(&Rule::InvalidFunctionName) {
                     if let Some(diagnostic) = pep8_naming::rules::invalid_function_name(
                         stmt,
                         name,
@@ -459,7 +459,11 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N804) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::InvalidFirstArgumentNameForClassMethod)
+                {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_first_argument_name_for_class_method(
                             self,
@@ -473,7 +477,11 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N805) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::InvalidFirstArgumentNameForMethod)
+                {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_first_argument_name_for_method(
                             self,
@@ -487,7 +495,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N807) {
+                if self.settings.rules.enabled(&Rule::DunderFunctionName) {
                     if let Some(diagnostic) = pep8_naming::rules::dunder_function_name(
                         self.current_scope(),
                         stmt,
@@ -498,38 +506,41 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::UP011)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::LRUCacheWithoutParameters)
                     && self.settings.target_version >= PythonVersion::Py38
                 {
                     pyupgrade::rules::lru_cache_without_parameters(self, decorator_list);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP033)
+                if self.settings.rules.enabled(&Rule::FunctoolsCache)
                     && self.settings.target_version >= PythonVersion::Py39
                 {
                     pyupgrade::rules::functools_cache(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B018) {
+                if self.settings.rules.enabled(&Rule::UselessExpression) {
                     flake8_bugbear::rules::useless_expression(self, body);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B019) {
+                if self.settings.rules.enabled(&Rule::CachedInstanceMethod) {
                     flake8_bugbear::rules::cached_instance_method(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::RET501)
-                    || self.settings.rules.enabled(&RuleCode::RET502)
-                    || self.settings.rules.enabled(&RuleCode::RET503)
-                    || self.settings.rules.enabled(&RuleCode::RET504)
-                    || self.settings.rules.enabled(&RuleCode::RET505)
-                    || self.settings.rules.enabled(&RuleCode::RET506)
-                    || self.settings.rules.enabled(&RuleCode::RET507)
-                    || self.settings.rules.enabled(&RuleCode::RET508)
+                if self.settings.rules.enabled(&Rule::UnnecessaryReturnNone)
+                    || self.settings.rules.enabled(&Rule::ImplicitReturnValue)
+                    || self.settings.rules.enabled(&Rule::ImplicitReturn)
+                    || self.settings.rules.enabled(&Rule::UnnecessaryAssign)
+                    || self.settings.rules.enabled(&Rule::SuperfluousElseReturn)
+                    || self.settings.rules.enabled(&Rule::SuperfluousElseRaise)
+                    || self.settings.rules.enabled(&Rule::SuperfluousElseContinue)
+                    || self.settings.rules.enabled(&Rule::SuperfluousElseBreak)
                 {
                     flake8_return::rules::function(self, body);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::C901) {
+                if self.settings.rules.enabled(&Rule::FunctionIsTooComplex) {
                     if let Some(diagnostic) = mccabe::rules::function_is_too_complex(
                         stmt,
                         name,
@@ -541,26 +552,41 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::S107) {
+                if self.settings.rules.enabled(&Rule::HardcodedPasswordDefault) {
                     self.diagnostics
                         .extend(flake8_bandit::rules::hardcoded_password_default(args));
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PLR0206) {
+                if self.settings.rules.enabled(&Rule::PropertyWithParameters) {
                     pylint::rules::property_with_parameters(self, stmt, decorator_list, args);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT001)
-                    || self.settings.rules.enabled(&RuleCode::PT002)
-                    || self.settings.rules.enabled(&RuleCode::PT003)
-                    || self.settings.rules.enabled(&RuleCode::PT004)
-                    || self.settings.rules.enabled(&RuleCode::PT005)
-                    || self.settings.rules.enabled(&RuleCode::PT019)
-                    || self.settings.rules.enabled(&RuleCode::PT020)
-                    || self.settings.rules.enabled(&RuleCode::PT021)
-                    || self.settings.rules.enabled(&RuleCode::PT022)
-                    || self.settings.rules.enabled(&RuleCode::PT024)
-                    || self.settings.rules.enabled(&RuleCode::PT025)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::IncorrectFixtureParenthesesStyle)
+                    || self.settings.rules.enabled(&Rule::FixturePositionalArgs)
+                    || self.settings.rules.enabled(&Rule::ExtraneousScopeFunction)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::MissingFixtureNameUnderscore)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::IncorrectFixtureNameUnderscore)
+                    || self.settings.rules.enabled(&Rule::FixtureParamWithoutValue)
+                    || self.settings.rules.enabled(&Rule::DeprecatedYieldFixture)
+                    || self.settings.rules.enabled(&Rule::FixtureFinalizerCallback)
+                    || self.settings.rules.enabled(&Rule::UselessYieldFixture)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::ErroneousUseFixturesOnFixture)
                 {
                     flake8_pytest_style::rules::fixture(
                         self,
@@ -572,14 +598,26 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT006)
-                    || self.settings.rules.enabled(&RuleCode::PT007)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ParametrizeNamesWrongType)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::ParametrizeValuesWrongType)
                 {
                     flake8_pytest_style::rules::parametrize(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT023)
-                    || self.settings.rules.enabled(&RuleCode::PT026)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::IncorrectMarkParenthesesStyle)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::UseFixturesWithoutParameters)
                 {
                     flake8_pytest_style::rules::marks(self, decorator_list);
                 }
@@ -636,7 +674,7 @@ where
                 );
             }
             StmtKind::Return { .. } => {
-                if self.settings.rules.enabled(&RuleCode::F706) {
+                if self.settings.rules.enabled(&Rule::ReturnOutsideFunction) {
                     if let Some(&index) = self.scope_stack.last() {
                         if matches!(
                             self.scopes[index].kind,
@@ -657,11 +695,11 @@ where
                 decorator_list,
                 body,
             } => {
-                if self.settings.rules.enabled(&RuleCode::UP004) {
+                if self.settings.rules.enabled(&Rule::UselessObjectInheritance) {
                     pyupgrade::rules::useless_object_inheritance(self, stmt, name, bases, keywords);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::E742) {
+                if self.settings.rules.enabled(&Rule::AmbiguousClassName) {
                     if let Some(diagnostic) = pycodestyle::rules::ambiguous_class_name(name, || {
                         helpers::identifier_range(stmt, self.locator)
                     }) {
@@ -669,7 +707,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N801) {
+                if self.settings.rules.enabled(&Rule::InvalidClassName) {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_class_name(stmt, name, self.locator)
                     {
@@ -677,7 +715,11 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::N818) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ErrorSuffixOnExceptionName)
+                {
                     if let Some(diagnostic) = pep8_naming::rules::error_suffix_on_exception_name(
                         stmt,
                         bases,
@@ -688,27 +730,41 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B018) {
+                if self.settings.rules.enabled(&Rule::UselessExpression) {
                     flake8_bugbear::rules::useless_expression(self, body);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B024)
-                    || self.settings.rules.enabled(&RuleCode::B027)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::AbstractBaseClassWithoutAbstractMethod)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::EmptyMethodWithoutAbstractDecorator)
                 {
                     flake8_bugbear::rules::abstract_base_class(
                         self, stmt, name, bases, keywords, body,
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT023) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::IncorrectMarkParenthesesStyle)
+                {
                     flake8_pytest_style::rules::marks(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PIE794) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::DupeClassFieldDefinitions)
+                {
                     flake8_pie::rules::dupe_class_field_definitions(self, stmt, body);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PIE796) {
+                if self.settings.rules.enabled(&Rule::PreferUniqueEnums) {
                     flake8_pie::rules::prefer_unique_enums(self, stmt, body);
                 }
 
@@ -725,7 +781,7 @@ where
                 }
             }
             StmtKind::Import { names } => {
-                if self.settings.rules.enabled(&RuleCode::E401) {
+                if self.settings.rules.enabled(&Rule::MultipleImportsOnOneLine) {
                     if names.len() > 1 {
                         self.diagnostics.push(Diagnostic::new(
                             violations::MultipleImportsOnOneLine,
@@ -734,7 +790,11 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::E402) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ModuleImportNotAtTopOfFile)
+                {
                     if self.seen_import_boundary && stmt.location.column() == 0 {
                         self.diagnostics.push(Diagnostic::new(
                             violations::ModuleImportNotAtTopOfFile,
@@ -742,10 +802,10 @@ where
                         ));
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::UP023) {
+                if self.settings.rules.enabled(&Rule::RewriteCElementTree) {
                     pyupgrade::rules::replace_c_element_tree(self, stmt);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP026) {
+                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_import(self, stmt);
                 }
 
@@ -804,7 +864,7 @@ where
                     }
 
                     // flake8-debugger
-                    if self.settings.rules.enabled(&RuleCode::T100) {
+                    if self.settings.rules.enabled(&Rule::Debugger) {
                         if let Some(diagnostic) =
                             flake8_debugger::rules::debugger_import(stmt, None, &alias.node.name)
                         {
@@ -813,7 +873,7 @@ where
                     }
 
                     // flake8_tidy_imports
-                    if self.settings.rules.enabled(&RuleCode::TID251) {
+                    if self.settings.rules.enabled(&Rule::BannedApi) {
                         if let Some(diagnostic) =
                             flake8_tidy_imports::banned_api::name_or_parent_is_banned(
                                 alias,
@@ -826,16 +886,20 @@ where
                     }
 
                     // pylint
-                    if self.settings.rules.enabled(&RuleCode::PLC0414) {
+                    if self.settings.rules.enabled(&Rule::UselessImportAlias) {
                         pylint::rules::useless_import_alias(self, alias);
                     }
-                    if self.settings.rules.enabled(&RuleCode::PLR0402) {
+                    if self.settings.rules.enabled(&Rule::ConsiderUsingFromImport) {
                         pylint::rules::use_from_import(self, alias);
                     }
 
                     if let Some(asname) = &alias.node.asname {
                         let name = alias.node.name.split('.').last().unwrap();
-                        if self.settings.rules.enabled(&RuleCode::N811) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::ConstantImportedAsNonConstant)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
                                     stmt,
@@ -848,7 +912,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N812) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::LowercaseImportedAsNonLowercase)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
                                     stmt,
@@ -861,7 +929,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N813) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsLowercase)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
                                     stmt,
@@ -874,7 +946,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N814) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsConstant)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
                                     stmt,
@@ -887,7 +963,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N817) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsAcronym)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
                                     stmt,
@@ -901,7 +981,11 @@ where
                         }
                     }
 
-                    if self.settings.rules.enabled(&RuleCode::ICN001) {
+                    if self
+                        .settings
+                        .rules
+                        .enabled(&Rule::ImportAliasIsNotConventional)
+                    {
                         if let Some(diagnostic) =
                             flake8_import_conventions::rules::check_conventional_import(
                                 stmt,
@@ -914,7 +998,7 @@ where
                         }
                     }
 
-                    if self.settings.rules.enabled(&RuleCode::PT013) {
+                    if self.settings.rules.enabled(&Rule::IncorrectPytestImport) {
                         if let Some(diagnostic) = flake8_pytest_style::rules::import(
                             stmt,
                             &alias.node.name,
@@ -930,7 +1014,11 @@ where
                 module,
                 level,
             } => {
-                if self.settings.rules.enabled(&RuleCode::E402) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ModuleImportNotAtTopOfFile)
+                {
                     if self.seen_import_boundary && stmt.location.column() == 0 {
                         self.diagnostics.push(Diagnostic::new(
                             violations::ModuleImportNotAtTopOfFile,
@@ -939,24 +1027,24 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::UP010) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryFutureImport) {
                     if let Some("__future__") = module.as_deref() {
                         pyupgrade::rules::unnecessary_future_import(self, stmt, names);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::UP026) {
+                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_import(self, stmt);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP023) {
+                if self.settings.rules.enabled(&Rule::RewriteCElementTree) {
                     pyupgrade::rules::replace_c_element_tree(self, stmt);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP029) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryBuiltinImport) {
                     if let Some(module) = module.as_deref() {
                         pyupgrade::rules::unnecessary_builtin_import(self, stmt, module, names);
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::TID251) {
+                if self.settings.rules.enabled(&Rule::BannedApi) {
                     if let Some(module) = module {
                         for name in names {
                             if let Some(diagnostic) =
@@ -981,7 +1069,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT013) {
+                if self.settings.rules.enabled(&Rule::IncorrectPytestImport) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::import_from(
                         stmt,
                         module.as_deref(),
@@ -1016,7 +1104,7 @@ where
                             self.annotations_future_enabled = true;
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::F407) {
+                        if self.settings.rules.enabled(&Rule::FutureFeatureNotDefined) {
                             if !ALL_FEATURE_NAMES.contains(&&*alias.node.name) {
                                 self.diagnostics.push(Diagnostic::new(
                                     violations::FutureFeatureNotDefined(
@@ -1027,7 +1115,9 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::F404) && !self.futures_allowed {
+                        if self.settings.rules.enabled(&Rule::LateFutureImport)
+                            && !self.futures_allowed
+                        {
                             self.diagnostics.push(Diagnostic::new(
                                 violations::LateFutureImport,
                                 Range::from_located(stmt),
@@ -1044,7 +1134,7 @@ where
                             },
                         );
 
-                        if self.settings.rules.enabled(&RuleCode::F406) {
+                        if self.settings.rules.enabled(&Rule::ImportStarNotPermitted) {
                             let scope = &self.scopes
                                 [*(self.scope_stack.last().expect("No current scope found"))];
                             if !matches!(scope.kind, ScopeKind::Module) {
@@ -1060,7 +1150,7 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::F403) {
+                        if self.settings.rules.enabled(&Rule::ImportStarUsed) {
                             self.diagnostics.push(Diagnostic::new(
                                 violations::ImportStarUsed(helpers::format_import_from(
                                     level.as_ref(),
@@ -1117,7 +1207,7 @@ where
                         );
                     }
 
-                    if self.settings.rules.enabled(&RuleCode::TID252) {
+                    if self.settings.rules.enabled(&Rule::RelativeImports) {
                         if let Some(diagnostic) =
                             flake8_tidy_imports::relative_imports::banned_relative_import(
                                 stmt,
@@ -1130,7 +1220,7 @@ where
                     }
 
                     // flake8-debugger
-                    if self.settings.rules.enabled(&RuleCode::T100) {
+                    if self.settings.rules.enabled(&Rule::Debugger) {
                         if let Some(diagnostic) = flake8_debugger::rules::debugger_import(
                             stmt,
                             module.as_deref(),
@@ -1141,7 +1231,11 @@ where
                     }
 
                     if let Some(asname) = &alias.node.asname {
-                        if self.settings.rules.enabled(&RuleCode::N811) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::ConstantImportedAsNonConstant)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
                                     stmt,
@@ -1154,7 +1248,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N812) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::LowercaseImportedAsNonLowercase)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
                                     stmt,
@@ -1167,7 +1265,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N813) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsLowercase)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
                                     stmt,
@@ -1180,7 +1282,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N814) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsConstant)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
                                     stmt,
@@ -1193,7 +1299,11 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&RuleCode::N817) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(&Rule::CamelcaseImportedAsAcronym)
+                        {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
                                     stmt,
@@ -1207,32 +1317,32 @@ where
                         }
 
                         // pylint
-                        if self.settings.rules.enabled(&RuleCode::PLC0414) {
+                        if self.settings.rules.enabled(&Rule::UselessImportAlias) {
                             pylint::rules::useless_import_alias(self, alias);
                         }
                     }
                 }
             }
             StmtKind::Raise { exc, .. } => {
-                if self.settings.rules.enabled(&RuleCode::F901) {
+                if self.settings.rules.enabled(&Rule::RaiseNotImplemented) {
                     if let Some(expr) = exc {
                         pyflakes::rules::raise_not_implemented(self, expr);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::B016) {
+                if self.settings.rules.enabled(&Rule::CannotRaiseLiteral) {
                     if let Some(exc) = exc {
                         flake8_bugbear::rules::cannot_raise_literal(self, exc);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::EM101)
-                    || self.settings.rules.enabled(&RuleCode::EM102)
-                    || self.settings.rules.enabled(&RuleCode::EM103)
+                if self.settings.rules.enabled(&Rule::RawStringInException)
+                    || self.settings.rules.enabled(&Rule::FStringInException)
+                    || self.settings.rules.enabled(&Rule::DotFormatInException)
                 {
                     if let Some(exc) = exc {
                         flake8_errmsg::rules::string_in_exception(self, exc);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::UP024) {
+                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
                     if let Some(item) = exc {
                         pyupgrade::rules::os_error_alias(self, &item);
                     }
@@ -1242,33 +1352,37 @@ where
                 self.handle_node_load(target);
             }
             StmtKind::If { test, body, orelse } => {
-                if self.settings.rules.enabled(&RuleCode::F634) {
+                if self.settings.rules.enabled(&Rule::IfTuple) {
                     pyflakes::rules::if_tuple(self, stmt, test);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM102) {
+                if self.settings.rules.enabled(&Rule::NestedIfStatements) {
                     flake8_simplify::rules::nested_if_statements(self, stmt);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM103) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ReturnBoolConditionDirectly)
+                {
                     flake8_simplify::rules::return_bool_condition_directly(self, stmt);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM108) {
+                if self.settings.rules.enabled(&Rule::UseTernaryOperator) {
                     flake8_simplify::rules::use_ternary_operator(
                         self,
                         stmt,
                         self.current_stmt_parent().map(|parent| parent.0),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM401) {
+                if self.settings.rules.enabled(&Rule::DictGetWithDefault) {
                     flake8_simplify::rules::use_dict_get_with_default(
                         self, stmt, test, body, orelse,
                     );
                 }
             }
             StmtKind::Assert { test, msg } => {
-                if self.settings.rules.enabled(&RuleCode::F631) {
+                if self.settings.rules.enabled(&Rule::AssertTuple) {
                     pyflakes::rules::assert_tuple(self, stmt, test);
                 }
-                if self.settings.rules.enabled(&RuleCode::B011) {
+                if self.settings.rules.enabled(&Rule::DoNotAssertFalse) {
                     flake8_bugbear::rules::assert_false(
                         self,
                         stmt,
@@ -1276,16 +1390,16 @@ where
                         msg.as_ref().map(|expr| &**expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::S101) {
+                if self.settings.rules.enabled(&Rule::AssertUsed) {
                     self.diagnostics
                         .push(flake8_bandit::rules::assert_used(stmt));
                 }
-                if self.settings.rules.enabled(&RuleCode::PT015) {
+                if self.settings.rules.enabled(&Rule::AssertAlwaysFalse) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::assert_falsy(stmt, test) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::PT018) {
+                if self.settings.rules.enabled(&Rule::CompositeAssertion) {
                     if let Some(diagnostic) =
                         flake8_pytest_style::rules::composite_condition(stmt, test)
                     {
@@ -1294,13 +1408,17 @@ where
                 }
             }
             StmtKind::With { items, body, .. } => {
-                if self.settings.rules.enabled(&RuleCode::B017) {
+                if self.settings.rules.enabled(&Rule::NoAssertRaisesException) {
                     flake8_bugbear::rules::assert_raises_exception(self, stmt, items);
                 }
-                if self.settings.rules.enabled(&RuleCode::PT012) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::RaisesWithMultipleStatements)
+                {
                     flake8_pytest_style::rules::complex_raises(self, stmt, items, body);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM117) {
+                if self.settings.rules.enabled(&Rule::MultipleWithStatements) {
                     flake8_simplify::rules::multiple_with_statements(
                         self,
                         stmt,
@@ -1310,10 +1428,10 @@ where
                 }
             }
             StmtKind::While { body, orelse, .. } => {
-                if self.settings.rules.enabled(&RuleCode::B023) {
+                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Stmt(stmt));
                 }
-                if self.settings.rules.enabled(&RuleCode::PLW0120) {
+                if self.settings.rules.enabled(&Rule::UselessElseOnLoop) {
                     pylint::rules::useless_else_on_loop(self, stmt, body, orelse);
                 }
             }
@@ -1331,25 +1449,33 @@ where
                 orelse,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::B007) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnusedLoopControlVariable)
+                {
                     flake8_bugbear::rules::unused_loop_control_variable(self, target, body);
                 }
-                if self.settings.rules.enabled(&RuleCode::B020) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::LoopVariableOverridesIterator)
+                {
                     flake8_bugbear::rules::loop_variable_overrides_iterator(self, target, iter);
                 }
-                if self.settings.rules.enabled(&RuleCode::B023) {
+                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Stmt(stmt));
                 }
-                if self.settings.rules.enabled(&RuleCode::PLW0120) {
+                if self.settings.rules.enabled(&Rule::UselessElseOnLoop) {
                     pylint::rules::useless_else_on_loop(self, stmt, body, orelse);
                 }
                 if matches!(stmt.node, StmtKind::For { .. }) {
-                    if self.settings.rules.enabled(&RuleCode::SIM110)
-                        || self.settings.rules.enabled(&RuleCode::SIM111)
+                    if self.settings.rules.enabled(&Rule::ConvertLoopToAny)
+                        || self.settings.rules.enabled(&Rule::ConvertLoopToAll)
                     {
                         flake8_simplify::rules::convert_for_loop_to_any_all(self, stmt, None);
                     }
-                    if self.settings.rules.enabled(&RuleCode::SIM118) {
+                    if self.settings.rules.enabled(&Rule::KeyInDict) {
                         flake8_simplify::rules::key_in_dict_for(self, target, iter);
                     }
                 }
@@ -1361,52 +1487,62 @@ where
                 finalbody,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::F707) {
+                if self.settings.rules.enabled(&Rule::DefaultExceptNotLast) {
                     if let Some(diagnostic) =
                         pyflakes::rules::default_except_not_last(handlers, self.locator)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::B014)
-                    || self.settings.rules.enabled(&RuleCode::B025)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::DuplicateHandlerException)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::DuplicateTryBlockException)
                 {
                     flake8_bugbear::rules::duplicate_exceptions(self, handlers);
                 }
-                if self.settings.rules.enabled(&RuleCode::B013) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::RedundantTupleInExceptionHandler)
+                {
                     flake8_bugbear::rules::redundant_tuple_in_exception_handler(self, handlers);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP024) {
+                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
                     pyupgrade::rules::os_error_alias(self, &handlers);
                 }
-                if self.settings.rules.enabled(&RuleCode::PT017) {
+                if self.settings.rules.enabled(&Rule::AssertInExcept) {
                     self.diagnostics.extend(
                         flake8_pytest_style::rules::assert_in_exception_handler(handlers),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM105) {
+                if self.settings.rules.enabled(&Rule::UseContextlibSuppress) {
                     flake8_simplify::rules::use_contextlib_suppress(
                         self, stmt, body, handlers, orelse, finalbody,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM107) {
+                if self.settings.rules.enabled(&Rule::ReturnInTryExceptFinally) {
                     flake8_simplify::rules::return_in_try_except_finally(
                         self, body, handlers, finalbody,
                     );
                 }
             }
             StmtKind::Assign { targets, value, .. } => {
-                if self.settings.rules.enabled(&RuleCode::E731) {
+                if self.settings.rules.enabled(&Rule::DoNotAssignLambda) {
                     if let [target] = &targets[..] {
                         pycodestyle::rules::do_not_assign_lambda(self, target, value, stmt);
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B003) {
+                if self.settings.rules.enabled(&Rule::AssignmentToOsEnviron) {
                     flake8_bugbear::rules::assignment_to_os_environ(self, targets);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::S105) {
+                if self.settings.rules.enabled(&Rule::HardcodedPasswordString) {
                     if let Some(diagnostic) =
                         flake8_bandit::rules::assign_hardcoded_password_string(value, targets)
                     {
@@ -1414,31 +1550,39 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::UP001) {
+                if self.settings.rules.enabled(&Rule::UselessMetaclassType) {
                     pyupgrade::rules::useless_metaclass_type(self, stmt, value, targets);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP013) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ConvertTypedDictFunctionalToClass)
+                {
                     pyupgrade::rules::convert_typed_dict_functional_to_class(
                         self, stmt, targets, value,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::UP014) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ConvertNamedTupleFunctionalToClass)
+                {
                     pyupgrade::rules::convert_named_tuple_functional_to_class(
                         self, stmt, targets, value,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::UP027) {
+                if self.settings.rules.enabled(&Rule::RewriteListComprehension) {
                     pyupgrade::rules::unpack_list_comprehension(self, targets, value);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PD901) {
+                if self.settings.rules.enabled(&Rule::DfIsABadVariableName) {
                     if let Some(diagnostic) = pandas_vet::rules::assignment_to_df(targets) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
             }
             StmtKind::AnnAssign { target, value, .. } => {
-                if self.settings.rules.enabled(&RuleCode::E731) {
+                if self.settings.rules.enabled(&Rule::DoNotAssignLambda) {
                     if let Some(value) = value {
                         pycodestyle::rules::do_not_assign_lambda(self, target, value, stmt);
                     }
@@ -1446,10 +1590,14 @@ where
             }
             StmtKind::Delete { .. } => {}
             StmtKind::Expr { value, .. } => {
-                if self.settings.rules.enabled(&RuleCode::B015) {
+                if self.settings.rules.enabled(&Rule::UselessComparison) {
                     flake8_bugbear::rules::useless_comparison(self, value);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM112) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UseCapitalEnvironmentVariables)
+                {
                     flake8_simplify::rules::use_capital_environment_variables(self, value);
                 }
             }
@@ -1473,7 +1621,7 @@ where
                 decorator_list,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::B021) {
+                if self.settings.rules.enabled(&Rule::FStringDocstring) {
                     flake8_bugbear::rules::f_string_docstring(self, body);
                 }
                 let definition = docstrings::extraction::extract(
@@ -1482,7 +1630,7 @@ where
                     body,
                     &Documentable::Function,
                 );
-                if self.settings.rules.enabled(&RuleCode::UP028) {
+                if self.settings.rules.enabled(&Rule::RewriteYieldFrom) {
                     pyupgrade::rules::rewrite_yield_from(self, stmt);
                 }
                 let scope = transition_scope(&self.visible_scope, stmt, &Documentable::Function);
@@ -1537,7 +1685,7 @@ where
                 decorator_list,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::B021) {
+                if self.settings.rules.enabled(&Rule::FStringDocstring) {
                     flake8_bugbear::rules::f_string_docstring(self, body);
                 }
                 let definition = docstrings::extraction::extract(
@@ -1597,7 +1745,7 @@ where
                     .map(|call_path| call_path.to_vec())
                     .collect();
                 self.except_handlers.push(handler_names);
-                if self.settings.rules.enabled(&RuleCode::B012) {
+                if self.settings.rules.enabled(&Rule::JumpStatementInFinally) {
                     flake8_bugbear::rules::jump_statement_in_finally(self, finalbody);
                 }
                 self.visit_body(body);
@@ -1700,7 +1848,7 @@ where
                 // Ex) Optional[...]
                 if !self.in_deferred_string_type_definition
                     && self.in_annotation
-                    && self.settings.rules.enabled(&RuleCode::UP007)
+                    && self.settings.rules.enabled(&Rule::UsePEP604Annotation)
                     && (self.settings.target_version >= PythonVersion::Py310
                         || (self.settings.target_version >= PythonVersion::Py37
                             && !self.settings.pyupgrade.keep_runtime_typing
@@ -1713,19 +1861,28 @@ where
                     self.in_literal = true;
                 }
 
-                if self.settings.rules.enabled(&RuleCode::YTT101)
-                    || self.settings.rules.enabled(&RuleCode::YTT102)
-                    || self.settings.rules.enabled(&RuleCode::YTT301)
-                    || self.settings.rules.enabled(&RuleCode::YTT303)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::SysVersionSlice3Referenced)
+                    || self.settings.rules.enabled(&Rule::SysVersion2Referenced)
+                    || self.settings.rules.enabled(&Rule::SysVersion0Referenced)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SysVersionSlice1Referenced)
                 {
                     flake8_2020::rules::subscript(self, value, slice);
                 }
             }
             ExprKind::Tuple { elts, ctx } | ExprKind::List { elts, ctx } => {
                 if matches!(ctx, ExprContext::Store) {
-                    let check_too_many_expressions = self.settings.rules.enabled(&RuleCode::F621);
+                    let check_too_many_expressions = self
+                        .settings
+                        .rules
+                        .enabled(&Rule::ExpressionsInStarAssignment);
                     let check_two_starred_expressions =
-                        self.settings.rules.enabled(&RuleCode::F622);
+                        self.settings.rules.enabled(&Rule::TwoStarredExpressions);
                     if let Some(diagnostic) = pyflakes::rules::starred_expressions(
                         elts,
                         check_too_many_expressions,
@@ -1739,13 +1896,13 @@ where
             ExprKind::Name { id, ctx } => {
                 match ctx {
                     ExprContext::Load => {
-                        if self.settings.rules.enabled(&RuleCode::UP019) {
+                        if self.settings.rules.enabled(&Rule::TypingTextStrAlias) {
                             pyupgrade::rules::typing_text_str_alias(self, expr);
                         }
 
                         // Ex) List[...]
                         if !self.in_deferred_string_type_definition
-                            && self.settings.rules.enabled(&RuleCode::UP006)
+                            && self.settings.rules.enabled(&Rule::UsePEP585Annotation)
                             && (self.settings.target_version >= PythonVersion::Py39
                                 || (self.settings.target_version >= PythonVersion::Py37
                                     && !self.settings.pyupgrade.keep_runtime_typing
@@ -1759,7 +1916,7 @@ where
                         self.handle_node_load(expr);
                     }
                     ExprContext::Store => {
-                        if self.settings.rules.enabled(&RuleCode::E741) {
+                        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
                             if let Some(diagnostic) = pycodestyle::rules::ambiguous_variable_name(
                                 id,
                                 Range::from_located(expr),
@@ -1775,18 +1932,22 @@ where
                     ExprContext::Del => self.handle_node_delete(expr),
                 }
 
-                if self.settings.rules.enabled(&RuleCode::YTT202) {
+                if self.settings.rules.enabled(&Rule::SixPY3Referenced) {
                     flake8_2020::rules::name_or_attribute(self, expr);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PLE0118) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UsedPriorGlobalDeclaration)
+                {
                     pylint::rules::used_prior_global_declaration(self, id, expr);
                 }
             }
             ExprKind::Attribute { attr, value, .. } => {
                 // Ex) typing.List[...]
                 if !self.in_deferred_string_type_definition
-                    && self.settings.rules.enabled(&RuleCode::UP006)
+                    && self.settings.rules.enabled(&Rule::UsePEP585Annotation)
                     && (self.settings.target_version >= PythonVersion::Py39
                         || (self.settings.target_version >= PythonVersion::Py37
                             && self.annotations_future_enabled
@@ -1796,31 +1957,31 @@ where
                     pyupgrade::rules::use_pep585_annotation(self, expr);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::UP016) {
+                if self.settings.rules.enabled(&Rule::RemoveSixCompat) {
                     pyupgrade::rules::remove_six_compat(self, expr);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::UP017)
+                if self.settings.rules.enabled(&Rule::DatetimeTimezoneUTC)
                     && self.settings.target_version >= PythonVersion::Py311
                 {
                     pyupgrade::rules::datetime_utc_alias(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP019) {
+                if self.settings.rules.enabled(&Rule::TypingTextStrAlias) {
                     pyupgrade::rules::typing_text_str_alias(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP026) {
+                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_attribute(self, expr);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::YTT202) {
+                if self.settings.rules.enabled(&Rule::SixPY3Referenced) {
                     flake8_2020::rules::name_or_attribute(self, expr);
                 }
 
                 for (code, name) in vec![
-                    (RuleCode::PD007, "ix"),
-                    (RuleCode::PD008, "at"),
-                    (RuleCode::PD009, "iat"),
-                    (RuleCode::PD011, "values"),
+                    (Rule::UseOfDotIx, "ix"),
+                    (Rule::UseOfDotAt, "at"),
+                    (Rule::UseOfDotIat, "iat"),
+                    (Rule::UseOfDotValues, "values"),
                 ] {
                     if self.settings.rules.enabled(&code) {
                         if attr == name {
@@ -1860,7 +2021,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::TID251) {
+                if self.settings.rules.enabled(&Rule::BannedApi) {
                     flake8_tidy_imports::banned_api::banned_attribute_access(self, expr);
                 }
             }
@@ -1870,14 +2031,14 @@ where
                 keywords,
             } => {
                 // pyflakes
-                if self.settings.rules.enabled(&RuleCode::F521)
-                    || self.settings.rules.enabled(&RuleCode::F522)
-                    || self.settings.rules.enabled(&RuleCode::F523)
-                    || self.settings.rules.enabled(&RuleCode::F524)
-                    || self.settings.rules.enabled(&RuleCode::F525)
+                if self.settings.rules.enabled(&Rule::StringDotFormatInvalidFormat)
+                    || self.settings.rules.enabled(&Rule::StringDotFormatExtraNamedArguments)
+                    || self.settings.rules.enabled(&Rule::StringDotFormatExtraPositionalArguments)
+                    || self.settings.rules.enabled(&Rule::StringDotFormatMissingArguments)
+                    || self.settings.rules.enabled(&Rule::StringDotFormatMixingAutomatic)
                     // pyupgrade
-                    || self.settings.rules.enabled(&RuleCode::UP030)
-                    || self.settings.rules.enabled(&RuleCode::UP032)
+                    || self.settings.rules.enabled(&Rule::FormatLiterals)
+                    || self.settings.rules.enabled(&Rule::FString)
                 {
                     if let ExprKind::Attribute { value, attr, .. } = &func.node {
                         if let ExprKind::Constant {
@@ -1890,7 +2051,11 @@ where
                                 let location = Range::from_located(expr);
                                 match pyflakes::format::FormatSummary::try_from(value.as_ref()) {
                                     Err(e) => {
-                                        if self.settings.rules.enabled(&RuleCode::F521) {
+                                        if self
+                                            .settings
+                                            .rules
+                                            .enabled(&Rule::StringDotFormatInvalidFormat)
+                                        {
                                             self.diagnostics.push(Diagnostic::new(
                                                 violations::StringDotFormatInvalidFormat(
                                                     pyflakes::format::error_to_string(&e),
@@ -1900,36 +2065,52 @@ where
                                         }
                                     }
                                     Ok(summary) => {
-                                        if self.settings.rules.enabled(&RuleCode::F522) {
+                                        if self
+                                            .settings
+                                            .rules
+                                            .enabled(&Rule::StringDotFormatExtraNamedArguments)
+                                        {
                                             pyflakes::rules::string_dot_format_extra_named_arguments(
                                                 self, &summary, keywords, location,
                                             );
                                         }
 
-                                        if self.settings.rules.enabled(&RuleCode::F523) {
+                                        if self
+                                            .settings
+                                            .rules
+                                            .enabled(&Rule::StringDotFormatExtraPositionalArguments)
+                                        {
                                             pyflakes::rules::string_dot_format_extra_positional_arguments(
                                                 self,
                                                 &summary, args, location,
                                             );
                                         }
 
-                                        if self.settings.rules.enabled(&RuleCode::F524) {
+                                        if self
+                                            .settings
+                                            .rules
+                                            .enabled(&Rule::StringDotFormatMissingArguments)
+                                        {
                                             pyflakes::rules::string_dot_format_missing_argument(
                                                 self, &summary, args, keywords, location,
                                             );
                                         }
 
-                                        if self.settings.rules.enabled(&RuleCode::F525) {
+                                        if self
+                                            .settings
+                                            .rules
+                                            .enabled(&Rule::StringDotFormatMixingAutomatic)
+                                        {
                                             pyflakes::rules::string_dot_format_mixing_automatic(
                                                 self, &summary, location,
                                             );
                                         }
 
-                                        if self.settings.rules.enabled(&RuleCode::UP030) {
+                                        if self.settings.rules.enabled(&Rule::FormatLiterals) {
                                             pyupgrade::rules::format_literals(self, &summary, expr);
                                         }
 
-                                        if self.settings.rules.enabled(&RuleCode::UP032) {
+                                        if self.settings.rules.enabled(&Rule::FString) {
                                             pyupgrade::rules::f_strings(self, &summary, expr);
                                         }
                                     }
@@ -1940,188 +2121,240 @@ where
                 }
 
                 // pyupgrade
-                if self.settings.rules.enabled(&RuleCode::UP003) {
+                if self.settings.rules.enabled(&Rule::TypeOfPrimitive) {
                     pyupgrade::rules::type_of_primitive(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP005) {
+                if self.settings.rules.enabled(&Rule::DeprecatedUnittestAlias) {
                     pyupgrade::rules::deprecated_unittest_alias(self, func);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP008) {
+                if self.settings.rules.enabled(&Rule::SuperCallWithParameters) {
                     pyupgrade::rules::super_call_with_parameters(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP012) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryEncodeUTF8) {
                     pyupgrade::rules::unnecessary_encode_utf8(self, expr, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP015) {
+                if self.settings.rules.enabled(&Rule::RedundantOpenModes) {
                     pyupgrade::rules::redundant_open_modes(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP016) {
+                if self.settings.rules.enabled(&Rule::RemoveSixCompat) {
                     pyupgrade::rules::remove_six_compat(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP018) {
+                if self.settings.rules.enabled(&Rule::NativeLiterals) {
                     pyupgrade::rules::native_literals(self, expr, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP020) {
+                if self.settings.rules.enabled(&Rule::OpenAlias) {
                     pyupgrade::rules::open_alias(self, expr, func);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP021) {
+                if self.settings.rules.enabled(&Rule::ReplaceUniversalNewlines) {
                     pyupgrade::rules::replace_universal_newlines(self, expr, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP022) {
+                if self.settings.rules.enabled(&Rule::ReplaceStdoutStderr) {
                     pyupgrade::rules::replace_stdout_stderr(self, expr, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::UP024) {
+                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
                     pyupgrade::rules::os_error_alias(self, &expr);
                 }
 
                 // flake8-print
-                if self.settings.rules.enabled(&RuleCode::T201)
-                    || self.settings.rules.enabled(&RuleCode::T203)
+                if self.settings.rules.enabled(&Rule::PrintFound)
+                    || self.settings.rules.enabled(&Rule::PPrintFound)
                 {
                     flake8_print::rules::print_call(self, func, keywords);
                 }
 
                 // flake8-bugbear
-                if self.settings.rules.enabled(&RuleCode::B004) {
+                if self.settings.rules.enabled(&Rule::UnreliableCallableCheck) {
                     flake8_bugbear::rules::unreliable_callable_check(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::B005) {
+                if self.settings.rules.enabled(&Rule::StripWithMultiCharacters) {
                     flake8_bugbear::rules::strip_with_multi_characters(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::B009) {
+                if self.settings.rules.enabled(&Rule::GetAttrWithConstant) {
                     flake8_bugbear::rules::getattr_with_constant(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::B010) {
+                if self.settings.rules.enabled(&Rule::SetAttrWithConstant) {
                     flake8_bugbear::rules::setattr_with_constant(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::B022) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UselessContextlibSuppress)
+                {
                     flake8_bugbear::rules::useless_contextlib_suppress(self, expr, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::B026) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::StarArgUnpackingAfterKeywordArg)
+                {
                     flake8_bugbear::rules::star_arg_unpacking_after_keyword_arg(
                         self, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::B905)
+                if self.settings.rules.enabled(&Rule::ZipWithoutExplicitStrict)
                     && self.settings.target_version >= PythonVersion::Py310
                 {
                     flake8_bugbear::rules::zip_without_explicit_strict(self, expr, func, keywords);
                 }
 
                 // flake8-bandit
-                if self.settings.rules.enabled(&RuleCode::S102) {
+                if self.settings.rules.enabled(&Rule::ExecUsed) {
                     if let Some(diagnostic) = flake8_bandit::rules::exec_used(expr, func) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::S103) {
+                if self.settings.rules.enabled(&Rule::BadFilePermissions) {
                     flake8_bandit::rules::bad_file_permissions(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::S501) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::RequestWithNoCertValidation)
+                {
                     flake8_bandit::rules::request_with_no_cert_validation(
                         self, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::S506) {
+                if self.settings.rules.enabled(&Rule::UnsafeYAMLLoad) {
                     flake8_bandit::rules::unsafe_yaml_load(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::S508) {
+                if self.settings.rules.enabled(&Rule::SnmpInsecureVersion) {
                     flake8_bandit::rules::snmp_insecure_version(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::S509) {
+                if self.settings.rules.enabled(&Rule::SnmpWeakCryptography) {
                     flake8_bandit::rules::snmp_weak_cryptography(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::S701) {
+                if self.settings.rules.enabled(&Rule::Jinja2AutoescapeFalse) {
                     flake8_bandit::rules::jinja2_autoescape_false(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&RuleCode::S106) {
+                if self.settings.rules.enabled(&Rule::HardcodedPasswordFuncArg) {
                     self.diagnostics
                         .extend(flake8_bandit::rules::hardcoded_password_func_arg(keywords));
                 }
-                if self.settings.rules.enabled(&RuleCode::S324) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::HashlibInsecureHashFunction)
+                {
                     flake8_bandit::rules::hashlib_insecure_hash_functions(
                         self, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::S113) {
+                if self.settings.rules.enabled(&Rule::RequestWithoutTimeout) {
                     flake8_bandit::rules::request_without_timeout(self, func, args, keywords);
                 }
 
                 // flake8-comprehensions
-                if self.settings.rules.enabled(&RuleCode::C400) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorList) {
                     flake8_comprehensions::rules::unnecessary_generator_list(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C401) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorSet) {
                     flake8_comprehensions::rules::unnecessary_generator_set(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C402) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorDict) {
                     flake8_comprehensions::rules::unnecessary_generator_dict(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C403) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryListComprehensionSet)
+                {
                     flake8_comprehensions::rules::unnecessary_list_comprehension_set(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C404) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryListComprehensionDict)
+                {
                     flake8_comprehensions::rules::unnecessary_list_comprehension_dict(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C405) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryLiteralSet) {
                     flake8_comprehensions::rules::unnecessary_literal_set(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C406) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryLiteralDict) {
                     flake8_comprehensions::rules::unnecessary_literal_dict(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C408) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryCollectionCall)
+                {
                     flake8_comprehensions::rules::unnecessary_collection_call(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C409) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryLiteralWithinTupleCall)
+                {
                     flake8_comprehensions::rules::unnecessary_literal_within_tuple_call(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C410) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryLiteralWithinListCall)
+                {
                     flake8_comprehensions::rules::unnecessary_literal_within_list_call(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C411) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryListCall) {
                     flake8_comprehensions::rules::unnecessary_list_call(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&RuleCode::C413) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryCallAroundSorted)
+                {
                     flake8_comprehensions::rules::unnecessary_call_around_sorted(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C414) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryDoubleCastOrProcess)
+                {
                     flake8_comprehensions::rules::unnecessary_double_cast_or_process(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C415) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessarySubscriptReversal)
+                {
                     flake8_comprehensions::rules::unnecessary_subscript_reversal(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::C417) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryMap) {
                     flake8_comprehensions::rules::unnecessary_map(self, expr, func, args);
                 }
 
                 // flake8-boolean-trap
-                if self.settings.rules.enabled(&RuleCode::FBT003) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::BooleanPositionalValueInFunctionCall)
+                {
                     flake8_boolean_trap::rules::check_boolean_positional_value_in_function_call(
                         self, args, func,
                     );
@@ -2135,22 +2368,22 @@ where
                 }
 
                 // flake8-debugger
-                if self.settings.rules.enabled(&RuleCode::T100) {
+                if self.settings.rules.enabled(&Rule::Debugger) {
                     flake8_debugger::rules::debugger_call(self, expr, func);
                 }
 
                 // pandas-vet
-                if self.settings.rules.enabled(&RuleCode::PD002) {
+                if self.settings.rules.enabled(&Rule::UseOfInplaceArgument) {
                     self.diagnostics
                         .extend(pandas_vet::rules::inplace_argument(keywords).into_iter());
                 }
                 for (code, name) in vec![
-                    (RuleCode::PD003, "isnull"),
-                    (RuleCode::PD004, "notnull"),
-                    (RuleCode::PD010, "pivot"),
-                    (RuleCode::PD010, "unstack"),
-                    (RuleCode::PD012, "read_table"),
-                    (RuleCode::PD013, "stack"),
+                    (Rule::UseOfDotIsNull, "isnull"),
+                    (Rule::UseOfDotNotNull, "notnull"),
+                    (Rule::UseOfDotPivotOrUnstack, "pivot"),
+                    (Rule::UseOfDotPivotOrUnstack, "unstack"),
+                    (Rule::UseOfDotReadTable, "read_table"),
+                    (Rule::UseOfDotStack, "stack"),
                 ] {
                     if self.settings.rules.enabled(&code) {
                         if let ExprKind::Attribute { value, attr, .. } = &func.node {
@@ -2192,14 +2425,18 @@ where
                         }
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::PD015) {
+                if self.settings.rules.enabled(&Rule::UseOfPdMerge) {
                     if let Some(diagnostic) = pandas_vet::rules::use_of_pd_merge(func) {
                         self.diagnostics.push(diagnostic);
                     };
                 }
 
                 // flake8-datetimez
-                if self.settings.rules.enabled(&RuleCode::DTZ001) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::CallDatetimeWithoutTzinfo)
+                {
                     flake8_datetimez::rules::call_datetime_without_tzinfo(
                         self,
                         func,
@@ -2208,28 +2445,36 @@ where
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ002) {
+                if self.settings.rules.enabled(&Rule::CallDatetimeToday) {
                     flake8_datetimez::rules::call_datetime_today(
                         self,
                         func,
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ003) {
+                if self.settings.rules.enabled(&Rule::CallDatetimeUtcnow) {
                     flake8_datetimez::rules::call_datetime_utcnow(
                         self,
                         func,
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ004) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::CallDatetimeUtcfromtimestamp)
+                {
                     flake8_datetimez::rules::call_datetime_utcfromtimestamp(
                         self,
                         func,
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ005) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::CallDatetimeNowWithoutTzinfo)
+                {
                     flake8_datetimez::rules::call_datetime_now_without_tzinfo(
                         self,
                         func,
@@ -2238,7 +2483,11 @@ where
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ006) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::CallDatetimeFromtimestamp)
+                {
                     flake8_datetimez::rules::call_datetime_fromtimestamp(
                         self,
                         func,
@@ -2247,7 +2496,11 @@ where
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ007) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::CallDatetimeStrptimeWithoutZone)
+                {
                     flake8_datetimez::rules::call_datetime_strptime_without_zone(
                         self,
                         func,
@@ -2255,10 +2508,10 @@ where
                         Range::from_located(expr),
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ011) {
+                if self.settings.rules.enabled(&Rule::CallDateToday) {
                     flake8_datetimez::rules::call_date_today(self, func, Range::from_located(expr));
                 }
-                if self.settings.rules.enabled(&RuleCode::DTZ012) {
+                if self.settings.rules.enabled(&Rule::CallDateFromtimestamp) {
                     flake8_datetimez::rules::call_date_fromtimestamp(
                         self,
                         func,
@@ -2267,30 +2520,34 @@ where
                 }
 
                 // pygrep-hooks
-                if self.settings.rules.enabled(&RuleCode::PGH001) {
+                if self.settings.rules.enabled(&Rule::NoEval) {
                     pygrep_hooks::rules::no_eval(self, func);
                 }
-                if self.settings.rules.enabled(&RuleCode::PGH002) {
+                if self.settings.rules.enabled(&Rule::DeprecatedLogWarn) {
                     pygrep_hooks::rules::deprecated_log_warn(self, func);
                 }
 
                 // pylint
-                if self.settings.rules.enabled(&RuleCode::PLC3002) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnnecessaryDirectLambdaCall)
+                {
                     pylint::rules::unnecessary_direct_lambda_call(self, expr, func);
                 }
-                if self.settings.rules.enabled(&RuleCode::PLR1722) {
+                if self.settings.rules.enabled(&Rule::UseSysExit) {
                     pylint::rules::use_sys_exit(self, func);
                 }
 
                 // flake8-pytest-style
-                if self.settings.rules.enabled(&RuleCode::PT008) {
+                if self.settings.rules.enabled(&Rule::PatchWithLambda) {
                     if let Some(diagnostic) =
                         flake8_pytest_style::rules::patch_with_lambda(func, args, keywords)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::PT009) {
+                if self.settings.rules.enabled(&Rule::UnittestAssertion) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::unittest_assertion(
                         self, expr, func, args, keywords,
                     ) {
@@ -2298,18 +2555,22 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT010)
-                    || self.settings.rules.enabled(&RuleCode::PT011)
+                if self.settings.rules.enabled(&Rule::RaisesWithoutException)
+                    || self.settings.rules.enabled(&Rule::RaisesTooBroad)
                 {
                     flake8_pytest_style::rules::raises_call(self, func, args, keywords);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PT016) {
+                if self.settings.rules.enabled(&Rule::FailWithoutMessage) {
                     flake8_pytest_style::rules::fail_call(self, func, args, keywords);
                 }
 
                 // ruff
-                if self.settings.rules.enabled(&RuleCode::RUF004) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::KeywordArgumentBeforeStarArgument)
+                {
                     self.diagnostics
                         .extend(ruff::rules::keyword_argument_before_star_argument(
                             args, keywords,
@@ -2317,19 +2578,29 @@ where
                 }
 
                 // flake8-simplify
-                if self.settings.rules.enabled(&RuleCode::SIM115) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::OpenFileWithContextHandler)
+                {
                     flake8_simplify::rules::open_file_with_context_handler(self, func);
                 }
             }
             ExprKind::Dict { keys, values } => {
-                if self.settings.rules.enabled(&RuleCode::F601)
-                    || self.settings.rules.enabled(&RuleCode::F602)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::MultiValueRepeatedKeyLiteral)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::MultiValueRepeatedKeyVariable)
                 {
                     pyflakes::rules::repeated_keys(self, keys, values);
                 }
             }
             ExprKind::Yield { .. } => {
-                if self.settings.rules.enabled(&RuleCode::F704) {
+                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
                     let scope = self.current_scope();
                     if matches!(scope.kind, ScopeKind::Class(_) | ScopeKind::Module) {
                         self.diagnostics.push(Diagnostic::new(
@@ -2340,7 +2611,7 @@ where
                 }
             }
             ExprKind::YieldFrom { .. } => {
-                if self.settings.rules.enabled(&RuleCode::F704) {
+                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
                     let scope = self.current_scope();
                     if matches!(scope.kind, ScopeKind::Class(_) | ScopeKind::Module) {
                         self.diagnostics.push(Diagnostic::new(
@@ -2351,7 +2622,7 @@ where
                 }
             }
             ExprKind::Await { .. } => {
-                if self.settings.rules.enabled(&RuleCode::F704) {
+                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
                     let scope = self.current_scope();
                     if matches!(scope.kind, ScopeKind::Class(_) | ScopeKind::Module) {
                         self.diagnostics.push(Diagnostic::new(
@@ -2360,12 +2631,16 @@ where
                         ));
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::PLE1142) {
+                if self.settings.rules.enabled(&Rule::AwaitOutsideAsync) {
                     pylint::rules::await_outside_async(self, expr);
                 }
             }
             ExprKind::JoinedStr { values } => {
-                if self.settings.rules.enabled(&RuleCode::F541) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::FStringMissingPlaceholders)
+                {
                     pyflakes::rules::f_string_missing_placeholders(expr, values, self);
                 }
             }
@@ -2374,7 +2649,7 @@ where
                 op: Operator::RShift,
                 ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::F633) {
+                if self.settings.rules.enabled(&Rule::InvalidPrintSyntax) {
                     pyflakes::rules::invalid_print_syntax(self, left);
                 }
             }
@@ -2388,15 +2663,42 @@ where
                     ..
                 } = &left.node
                 {
-                    if self.settings.rules.enabled(&RuleCode::F501)
-                        || self.settings.rules.enabled(&RuleCode::F502)
-                        || self.settings.rules.enabled(&RuleCode::F503)
-                        || self.settings.rules.enabled(&RuleCode::F504)
-                        || self.settings.rules.enabled(&RuleCode::F505)
-                        || self.settings.rules.enabled(&RuleCode::F506)
-                        || self.settings.rules.enabled(&RuleCode::F507)
-                        || self.settings.rules.enabled(&RuleCode::F508)
-                        || self.settings.rules.enabled(&RuleCode::F509)
+                    if self
+                        .settings
+                        .rules
+                        .enabled(&Rule::PercentFormatInvalidFormat)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatExpectedMapping)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatExpectedSequence)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatExtraNamedArguments)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatMissingArgument)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatMixedPositionalAndNamed)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatPositionalCountMismatch)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatStarRequiresSequence)
+                        || self
+                            .settings
+                            .rules
+                            .enabled(&Rule::PercentFormatUnsupportedFormatCharacter)
                     {
                         let location = Range::from_located(expr);
                         match pyflakes::cformat::CFormatSummary::try_from(value.as_ref()) {
@@ -2404,7 +2706,11 @@ where
                                 typ: CFormatErrorType::UnsupportedFormatChar(c),
                                 ..
                             }) => {
-                                if self.settings.rules.enabled(&RuleCode::F509) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatUnsupportedFormatCharacter)
+                                {
                                     self.diagnostics.push(Diagnostic::new(
                                         violations::PercentFormatUnsupportedFormatCharacter(c),
                                         location,
@@ -2412,7 +2718,11 @@ where
                                 }
                             }
                             Err(e) => {
-                                if self.settings.rules.enabled(&RuleCode::F501) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatInvalidFormat)
+                                {
                                     self.diagnostics.push(Diagnostic::new(
                                         violations::PercentFormatInvalidFormat(e.to_string()),
                                         location,
@@ -2420,37 +2730,65 @@ where
                                 }
                             }
                             Ok(summary) => {
-                                if self.settings.rules.enabled(&RuleCode::F502) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatExpectedMapping)
+                                {
                                     pyflakes::rules::percent_format_expected_mapping(
                                         self, &summary, right, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F503) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatExpectedSequence)
+                                {
                                     pyflakes::rules::percent_format_expected_sequence(
                                         self, &summary, right, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F504) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatExtraNamedArguments)
+                                {
                                     pyflakes::rules::percent_format_extra_named_arguments(
                                         self, &summary, right, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F505) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatMissingArgument)
+                                {
                                     pyflakes::rules::percent_format_missing_arguments(
                                         self, &summary, right, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F506) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatMixedPositionalAndNamed)
+                                {
                                     pyflakes::rules::percent_format_mixed_positional_and_named(
                                         self, &summary, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F507) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatPositionalCountMismatch)
+                                {
                                     pyflakes::rules::percent_format_positional_count_mismatch(
                                         self, &summary, right, location,
                                     );
                                 }
-                                if self.settings.rules.enabled(&RuleCode::F508) {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(&Rule::PercentFormatStarRequiresSequence)
+                                {
                                     pyflakes::rules::percent_format_star_requires_sequence(
                                         self, &summary, right, location,
                                     );
@@ -2463,15 +2801,19 @@ where
             ExprKind::BinOp {
                 op: Operator::Add, ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::ISC003) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ExplicitStringConcatenation)
+                {
                     if let Some(diagnostic) = flake8_implicit_str_concat::rules::explicit(expr) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
             }
             ExprKind::UnaryOp { op, operand } => {
-                let check_not_in = self.settings.rules.enabled(&RuleCode::E713);
-                let check_not_is = self.settings.rules.enabled(&RuleCode::E714);
+                let check_not_in = self.settings.rules.enabled(&Rule::NotInTest);
+                let check_not_is = self.settings.rules.enabled(&Rule::NotIsTest);
                 if check_not_in || check_not_is {
                     pycodestyle::rules::not_tests(
                         self,
@@ -2483,17 +2825,17 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::B002) {
+                if self.settings.rules.enabled(&Rule::UnaryPrefixIncrement) {
                     flake8_bugbear::rules::unary_prefix_increment(self, expr, op, operand);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::SIM201) {
+                if self.settings.rules.enabled(&Rule::NegateEqualOp) {
                     flake8_simplify::rules::negation_with_equal_op(self, expr, op, operand);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM202) {
+                if self.settings.rules.enabled(&Rule::NegateNotEqualOp) {
                     flake8_simplify::rules::negation_with_not_equal_op(self, expr, op, operand);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM208) {
+                if self.settings.rules.enabled(&Rule::DoubleNegation) {
                     flake8_simplify::rules::double_negation(self, expr, op, operand);
                 }
             }
@@ -2502,8 +2844,9 @@ where
                 ops,
                 comparators,
             } => {
-                let check_none_comparisons = self.settings.rules.enabled(&RuleCode::E711);
-                let check_true_false_comparisons = self.settings.rules.enabled(&RuleCode::E712);
+                let check_none_comparisons = self.settings.rules.enabled(&Rule::NoneComparison);
+                let check_true_false_comparisons =
+                    self.settings.rules.enabled(&Rule::TrueFalseComparison);
                 if check_none_comparisons || check_true_false_comparisons {
                     pycodestyle::rules::literal_comparisons(
                         self,
@@ -2516,7 +2859,7 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::F632) {
+                if self.settings.rules.enabled(&Rule::IsLiteral) {
                     pyflakes::rules::invalid_literal_comparison(
                         self,
                         left,
@@ -2526,7 +2869,7 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::E721) {
+                if self.settings.rules.enabled(&Rule::TypeComparison) {
                     self.diagnostics.extend(pycodestyle::rules::type_comparison(
                         ops,
                         comparators,
@@ -2534,16 +2877,22 @@ where
                     ));
                 }
 
-                if self.settings.rules.enabled(&RuleCode::YTT103)
-                    || self.settings.rules.enabled(&RuleCode::YTT201)
-                    || self.settings.rules.enabled(&RuleCode::YTT203)
-                    || self.settings.rules.enabled(&RuleCode::YTT204)
-                    || self.settings.rules.enabled(&RuleCode::YTT302)
+                if self.settings.rules.enabled(&Rule::SysVersionCmpStr3)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SysVersionInfo0Eq3Referenced)
+                    || self.settings.rules.enabled(&Rule::SysVersionInfo1CmpInt)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SysVersionInfoMinorCmpInt)
+                    || self.settings.rules.enabled(&Rule::SysVersionCmpStr10)
                 {
                     flake8_2020::rules::compare(self, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::S105) {
+                if self.settings.rules.enabled(&Rule::HardcodedPasswordString) {
                     self.diagnostics.extend(
                         flake8_bandit::rules::compare_to_hardcoded_password_string(
                             left,
@@ -2552,19 +2901,19 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PLR0133) {
+                if self.settings.rules.enabled(&Rule::ConstantComparison) {
                     pylint::rules::constant_comparison(self, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::PLR2004) {
+                if self.settings.rules.enabled(&Rule::MagicValueComparison) {
                     pylint::rules::magic_value_comparison(self, left, comparators);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::SIM118) {
+                if self.settings.rules.enabled(&Rule::KeyInDict) {
                     flake8_simplify::rules::key_in_dict_compare(self, expr, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&RuleCode::SIM300) {
+                if self.settings.rules.enabled(&Rule::YodaConditions) {
                     flake8_simplify::rules::yoda_conditions(self, expr, left, ops, comparators);
                 }
             }
@@ -2580,7 +2929,11 @@ where
                         (self.scope_stack.clone(), self.parents.clone()),
                     ));
                 }
-                if self.settings.rules.enabled(&RuleCode::S104) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::HardcodedBindAllInterfaces)
+                {
                     if let Some(diagnostic) = flake8_bandit::rules::hardcoded_bind_all_interfaces(
                         value,
                         &Range::from_located(expr),
@@ -2588,7 +2941,7 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::S108) {
+                if self.settings.rules.enabled(&Rule::HardcodedTempFile) {
                     if let Some(diagnostic) = flake8_bandit::rules::hardcoded_tmp_directory(
                         expr,
                         value,
@@ -2597,12 +2950,12 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::UP025) {
+                if self.settings.rules.enabled(&Rule::RewriteUnicodeLiteral) {
                     pyupgrade::rules::rewrite_unicode_literal(self, expr, kind.as_deref());
                 }
             }
             ExprKind::Lambda { args, body, .. } => {
-                if self.settings.rules.enabled(&RuleCode::PIE807) {
+                if self.settings.rules.enabled(&Rule::PreferListBuiltin) {
                     flake8_pie::rules::prefer_list_builtin(self, expr);
                 }
 
@@ -2641,57 +2994,61 @@ where
                 self.push_scope(Scope::new(ScopeKind::Lambda(Lambda { args, body })));
             }
             ExprKind::IfExp { test, body, orelse } => {
-                if self.settings.rules.enabled(&RuleCode::SIM210) {
+                if self.settings.rules.enabled(&Rule::IfExprWithTrueFalse) {
                     flake8_simplify::rules::explicit_true_false_in_ifexpr(
                         self, expr, test, body, orelse,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM211) {
+                if self.settings.rules.enabled(&Rule::IfExprWithFalseTrue) {
                     flake8_simplify::rules::explicit_false_true_in_ifexpr(
                         self, expr, test, body, orelse,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM212) {
+                if self.settings.rules.enabled(&Rule::IfExprWithTwistedArms) {
                     flake8_simplify::rules::twisted_arms_in_ifexpr(self, expr, test, body, orelse);
                 }
             }
             ExprKind::ListComp { elt, generators } | ExprKind::SetComp { elt, generators } => {
-                if self.settings.rules.enabled(&RuleCode::C416) {
+                if self.settings.rules.enabled(&Rule::UnnecessaryComprehension) {
                     flake8_comprehensions::rules::unnecessary_comprehension(
                         self, expr, elt, generators,
                     );
                 }
-                if self.settings.rules.enabled(&RuleCode::B023) {
+                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Expr(expr));
                 }
                 self.push_scope(Scope::new(ScopeKind::Generator));
             }
             ExprKind::GeneratorExp { .. } | ExprKind::DictComp { .. } => {
-                if self.settings.rules.enabled(&RuleCode::B023) {
+                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Expr(expr));
                 }
                 self.push_scope(Scope::new(ScopeKind::Generator));
             }
             ExprKind::BoolOp { op, values } => {
-                if self.settings.rules.enabled(&RuleCode::PLR1701) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ConsiderMergingIsinstance)
+                {
                     pylint::rules::merge_isinstance(self, expr, op, values);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM101) {
+                if self.settings.rules.enabled(&Rule::DuplicateIsinstanceCall) {
                     flake8_simplify::rules::duplicate_isinstance_call(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM109) {
+                if self.settings.rules.enabled(&Rule::CompareWithTuple) {
                     flake8_simplify::rules::compare_with_tuple(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM220) {
+                if self.settings.rules.enabled(&Rule::AAndNotA) {
                     flake8_simplify::rules::a_and_not_a(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM221) {
+                if self.settings.rules.enabled(&Rule::AOrNotA) {
                     flake8_simplify::rules::a_or_not_a(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM222) {
+                if self.settings.rules.enabled(&Rule::OrTrue) {
                     flake8_simplify::rules::or_true(self, expr);
                 }
-                if self.settings.rules.enabled(&RuleCode::SIM223) {
+                if self.settings.rules.enabled(&Rule::AndFalse) {
                     flake8_simplify::rules::and_false(self, expr);
                 }
             }
@@ -2953,7 +3310,7 @@ where
             ExcepthandlerKind::ExceptHandler {
                 type_, name, body, ..
             } => {
-                if self.settings.rules.enabled(&RuleCode::E722) {
+                if self.settings.rules.enabled(&Rule::DoNotUseBareExcept) {
                     if let Some(diagnostic) = pycodestyle::rules::do_not_use_bare_except(
                         type_.as_deref(),
                         body,
@@ -2963,10 +3320,14 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&RuleCode::B904) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::RaiseWithoutFromInsideExcept)
+                {
                     flake8_bugbear::rules::raise_without_from_inside_except(self, body);
                 }
-                if self.settings.rules.enabled(&RuleCode::BLE001) {
+                if self.settings.rules.enabled(&Rule::BlindExcept) {
                     flake8_blind_except::rules::blind_except(
                         self,
                         type_.as_deref(),
@@ -2976,7 +3337,7 @@ where
                 }
                 match name {
                     Some(name) => {
-                        if self.settings.rules.enabled(&RuleCode::E741) {
+                        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
                             if let Some(diagnostic) = pycodestyle::rules::ambiguous_variable_name(
                                 name,
                                 helpers::excepthandler_name_range(excepthandler, self.locator)
@@ -3026,12 +3387,12 @@ where
                             &scope.values.remove(&name.as_str())
                         } {
                             if self.bindings[*index].used.is_none() {
-                                if self.settings.rules.enabled(&RuleCode::F841) {
+                                if self.settings.rules.enabled(&Rule::UnusedVariable) {
                                     let mut diagnostic = Diagnostic::new(
                                         violations::UnusedVariable(name.to_string()),
                                         name_range,
                                     );
-                                    if self.patch(&RuleCode::F841) {
+                                    if self.patch(&Rule::UnusedVariable) {
                                         match pyflakes::fixes::remove_exception_handler_assignment(
                                             excepthandler,
                                             self.locator,
@@ -3077,7 +3438,7 @@ where
     }
 
     fn visit_comprehension(&mut self, comprehension: &'b Comprehension) {
-        if self.settings.rules.enabled(&RuleCode::SIM118) {
+        if self.settings.rules.enabled(&Rule::KeyInDict) {
             flake8_simplify::rules::key_in_dict_for(
                 self,
                 &comprehension.target,
@@ -3088,18 +3449,30 @@ where
     }
 
     fn visit_arguments(&mut self, arguments: &'b Arguments) {
-        if self.settings.rules.enabled(&RuleCode::B006) {
+        if self.settings.rules.enabled(&Rule::MutableArgumentDefault) {
             flake8_bugbear::rules::mutable_argument_default(self, arguments);
         }
-        if self.settings.rules.enabled(&RuleCode::B008) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::FunctionCallArgumentDefault)
+        {
             flake8_bugbear::rules::function_call_argument_default(self, arguments);
         }
 
         // flake8-boolean-trap
-        if self.settings.rules.enabled(&RuleCode::FBT001) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::BooleanPositionalArgInFunctionDefinition)
+        {
             flake8_boolean_trap::rules::check_positional_boolean_in_def(self, arguments);
         }
-        if self.settings.rules.enabled(&RuleCode::FBT002) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::BooleanDefaultValueInFunctionDefinition)
+        {
             flake8_boolean_trap::rules::check_boolean_default_value_in_function_definition(
                 self, arguments,
             );
@@ -3137,7 +3510,7 @@ where
             },
         );
 
-        if self.settings.rules.enabled(&RuleCode::E741) {
+        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
             if let Some(diagnostic) =
                 pycodestyle::rules::ambiguous_variable_name(&arg.node.arg, Range::from_located(arg))
             {
@@ -3145,7 +3518,7 @@ where
             }
         }
 
-        if self.settings.rules.enabled(&RuleCode::N803) {
+        if self.settings.rules.enabled(&Rule::InvalidArgumentName) {
             if let Some(diagnostic) = pep8_naming::rules::invalid_argument_name(&arg.node.arg, arg)
             {
                 self.diagnostics.push(diagnostic);
@@ -3156,12 +3529,12 @@ where
     }
 
     fn visit_body(&mut self, body: &'b [Stmt]) {
-        if self.settings.rules.enabled(&RuleCode::PIE790) {
+        if self.settings.rules.enabled(&Rule::NoUnnecessaryPass) {
             flake8_pie::rules::no_unnecessary_pass(self, body);
         }
 
-        if self.settings.rules.enabled(&RuleCode::SIM110)
-            || self.settings.rules.enabled(&RuleCode::SIM111)
+        if self.settings.rules.enabled(&Rule::ConvertLoopToAny)
+            || self.settings.rules.enabled(&Rule::ConvertLoopToAll)
         {
             for (stmt, sibling) in body.iter().tuple_windows() {
                 if matches!(stmt.node, StmtKind::For { .. })
@@ -3307,7 +3680,7 @@ impl<'a> Checker<'a> {
                 );
                 if matches!(binding.kind, BindingKind::LoopVar) && existing_is_import {
                     overridden = Some((*scope_index, *existing_binding_index));
-                    if self.settings.rules.enabled(&RuleCode::F402) {
+                    if self.settings.rules.enabled(&Rule::ImportShadowedByLoopVar) {
                         self.diagnostics.push(Diagnostic::new(
                             violations::ImportShadowedByLoopVar(
                                 name.to_string(),
@@ -3327,7 +3700,7 @@ impl<'a> Checker<'a> {
                             ))
                     {
                         overridden = Some((*scope_index, *existing_binding_index));
-                        if self.settings.rules.enabled(&RuleCode::F811) {
+                        if self.settings.rules.enabled(&Rule::RedefinedWhileUnused) {
                             self.diagnostics.push(Diagnostic::new(
                                 violations::RedefinedWhileUnused(
                                     name.to_string(),
@@ -3453,7 +3826,7 @@ impl<'a> Checker<'a> {
             }
 
             if import_starred {
-                if self.settings.rules.enabled(&RuleCode::F405) {
+                if self.settings.rules.enabled(&Rule::ImportStarUsage) {
                     let mut from_list = vec![];
                     for scope_index in self.scope_stack.iter().rev() {
                         let scope = &self.scopes[*scope_index];
@@ -3476,7 +3849,7 @@ impl<'a> Checker<'a> {
                 return;
             }
 
-            if self.settings.rules.enabled(&RuleCode::F821) {
+            if self.settings.rules.enabled(&Rule::UndefinedName) {
                 // Allow __path__.
                 if self.path.ends_with("__init__.py") && id == "__path__" {
                     return;
@@ -3513,7 +3886,7 @@ impl<'a> Checker<'a> {
     {
         let parent = self.current_stmt().0;
 
-        if self.settings.rules.enabled(&RuleCode::F823) {
+        if self.settings.rules.enabled(&Rule::UndefinedLocal) {
             let scopes: Vec<&Scope> = self
                 .scope_stack
                 .iter()
@@ -3525,7 +3898,11 @@ impl<'a> Checker<'a> {
             }
         }
 
-        if self.settings.rules.enabled(&RuleCode::N806) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::NonLowercaseVariableInFunction)
+        {
             if matches!(self.current_scope().kind, ScopeKind::Function(..)) {
                 // Ignore globals.
                 if !self.current_scope().values.get(id).map_or(false, |index| {
@@ -3536,13 +3913,21 @@ impl<'a> Checker<'a> {
             }
         }
 
-        if self.settings.rules.enabled(&RuleCode::N815) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::MixedCaseVariableInClassScope)
+        {
             if matches!(self.current_scope().kind, ScopeKind::Class(..)) {
                 pep8_naming::rules::mixed_case_variable_in_class_scope(self, expr, parent, id);
             }
         }
 
-        if self.settings.rules.enabled(&RuleCode::N816) {
+        if self
+            .settings
+            .rules
+            .enabled(&Rule::MixedCaseVariableInGlobalScope)
+        {
             if matches!(self.current_scope().kind, ScopeKind::Module) {
                 pep8_naming::rules::mixed_case_variable_in_global_scope(self, expr, parent, id);
             }
@@ -3667,7 +4052,7 @@ impl<'a> Checker<'a> {
             let scope =
                 &mut self.scopes[*(self.scope_stack.last().expect("No current scope found"))];
             if scope.values.remove(&id.as_str()).is_none()
-                && self.settings.rules.enabled(&RuleCode::F821)
+                && self.settings.rules.enabled(&Rule::UndefinedName)
             {
                 self.diagnostics.push(Diagnostic::new(
                     violations::UndefinedName(id.to_string()),
@@ -3681,7 +4066,7 @@ impl<'a> Checker<'a> {
     where
         'b: 'a,
     {
-        if self.settings.rules.enabled(&RuleCode::B021) {
+        if self.settings.rules.enabled(&Rule::FStringDocstring) {
             flake8_bugbear::rules::f_string_docstring(self, python_ast);
         }
         let docstring = docstrings::extraction::docstring_from(python_ast);
@@ -3730,7 +4115,11 @@ impl<'a> Checker<'a> {
                 allocator.push(expr);
                 stacks.push((in_annotation, context));
             } else {
-                if self.settings.rules.enabled(&RuleCode::F722) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::ForwardAnnotationSyntaxError)
+                {
                     self.diagnostics.push(Diagnostic::new(
                         violations::ForwardAnnotationSyntaxError(expression.to_string()),
                         range,
@@ -3792,17 +4181,23 @@ impl<'a> Checker<'a> {
         while let Some((scopes, _parents)) = self.deferred_assignments.pop() {
             let scope_index = scopes[scopes.len() - 1];
             let parent_scope_index = scopes[scopes.len() - 2];
-            if self.settings.rules.enabled(&RuleCode::F841) {
+            if self.settings.rules.enabled(&Rule::UnusedVariable) {
                 pyflakes::rules::unused_variable(self, scope_index);
             }
-            if self.settings.rules.enabled(&RuleCode::F842) {
+            if self.settings.rules.enabled(&Rule::UnusedAnnotation) {
                 pyflakes::rules::unused_annotation(self, scope_index);
             }
-            if self.settings.rules.enabled(&RuleCode::ARG001)
-                || self.settings.rules.enabled(&RuleCode::ARG002)
-                || self.settings.rules.enabled(&RuleCode::ARG003)
-                || self.settings.rules.enabled(&RuleCode::ARG004)
-                || self.settings.rules.enabled(&RuleCode::ARG005)
+            if self.settings.rules.enabled(&Rule::UnusedFunctionArgument)
+                || self.settings.rules.enabled(&Rule::UnusedMethodArgument)
+                || self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnusedClassMethodArgument)
+                || self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UnusedStaticMethodArgument)
+                || self.settings.rules.enabled(&Rule::UnusedLambdaArgument)
             {
                 self.diagnostics
                     .extend(flake8_unused_arguments::rules::unused_arguments(
@@ -3816,11 +4211,14 @@ impl<'a> Checker<'a> {
     }
 
     fn check_dead_scopes(&mut self) {
-        if !self.settings.rules.enabled(&RuleCode::F401)
-            && !self.settings.rules.enabled(&RuleCode::F405)
-            && !self.settings.rules.enabled(&RuleCode::F811)
-            && !self.settings.rules.enabled(&RuleCode::F822)
-            && !self.settings.rules.enabled(&RuleCode::PLW0602)
+        if !self.settings.rules.enabled(&Rule::UnusedImport)
+            && !self.settings.rules.enabled(&Rule::ImportStarUsage)
+            && !self.settings.rules.enabled(&Rule::RedefinedWhileUnused)
+            && !self.settings.rules.enabled(&Rule::UndefinedExport)
+            && !self
+                .settings
+                .rules
+                .enabled(&Rule::GlobalVariableNotAssigned)
         {
             return;
         }
@@ -3833,7 +4231,11 @@ impl<'a> Checker<'a> {
             .map(|index| &self.scopes[*index])
         {
             // PLW0602
-            if self.settings.rules.enabled(&RuleCode::PLW0602) {
+            if self
+                .settings
+                .rules
+                .enabled(&Rule::GlobalVariableNotAssigned)
+            {
                 for (name, index) in &scope.values {
                     let binding = &self.bindings[*index];
                     if matches!(binding.kind, BindingKind::Global) {
@@ -3860,7 +4262,7 @@ impl<'a> Checker<'a> {
                     _ => None,
                 });
 
-            if self.settings.rules.enabled(&RuleCode::F822) {
+            if self.settings.rules.enabled(&Rule::UndefinedExport) {
                 if !scope.import_starred && !self.path.ends_with("__init__.py") {
                     if let Some(all_binding) = all_binding {
                         if let Some(names) = &all_names {
@@ -3880,7 +4282,7 @@ impl<'a> Checker<'a> {
             // Look for any bindings that were redefined in another scope, and remain
             // unused. Note that we only store references in `redefinitions` if
             // the bindings are in different scopes.
-            if self.settings.rules.enabled(&RuleCode::F811) {
+            if self.settings.rules.enabled(&Rule::RedefinedWhileUnused) {
                 for (name, index) in &scope.values {
                     let binding = &self.bindings[*index];
 
@@ -3917,7 +4319,7 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            if self.settings.rules.enabled(&RuleCode::F405) {
+            if self.settings.rules.enabled(&Rule::ImportStarUsage) {
                 if scope.import_starred {
                     if let Some(all_binding) = all_binding {
                         if let Some(names) = &all_names {
@@ -3949,7 +4351,7 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            if self.settings.rules.enabled(&RuleCode::F401) {
+            if self.settings.rules.enabled(&Rule::UnusedImport) {
                 // Collect all unused imports by location. (Multiple unused imports at the same
                 // location indicates an `import from`.)
                 type UnusedImport<'a> = (&'a str, &'a Range);
@@ -3997,9 +4399,9 @@ impl<'a> Checker<'a> {
                         None
                     };
 
-                    if self.is_ignored(&RuleCode::F401, diagnostic_lineno)
+                    if self.is_ignored(&Rule::UnusedImport, diagnostic_lineno)
                         || parent_lineno.map_or(false, |parent_lineno| {
-                            self.is_ignored(&RuleCode::F401, parent_lineno)
+                            self.is_ignored(&Rule::UnusedImport, parent_lineno)
                         })
                     {
                         ignored
@@ -4023,7 +4425,7 @@ impl<'a> Checker<'a> {
                     let child: &Stmt = defined_by.into();
                     let parent: Option<&Stmt> = defined_in.map(std::convert::Into::into);
 
-                    let fix = if !ignore_init && self.patch(&RuleCode::F401) {
+                    let fix = if !ignore_init && self.patch(&Rule::UnusedImport) {
                         let deleted: Vec<&Stmt> = self
                             .deletions
                             .iter()
@@ -4094,62 +4496,116 @@ impl<'a> Checker<'a> {
     }
 
     fn check_definitions(&mut self) {
-        let enforce_annotations = self.settings.rules.enabled(&RuleCode::ANN001)
-            || self.settings.rules.enabled(&RuleCode::ANN002)
-            || self.settings.rules.enabled(&RuleCode::ANN003)
-            || self.settings.rules.enabled(&RuleCode::ANN101)
-            || self.settings.rules.enabled(&RuleCode::ANN102)
-            || self.settings.rules.enabled(&RuleCode::ANN201)
-            || self.settings.rules.enabled(&RuleCode::ANN202)
-            || self.settings.rules.enabled(&RuleCode::ANN204)
-            || self.settings.rules.enabled(&RuleCode::ANN205)
-            || self.settings.rules.enabled(&RuleCode::ANN206)
-            || self.settings.rules.enabled(&RuleCode::ANN401);
-        let enforce_docstrings = self.settings.rules.enabled(&RuleCode::D100)
-            || self.settings.rules.enabled(&RuleCode::D101)
-            || self.settings.rules.enabled(&RuleCode::D102)
-            || self.settings.rules.enabled(&RuleCode::D103)
-            || self.settings.rules.enabled(&RuleCode::D104)
-            || self.settings.rules.enabled(&RuleCode::D105)
-            || self.settings.rules.enabled(&RuleCode::D106)
-            || self.settings.rules.enabled(&RuleCode::D107)
-            || self.settings.rules.enabled(&RuleCode::D200)
-            || self.settings.rules.enabled(&RuleCode::D201)
-            || self.settings.rules.enabled(&RuleCode::D202)
-            || self.settings.rules.enabled(&RuleCode::D203)
-            || self.settings.rules.enabled(&RuleCode::D204)
-            || self.settings.rules.enabled(&RuleCode::D205)
-            || self.settings.rules.enabled(&RuleCode::D206)
-            || self.settings.rules.enabled(&RuleCode::D207)
-            || self.settings.rules.enabled(&RuleCode::D208)
-            || self.settings.rules.enabled(&RuleCode::D209)
-            || self.settings.rules.enabled(&RuleCode::D210)
-            || self.settings.rules.enabled(&RuleCode::D211)
-            || self.settings.rules.enabled(&RuleCode::D212)
-            || self.settings.rules.enabled(&RuleCode::D213)
-            || self.settings.rules.enabled(&RuleCode::D214)
-            || self.settings.rules.enabled(&RuleCode::D215)
-            || self.settings.rules.enabled(&RuleCode::D300)
-            || self.settings.rules.enabled(&RuleCode::D301)
-            || self.settings.rules.enabled(&RuleCode::D400)
-            || self.settings.rules.enabled(&RuleCode::D402)
-            || self.settings.rules.enabled(&RuleCode::D403)
-            || self.settings.rules.enabled(&RuleCode::D404)
-            || self.settings.rules.enabled(&RuleCode::D405)
-            || self.settings.rules.enabled(&RuleCode::D406)
-            || self.settings.rules.enabled(&RuleCode::D407)
-            || self.settings.rules.enabled(&RuleCode::D408)
-            || self.settings.rules.enabled(&RuleCode::D409)
-            || self.settings.rules.enabled(&RuleCode::D410)
-            || self.settings.rules.enabled(&RuleCode::D411)
-            || self.settings.rules.enabled(&RuleCode::D412)
-            || self.settings.rules.enabled(&RuleCode::D413)
-            || self.settings.rules.enabled(&RuleCode::D414)
-            || self.settings.rules.enabled(&RuleCode::D415)
-            || self.settings.rules.enabled(&RuleCode::D416)
-            || self.settings.rules.enabled(&RuleCode::D417)
-            || self.settings.rules.enabled(&RuleCode::D418)
-            || self.settings.rules.enabled(&RuleCode::D419);
+        let enforce_annotations = self
+            .settings
+            .rules
+            .enabled(&Rule::MissingTypeFunctionArgument)
+            || self.settings.rules.enabled(&Rule::MissingTypeArgs)
+            || self.settings.rules.enabled(&Rule::MissingTypeKwargs)
+            || self.settings.rules.enabled(&Rule::MissingTypeSelf)
+            || self.settings.rules.enabled(&Rule::MissingTypeCls)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MissingReturnTypePublicFunction)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MissingReturnTypePrivateFunction)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MissingReturnTypeSpecialMethod)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MissingReturnTypeStaticMethod)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MissingReturnTypeClassMethod)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::DynamicallyTypedExpression);
+        let enforce_docstrings = self.settings.rules.enabled(&Rule::PublicModule)
+            || self.settings.rules.enabled(&Rule::PublicClass)
+            || self.settings.rules.enabled(&Rule::PublicMethod)
+            || self.settings.rules.enabled(&Rule::PublicFunction)
+            || self.settings.rules.enabled(&Rule::PublicPackage)
+            || self.settings.rules.enabled(&Rule::MagicMethod)
+            || self.settings.rules.enabled(&Rule::PublicNestedClass)
+            || self.settings.rules.enabled(&Rule::PublicInit)
+            || self.settings.rules.enabled(&Rule::FitsOnOneLine)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::NoBlankLineBeforeFunction)
+            || self.settings.rules.enabled(&Rule::NoBlankLineAfterFunction)
+            || self.settings.rules.enabled(&Rule::OneBlankLineBeforeClass)
+            || self.settings.rules.enabled(&Rule::OneBlankLineAfterClass)
+            || self.settings.rules.enabled(&Rule::BlankLineAfterSummary)
+            || self.settings.rules.enabled(&Rule::IndentWithSpaces)
+            || self.settings.rules.enabled(&Rule::NoUnderIndentation)
+            || self.settings.rules.enabled(&Rule::NoOverIndentation)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::NewLineAfterLastParagraph)
+            || self.settings.rules.enabled(&Rule::NoSurroundingWhitespace)
+            || self.settings.rules.enabled(&Rule::NoBlankLineBeforeClass)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MultiLineSummaryFirstLine)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::MultiLineSummarySecondLine)
+            || self.settings.rules.enabled(&Rule::SectionNotOverIndented)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::SectionUnderlineNotOverIndented)
+            || self.settings.rules.enabled(&Rule::UsesTripleQuotes)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::UsesRPrefixForBackslashedContent)
+            || self.settings.rules.enabled(&Rule::EndsInPeriod)
+            || self.settings.rules.enabled(&Rule::NoSignature)
+            || self.settings.rules.enabled(&Rule::FirstLineCapitalized)
+            || self.settings.rules.enabled(&Rule::NoThisPrefix)
+            || self.settings.rules.enabled(&Rule::CapitalizeSectionName)
+            || self.settings.rules.enabled(&Rule::NewLineAfterSectionName)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::DashedUnderlineAfterSection)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::SectionUnderlineAfterName)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::SectionUnderlineMatchesSectionLength)
+            || self.settings.rules.enabled(&Rule::BlankLineAfterSection)
+            || self.settings.rules.enabled(&Rule::BlankLineBeforeSection)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
+            || self
+                .settings
+                .rules
+                .enabled(&Rule::BlankLineAfterLastSection)
+            || self.settings.rules.enabled(&Rule::NonEmptySection)
+            || self.settings.rules.enabled(&Rule::EndsInPunctuation)
+            || self.settings.rules.enabled(&Rule::SectionNameEndsInColon)
+            || self.settings.rules.enabled(&Rule::DocumentAllArguments)
+            || self.settings.rules.enabled(&Rule::SkipDocstring)
+            || self.settings.rules.enabled(&Rule::NonEmpty);
 
         let mut overloaded_name: Option<String> = None;
         self.definitions.reverse();
@@ -4205,79 +4661,117 @@ impl<'a> Checker<'a> {
                     continue;
                 }
 
-                if self.settings.rules.enabled(&RuleCode::D200) {
+                if self.settings.rules.enabled(&Rule::FitsOnOneLine) {
                     pydocstyle::rules::one_liner(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D201)
-                    || self.settings.rules.enabled(&RuleCode::D202)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::NoBlankLineBeforeFunction)
+                    || self.settings.rules.enabled(&Rule::NoBlankLineAfterFunction)
                 {
                     pydocstyle::rules::blank_before_after_function(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D203)
-                    || self.settings.rules.enabled(&RuleCode::D204)
-                    || self.settings.rules.enabled(&RuleCode::D211)
+                if self.settings.rules.enabled(&Rule::OneBlankLineBeforeClass)
+                    || self.settings.rules.enabled(&Rule::OneBlankLineAfterClass)
+                    || self.settings.rules.enabled(&Rule::NoBlankLineBeforeClass)
                 {
                     pydocstyle::rules::blank_before_after_class(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D205) {
+                if self.settings.rules.enabled(&Rule::BlankLineAfterSummary) {
                     pydocstyle::rules::blank_after_summary(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D206)
-                    || self.settings.rules.enabled(&RuleCode::D207)
-                    || self.settings.rules.enabled(&RuleCode::D208)
+                if self.settings.rules.enabled(&Rule::IndentWithSpaces)
+                    || self.settings.rules.enabled(&Rule::NoUnderIndentation)
+                    || self.settings.rules.enabled(&Rule::NoOverIndentation)
                 {
                     pydocstyle::rules::indent(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D209) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::NewLineAfterLastParagraph)
+                {
                     pydocstyle::rules::newline_after_last_paragraph(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D210) {
+                if self.settings.rules.enabled(&Rule::NoSurroundingWhitespace) {
                     pydocstyle::rules::no_surrounding_whitespace(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D212)
-                    || self.settings.rules.enabled(&RuleCode::D213)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::MultiLineSummaryFirstLine)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::MultiLineSummarySecondLine)
                 {
                     pydocstyle::rules::multi_line_summary_start(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D300) {
+                if self.settings.rules.enabled(&Rule::UsesTripleQuotes) {
                     pydocstyle::rules::triple_quotes(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D301) {
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::UsesRPrefixForBackslashedContent)
+                {
                     pydocstyle::rules::backslashes(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D400) {
+                if self.settings.rules.enabled(&Rule::EndsInPeriod) {
                     pydocstyle::rules::ends_with_period(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D402) {
+                if self.settings.rules.enabled(&Rule::NoSignature) {
                     pydocstyle::rules::no_signature(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D403) {
+                if self.settings.rules.enabled(&Rule::FirstLineCapitalized) {
                     pydocstyle::rules::capitalized(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D404) {
+                if self.settings.rules.enabled(&Rule::NoThisPrefix) {
                     pydocstyle::rules::starts_with_this(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D415) {
+                if self.settings.rules.enabled(&Rule::EndsInPunctuation) {
                     pydocstyle::rules::ends_with_punctuation(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D418) {
+                if self.settings.rules.enabled(&Rule::SkipDocstring) {
                     pydocstyle::rules::if_needed(self, &docstring);
                 }
-                if self.settings.rules.enabled(&RuleCode::D212)
-                    || self.settings.rules.enabled(&RuleCode::D214)
-                    || self.settings.rules.enabled(&RuleCode::D215)
-                    || self.settings.rules.enabled(&RuleCode::D405)
-                    || self.settings.rules.enabled(&RuleCode::D406)
-                    || self.settings.rules.enabled(&RuleCode::D407)
-                    || self.settings.rules.enabled(&RuleCode::D408)
-                    || self.settings.rules.enabled(&RuleCode::D409)
-                    || self.settings.rules.enabled(&RuleCode::D410)
-                    || self.settings.rules.enabled(&RuleCode::D411)
-                    || self.settings.rules.enabled(&RuleCode::D412)
-                    || self.settings.rules.enabled(&RuleCode::D413)
-                    || self.settings.rules.enabled(&RuleCode::D414)
-                    || self.settings.rules.enabled(&RuleCode::D416)
-                    || self.settings.rules.enabled(&RuleCode::D417)
+                if self
+                    .settings
+                    .rules
+                    .enabled(&Rule::MultiLineSummaryFirstLine)
+                    || self.settings.rules.enabled(&Rule::SectionNotOverIndented)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SectionUnderlineNotOverIndented)
+                    || self.settings.rules.enabled(&Rule::CapitalizeSectionName)
+                    || self.settings.rules.enabled(&Rule::NewLineAfterSectionName)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::DashedUnderlineAfterSection)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SectionUnderlineAfterName)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::SectionUnderlineMatchesSectionLength)
+                    || self.settings.rules.enabled(&Rule::BlankLineAfterSection)
+                    || self.settings.rules.enabled(&Rule::BlankLineBeforeSection)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
+                    || self
+                        .settings
+                        .rules
+                        .enabled(&Rule::BlankLineAfterLastSection)
+                    || self.settings.rules.enabled(&Rule::NonEmptySection)
+                    || self.settings.rules.enabled(&Rule::SectionNameEndsInColon)
+                    || self.settings.rules.enabled(&Rule::DocumentAllArguments)
                 {
                     pydocstyle::rules::sections(
                         self,
@@ -4291,7 +4785,11 @@ impl<'a> Checker<'a> {
 
     fn check_builtin_shadowing<T>(&mut self, name: &str, located: &Located<T>, is_attribute: bool) {
         if is_attribute && matches!(self.current_scope().kind, ScopeKind::Class(_)) {
-            if self.settings.rules.enabled(&RuleCode::A003) {
+            if self
+                .settings
+                .rules
+                .enabled(&Rule::BuiltinAttributeShadowing)
+            {
                 if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                     name,
                     located,
@@ -4301,7 +4799,7 @@ impl<'a> Checker<'a> {
                 }
             }
         } else {
-            if self.settings.rules.enabled(&RuleCode::A001) {
+            if self.settings.rules.enabled(&Rule::BuiltinVariableShadowing) {
                 if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                     name,
                     located,
@@ -4314,7 +4812,7 @@ impl<'a> Checker<'a> {
     }
 
     fn check_builtin_arg_shadowing(&mut self, name: &str, arg: &Arg) {
-        if self.settings.rules.enabled(&RuleCode::A002) {
+        if self.settings.rules.enabled(&Rule::BuiltinArgumentShadowing) {
             if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                 name,
                 arg,

--- a/src/checkers/filesystem.rs
+++ b/src/checkers/filesystem.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::flake8_no_pep420::rules::implicit_namespace_package;
 use crate::settings::Settings;
 
@@ -8,7 +8,7 @@ pub fn check_file_path(path: &Path, settings: &Settings) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
     // flake8-no-pep420
-    if settings.rules.enabled(&RuleCode::INP001) {
+    if settings.rules.enabled(&Rule::ImplicitNamespacePackage) {
         if let Some(diagnostic) = implicit_namespace_package(path) {
             diagnostics.push(diagnostic);
         }

--- a/src/checkers/imports.rs
+++ b/src/checkers/imports.rs
@@ -6,7 +6,7 @@ use rustpython_parser::ast::Suite;
 
 use crate::ast::visitor::Visitor;
 use crate::directives::IsortDirectives;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::isort;
 use crate::rules::isort::track::{Block, ImportTracker};
 use crate::settings::{flags, Settings};
@@ -36,7 +36,7 @@ pub fn check_imports(
 
     // Enforce import rules.
     let mut diagnostics = vec![];
-    if settings.rules.enabled(&RuleCode::I001) {
+    if settings.rules.enabled(&Rule::UnsortedImports) {
         for block in &blocks {
             if !block.imports.is_empty() {
                 if let Some(diagnostic) = isort::rules::organize_imports(
@@ -47,7 +47,7 @@ pub fn check_imports(
             }
         }
     }
-    if settings.rules.enabled(&RuleCode::I002) {
+    if settings.rules.enabled(&Rule::MissingRequiredImport) {
         diagnostics.extend(isort::rules::add_required_imports(
             &blocks, python_ast, locator, settings, autofix,
         ));

--- a/src/checkers/lines.rs
+++ b/src/checkers/lines.rs
@@ -1,6 +1,6 @@
 //! Lint rules based on checking raw physical lines.
 
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::pycodestyle::rules::{
     doc_line_too_long, line_too_long, no_newline_at_end_of_file,
 };
@@ -17,12 +17,14 @@ pub fn check_lines(
 ) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
-    let enforce_blanket_noqa = settings.rules.enabled(&RuleCode::PGH004);
-    let enforce_blanket_type_ignore = settings.rules.enabled(&RuleCode::PGH003);
-    let enforce_doc_line_too_long = settings.rules.enabled(&RuleCode::W505);
-    let enforce_line_too_long = settings.rules.enabled(&RuleCode::E501);
-    let enforce_no_newline_at_end_of_file = settings.rules.enabled(&RuleCode::W292);
-    let enforce_unnecessary_coding_comment = settings.rules.enabled(&RuleCode::UP009);
+    let enforce_blanket_noqa = settings.rules.enabled(&Rule::BlanketNOQA);
+    let enforce_blanket_type_ignore = settings.rules.enabled(&Rule::BlanketTypeIgnore);
+    let enforce_doc_line_too_long = settings.rules.enabled(&Rule::DocLineTooLong);
+    let enforce_line_too_long = settings.rules.enabled(&Rule::LineTooLong);
+    let enforce_no_newline_at_end_of_file = settings.rules.enabled(&Rule::NoNewLineAtEndOfFile);
+    let enforce_unnecessary_coding_comment = settings
+        .rules
+        .enabled(&Rule::PEP3120UnnecessaryCodingComment);
 
     let mut commented_lines_iter = commented_lines.iter().peekable();
     let mut doc_lines_iter = doc_lines.iter().peekable();
@@ -37,7 +39,9 @@ pub fn check_lines(
                         index,
                         line,
                         matches!(autofix, flags::Autofix::Enabled)
-                            && settings.rules.should_fix(&RuleCode::UP009),
+                            && settings
+                                .rules
+                                .should_fix(&Rule::PEP3120UnnecessaryCodingComment),
                     ) {
                         diagnostics.push(diagnostic);
                     }
@@ -79,7 +83,7 @@ pub fn check_lines(
         if let Some(diagnostic) = no_newline_at_end_of_file(
             contents,
             matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(&RuleCode::W292),
+                && settings.rules.should_fix(&Rule::NoNewLineAtEndOfFile),
         ) {
             diagnostics.push(diagnostic);
         }
@@ -92,7 +96,7 @@ pub fn check_lines(
 mod tests {
 
     use super::check_lines;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::{flags, Settings};
 
     #[test]
@@ -105,7 +109,7 @@ mod tests {
                 &[],
                 &Settings {
                     line_length,
-                    ..Settings::for_rule(RuleCode::E501)
+                    ..Settings::for_rule(Rule::LineTooLong)
                 },
                 flags::Autofix::Enabled,
             )

--- a/src/checkers/noqa.rs
+++ b/src/checkers/noqa.rs
@@ -56,13 +56,13 @@ pub fn check_noqa(
                 });
                 match noqa {
                     (Directive::All(..), matches) => {
-                        matches.push(diagnostic.kind.rule().as_ref());
+                        matches.push(diagnostic.kind.rule().code());
                         ignored.push(index);
                         continue;
                     }
                     (Directive::Codes(.., codes), matches) => {
                         if noqa::includes(diagnostic.kind.rule(), codes) {
-                            matches.push(diagnostic.kind.rule().as_ref());
+                            matches.push(diagnostic.kind.rule().code());
                             ignored.push(index);
                             continue;
                         }
@@ -83,12 +83,12 @@ pub fn check_noqa(
                 .or_insert_with(|| (noqa::extract_noqa_directive(lines[noqa_lineno - 1]), vec![]));
             match noqa {
                 (Directive::All(..), matches) => {
-                    matches.push(diagnostic.kind.rule().as_ref());
+                    matches.push(diagnostic.kind.rule().code());
                     ignored.push(index);
                 }
                 (Directive::Codes(.., codes), matches) => {
                     if noqa::includes(diagnostic.kind.rule(), codes) {
-                        matches.push(diagnostic.kind.rule().as_ref());
+                        matches.push(diagnostic.kind.rule().code());
                         ignored.push(index);
                     }
                 }
@@ -125,8 +125,8 @@ pub fn check_noqa(
                     let mut valid_codes = vec![];
                     let mut self_ignore = false;
                     for code in codes {
-                        let code = CODE_REDIRECTS.get(code).map_or(code, AsRef::as_ref);
-                        if code == RuleCode::RUF100.as_ref() {
+                        let code = CODE_REDIRECTS.get(code).map_or(code, |r| r.code());
+                        if code == RuleCode::RUF100.code() {
                             self_ignore = true;
                             break;
                         }

--- a/src/checkers/noqa.rs
+++ b/src/checkers/noqa.rs
@@ -56,13 +56,13 @@ pub fn check_noqa(
                 });
                 match noqa {
                     (Directive::All(..), matches) => {
-                        matches.push(diagnostic.kind.code().as_ref());
+                        matches.push(diagnostic.kind.rule().as_ref());
                         ignored.push(index);
                         continue;
                     }
                     (Directive::Codes(.., codes), matches) => {
-                        if noqa::includes(diagnostic.kind.code(), codes) {
-                            matches.push(diagnostic.kind.code().as_ref());
+                        if noqa::includes(diagnostic.kind.rule(), codes) {
+                            matches.push(diagnostic.kind.rule().as_ref());
                             ignored.push(index);
                             continue;
                         }
@@ -83,12 +83,12 @@ pub fn check_noqa(
                 .or_insert_with(|| (noqa::extract_noqa_directive(lines[noqa_lineno - 1]), vec![]));
             match noqa {
                 (Directive::All(..), matches) => {
-                    matches.push(diagnostic.kind.code().as_ref());
+                    matches.push(diagnostic.kind.rule().as_ref());
                     ignored.push(index);
                 }
                 (Directive::Codes(.., codes), matches) => {
-                    if noqa::includes(diagnostic.kind.code(), codes) {
-                        matches.push(diagnostic.kind.code().as_ref());
+                    if noqa::includes(diagnostic.kind.rule(), codes) {
+                        matches.push(diagnostic.kind.rule().as_ref());
                         ignored.push(index);
                     }
                 }
@@ -108,7 +108,7 @@ pub fn check_noqa(
                             Range::new(Location::new(row + 1, start), Location::new(row + 1, end)),
                         );
                         if matches!(autofix, flags::Autofix::Enabled)
-                            && settings.rules.should_fix(diagnostic.kind.code())
+                            && settings.rules.should_fix(diagnostic.kind.rule())
                         {
                             diagnostic.amend(Fix::deletion(
                                 Location::new(row + 1, start - spaces),
@@ -172,7 +172,7 @@ pub fn check_noqa(
                             Range::new(Location::new(row + 1, start), Location::new(row + 1, end)),
                         );
                         if matches!(autofix, flags::Autofix::Enabled)
-                            && settings.rules.should_fix(diagnostic.kind.code())
+                            && settings.rules.should_fix(diagnostic.kind.rule())
                         {
                             if valid_codes.is_empty() {
                                 diagnostic.amend(Fix::deletion(

--- a/src/checkers/noqa.rs
+++ b/src/checkers/noqa.rs
@@ -6,7 +6,7 @@ use rustpython_parser::ast::Location;
 use crate::ast::types::Range;
 use crate::fix::Fix;
 use crate::noqa::{is_file_exempt, Directive};
-use crate::registry::{Diagnostic, DiagnosticKind, Rule, RuleCode, CODE_REDIRECTS};
+use crate::registry::{Diagnostic, DiagnosticKind, Rule, CODE_REDIRECTS};
 use crate::settings::{flags, Settings};
 use crate::violations::UnusedCodes;
 use crate::{noqa, violations};
@@ -22,7 +22,7 @@ pub fn check_noqa(
     let mut noqa_directives: IntMap<usize, (Directive, Vec<&str>)> = IntMap::default();
     let mut ignored = vec![];
 
-    let enforce_noqa = settings.rules.enabled(&RuleCode::RUF100);
+    let enforce_noqa = settings.rules.enabled(&Rule::UnusedNOQA);
 
     let lines: Vec<&str> = contents.lines().collect();
     for lineno in commented_lines {
@@ -124,7 +124,7 @@ pub fn check_noqa(
                     let mut self_ignore = false;
                     for code in codes {
                         let code = CODE_REDIRECTS.get(code).map_or(code, |r| r.code());
-                        if code == RuleCode::RUF100.code() {
+                        if code == Rule::UnusedNOQA.code() {
                             self_ignore = true;
                             break;
                         }

--- a/src/checkers/noqa.rs
+++ b/src/checkers/noqa.rs
@@ -1,14 +1,12 @@
 //! `NoQA` enforcement and validation.
 
-use std::str::FromStr;
-
 use nohash_hasher::IntMap;
 use rustpython_parser::ast::Location;
 
 use crate::ast::types::Range;
 use crate::fix::Fix;
 use crate::noqa::{is_file_exempt, Directive};
-use crate::registry::{Diagnostic, DiagnosticKind, RuleCode, CODE_REDIRECTS};
+use crate::registry::{Diagnostic, DiagnosticKind, Rule, RuleCode, CODE_REDIRECTS};
 use crate::settings::{flags, Settings};
 use crate::violations::UnusedCodes;
 use crate::{noqa, violations};
@@ -134,8 +132,8 @@ pub fn check_noqa(
                         if matches.contains(&code) || settings.external.contains(code) {
                             valid_codes.push(code);
                         } else {
-                            if let Ok(rule_code) = RuleCode::from_str(code) {
-                                if settings.rules.enabled(&rule_code) {
+                            if let Ok(rule) = Rule::from_code(code) {
+                                if settings.rules.enabled(rule) {
                                     unmatched_codes.push(code);
                                 } else {
                                     disabled_codes.push(code);

--- a/src/checkers/tokens.rs
+++ b/src/checkers/tokens.rs
@@ -75,7 +75,7 @@ pub fn check_tokens(
                     settings,
                     autofix,
                 ) {
-                    if settings.rules.enabled(diagnostic.kind.code()) {
+                    if settings.rules.enabled(diagnostic.kind.rule()) {
                         diagnostics.push(diagnostic);
                     }
                 }
@@ -112,7 +112,7 @@ pub fn check_tokens(
         diagnostics.extend(
             flake8_implicit_str_concat::rules::implicit(tokens)
                 .into_iter()
-                .filter(|diagnostic| settings.rules.enabled(diagnostic.kind.code())),
+                .filter(|diagnostic| settings.rules.enabled(diagnostic.kind.rule())),
         );
     }
 
@@ -121,7 +121,7 @@ pub fn check_tokens(
         diagnostics.extend(
             flake8_commas::rules::trailing_commas(tokens, settings, autofix)
                 .into_iter()
-                .filter(|diagnostic| settings.rules.enabled(diagnostic.kind.code())),
+                .filter(|diagnostic| settings.rules.enabled(diagnostic.kind.rule())),
         );
     }
 

--- a/src/checkers/tokens.rs
+++ b/src/checkers/tokens.rs
@@ -3,7 +3,7 @@
 use rustpython_parser::lexer::{LexResult, Tok};
 
 use crate::lex::docstring_detection::StateMachine;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::ruff::rules::Context;
 use crate::rules::{
     eradicate, flake8_commas, flake8_implicit_str_concat, flake8_quotes, pycodestyle, ruff,
@@ -19,20 +19,32 @@ pub fn check_tokens(
 ) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
-    let enforce_ambiguous_unicode_character = settings.rules.enabled(&RuleCode::RUF001)
-        || settings.rules.enabled(&RuleCode::RUF002)
-        || settings.rules.enabled(&RuleCode::RUF003);
-    let enforce_quotes = settings.rules.enabled(&RuleCode::Q000)
-        || settings.rules.enabled(&RuleCode::Q001)
-        || settings.rules.enabled(&RuleCode::Q002)
-        || settings.rules.enabled(&RuleCode::Q003);
-    let enforce_commented_out_code = settings.rules.enabled(&RuleCode::ERA001);
-    let enforce_invalid_escape_sequence = settings.rules.enabled(&RuleCode::W605);
-    let enforce_implicit_string_concatenation =
-        settings.rules.enabled(&RuleCode::ISC001) || settings.rules.enabled(&RuleCode::ISC002);
-    let enforce_trailing_comma = settings.rules.enabled(&RuleCode::COM812)
-        || settings.rules.enabled(&RuleCode::COM818)
-        || settings.rules.enabled(&RuleCode::COM819);
+    let enforce_ambiguous_unicode_character = settings
+        .rules
+        .enabled(&Rule::AmbiguousUnicodeCharacterString)
+        || settings
+            .rules
+            .enabled(&Rule::AmbiguousUnicodeCharacterDocstring)
+        || settings
+            .rules
+            .enabled(&Rule::AmbiguousUnicodeCharacterComment);
+    let enforce_quotes = settings.rules.enabled(&Rule::BadQuotesInlineString)
+        || settings.rules.enabled(&Rule::BadQuotesMultilineString)
+        || settings.rules.enabled(&Rule::BadQuotesDocstring)
+        || settings.rules.enabled(&Rule::AvoidQuoteEscape);
+    let enforce_commented_out_code = settings.rules.enabled(&Rule::CommentedOutCode);
+    let enforce_invalid_escape_sequence = settings.rules.enabled(&Rule::InvalidEscapeSequence);
+    let enforce_implicit_string_concatenation = settings
+        .rules
+        .enabled(&Rule::SingleLineImplicitStringConcatenation)
+        || settings
+            .rules
+            .enabled(&Rule::MultiLineImplicitStringConcatenation);
+    let enforce_trailing_comma = settings.rules.enabled(&Rule::TrailingCommaMissing)
+        || settings
+            .rules
+            .enabled(&Rule::TrailingCommaOnBareTupleProhibited)
+        || settings.rules.enabled(&Rule::TrailingCommaProhibited);
 
     let mut state_machine = StateMachine::default();
     for &(start, ref tok, end) in tokens.iter().flatten() {
@@ -101,7 +113,7 @@ pub fn check_tokens(
                     start,
                     end,
                     matches!(autofix, flags::Autofix::Enabled)
-                        && settings.rules.should_fix(&RuleCode::W605),
+                        && settings.rules.should_fix(&Rule::InvalidEscapeSequence),
                 ));
             }
         }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, Result};
 use path_absolutize::{path_dedot, Absolutize};
 use rustc_hash::FxHashSet;
 
-use crate::registry::RuleCode;
+use crate::registry::Rule;
 use crate::settings::hashable::{HashableGlobMatcher, HashableHashSet};
 
 /// Extract the absolute path and basename (as strings) from a Path.
@@ -29,9 +29,9 @@ pub(crate) fn ignores_from_path<'a>(
     pattern_code_pairs: &'a [(
         HashableGlobMatcher,
         HashableGlobMatcher,
-        HashableHashSet<RuleCode>,
+        HashableHashSet<Rule>,
     )],
-) -> Result<FxHashSet<&'a RuleCode>> {
+) -> Result<FxHashSet<&'a Rule>> {
     let (file_path, file_basename) = extract_path_names(path)?;
     Ok(pattern_code_pairs
         .iter()

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -182,7 +182,7 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
     let messages: Vec<ExpandedMessage> = diagnostics
         .into_iter()
         .map(|diagnostic| ExpandedMessage {
-            code: diagnostic.kind.code().clone(),
+            code: diagnostic.kind.rule().clone(),
             message: diagnostic.kind.body(),
             location: diagnostic.location,
             end_location: diagnostic.end_location,

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::directives;
 use crate::linter::check_path;
-use crate::registry::RuleCode;
+use crate::registry::Rule;
 use crate::rules::{
     flake8_annotations, flake8_bandit, flake8_bugbear, flake8_errmsg, flake8_import_conventions,
     flake8_pytest_style, flake8_quotes, flake8_tidy_imports, flake8_unused_arguments, isort,
@@ -58,7 +58,7 @@ struct ExpandedMessage {
     fix: Option<ExpandedFix>,
 }
 
-struct SerializeRuleAsCode(RuleCode);
+struct SerializeRuleAsCode(Rule);
 
 impl Serialize for SerializeRuleAsCode {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -241,7 +241,7 @@ mod test {
             "if (1, 2): pass",
             r#"{}"#,
             [ExpandedMessage {
-                code: RuleCode::F634.into(),
+                code: Rule::IfTuple.into(),
                 message: "If test is a tuple, which is always `True`".to_string(),
                 location: Location::new(1, 0),
                 end_location: Location::new(1, 15),

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -16,7 +16,7 @@ use crate::directives::Directives;
 use crate::doc_lines::{doc_lines_from_ast, doc_lines_from_tokens};
 use crate::message::{Message, Source};
 use crate::noqa::add_noqa;
-use crate::registry::{Diagnostic, LintSource, RuleCode};
+use crate::registry::{Diagnostic, LintSource, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::{Indexer, Locator, Stylist};
 use crate::{directives, fs, rustpython_helpers, violations};
@@ -48,7 +48,7 @@ pub fn check_path(
 
     // Collect doc lines. This requires a rare mix of tokens (for comments) and AST
     // (for docstrings), which demands special-casing at this level.
-    let use_doc_lines = settings.rules.enabled(&RuleCode::W505);
+    let use_doc_lines = settings.rules.enabled(&Rule::DocLineTooLong);
     let mut doc_lines = vec![];
     if use_doc_lines {
         doc_lines.extend(doc_lines_from_tokens(&tokens));
@@ -116,7 +116,7 @@ pub fn check_path(
                 }
             }
             Err(parse_error) => {
-                if settings.rules.enabled(&RuleCode::E999) {
+                if settings.rules.enabled(&Rule::SyntaxError) {
                     diagnostics.push(Diagnostic::new(
                         violations::SyntaxError(parse_error.error.to_string()),
                         Range::new(parse_error.location, parse_error.location),

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -170,7 +170,7 @@ pub fn check_path(
         if !ignores.is_empty() {
             return Ok(diagnostics
                 .into_iter()
-                .filter(|diagnostic| !ignores.contains(&diagnostic.kind.code()))
+                .filter(|diagnostic| !ignores.contains(&diagnostic.kind.rule()))
                 .collect());
         }
     }

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -115,7 +115,7 @@ fn add_noqa_inner(
             // duplication, whereby some parent `noqa` directives become
             // redundant.
             if diagnostic.location.row() == lineno + 1 {
-                codes.insert(diagnostic.kind.code());
+                codes.insert(diagnostic.kind.rule());
             }
         }
 

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -70,10 +70,10 @@ pub fn extract_noqa_directive(line: &str) -> Directive {
 /// Returns `true` if the string list of `codes` includes `code` (or an alias
 /// thereof).
 pub fn includes(needle: &RuleCode, haystack: &[&str]) -> bool {
-    let needle: &str = needle.as_ref();
+    let needle: &str = needle.code();
     haystack.iter().any(|candidate| {
         if let Some(candidate) = CODE_REDIRECTS.get(candidate) {
-            needle == candidate.as_ref()
+            needle == candidate.code()
         } else {
             &needle == candidate
         }
@@ -138,7 +138,7 @@ fn add_noqa_inner(
                 output.push_str(line);
                 output.push_str(line_ending);
             }
-            Some(codes) => {
+            Some(rules) => {
                 match extract_noqa_directive(line) {
                     Directive::None => {
                         // Add existing content.
@@ -148,7 +148,7 @@ fn add_noqa_inner(
                         output.push_str("  # noqa: ");
 
                         // Add codes.
-                        let codes: Vec<&str> = codes.iter().map(AsRef::as_ref).collect();
+                        let codes: Vec<&str> = rules.iter().map(|r| r.code()).collect();
                         let suffix = codes.join(", ");
                         output.push_str(&suffix);
                         output.push_str(line_ending);
@@ -163,7 +163,7 @@ fn add_noqa_inner(
 
                         // Add codes.
                         let codes: Vec<&str> =
-                            codes.iter().map(AsRef::as_ref).sorted_unstable().collect();
+                            rules.iter().map(|r| r.code()).sorted_unstable().collect();
                         let suffix = codes.join(", ");
                         output.push_str(&suffix);
                         output.push_str(line_ending);
@@ -181,9 +181,9 @@ fn add_noqa_inner(
                         formatted.push_str("  # noqa: ");
 
                         // Add codes.
-                        let codes: Vec<&str> = codes
+                        let codes: Vec<&str> = rules
                             .iter()
-                            .map(AsRef::as_ref)
+                            .map(|r| r.code())
                             .chain(existing.into_iter().filter(|code| external.contains(*code)))
                             .sorted_unstable()
                             .collect();

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::registry::{Diagnostic, RuleCode, CODE_REDIRECTS};
+use crate::registry::{Diagnostic, Rule, CODE_REDIRECTS};
 use crate::settings::hashable::HashableHashSet;
 use crate::source_code::LineEnding;
 
@@ -69,7 +69,7 @@ pub fn extract_noqa_directive(line: &str) -> Directive {
 
 /// Returns `true` if the string list of `codes` includes `code` (or an alias
 /// thereof).
-pub fn includes(needle: &RuleCode, haystack: &[&str]) -> bool {
+pub fn includes(needle: &Rule, haystack: &[&str]) -> bool {
     let needle: &str = needle.code();
     haystack.iter().any(|candidate| {
         if let Some(candidate) = CODE_REDIRECTS.get(candidate) {
@@ -101,14 +101,14 @@ fn add_noqa_inner(
     external: &HashableHashSet<String>,
     line_ending: &LineEnding,
 ) -> (usize, String) {
-    let mut matches_by_line: FxHashMap<usize, FxHashSet<&RuleCode>> = FxHashMap::default();
+    let mut matches_by_line: FxHashMap<usize, FxHashSet<&Rule>> = FxHashMap::default();
     for (lineno, line) in contents.lines().enumerate() {
         // If we hit an exemption for the entire file, bail.
         if is_file_exempt(line) {
             return (0, contents.to_string());
         }
 
-        let mut codes: FxHashSet<&RuleCode> = FxHashSet::default();
+        let mut codes: FxHashSet<&Rule> = FxHashSet::default();
         for diagnostic in diagnostics {
             // TODO(charlie): Consider respecting parent `noqa` directives. For now, we'll
             // add a `noqa` for every diagnostic, on its own line. This could lead to

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -2,7 +2,6 @@
 
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use ruff_macros::RuleCodePrefix;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Location;
 use serde::{Deserialize, Serialize};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Location;
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, Display, EnumIter, EnumString};
+use strum_macros::{AsRefStr, EnumIter, EnumString};
 
 use crate::ast::types::Range;
 use crate::fix::Fix;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Location;
 use serde::{Deserialize, Serialize};
-use strum_macros::{AsRefStr, EnumIter, EnumString};
+use strum_macros::{AsRefStr, EnumIter};
 
 use crate::ast::types::Range;
 use crate::fix::Fix;
@@ -712,8 +712,6 @@ pub static CODE_REDIRECTS: Lazy<FxHashMap<&'static str, RuleCode>> = Lazy::new(|
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
     use strum::IntoEnumIterator;
 
     use crate::registry::Rule;
@@ -722,7 +720,7 @@ mod tests {
     fn check_code_serialization() {
         for rule in Rule::iter() {
             assert!(
-                Rule::from_str(rule.code()).is_ok(),
+                Rule::from_code(rule.code()).is_ok(),
                 "{rule:?} could not be round-trip serialized."
             );
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,4 +1,4 @@
-//! Registry of [`RuleCode`] to [`DiagnosticKind`] mappings.
+//! Registry of [`Rule`] to [`DiagnosticKind`] mappings.
 
 use itertools::Itertools;
 use once_cell::sync::Lazy;
@@ -542,35 +542,35 @@ pub enum LintSource {
     Filesystem,
 }
 
-impl RuleCode {
+impl Rule {
     /// The source for the diagnostic (either the AST, the filesystem, or the
     /// physical lines).
     pub fn lint_source(&self) -> &'static LintSource {
         match self {
-            RuleCode::RUF100 => &LintSource::NoQa,
-            RuleCode::E501
-            | RuleCode::W292
-            | RuleCode::W505
-            | RuleCode::UP009
-            | RuleCode::PGH003
-            | RuleCode::PGH004 => &LintSource::Lines,
-            RuleCode::ERA001
-            | RuleCode::ISC001
-            | RuleCode::ISC002
-            | RuleCode::Q000
-            | RuleCode::Q001
-            | RuleCode::Q002
-            | RuleCode::Q003
-            | RuleCode::W605
-            | RuleCode::COM812
-            | RuleCode::COM818
-            | RuleCode::COM819
-            | RuleCode::RUF001
-            | RuleCode::RUF002
-            | RuleCode::RUF003 => &LintSource::Tokens,
-            RuleCode::E902 => &LintSource::Io,
-            RuleCode::I001 | RuleCode::I002 => &LintSource::Imports,
-            RuleCode::INP001 => &LintSource::Filesystem,
+            Rule::UnusedNOQA => &LintSource::NoQa,
+            Rule::LineTooLong
+            | Rule::NoNewLineAtEndOfFile
+            | Rule::DocLineTooLong
+            | Rule::PEP3120UnnecessaryCodingComment
+            | Rule::BlanketTypeIgnore
+            | Rule::BlanketNOQA => &LintSource::Lines,
+            Rule::CommentedOutCode
+            | Rule::SingleLineImplicitStringConcatenation
+            | Rule::MultiLineImplicitStringConcatenation
+            | Rule::BadQuotesInlineString
+            | Rule::BadQuotesMultilineString
+            | Rule::BadQuotesDocstring
+            | Rule::AvoidQuoteEscape
+            | Rule::InvalidEscapeSequence
+            | Rule::TrailingCommaMissing
+            | Rule::TrailingCommaOnBareTupleProhibited
+            | Rule::TrailingCommaProhibited
+            | Rule::AmbiguousUnicodeCharacterString
+            | Rule::AmbiguousUnicodeCharacterDocstring
+            | Rule::AmbiguousUnicodeCharacterComment => &LintSource::Tokens,
+            Rule::IOError => &LintSource::Io,
+            Rule::UnsortedImports | Rule::MissingRequiredImport => &LintSource::Imports,
+            Rule::ImplicitNamespacePackage => &LintSource::Filesystem,
             _ => &LintSource::Ast,
         }
     }
@@ -649,64 +649,64 @@ impl Diagnostic {
 }
 
 /// Pairs of checks that shouldn't be enabled together.
-pub const INCOMPATIBLE_CODES: &[(RuleCode, RuleCode, &str)] = &[(
-    RuleCode::D203,
-    RuleCode::D211,
+pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str)] = &[(
+    Rule::OneBlankLineBeforeClass,
+    Rule::NoBlankLineBeforeClass,
     "`D203` (OneBlankLineBeforeClass) and `D211` (NoBlankLinesBeforeClass) are incompatible. \
      Consider adding `D203` to `ignore`.",
 )];
 
-/// A hash map from deprecated to latest `RuleCode`.
-pub static CODE_REDIRECTS: Lazy<FxHashMap<&'static str, RuleCode>> = Lazy::new(|| {
+/// A hash map from deprecated to latest `Rule`.
+pub static CODE_REDIRECTS: Lazy<FxHashMap<&'static str, Rule>> = Lazy::new(|| {
     FxHashMap::from_iter([
         // TODO(charlie): Remove by 2023-01-01.
-        ("U001", RuleCode::UP001),
-        ("U003", RuleCode::UP003),
-        ("U004", RuleCode::UP004),
-        ("U005", RuleCode::UP005),
-        ("U006", RuleCode::UP006),
-        ("U007", RuleCode::UP007),
-        ("U008", RuleCode::UP008),
-        ("U009", RuleCode::UP009),
-        ("U010", RuleCode::UP010),
-        ("U011", RuleCode::UP011),
-        ("U012", RuleCode::UP012),
-        ("U013", RuleCode::UP013),
-        ("U014", RuleCode::UP014),
-        ("U015", RuleCode::UP015),
-        ("U016", RuleCode::UP016),
-        ("U017", RuleCode::UP017),
-        ("U019", RuleCode::UP019),
+        ("U001", Rule::UselessMetaclassType),
+        ("U003", Rule::TypeOfPrimitive),
+        ("U004", Rule::UselessObjectInheritance),
+        ("U005", Rule::DeprecatedUnittestAlias),
+        ("U006", Rule::UsePEP585Annotation),
+        ("U007", Rule::UsePEP604Annotation),
+        ("U008", Rule::SuperCallWithParameters),
+        ("U009", Rule::PEP3120UnnecessaryCodingComment),
+        ("U010", Rule::UnnecessaryFutureImport),
+        ("U011", Rule::LRUCacheWithoutParameters),
+        ("U012", Rule::UnnecessaryEncodeUTF8),
+        ("U013", Rule::ConvertTypedDictFunctionalToClass),
+        ("U014", Rule::ConvertNamedTupleFunctionalToClass),
+        ("U015", Rule::RedundantOpenModes),
+        ("U016", Rule::RemoveSixCompat),
+        ("U017", Rule::DatetimeTimezoneUTC),
+        ("U019", Rule::TypingTextStrAlias),
         // TODO(charlie): Remove by 2023-02-01.
-        ("I252", RuleCode::TID252),
-        ("M001", RuleCode::RUF100),
+        ("I252", Rule::RelativeImports),
+        ("M001", Rule::UnusedNOQA),
         // TODO(charlie): Remove by 2023-02-01.
-        ("PDV002", RuleCode::PD002),
-        ("PDV003", RuleCode::PD003),
-        ("PDV004", RuleCode::PD004),
-        ("PDV007", RuleCode::PD007),
-        ("PDV008", RuleCode::PD008),
-        ("PDV009", RuleCode::PD009),
-        ("PDV010", RuleCode::PD010),
-        ("PDV011", RuleCode::PD011),
-        ("PDV012", RuleCode::PD012),
-        ("PDV013", RuleCode::PD013),
-        ("PDV015", RuleCode::PD015),
-        ("PDV901", RuleCode::PD901),
+        ("PDV002", Rule::UseOfInplaceArgument),
+        ("PDV003", Rule::UseOfDotIsNull),
+        ("PDV004", Rule::UseOfDotNotNull),
+        ("PDV007", Rule::UseOfDotIx),
+        ("PDV008", Rule::UseOfDotAt),
+        ("PDV009", Rule::UseOfDotIat),
+        ("PDV010", Rule::UseOfDotPivotOrUnstack),
+        ("PDV011", Rule::UseOfDotValues),
+        ("PDV012", Rule::UseOfDotReadTable),
+        ("PDV013", Rule::UseOfDotStack),
+        ("PDV015", Rule::UseOfPdMerge),
+        ("PDV901", Rule::DfIsABadVariableName),
         // TODO(charlie): Remove by 2023-02-01.
-        ("R501", RuleCode::RET501),
-        ("R502", RuleCode::RET502),
-        ("R503", RuleCode::RET503),
-        ("R504", RuleCode::RET504),
-        ("R505", RuleCode::RET505),
-        ("R506", RuleCode::RET506),
-        ("R507", RuleCode::RET507),
-        ("R508", RuleCode::RET508),
+        ("R501", Rule::UnnecessaryReturnNone),
+        ("R502", Rule::ImplicitReturnValue),
+        ("R503", Rule::ImplicitReturn),
+        ("R504", Rule::UnnecessaryAssign),
+        ("R505", Rule::SuperfluousElseReturn),
+        ("R506", Rule::SuperfluousElseRaise),
+        ("R507", Rule::SuperfluousElseContinue),
+        ("R508", Rule::SuperfluousElseBreak),
         // TODO(charlie): Remove by 2023-02-01.
-        ("IC001", RuleCode::ICN001),
-        ("IC002", RuleCode::ICN001),
-        ("IC003", RuleCode::ICN001),
-        ("IC004", RuleCode::ICN001),
+        ("IC001", Rule::ImportAliasIsNotConventional),
+        ("IC002", Rule::ImportAliasIsNotConventional),
+        ("IC003", Rule::ImportAliasIsNotConventional),
+        ("IC004", Rule::ImportAliasIsNotConventional),
     ])
 });
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -716,26 +716,26 @@ mod tests {
 
     use strum::IntoEnumIterator;
 
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
 
     #[test]
     fn check_code_serialization() {
-        for check_code in RuleCode::iter() {
+        for rule in Rule::iter() {
             assert!(
-                RuleCode::from_str(check_code.as_ref()).is_ok(),
-                "{check_code:?} could not be round-trip serialized."
+                Rule::from_str(rule.code()).is_ok(),
+                "{rule:?} could not be round-trip serialized."
             );
         }
     }
 
     #[test]
     fn fixable_codes() {
-        for check_code in RuleCode::iter() {
-            let kind = check_code.kind();
+        for rule in Rule::iter() {
+            let kind = rule.kind();
             if kind.fixable() {
                 assert!(
                     kind.commit().is_some(),
-                    "{check_code:?} is fixable but has no commit message."
+                    "{rule:?} is fixable but has no commit message."
                 );
             }
         }

--- a/src/rules/eradicate/mod.rs
+++ b/src/rules/eradicate/mod.rs
@@ -10,11 +10,11 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::ERA001, Path::new("ERA001.py"); "ERA001")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::CommentedOutCode, Path::new("ERA001.py"); "ERA001")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/eradicate")

--- a/src/rules/eradicate/mod.rs
+++ b/src/rules/eradicate/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -16,7 +15,7 @@ mod tests {
 
     #[test_case(RuleCode::ERA001, Path::new("ERA001.py"); "ERA001")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/eradicate")
                 .join(path)

--- a/src/rules/eradicate/rules.rs
+++ b/src/rules/eradicate/rules.rs
@@ -3,7 +3,7 @@ use rustpython_ast::Location;
 use super::detection::comment_contains_code;
 use crate::ast::types::Range;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violations;
@@ -35,7 +35,7 @@ pub fn commented_out_code(
     if is_standalone_comment(&line) && comment_contains_code(&line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(violations::CommentedOutCode, Range::new(start, end));
         if matches!(autofix, flags::Autofix::Enabled)
-            && settings.rules.should_fix(&RuleCode::ERA001)
+            && settings.rules.should_fix(&Rule::CommentedOutCode)
         {
             diagnostic.amend(Fix::deletion(location, end_location));
         }

--- a/src/rules/flake8_2020/mod.rs
+++ b/src/rules/flake8_2020/mod.rs
@@ -9,20 +9,20 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::YTT101, Path::new("YTT101.py"); "YTT101")]
-    #[test_case(RuleCode::YTT102, Path::new("YTT102.py"); "YTT102")]
-    #[test_case(RuleCode::YTT103, Path::new("YTT103.py"); "YTT103")]
-    #[test_case(RuleCode::YTT201, Path::new("YTT201.py"); "YTT201")]
-    #[test_case(RuleCode::YTT202, Path::new("YTT202.py"); "YTT202")]
-    #[test_case(RuleCode::YTT203, Path::new("YTT203.py"); "YTT203")]
-    #[test_case(RuleCode::YTT204, Path::new("YTT204.py"); "YTT204")]
-    #[test_case(RuleCode::YTT301, Path::new("YTT301.py"); "YTT301")]
-    #[test_case(RuleCode::YTT302, Path::new("YTT302.py"); "YTT302")]
-    #[test_case(RuleCode::YTT303, Path::new("YTT303.py"); "YTT303")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::SysVersionSlice3Referenced, Path::new("YTT101.py"); "YTT101")]
+    #[test_case(Rule::SysVersion2Referenced, Path::new("YTT102.py"); "YTT102")]
+    #[test_case(Rule::SysVersionCmpStr3, Path::new("YTT103.py"); "YTT103")]
+    #[test_case(Rule::SysVersionInfo0Eq3Referenced, Path::new("YTT201.py"); "YTT201")]
+    #[test_case(Rule::SixPY3Referenced, Path::new("YTT202.py"); "YTT202")]
+    #[test_case(Rule::SysVersionInfo1CmpInt, Path::new("YTT203.py"); "YTT203")]
+    #[test_case(Rule::SysVersionInfoMinorCmpInt, Path::new("YTT204.py"); "YTT204")]
+    #[test_case(Rule::SysVersion0Referenced, Path::new("YTT301.py"); "YTT301")]
+    #[test_case(Rule::SysVersionCmpStr10, Path::new("YTT302.py"); "YTT302")]
+    #[test_case(Rule::SysVersionSlice1Referenced, Path::new("YTT303.py"); "YTT303")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_2020")

--- a/src/rules/flake8_2020/mod.rs
+++ b/src/rules/flake8_2020/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -24,7 +23,7 @@ mod tests {
     #[test_case(RuleCode::YTT302, Path::new("YTT302.py"); "YTT302")]
     #[test_case(RuleCode::YTT303, Path::new("YTT303.py"); "YTT303")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_2020")
                 .join(path)

--- a/src/rules/flake8_2020/rules.rs
+++ b/src/rules/flake8_2020/rules.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Cmpop, Constant, Expr, ExprKind, Located};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 fn is_sys(checker: &Checker, expr: &Expr, target: &str) -> bool {
@@ -27,13 +27,21 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                     ..
                 } = &upper.node
                 {
-                    if *i == BigInt::from(1) && checker.settings.rules.enabled(&RuleCode::YTT303) {
+                    if *i == BigInt::from(1)
+                        && checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::SysVersionSlice1Referenced)
+                    {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::SysVersionSlice1Referenced,
                             Range::from_located(value),
                         ));
                     } else if *i == BigInt::from(3)
-                        && checker.settings.rules.enabled(&RuleCode::YTT101)
+                        && checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::SysVersionSlice3Referenced)
                     {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::SysVersionSlice3Referenced,
@@ -47,12 +55,15 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                 value: Constant::Int(i),
                 ..
             } => {
-                if *i == BigInt::from(2) && checker.settings.rules.enabled(&RuleCode::YTT102) {
+                if *i == BigInt::from(2)
+                    && checker.settings.rules.enabled(&Rule::SysVersion2Referenced)
+                {
                     checker.diagnostics.push(Diagnostic::new(
                         violations::SysVersion2Referenced,
                         Range::from_located(value),
                     ));
-                } else if *i == BigInt::from(0) && checker.settings.rules.enabled(&RuleCode::YTT301)
+                } else if *i == BigInt::from(0)
+                    && checker.settings.rules.enabled(&Rule::SysVersion0Referenced)
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         violations::SysVersion0Referenced,
@@ -89,7 +100,10 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                     ) = (ops, comparators)
                     {
                         if *n == BigInt::from(3)
-                            && checker.settings.rules.enabled(&RuleCode::YTT201)
+                            && checker
+                                .settings
+                                .rules
+                                .enabled(&Rule::SysVersionInfo0Eq3Referenced)
                         {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::SysVersionInfo0Eq3Referenced,
@@ -110,7 +124,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                         }],
                     ) = (ops, comparators)
                     {
-                        if checker.settings.rules.enabled(&RuleCode::YTT203) {
+                        if checker.settings.rules.enabled(&Rule::SysVersionInfo1CmpInt) {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::SysVersionInfo1CmpInt,
                                 Range::from_located(left),
@@ -136,7 +150,11 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                 }],
             ) = (ops, comparators)
             {
-                if checker.settings.rules.enabled(&RuleCode::YTT204) {
+                if checker
+                    .settings
+                    .rules
+                    .enabled(&Rule::SysVersionInfoMinorCmpInt)
+                {
                     checker.diagnostics.push(Diagnostic::new(
                         violations::SysVersionInfoMinorCmpInt,
                         Range::from_located(left),
@@ -162,13 +180,13 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
         ) = (ops, comparators)
         {
             if s.len() == 1 {
-                if checker.settings.rules.enabled(&RuleCode::YTT302) {
+                if checker.settings.rules.enabled(&Rule::SysVersionCmpStr10) {
                     checker.diagnostics.push(Diagnostic::new(
                         violations::SysVersionCmpStr10,
                         Range::from_located(left),
                     ));
                 }
-            } else if checker.settings.rules.enabled(&RuleCode::YTT103) {
+            } else if checker.settings.rules.enabled(&Rule::SysVersionCmpStr3) {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::SysVersionCmpStr3,
                     Range::from_located(left),

--- a/src/rules/flake8_annotations/mod.rs
+++ b/src/rules/flake8_annotations/mod.rs
@@ -11,7 +11,7 @@ mod tests {
     use anyhow::Result;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test]
@@ -20,17 +20,17 @@ mod tests {
             Path::new("./resources/test/fixtures/flake8_annotations/annotation_presence.py"),
             &Settings {
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN001,
-                    RuleCode::ANN002,
-                    RuleCode::ANN003,
-                    RuleCode::ANN101,
-                    RuleCode::ANN102,
-                    RuleCode::ANN201,
-                    RuleCode::ANN202,
-                    RuleCode::ANN204,
-                    RuleCode::ANN205,
-                    RuleCode::ANN206,
-                    RuleCode::ANN401,
+                    Rule::MissingTypeFunctionArgument,
+                    Rule::MissingTypeArgs,
+                    Rule::MissingTypeKwargs,
+                    Rule::MissingTypeSelf,
+                    Rule::MissingTypeCls,
+                    Rule::MissingReturnTypePublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
+                    Rule::DynamicallyTypedExpression,
                 ])
             },
         )?;
@@ -50,11 +50,11 @@ mod tests {
                     allow_star_arg_any: false,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN001,
-                    RuleCode::ANN002,
-                    RuleCode::ANN003,
-                    RuleCode::ANN101,
-                    RuleCode::ANN102,
+                    Rule::MissingTypeFunctionArgument,
+                    Rule::MissingTypeArgs,
+                    Rule::MissingTypeKwargs,
+                    Rule::MissingTypeSelf,
+                    Rule::MissingTypeCls,
                 ])
             },
         )?;
@@ -74,11 +74,11 @@ mod tests {
                     allow_star_arg_any: false,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN201,
-                    RuleCode::ANN202,
-                    RuleCode::ANN204,
-                    RuleCode::ANN205,
-                    RuleCode::ANN206,
+                    Rule::MissingReturnTypePublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
                 ])
             },
         )?;
@@ -98,11 +98,11 @@ mod tests {
                     allow_star_arg_any: false,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN201,
-                    RuleCode::ANN202,
-                    RuleCode::ANN204,
-                    RuleCode::ANN205,
-                    RuleCode::ANN206,
+                    Rule::MissingReturnTypePublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
                 ])
             },
         )?;
@@ -121,7 +121,7 @@ mod tests {
                     suppress_none_returning: false,
                     allow_star_arg_any: true,
                 },
-                ..Settings::for_rules(vec![RuleCode::ANN401])
+                ..Settings::for_rules(vec![Rule::DynamicallyTypedExpression])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -134,11 +134,11 @@ mod tests {
             Path::new("./resources/test/fixtures/flake8_annotations/allow_overload.py"),
             &Settings {
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN201,
-                    RuleCode::ANN202,
-                    RuleCode::ANN204,
-                    RuleCode::ANN205,
-                    RuleCode::ANN206,
+                    Rule::MissingReturnTypePublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
                 ])
             },
         )?;
@@ -152,11 +152,11 @@ mod tests {
             Path::new("./resources/test/fixtures/flake8_annotations/allow_nested_overload.py"),
             &Settings {
                 ..Settings::for_rules(vec![
-                    RuleCode::ANN201,
-                    RuleCode::ANN202,
-                    RuleCode::ANN204,
-                    RuleCode::ANN205,
-                    RuleCode::ANN206,
+                    Rule::MissingReturnTypePublicFunction,
+                    Rule::MissingReturnTypePrivateFunction,
+                    Rule::MissingReturnTypeSpecialMethod,
+                    Rule::MissingReturnTypeStaticMethod,
+                    Rule::MissingReturnTypeClassMethod,
                 ])
             },
         )?;

--- a/src/rules/flake8_annotations/rules.rs
+++ b/src/rules/flake8_annotations/rules.rs
@@ -330,7 +330,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                                 violations::MissingReturnTypeSpecialMethod(name.to_string()),
                                 helpers::identifier_range(stmt, checker.locator),
                             );
-                            if checker.patch(diagnostic.kind.code()) {
+                            if checker.patch(diagnostic.kind.rule()) {
                                 match fixes::add_return_none_annotation(checker.locator, stmt) {
                                     Ok(fix) => {
                                         diagnostic.amend(fix);

--- a/src/rules/flake8_annotations/rules.rs
+++ b/src/rules/flake8_annotations/rules.rs
@@ -8,7 +8,7 @@ use crate::ast::visitor::Visitor;
 use crate::ast::{cast, helpers, visitor};
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{Definition, DefinitionKind};
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::visibility::Visibility;
 use crate::{violations, visibility};
 
@@ -85,14 +85,22 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 .chain(args.kwonlyargs.iter())
             {
                 if let Some(expr) = &arg.node.annotation {
-                    if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::DynamicallyTypedExpression)
+                    {
                         check_dynamically_typed(checker, expr, || arg.node.arg.to_string());
                     };
                 } else {
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN001) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MissingTypeFunctionArgument)
+                        {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeFunctionArgument(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -106,7 +114,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
             if let Some(arg) = &args.vararg {
                 if let Some(expr) = &arg.node.annotation {
                     if !checker.settings.flake8_annotations.allow_star_arg_any {
-                        if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::DynamicallyTypedExpression)
+                        {
                             let name = arg.node.arg.to_string();
                             check_dynamically_typed(checker, expr, || format!("*{name}"));
                         }
@@ -115,7 +127,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN002) {
+                        if checker.settings.rules.enabled(&Rule::MissingTypeArgs) {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeArgs(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -129,7 +141,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
             if let Some(arg) = &args.kwarg {
                 if let Some(expr) = &arg.node.annotation {
                     if !checker.settings.flake8_annotations.allow_star_arg_any {
-                        if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::DynamicallyTypedExpression)
+                        {
                             let name = arg.node.arg.to_string();
                             check_dynamically_typed(checker, expr, || format!("**{name}"));
                         }
@@ -138,7 +154,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN003) {
+                        if checker.settings.rules.enabled(&Rule::MissingTypeKwargs) {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeKwargs(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -150,7 +166,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
 
             // ANN201, ANN202, ANN401
             if let Some(expr) = &returns {
-                if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                if checker
+                    .settings
+                    .rules
+                    .enabled(&Rule::DynamicallyTypedExpression)
+                {
                     check_dynamically_typed(checker, expr, || name.to_string());
                 };
             } else {
@@ -164,7 +184,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
 
                 match visibility {
                     Visibility::Public => {
-                        if checker.settings.rules.enabled(&RuleCode::ANN201) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MissingReturnTypePublicFunction)
+                        {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingReturnTypePublicFunction(name.to_string()),
                                 helpers::identifier_range(stmt, checker.locator),
@@ -172,7 +196,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                         }
                     }
                     Visibility::Private => {
-                        if checker.settings.rules.enabled(&RuleCode::ANN202) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MissingReturnTypePrivateFunction)
+                        {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingReturnTypePrivateFunction(name.to_string()),
                                 helpers::identifier_range(stmt, checker.locator),
@@ -203,14 +231,22 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 // ANN401 for dynamically typed arguments
                 if let Some(annotation) = &arg.node.annotation {
                     has_any_typed_arg = true;
-                    if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::DynamicallyTypedExpression)
+                    {
                         check_dynamically_typed(checker, annotation, || arg.node.arg.to_string());
                     }
                 } else {
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN001) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MissingTypeFunctionArgument)
+                        {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeFunctionArgument(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -225,7 +261,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 has_any_typed_arg = true;
                 if let Some(expr) = &arg.node.annotation {
                     if !checker.settings.flake8_annotations.allow_star_arg_any {
-                        if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::DynamicallyTypedExpression)
+                        {
                             let name = arg.node.arg.to_string();
                             check_dynamically_typed(checker, expr, || format!("*{name}"));
                         }
@@ -234,7 +274,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN002) {
+                        if checker.settings.rules.enabled(&Rule::MissingTypeArgs) {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeArgs(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -249,7 +289,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 has_any_typed_arg = true;
                 if let Some(expr) = &arg.node.annotation {
                     if !checker.settings.flake8_annotations.allow_star_arg_any {
-                        if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::DynamicallyTypedExpression)
+                        {
                             let name = arg.node.arg.to_string();
                             check_dynamically_typed(checker, expr, || format!("**{name}"));
                         }
@@ -258,7 +302,7 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                     if !(checker.settings.flake8_annotations.suppress_dummy_args
                         && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                     {
-                        if checker.settings.rules.enabled(&RuleCode::ANN003) {
+                        if checker.settings.rules.enabled(&Rule::MissingTypeKwargs) {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::MissingTypeKwargs(arg.node.arg.to_string()),
                                 Range::from_located(arg),
@@ -273,14 +317,14 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 if let Some(arg) = args.args.first() {
                     if arg.node.annotation.is_none() {
                         if visibility::is_classmethod(checker, cast::decorator_list(stmt)) {
-                            if checker.settings.rules.enabled(&RuleCode::ANN102) {
+                            if checker.settings.rules.enabled(&Rule::MissingTypeCls) {
                                 checker.diagnostics.push(Diagnostic::new(
                                     violations::MissingTypeCls(arg.node.arg.to_string()),
                                     Range::from_located(arg),
                                 ));
                             }
                         } else {
-                            if checker.settings.rules.enabled(&RuleCode::ANN101) {
+                            if checker.settings.rules.enabled(&Rule::MissingTypeSelf) {
                                 checker.diagnostics.push(Diagnostic::new(
                                     violations::MissingTypeSelf(arg.node.arg.to_string()),
                                     Range::from_located(arg),
@@ -293,7 +337,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
 
             // ANN201, ANN202
             if let Some(expr) = &returns {
-                if checker.settings.rules.enabled(&RuleCode::ANN401) {
+                if checker
+                    .settings
+                    .rules
+                    .enabled(&Rule::DynamicallyTypedExpression)
+                {
                     check_dynamically_typed(checker, expr, || name.to_string());
                 }
             } else {
@@ -306,14 +354,22 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 }
 
                 if visibility::is_classmethod(checker, cast::decorator_list(stmt)) {
-                    if checker.settings.rules.enabled(&RuleCode::ANN206) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::MissingReturnTypeClassMethod)
+                    {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::MissingReturnTypeClassMethod(name.to_string()),
                             helpers::identifier_range(stmt, checker.locator),
                         ));
                     }
                 } else if visibility::is_staticmethod(checker, cast::decorator_list(stmt)) {
-                    if checker.settings.rules.enabled(&RuleCode::ANN205) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::MissingReturnTypeStaticMethod)
+                    {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::MissingReturnTypeStaticMethod(name.to_string()),
                             helpers::identifier_range(stmt, checker.locator),
@@ -322,7 +378,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 } else if visibility::is_init(cast::name(stmt)) {
                     // Allow omission of return annotation in `__init__` functions, as long as at
                     // least one argument is typed.
-                    if checker.settings.rules.enabled(&RuleCode::ANN204) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::MissingReturnTypeSpecialMethod)
+                    {
                         if !(checker.settings.flake8_annotations.mypy_init_return
                             && has_any_typed_arg)
                         {
@@ -342,7 +402,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                         }
                     }
                 } else if visibility::is_magic(cast::name(stmt)) {
-                    if checker.settings.rules.enabled(&RuleCode::ANN204) {
+                    if checker
+                        .settings
+                        .rules
+                        .enabled(&Rule::MissingReturnTypeSpecialMethod)
+                    {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::MissingReturnTypeSpecialMethod(name.to_string()),
                             helpers::identifier_range(stmt, checker.locator),
@@ -351,7 +415,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                 } else {
                     match visibility {
                         Visibility::Public => {
-                            if checker.settings.rules.enabled(&RuleCode::ANN201) {
+                            if checker
+                                .settings
+                                .rules
+                                .enabled(&Rule::MissingReturnTypePublicFunction)
+                            {
                                 checker.diagnostics.push(Diagnostic::new(
                                     violations::MissingReturnTypePublicFunction(name.to_string()),
                                     helpers::identifier_range(stmt, checker.locator),
@@ -359,7 +427,11 @@ pub fn definition(checker: &mut Checker, definition: &Definition, visibility: &V
                             }
                         }
                         Visibility::Private => {
-                            if checker.settings.rules.enabled(&RuleCode::ANN202) {
+                            if checker
+                                .settings
+                                .rules
+                                .enabled(&Rule::MissingReturnTypePrivateFunction)
+                            {
                                 checker.diagnostics.push(Diagnostic::new(
                                     violations::MissingReturnTypePrivateFunction(name.to_string()),
                                     helpers::identifier_range(stmt, checker.locator),

--- a/src/rules/flake8_bandit/mod.rs
+++ b/src/rules/flake8_bandit/mod.rs
@@ -11,25 +11,25 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
-    #[test_case(RuleCode::S101, Path::new("S101.py"); "S101")]
-    #[test_case(RuleCode::S102, Path::new("S102.py"); "S102")]
-    #[test_case(RuleCode::S103, Path::new("S103.py"); "S103")]
-    #[test_case(RuleCode::S104, Path::new("S104.py"); "S104")]
-    #[test_case(RuleCode::S105, Path::new("S105.py"); "S105")]
-    #[test_case(RuleCode::S106, Path::new("S106.py"); "S106")]
-    #[test_case(RuleCode::S107, Path::new("S107.py"); "S107")]
-    #[test_case(RuleCode::S108, Path::new("S108.py"); "S108")]
-    #[test_case(RuleCode::S113, Path::new("S113.py"); "S113")]
-    #[test_case(RuleCode::S324, Path::new("S324.py"); "S324")]
-    #[test_case(RuleCode::S501, Path::new("S501.py"); "S501")]
-    #[test_case(RuleCode::S506, Path::new("S506.py"); "S506")]
-    #[test_case(RuleCode::S508, Path::new("S508.py"); "S508")]
-    #[test_case(RuleCode::S509, Path::new("S509.py"); "S509")]
-    #[test_case(RuleCode::S701, Path::new("S701.py"); "S701")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::AssertUsed, Path::new("S101.py"); "S101")]
+    #[test_case(Rule::ExecUsed, Path::new("S102.py"); "S102")]
+    #[test_case(Rule::BadFilePermissions, Path::new("S103.py"); "S103")]
+    #[test_case(Rule::HardcodedBindAllInterfaces, Path::new("S104.py"); "S104")]
+    #[test_case(Rule::HardcodedPasswordString, Path::new("S105.py"); "S105")]
+    #[test_case(Rule::HardcodedPasswordFuncArg, Path::new("S106.py"); "S106")]
+    #[test_case(Rule::HardcodedPasswordDefault, Path::new("S107.py"); "S107")]
+    #[test_case(Rule::HardcodedTempFile, Path::new("S108.py"); "S108")]
+    #[test_case(Rule::RequestWithoutTimeout, Path::new("S113.py"); "S113")]
+    #[test_case(Rule::HashlibInsecureHashFunction, Path::new("S324.py"); "S324")]
+    #[test_case(Rule::RequestWithNoCertValidation, Path::new("S501.py"); "S501")]
+    #[test_case(Rule::UnsafeYAMLLoad, Path::new("S506.py"); "S506")]
+    #[test_case(Rule::SnmpInsecureVersion, Path::new("S508.py"); "S508")]
+    #[test_case(Rule::SnmpWeakCryptography, Path::new("S509.py"); "S509")]
+    #[test_case(Rule::Jinja2AutoescapeFalse, Path::new("S701.py"); "S701")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_bandit")
@@ -54,7 +54,7 @@ mod tests {
                         "/foo".to_string(),
                     ],
                 },
-                ..Settings::for_rule(RuleCode::S108)
+                ..Settings::for_rule(Rule::HardcodedTempFile)
             },
         )?;
         insta::assert_yaml_snapshot!("S108_extend", diagnostics);

--- a/src/rules/flake8_bandit/mod.rs
+++ b/src/rules/flake8_bandit/mod.rs
@@ -30,7 +30,7 @@ mod tests {
     #[test_case(RuleCode::S509, Path::new("S509.py"); "S509")]
     #[test_case(RuleCode::S701, Path::new("S701.py"); "S701")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_bandit")
                 .join(path)

--- a/src/rules/flake8_blind_except/mod.rs
+++ b/src/rules/flake8_blind_except/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -15,7 +14,7 @@ mod tests {
 
     #[test_case(RuleCode::BLE001, Path::new("BLE.py"); "BLE001")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_blind_except")
                 .join(path)

--- a/src/rules/flake8_blind_except/mod.rs
+++ b/src/rules/flake8_blind_except/mod.rs
@@ -9,11 +9,11 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::BLE001, Path::new("BLE.py"); "BLE001")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::BlindExcept, Path::new("BLE.py"); "BLE001")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_blind_except")

--- a/src/rules/flake8_boolean_trap/mod.rs
+++ b/src/rules/flake8_boolean_trap/mod.rs
@@ -9,13 +9,13 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::FBT001, Path::new("FBT.py"); "FBT001")]
-    #[test_case(RuleCode::FBT002, Path::new("FBT.py"); "FBT002")]
-    #[test_case(RuleCode::FBT003, Path::new("FBT.py"); "FBT003")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::BooleanPositionalArgInFunctionDefinition, Path::new("FBT.py"); "FBT001")]
+    #[test_case(Rule::BooleanDefaultValueInFunctionDefinition, Path::new("FBT.py"); "FBT002")]
+    #[test_case(Rule::BooleanPositionalValueInFunctionCall, Path::new("FBT.py"); "FBT003")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_boolean_trap")

--- a/src/rules/flake8_boolean_trap/mod.rs
+++ b/src/rules/flake8_boolean_trap/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -17,7 +16,7 @@ mod tests {
     #[test_case(RuleCode::FBT002, Path::new("FBT.py"); "FBT002")]
     #[test_case(RuleCode::FBT003, Path::new("FBT.py"); "FBT003")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_boolean_trap")
                 .join(path)

--- a/src/rules/flake8_bugbear/mod.rs
+++ b/src/rules/flake8_bugbear/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test_case(RuleCode::B904, Path::new("B904.py"); "B904")]
     #[test_case(RuleCode::B905, Path::new("B905.py"); "B905")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_bugbear")
                 .join(path)

--- a/src/rules/flake8_bugbear/mod.rs
+++ b/src/rules/flake8_bugbear/mod.rs
@@ -10,38 +10,38 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
-    #[test_case(RuleCode::B002, Path::new("B002.py"); "B002")]
-    #[test_case(RuleCode::B003, Path::new("B003.py"); "B003")]
-    #[test_case(RuleCode::B004, Path::new("B004.py"); "B004")]
-    #[test_case(RuleCode::B005, Path::new("B005.py"); "B005")]
-    #[test_case(RuleCode::B006, Path::new("B006_B008.py"); "B006")]
-    #[test_case(RuleCode::B007, Path::new("B007.py"); "B007")]
-    #[test_case(RuleCode::B008, Path::new("B006_B008.py"); "B008")]
-    #[test_case(RuleCode::B009, Path::new("B009_B010.py"); "B009")]
-    #[test_case(RuleCode::B010, Path::new("B009_B010.py"); "B010")]
-    #[test_case(RuleCode::B011, Path::new("B011.py"); "B011")]
-    #[test_case(RuleCode::B012, Path::new("B012.py"); "B012")]
-    #[test_case(RuleCode::B013, Path::new("B013.py"); "B013")]
-    #[test_case(RuleCode::B014, Path::new("B014.py"); "B014")]
-    #[test_case(RuleCode::B015, Path::new("B015.py"); "B015")]
-    #[test_case(RuleCode::B016, Path::new("B016.py"); "B016")]
-    #[test_case(RuleCode::B017, Path::new("B017.py"); "B017")]
-    #[test_case(RuleCode::B018, Path::new("B018.py"); "B018")]
-    #[test_case(RuleCode::B019, Path::new("B019.py"); "B019")]
-    #[test_case(RuleCode::B020, Path::new("B020.py"); "B020")]
-    #[test_case(RuleCode::B021, Path::new("B021.py"); "B021")]
-    #[test_case(RuleCode::B022, Path::new("B022.py"); "B022")]
-    #[test_case(RuleCode::B023, Path::new("B023.py"); "B023")]
-    #[test_case(RuleCode::B024, Path::new("B024.py"); "B024")]
-    #[test_case(RuleCode::B025, Path::new("B025.py"); "B025")]
-    #[test_case(RuleCode::B026, Path::new("B026.py"); "B026")]
-    #[test_case(RuleCode::B027, Path::new("B027.py"); "B027")]
-    #[test_case(RuleCode::B904, Path::new("B904.py"); "B904")]
-    #[test_case(RuleCode::B905, Path::new("B905.py"); "B905")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UnaryPrefixIncrement, Path::new("B002.py"); "B002")]
+    #[test_case(Rule::AssignmentToOsEnviron, Path::new("B003.py"); "B003")]
+    #[test_case(Rule::UnreliableCallableCheck, Path::new("B004.py"); "B004")]
+    #[test_case(Rule::StripWithMultiCharacters, Path::new("B005.py"); "B005")]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"); "B006")]
+    #[test_case(Rule::UnusedLoopControlVariable, Path::new("B007.py"); "B007")]
+    #[test_case(Rule::FunctionCallArgumentDefault, Path::new("B006_B008.py"); "B008")]
+    #[test_case(Rule::GetAttrWithConstant, Path::new("B009_B010.py"); "B009")]
+    #[test_case(Rule::SetAttrWithConstant, Path::new("B009_B010.py"); "B010")]
+    #[test_case(Rule::DoNotAssertFalse, Path::new("B011.py"); "B011")]
+    #[test_case(Rule::JumpStatementInFinally, Path::new("B012.py"); "B012")]
+    #[test_case(Rule::RedundantTupleInExceptionHandler, Path::new("B013.py"); "B013")]
+    #[test_case(Rule::DuplicateHandlerException, Path::new("B014.py"); "B014")]
+    #[test_case(Rule::UselessComparison, Path::new("B015.py"); "B015")]
+    #[test_case(Rule::CannotRaiseLiteral, Path::new("B016.py"); "B016")]
+    #[test_case(Rule::NoAssertRaisesException, Path::new("B017.py"); "B017")]
+    #[test_case(Rule::UselessExpression, Path::new("B018.py"); "B018")]
+    #[test_case(Rule::CachedInstanceMethod, Path::new("B019.py"); "B019")]
+    #[test_case(Rule::LoopVariableOverridesIterator, Path::new("B020.py"); "B020")]
+    #[test_case(Rule::FStringDocstring, Path::new("B021.py"); "B021")]
+    #[test_case(Rule::UselessContextlibSuppress, Path::new("B022.py"); "B022")]
+    #[test_case(Rule::FunctionUsesLoopVariable, Path::new("B023.py"); "B023")]
+    #[test_case(Rule::AbstractBaseClassWithoutAbstractMethod, Path::new("B024.py"); "B024")]
+    #[test_case(Rule::DuplicateTryBlockException, Path::new("B025.py"); "B025")]
+    #[test_case(Rule::StarArgUnpackingAfterKeywordArg, Path::new("B026.py"); "B026")]
+    #[test_case(Rule::EmptyMethodWithoutAbstractDecorator, Path::new("B027.py"); "B027")]
+    #[test_case(Rule::RaiseWithoutFromInsideExcept, Path::new("B904.py"); "B904")]
+    #[test_case(Rule::ZipWithoutExplicitStrict, Path::new("B905.py"); "B905")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_bugbear")
@@ -65,7 +65,7 @@ mod tests {
                         "fastapi.Query".to_string(),
                     ],
                 },
-                ..Settings::for_rules(vec![RuleCode::B008])
+                ..Settings::for_rules(vec![Rule::FunctionCallArgumentDefault])
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);

--- a/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -2,7 +2,7 @@ use rustpython_ast::{Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 use crate::visibility::{is_abstract, is_overload};
 
@@ -78,7 +78,11 @@ pub fn abstract_base_class(
         let has_abstract_decorator = is_abstract(checker, decorator_list);
         has_abstract_method |= has_abstract_decorator;
 
-        if !checker.settings.rules.enabled(&RuleCode::B027) {
+        if !checker
+            .settings
+            .rules
+            .enabled(&Rule::EmptyMethodWithoutAbstractDecorator)
+        {
             continue;
         }
 
@@ -89,7 +93,11 @@ pub fn abstract_base_class(
             ));
         }
     }
-    if checker.settings.rules.enabled(&RuleCode::B024) {
+    if checker
+        .settings
+        .rules
+        .enabled(&Rule::AbstractBaseClassWithoutAbstractMethod)
+    {
         if !has_abstract_method {
             checker.diagnostics.push(Diagnostic::new(
                 violations::AbstractBaseClassWithoutAbstractMethod(name.to_string()),

--- a/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -47,7 +47,7 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
     };
 
     let mut diagnostic = Diagnostic::new(violations::DoNotAssertFalse, Range::from_located(test));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let mut generator: Generator = checker.stylist.into();
         generator.unparse_stmt(&assertion_error(msg));
         diagnostic.amend(Fix::replacement(

--- a/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -6,7 +6,7 @@ use crate::ast::helpers;
 use crate::ast::types::{CallPath, Range};
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Generator;
 use crate::violations;
 
@@ -41,7 +41,11 @@ fn duplicate_handler_exceptions<'a>(
         }
     }
 
-    if checker.settings.rules.enabled(&RuleCode::B014) {
+    if checker
+        .settings
+        .rules
+        .enabled(&Rule::DuplicateHandlerException)
+    {
         // TODO(charlie): Handle "BaseException" and redundant exception aliases.
         if !duplicates.is_empty() {
             let mut diagnostic = Diagnostic::new(
@@ -105,7 +109,11 @@ pub fn duplicate_exceptions(checker: &mut Checker, handlers: &[Excepthandler]) {
         }
     }
 
-    if checker.settings.rules.enabled(&RuleCode::B025) {
+    if checker
+        .settings
+        .rules
+        .enabled(&Rule::DuplicateTryBlockException)
+    {
         for (name, exprs) in duplicates {
             for expr in exprs {
                 checker.diagnostics.push(Diagnostic::new(

--- a/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -54,7 +54,7 @@ fn duplicate_handler_exceptions<'a>(
                 ),
                 Range::from_located(expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 let mut generator: Generator = checker.stylist.into();
                 if unique_elts.len() == 1 {
                     generator.unparse_expr(unique_elts[0], 0);

--- a/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -47,7 +47,7 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
 
     let mut diagnostic =
         Diagnostic::new(violations::GetAttrWithConstant, Range::from_located(expr));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let mut generator: Generator = checker.stylist.into();
         generator.unparse_expr(&attribute(obj, value), 0);
         diagnostic.amend(Fix::replacement(

--- a/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -23,7 +23,7 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             violations::RedundantTupleInExceptionHandler(elt.to_string()),
             Range::from_located(type_),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             let mut generator: Generator = checker.stylist.into();
             generator.unparse_expr(elt, 0);
             diagnostic.amend(Fix::replacement(

--- a/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -62,7 +62,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
         if expr == child.as_ref() {
             let mut diagnostic =
                 Diagnostic::new(violations::SetAttrWithConstant, Range::from_located(expr));
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     assignment(obj, name, value, checker.stylist),
                     expr.location,

--- a/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -66,7 +66,7 @@ pub fn unused_loop_control_variable(checker: &mut Checker, target: &Expr, body: 
             violations::UnusedLoopControlVariable(name.to_string()),
             Range::from_located(expr),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             // Prefix the variable name with an underscore.
             diagnostic.amend(Fix::replacement(
                 format!("_{name}"),

--- a/src/rules/flake8_builtins/mod.rs
+++ b/src/rules/flake8_builtins/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod types;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -18,7 +17,7 @@ mod tests {
     #[test_case(RuleCode::A002, Path::new("A002.py"); "A002")]
     #[test_case(RuleCode::A003, Path::new("A003.py"); "A003")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_builtins")
                 .join(path)

--- a/src/rules/flake8_builtins/mod.rs
+++ b/src/rules/flake8_builtins/mod.rs
@@ -10,13 +10,13 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::A001, Path::new("A001.py"); "A001")]
-    #[test_case(RuleCode::A002, Path::new("A002.py"); "A002")]
-    #[test_case(RuleCode::A003, Path::new("A003.py"); "A003")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::BuiltinVariableShadowing, Path::new("A001.py"); "A001")]
+    #[test_case(Rule::BuiltinArgumentShadowing, Path::new("A002.py"); "A002")]
+    #[test_case(Rule::BuiltinAttributeShadowing, Path::new("A003.py"); "A003")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_builtins")

--- a/src/rules/flake8_commas/mod.rs
+++ b/src/rules/flake8_commas/mod.rs
@@ -9,7 +9,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
     #[test_case(Path::new("COM81.py"); "COM81")]
@@ -20,9 +20,9 @@ mod tests {
                 .join(path)
                 .as_path(),
             &settings::Settings::for_rules(vec![
-                RuleCode::COM812,
-                RuleCode::COM818,
-                RuleCode::COM819,
+                Rule::TrailingCommaMissing,
+                Rule::TrailingCommaOnBareTupleProhibited,
+                Rule::TrailingCommaProhibited,
             ]),
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);

--- a/src/rules/flake8_commas/rules.rs
+++ b/src/rules/flake8_commas/rules.rs
@@ -4,7 +4,7 @@ use rustpython_parser::token::Tok;
 
 use crate::ast::types::Range;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::violations;
 
@@ -219,7 +219,7 @@ pub fn trailing_commas(
                 },
             );
             if matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(&RuleCode::COM819)
+                && settings.rules.should_fix(&Rule::TrailingCommaProhibited)
             {
                 diagnostic.amend(Fix::deletion(comma.0, comma.2));
             }
@@ -265,7 +265,7 @@ pub fn trailing_commas(
                 },
             );
             if matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(&RuleCode::COM812)
+                && settings.rules.should_fix(&Rule::TrailingCommaMissing)
             {
                 diagnostic.amend(Fix::insertion(",".to_owned(), missing_comma.2));
             }

--- a/src/rules/flake8_comprehensions/mod.rs
+++ b/src/rules/flake8_comprehensions/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -32,7 +31,7 @@ mod tests {
     #[test_case(RuleCode::C417, Path::new("C417.py"); "C417")]
 
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_comprehensions")
                 .join(path)

--- a/src/rules/flake8_comprehensions/mod.rs
+++ b/src/rules/flake8_comprehensions/mod.rs
@@ -10,27 +10,27 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::C400, Path::new("C400.py"); "C400")]
-    #[test_case(RuleCode::C401, Path::new("C401.py"); "C401")]
-    #[test_case(RuleCode::C402, Path::new("C402.py"); "C402")]
-    #[test_case(RuleCode::C403, Path::new("C403.py"); "C403")]
-    #[test_case(RuleCode::C404, Path::new("C404.py"); "C404")]
-    #[test_case(RuleCode::C405, Path::new("C405.py"); "C405")]
-    #[test_case(RuleCode::C406, Path::new("C406.py"); "C406")]
-    #[test_case(RuleCode::C408, Path::new("C408.py"); "C408")]
-    #[test_case(RuleCode::C409, Path::new("C409.py"); "C409")]
-    #[test_case(RuleCode::C410, Path::new("C410.py"); "C410")]
-    #[test_case(RuleCode::C411, Path::new("C411.py"); "C411")]
-    #[test_case(RuleCode::C413, Path::new("C413.py"); "C413")]
-    #[test_case(RuleCode::C414, Path::new("C414.py"); "C414")]
-    #[test_case(RuleCode::C415, Path::new("C415.py"); "C415")]
-    #[test_case(RuleCode::C416, Path::new("C416.py"); "C416")]
-    #[test_case(RuleCode::C417, Path::new("C417.py"); "C417")]
+    #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"); "C400")]
+    #[test_case(Rule::UnnecessaryGeneratorSet, Path::new("C401.py"); "C401")]
+    #[test_case(Rule::UnnecessaryGeneratorDict, Path::new("C402.py"); "C402")]
+    #[test_case(Rule::UnnecessaryListComprehensionSet, Path::new("C403.py"); "C403")]
+    #[test_case(Rule::UnnecessaryListComprehensionDict, Path::new("C404.py"); "C404")]
+    #[test_case(Rule::UnnecessaryLiteralSet, Path::new("C405.py"); "C405")]
+    #[test_case(Rule::UnnecessaryLiteralDict, Path::new("C406.py"); "C406")]
+    #[test_case(Rule::UnnecessaryCollectionCall, Path::new("C408.py"); "C408")]
+    #[test_case(Rule::UnnecessaryLiteralWithinTupleCall, Path::new("C409.py"); "C409")]
+    #[test_case(Rule::UnnecessaryLiteralWithinListCall, Path::new("C410.py"); "C410")]
+    #[test_case(Rule::UnnecessaryListCall, Path::new("C411.py"); "C411")]
+    #[test_case(Rule::UnnecessaryCallAroundSorted, Path::new("C413.py"); "C413")]
+    #[test_case(Rule::UnnecessaryDoubleCastOrProcess, Path::new("C414.py"); "C414")]
+    #[test_case(Rule::UnnecessarySubscriptReversal, Path::new("C415.py"); "C415")]
+    #[test_case(Rule::UnnecessaryComprehension, Path::new("C416.py"); "C416")]
+    #[test_case(Rule::UnnecessaryMap, Path::new("C417.py"); "C417")]
 
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_comprehensions")

--- a/src/rules/flake8_comprehensions/rules.rs
+++ b/src/rules/flake8_comprehensions/rules.rs
@@ -5,7 +5,7 @@ use rustpython_ast::{Comprehension, Constant, Expr, ExprKind, Keyword, Unaryop};
 use super::fixes;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 fn function_name(func: &Expr) -> Option<&str> {
@@ -65,7 +65,7 @@ pub fn unnecessary_generator_list(
             violations::UnnecessaryGeneratorList,
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::C400) {
+        if checker.patch(&Rule::UnnecessaryGeneratorList) {
             match fixes::fix_unnecessary_generator_list(checker.locator, expr) {
                 Ok(fix) => {
                     diagnostic.amend(fix);
@@ -96,7 +96,7 @@ pub fn unnecessary_generator_set(
             violations::UnnecessaryGeneratorSet,
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::C401) {
+        if checker.patch(&Rule::UnnecessaryGeneratorSet) {
             match fixes::fix_unnecessary_generator_set(checker.locator, expr) {
                 Ok(fix) => {
                     diagnostic.amend(fix);
@@ -126,7 +126,7 @@ pub fn unnecessary_generator_dict(
                     violations::UnnecessaryGeneratorDict,
                     Range::from_located(expr),
                 );
-                if checker.patch(&RuleCode::C402) {
+                if checker.patch(&Rule::UnnecessaryGeneratorDict) {
                     match fixes::fix_unnecessary_generator_dict(checker.locator, expr) {
                         Ok(fix) => {
                             diagnostic.amend(fix);
@@ -160,7 +160,7 @@ pub fn unnecessary_list_comprehension_set(
             violations::UnnecessaryListComprehensionSet,
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::C403) {
+        if checker.patch(&Rule::UnnecessaryListComprehensionSet) {
             match fixes::fix_unnecessary_list_comprehension_set(checker.locator, expr) {
                 Ok(fix) => {
                     diagnostic.amend(fix);
@@ -199,7 +199,7 @@ pub fn unnecessary_list_comprehension_dict(
         violations::UnnecessaryListComprehensionDict,
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C404) {
+    if checker.patch(&Rule::UnnecessaryListComprehensionDict) {
         match fixes::fix_unnecessary_list_comprehension_dict(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -233,7 +233,7 @@ pub fn unnecessary_literal_set(
         violations::UnnecessaryLiteralSet(kind.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C405) {
+    if checker.patch(&Rule::UnnecessaryLiteralSet) {
         match fixes::fix_unnecessary_literal_set(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -274,7 +274,7 @@ pub fn unnecessary_literal_dict(
         violations::UnnecessaryLiteralDict(kind.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C406) {
+    if checker.patch(&Rule::UnnecessaryLiteralDict) {
         match fixes::fix_unnecessary_literal_dict(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -315,7 +315,7 @@ pub fn unnecessary_collection_call(
         violations::UnnecessaryCollectionCall(id.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C408) {
+    if checker.patch(&Rule::UnnecessaryCollectionCall) {
         match fixes::fix_unnecessary_collection_call(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -348,7 +348,7 @@ pub fn unnecessary_literal_within_tuple_call(
         violations::UnnecessaryLiteralWithinTupleCall(argument_kind.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C409) {
+    if checker.patch(&Rule::UnnecessaryLiteralWithinTupleCall) {
         match fixes::fix_unnecessary_literal_within_tuple_call(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -381,7 +381,7 @@ pub fn unnecessary_literal_within_list_call(
         violations::UnnecessaryLiteralWithinListCall(argument_kind.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C410) {
+    if checker.patch(&Rule::UnnecessaryLiteralWithinListCall) {
         match fixes::fix_unnecessary_literal_within_list_call(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -405,7 +405,7 @@ pub fn unnecessary_list_call(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     }
     let mut diagnostic =
         Diagnostic::new(violations::UnnecessaryListCall, Range::from_located(expr));
-    if checker.patch(&RuleCode::C411) {
+    if checker.patch(&Rule::UnnecessaryListCall) {
         match fixes::fix_unnecessary_list_call(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -448,7 +448,7 @@ pub fn unnecessary_call_around_sorted(
         violations::UnnecessaryCallAroundSorted(outer.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C413) {
+    if checker.patch(&Rule::UnnecessaryCallAroundSorted) {
         match fixes::fix_unnecessary_call_around_sorted(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -611,7 +611,7 @@ pub fn unnecessary_comprehension(
         violations::UnnecessaryComprehension(id.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(&RuleCode::C416) {
+    if checker.patch(&Rule::UnnecessaryComprehension) {
         match fixes::fix_unnecessary_comprehension(checker.locator, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);

--- a/src/rules/flake8_datetimez/mod.rs
+++ b/src/rules/flake8_datetimez/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -23,7 +22,7 @@ mod tests {
     #[test_case(RuleCode::DTZ011, Path::new("DTZ011.py"); "DTZ011")]
     #[test_case(RuleCode::DTZ012, Path::new("DTZ012.py"); "DTZ012")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_datetimez")
                 .join(path)

--- a/src/rules/flake8_datetimez/mod.rs
+++ b/src/rules/flake8_datetimez/mod.rs
@@ -9,19 +9,19 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::DTZ001, Path::new("DTZ001.py"); "DTZ001")]
-    #[test_case(RuleCode::DTZ002, Path::new("DTZ002.py"); "DTZ002")]
-    #[test_case(RuleCode::DTZ003, Path::new("DTZ003.py"); "DTZ003")]
-    #[test_case(RuleCode::DTZ004, Path::new("DTZ004.py"); "DTZ004")]
-    #[test_case(RuleCode::DTZ005, Path::new("DTZ005.py"); "DTZ005")]
-    #[test_case(RuleCode::DTZ006, Path::new("DTZ006.py"); "DTZ006")]
-    #[test_case(RuleCode::DTZ007, Path::new("DTZ007.py"); "DTZ007")]
-    #[test_case(RuleCode::DTZ011, Path::new("DTZ011.py"); "DTZ011")]
-    #[test_case(RuleCode::DTZ012, Path::new("DTZ012.py"); "DTZ012")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::CallDatetimeWithoutTzinfo, Path::new("DTZ001.py"); "DTZ001")]
+    #[test_case(Rule::CallDatetimeToday, Path::new("DTZ002.py"); "DTZ002")]
+    #[test_case(Rule::CallDatetimeUtcnow, Path::new("DTZ003.py"); "DTZ003")]
+    #[test_case(Rule::CallDatetimeUtcfromtimestamp, Path::new("DTZ004.py"); "DTZ004")]
+    #[test_case(Rule::CallDatetimeNowWithoutTzinfo, Path::new("DTZ005.py"); "DTZ005")]
+    #[test_case(Rule::CallDatetimeFromtimestamp, Path::new("DTZ006.py"); "DTZ006")]
+    #[test_case(Rule::CallDatetimeStrptimeWithoutZone, Path::new("DTZ007.py"); "DTZ007")]
+    #[test_case(Rule::CallDateToday, Path::new("DTZ011.py"); "DTZ011")]
+    #[test_case(Rule::CallDateFromtimestamp, Path::new("DTZ012.py"); "DTZ012")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_datetimez")

--- a/src/rules/flake8_debugger/mod.rs
+++ b/src/rules/flake8_debugger/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod types;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -16,7 +15,7 @@ mod tests {
 
     #[test_case(RuleCode::T100, Path::new("T100.py"); "T100")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_debugger")
                 .join(path)

--- a/src/rules/flake8_debugger/mod.rs
+++ b/src/rules/flake8_debugger/mod.rs
@@ -10,11 +10,11 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::T100, Path::new("T100.py"); "T100")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::Debugger, Path::new("T100.py"); "T100")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_debugger")

--- a/src/rules/flake8_errmsg/mod.rs
+++ b/src/rules/flake8_errmsg/mod.rs
@@ -9,14 +9,18 @@ mod tests {
     use anyhow::Result;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
     #[test]
     fn defaults() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_errmsg/EM.py"),
-            &settings::Settings::for_rules(vec![RuleCode::EM101, RuleCode::EM102, RuleCode::EM103]),
+            &settings::Settings::for_rules(vec![
+                Rule::RawStringInException,
+                Rule::FStringInException,
+                Rule::DotFormatInException,
+            ]),
         )?;
         insta::assert_yaml_snapshot!("defaults", diagnostics);
         Ok(())
@@ -31,9 +35,9 @@ mod tests {
                     max_string_length: 20,
                 },
                 ..settings::Settings::for_rules(vec![
-                    RuleCode::EM101,
-                    RuleCode::EM102,
-                    RuleCode::EM103,
+                    Rule::RawStringInException,
+                    Rule::FStringInException,
+                    Rule::DotFormatInException,
                 ])
             },
         )?;

--- a/src/rules/flake8_errmsg/rules.rs
+++ b/src/rules/flake8_errmsg/rules.rs
@@ -2,7 +2,7 @@ use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// EM101, EM102, EM103
@@ -15,7 +15,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                     value: Constant::Str(string),
                     ..
                 } => {
-                    if checker.settings.rules.enabled(&RuleCode::EM101) {
+                    if checker.settings.rules.enabled(&Rule::RawStringInException) {
                         if string.len() > checker.settings.flake8_errmsg.max_string_length {
                             checker.diagnostics.push(Diagnostic::new(
                                 violations::RawStringInException,
@@ -26,7 +26,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                 }
                 // Check for f-strings
                 ExprKind::JoinedStr { .. } => {
-                    if checker.settings.rules.enabled(&RuleCode::EM102) {
+                    if checker.settings.rules.enabled(&Rule::FStringInException) {
                         checker.diagnostics.push(Diagnostic::new(
                             violations::FStringInException,
                             Range::from_located(first),
@@ -35,7 +35,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                 }
                 // Check for .format() calls
                 ExprKind::Call { func, .. } => {
-                    if checker.settings.rules.enabled(&RuleCode::EM103) {
+                    if checker.settings.rules.enabled(&Rule::DotFormatInException) {
                         if let ExprKind::Attribute { value, attr, .. } = &func.node {
                             if attr == "format" && matches!(value.node, ExprKind::Constant { .. }) {
                                 checker.diagnostics.push(Diagnostic::new(

--- a/src/rules/flake8_implicit_str_concat/mod.rs
+++ b/src/rules/flake8_implicit_str_concat/mod.rs
@@ -9,13 +9,13 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::ISC001, Path::new("ISC.py"); "ISC001")]
-    #[test_case(RuleCode::ISC002, Path::new("ISC.py"); "ISC002")]
-    #[test_case(RuleCode::ISC003, Path::new("ISC.py"); "ISC003")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::SingleLineImplicitStringConcatenation, Path::new("ISC.py"); "ISC001")]
+    #[test_case(Rule::MultiLineImplicitStringConcatenation, Path::new("ISC.py"); "ISC002")]
+    #[test_case(Rule::ExplicitStringConcatenation, Path::new("ISC.py"); "ISC003")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_implicit_str_concat")

--- a/src/rules/flake8_implicit_str_concat/mod.rs
+++ b/src/rules/flake8_implicit_str_concat/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -17,7 +16,7 @@ mod tests {
     #[test_case(RuleCode::ISC002, Path::new("ISC.py"); "ISC002")]
     #[test_case(RuleCode::ISC003, Path::new("ISC.py"); "ISC003")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_implicit_str_concat")
                 .join(path)

--- a/src/rules/flake8_import_conventions/mod.rs
+++ b/src/rules/flake8_import_conventions/mod.rs
@@ -10,14 +10,14 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test]
     fn defaults() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_import_conventions/defaults.py"),
-            &Settings::for_rule(RuleCode::ICN001),
+            &Settings::for_rule(Rule::ImportAliasIsNotConventional),
         )?;
         insta::assert_yaml_snapshot!("defaults", diagnostics);
         Ok(())
@@ -36,7 +36,7 @@ mod tests {
                     ])),
                 }
                 .into(),
-                ..Settings::for_rule(RuleCode::ICN001)
+                ..Settings::for_rule(Rule::ImportAliasIsNotConventional)
             },
         )?;
         insta::assert_yaml_snapshot!("custom", diagnostics);
@@ -58,7 +58,7 @@ mod tests {
                     extend_aliases: None,
                 }
                 .into(),
-                ..Settings::for_rule(RuleCode::ICN001)
+                ..Settings::for_rule(Rule::ImportAliasIsNotConventional)
             },
         )?;
         insta::assert_yaml_snapshot!("remove_default", diagnostics);
@@ -78,7 +78,7 @@ mod tests {
                     )])),
                 }
                 .into(),
-                ..Settings::for_rule(RuleCode::ICN001)
+                ..Settings::for_rule(Rule::ImportAliasIsNotConventional)
             },
         )?;
         insta::assert_yaml_snapshot!("override_default", diagnostics);

--- a/src/rules/flake8_no_pep420/mod.rs
+++ b/src/rules/flake8_no_pep420/mod.rs
@@ -9,7 +9,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test_case(Path::new("test_pass"); "INP001_0")]
@@ -24,7 +24,7 @@ mod tests {
                 .join(path)
                 .join("example.py")
                 .as_path(),
-            &Settings::for_rule(RuleCode::INP001),
+            &Settings::for_rule(Rule::ImplicitNamespacePackage),
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
         Ok(())

--- a/src/rules/flake8_pie/mod.rs
+++ b/src/rules/flake8_pie/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -18,7 +17,7 @@ mod tests {
     #[test_case(RuleCode::PIE796, Path::new("PIE796.py"); "PIE796")]
     #[test_case(RuleCode::PIE807, Path::new("PIE807.py"); "PIE807")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_pie")
                 .join(path)

--- a/src/rules/flake8_pie/mod.rs
+++ b/src/rules/flake8_pie/mod.rs
@@ -9,14 +9,14 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::PIE790, Path::new("PIE790.py"); "PIE790")]
-    #[test_case(RuleCode::PIE794, Path::new("PIE794.py"); "PIE794")]
-    #[test_case(RuleCode::PIE796, Path::new("PIE796.py"); "PIE796")]
-    #[test_case(RuleCode::PIE807, Path::new("PIE807.py"); "PIE807")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::NoUnnecessaryPass, Path::new("PIE790.py"); "PIE790")]
+    #[test_case(Rule::DupeClassFieldDefinitions, Path::new("PIE794.py"); "PIE794")]
+    #[test_case(Rule::PreferUniqueEnums, Path::new("PIE796.py"); "PIE796")]
+    #[test_case(Rule::PreferListBuiltin, Path::new("PIE807.py"); "PIE807")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_pie")

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -8,7 +8,7 @@ use crate::ast::types::{Range, RefEquality};
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// PIE790
@@ -33,7 +33,7 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                     violations::NoUnnecessaryPass,
                     Range::from_located(pass_stmt),
                 );
-                if checker.patch(&RuleCode::PIE790) {
+                if checker.patch(&Rule::NoUnnecessaryPass) {
                     match delete_stmt(pass_stmt, None, &[], checker.locator, checker.indexer) {
                         Ok(fix) => {
                             diagnostic.amend(fix);
@@ -86,7 +86,7 @@ pub fn dupe_class_field_definitions<'a, 'b>(
                 violations::DupeClassFieldDefinitions(target.to_string()),
                 Range::from_located(stmt),
             );
-            if checker.patch(&RuleCode::PIE794) {
+            if checker.patch(&Rule::DupeClassFieldDefinitions) {
                 let deleted: Vec<&Stmt> = checker
                     .deletions
                     .iter()
@@ -162,7 +162,7 @@ pub fn prefer_list_builtin(checker: &mut Checker, expr: &Expr) {
             if elts.is_empty() {
                 let mut diagnostic =
                     Diagnostic::new(violations::PreferListBuiltin, Range::from_located(expr));
-                if checker.patch(&RuleCode::PIE807) {
+                if checker.patch(&Rule::PreferListBuiltin) {
                     diagnostic.amend(Fix::replacement(
                         "list".to_string(),
                         expr.location,

--- a/src/rules/flake8_print/mod.rs
+++ b/src/rules/flake8_print/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -16,7 +15,7 @@ mod tests {
     #[test_case(RuleCode::T201, Path::new("T201.py"); "T201")]
     #[test_case(RuleCode::T203, Path::new("T203.py"); "T203")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_print")
                 .join(path)

--- a/src/rules/flake8_print/mod.rs
+++ b/src/rules/flake8_print/mod.rs
@@ -9,12 +9,12 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::T201, Path::new("T201.py"); "T201")]
-    #[test_case(RuleCode::T203, Path::new("T203.py"); "T203")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::PrintFound, Path::new("T201.py"); "T201")]
+    #[test_case(Rule::PPrintFound, Path::new("T203.py"); "T203")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_print")

--- a/src/rules/flake8_print/rules/print_call.rs
+++ b/src/rules/flake8_print/rules/print_call.rs
@@ -44,11 +44,11 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
         }
     };
 
-    if !checker.settings.rules.enabled(diagnostic.kind.code()) {
+    if !checker.settings.rules.enabled(diagnostic.kind.rule()) {
         return;
     }
 
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let defined_by = checker.current_stmt();
         let defined_in = checker.current_stmt_parent();
         if matches!(defined_by.node, StmtKind::Expr { .. }) {

--- a/src/rules/flake8_pytest_style/mod.rs
+++ b/src/rules/flake8_pytest_style/mod.rs
@@ -13,12 +13,12 @@ mod tests {
     use super::settings::Settings;
     use super::types;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::PT001, Path::new("PT001.py"), Settings::default(), "PT001_default"; "PT001_0")]
+    #[test_case(Rule::IncorrectFixtureParenthesesStyle, Path::new("PT001.py"), Settings::default(), "PT001_default"; "PT001_0")]
     #[test_case(
-        RuleCode::PT001,
+        Rule::IncorrectFixtureParenthesesStyle,
         Path::new("PT001.py"),
         Settings {
             fixture_parentheses: false,
@@ -27,13 +27,13 @@ mod tests {
         "PT001_no_parentheses";
         "PT001_1"
     )]
-    #[test_case(RuleCode::PT002, Path::new("PT002.py"), Settings::default(), "PT002"; "PT002")]
-    #[test_case(RuleCode::PT003, Path::new("PT003.py"), Settings::default(), "PT003"; "PT003")]
-    #[test_case(RuleCode::PT004, Path::new("PT004.py"), Settings::default(), "PT004"; "PT004")]
-    #[test_case(RuleCode::PT005, Path::new("PT005.py"), Settings::default(), "PT005"; "PT005")]
-    #[test_case(RuleCode::PT006, Path::new("PT006.py"), Settings::default(), "PT006_default"; "PT006_0")]
+    #[test_case(Rule::FixturePositionalArgs, Path::new("PT002.py"), Settings::default(), "PT002"; "PT002")]
+    #[test_case(Rule::ExtraneousScopeFunction, Path::new("PT003.py"), Settings::default(), "PT003"; "PT003")]
+    #[test_case(Rule::MissingFixtureNameUnderscore, Path::new("PT004.py"), Settings::default(), "PT004"; "PT004")]
+    #[test_case(Rule::IncorrectFixtureNameUnderscore, Path::new("PT005.py"), Settings::default(), "PT005"; "PT005")]
+    #[test_case(Rule::ParametrizeNamesWrongType, Path::new("PT006.py"), Settings::default(), "PT006_default"; "PT006_0")]
     #[test_case(
-        RuleCode::PT006,
+        Rule::ParametrizeNamesWrongType,
         Path::new("PT006.py"),
         Settings {
             parametrize_names_type: types::ParametrizeNameType::Csv,
@@ -43,7 +43,7 @@ mod tests {
         "PT006_1"
     )]
     #[test_case(
-        RuleCode::PT006,
+        Rule::ParametrizeNamesWrongType,
         Path::new("PT006.py"),
         Settings {
             parametrize_names_type: types::ParametrizeNameType::List,
@@ -53,14 +53,14 @@ mod tests {
         "PT006_2"
     )]
     #[test_case(
-        RuleCode::PT007,
+        Rule::ParametrizeValuesWrongType,
         Path::new("PT007.py"),
         Settings::default(),
         "PT007_list_of_tuples";
         "PT007_0"
     )]
     #[test_case(
-        RuleCode::PT007,
+        Rule::ParametrizeValuesWrongType,
         Path::new("PT007.py"),
         Settings {
             parametrize_values_type: types::ParametrizeValuesType::Tuple,
@@ -70,7 +70,7 @@ mod tests {
         "PT007_1"
     )]
     #[test_case(
-        RuleCode::PT007,
+        Rule::ParametrizeValuesWrongType,
         Path::new("PT007.py"),
         Settings {
             parametrize_values_type: types::ParametrizeValuesType::Tuple,
@@ -81,7 +81,7 @@ mod tests {
         "PT007_2"
     )]
     #[test_case(
-        RuleCode::PT007,
+        Rule::ParametrizeValuesWrongType,
         Path::new("PT007.py"),
         Settings {
             parametrize_values_row_type: types::ParametrizeValuesRowType::List,
@@ -91,29 +91,29 @@ mod tests {
         "PT007_3"
     )]
     #[test_case(
-        RuleCode::PT008,
+        Rule::PatchWithLambda,
         Path::new("PT008.py"),
         Settings::default(),
         "PT008";
         "PT008"
     )]
     #[test_case(
-        RuleCode::PT009,
+        Rule::UnittestAssertion,
         Path::new("PT009.py"),
         Settings::default(),
         "PT009";
         "PT009"
     )]
-    #[test_case(RuleCode::PT010, Path::new("PT010.py"), Settings::default(), "PT010"; "PT0010")]
+    #[test_case(Rule::RaisesWithoutException, Path::new("PT010.py"), Settings::default(), "PT010"; "PT0010")]
     #[test_case(
-        RuleCode::PT011,
+        Rule::RaisesTooBroad,
         Path::new("PT011.py"),
         Settings::default(),
         "PT011_default";
         "PT011_0"
     )]
     #[test_case(
-        RuleCode::PT011,
+        Rule::RaisesTooBroad,
         Path::new("PT011.py"),
         Settings {
             raises_extend_require_match_for: vec!["ZeroDivisionError".to_string()],
@@ -123,7 +123,7 @@ mod tests {
         "PT011_1"
     )]
     #[test_case(
-        RuleCode::PT011,
+        Rule::RaisesTooBroad,
         Path::new("PT011.py"),
         Settings {
             raises_require_match_for: vec!["ZeroDivisionError".to_string()],
@@ -133,84 +133,84 @@ mod tests {
         "PT011_2"
     )]
     #[test_case(
-        RuleCode::PT012,
+        Rule::RaisesWithMultipleStatements,
         Path::new("PT012.py"),
         Settings::default(),
         "PT012";
         "PT012"
     )]
     #[test_case(
-        RuleCode::PT013,
+        Rule::IncorrectPytestImport,
         Path::new("PT013.py"),
         Settings::default(),
         "PT013";
         "PT013"
     )]
     #[test_case(
-        RuleCode::PT015,
+        Rule::AssertAlwaysFalse,
         Path::new("PT015.py"),
         Settings::default(),
         "PT015";
         "PT015"
     )]
     #[test_case(
-        RuleCode::PT016,
+        Rule::FailWithoutMessage,
         Path::new("PT016.py"),
         Settings::default(),
         "PT016";
         "PT016"
     )]
     #[test_case(
-        RuleCode::PT017,
+        Rule::AssertInExcept,
         Path::new("PT017.py"),
         Settings::default(),
         "PT017";
         "PT017"
     )]
     #[test_case(
-        RuleCode::PT018,
+        Rule::CompositeAssertion,
         Path::new("PT018.py"),
         Settings::default(),
         "PT018";
         "PT018"
     )]
     #[test_case(
-        RuleCode::PT019,
+        Rule::FixtureParamWithoutValue,
         Path::new("PT019.py"),
         Settings::default(),
         "PT019";
         "PT019"
     )]
     #[test_case(
-        RuleCode::PT020,
+        Rule::DeprecatedYieldFixture,
         Path::new("PT020.py"),
         Settings::default(),
         "PT020";
         "PT020"
     )]
     #[test_case(
-        RuleCode::PT021,
+        Rule::FixtureFinalizerCallback,
         Path::new("PT021.py"),
         Settings::default(),
         "PT021";
         "PT021"
     )]
     #[test_case(
-        RuleCode::PT022,
+        Rule::UselessYieldFixture,
         Path::new("PT022.py"),
         Settings::default(),
         "PT022";
         "PT022"
     )]
     #[test_case(
-        RuleCode::PT023,
+        Rule::IncorrectMarkParenthesesStyle,
         Path::new("PT023.py"),
         Settings::default(),
         "PT023_default";
         "PT023_0"
     )]
     #[test_case(
-        RuleCode::PT023,
+        Rule::IncorrectMarkParenthesesStyle,
         Path::new("PT023.py"),
         Settings {
             mark_parentheses: false,
@@ -220,28 +220,28 @@ mod tests {
         "PT023_1"
     )]
     #[test_case(
-        RuleCode::PT024,
+        Rule::UnnecessaryAsyncioMarkOnFixture,
         Path::new("PT024.py"),
         Settings::default(),
         "PT024";
         "PT024"
     )]
     #[test_case(
-        RuleCode::PT025,
+        Rule::ErroneousUseFixturesOnFixture,
         Path::new("PT025.py"),
         Settings::default(),
         "PT025";
         "PT025"
     )]
     #[test_case(
-        RuleCode::PT026,
+        Rule::UseFixturesWithoutParameters,
         Path::new("PT026.py"),
         Settings::default(),
         "PT026";
         "PT026"
     )]
     fn test_pytest_style(
-        rule_code: RuleCode,
+        rule_code: Rule,
         path: &Path,
         plugin_settings: Settings,
         name: &str,

--- a/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -103,7 +103,7 @@ pub fn unittest_assertion(
                     violations::UnittestAssertion(unittest_assert.to_string()),
                     Range::from_located(func),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
                         diagnostic.amend(Fix::replacement(
                             unparse_stmt(&stmt, checker.stylist),

--- a/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -83,7 +83,7 @@ fn pytest_fixture_parentheses(
         violations::IncorrectFixtureParenthesesStyle(preferred.to_string(), actual.to_string()),
         Range::from_located(decorator),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(fix);
     }
     checker.diagnostics.push(diagnostic);
@@ -180,7 +180,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
                             violations::UselessYieldFixture(func_name.to_string()),
                             Range::from_located(stmt),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
                                 "return".to_string(),
                                 stmt.location,
@@ -252,7 +252,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     violations::UnnecessaryAsyncioMarkOnFixture,
                     Range::from_located(mark),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);
                     diagnostic.amend(Fix::deletion(start, end));
@@ -267,7 +267,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     violations::ErroneousUseFixturesOnFixture,
                     Range::from_located(mark),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);
                     diagnostic.amend(Fix::deletion(start, end));

--- a/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -10,7 +10,7 @@ use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 #[derive(Default)]
@@ -98,7 +98,10 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             keywords,
             ..
         } => {
-            if checker.settings.rules.enabled(&RuleCode::PT001)
+            if checker
+                .settings
+                .rules
+                .enabled(&Rule::IncorrectFixtureParenthesesStyle)
                 && !checker.settings.flake8_pytest_style.fixture_parentheses
                 && args.is_empty()
                 && keywords.is_empty()
@@ -111,14 +114,18 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 pytest_fixture_parentheses(checker, decorator, fix, "", "()");
             }
 
-            if checker.settings.rules.enabled(&RuleCode::PT002) && !args.is_empty() {
+            if checker.settings.rules.enabled(&Rule::FixturePositionalArgs) && !args.is_empty() {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::FixturePositionalArgs(func_name.to_string()),
                     Range::from_located(decorator),
                 ));
             }
 
-            if checker.settings.rules.enabled(&RuleCode::PT003) {
+            if checker
+                .settings
+                .rules
+                .enabled(&Rule::ExtraneousScopeFunction)
+            {
                 let scope_keyword = keywords
                     .iter()
                     .find(|kw| kw.node.arg == Some("scope".to_string()));
@@ -134,7 +141,10 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             }
         }
         _ => {
-            if checker.settings.rules.enabled(&RuleCode::PT001)
+            if checker
+                .settings
+                .rules
+                .enabled(&Rule::IncorrectFixtureParenthesesStyle)
                 && checker.settings.flake8_pytest_style.fixture_parentheses
             {
                 let fix = Fix::insertion("()".to_string(), decorator.end_location.unwrap());
@@ -152,7 +162,10 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
         visitor.visit_stmt(stmt);
     }
 
-    if checker.settings.rules.enabled(&RuleCode::PT005)
+    if checker
+        .settings
+        .rules
+        .enabled(&Rule::IncorrectFixtureNameUnderscore)
         && visitor.has_return_with_value
         && func_name.starts_with('_')
     {
@@ -160,7 +173,10 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
             violations::IncorrectFixtureNameUnderscore(func_name.to_string()),
             Range::from_located(func),
         ));
-    } else if checker.settings.rules.enabled(&RuleCode::PT004)
+    } else if checker
+        .settings
+        .rules
+        .enabled(&Rule::MissingFixtureNameUnderscore)
         && !visitor.has_return_with_value
         && !visitor.has_yield_from
         && !func_name.starts_with('_')
@@ -171,7 +187,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
         ));
     }
 
-    if checker.settings.rules.enabled(&RuleCode::PT022) {
+    if checker.settings.rules.enabled(&Rule::UselessYieldFixture) {
         if let Some(stmt) = body.last() {
             if let StmtKind::Expr { value, .. } = &stmt.node {
                 if let ExprKind::Yield { .. } = value.node {
@@ -246,7 +262,11 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
     for mark in get_mark_decorators(decorators) {
         let name = get_mark_name(mark);
 
-        if checker.settings.rules.enabled(&RuleCode::PT024) {
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+        {
             if name == "asyncio" {
                 let mut diagnostic = Diagnostic::new(
                     violations::UnnecessaryAsyncioMarkOnFixture,
@@ -261,7 +281,11 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
             }
         }
 
-        if checker.settings.rules.enabled(&RuleCode::PT025) {
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::ErroneousUseFixturesOnFixture)
+        {
             if name == "usefixtures" {
                 let mut diagnostic = Diagnostic::new(
                     violations::ErroneousUseFixturesOnFixture,
@@ -288,39 +312,69 @@ pub fn fixture(
 ) {
     let decorator = get_fixture_decorator(checker, decorators);
     if let Some(decorator) = decorator {
-        if checker.settings.rules.enabled(&RuleCode::PT001)
-            || checker.settings.rules.enabled(&RuleCode::PT002)
-            || checker.settings.rules.enabled(&RuleCode::PT003)
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::IncorrectFixtureParenthesesStyle)
+            || checker.settings.rules.enabled(&Rule::FixturePositionalArgs)
+            || checker
+                .settings
+                .rules
+                .enabled(&Rule::ExtraneousScopeFunction)
         {
             check_fixture_decorator(checker, func_name, decorator);
         }
 
-        if checker.settings.rules.enabled(&RuleCode::PT020)
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::DeprecatedYieldFixture)
             && checker.settings.flake8_pytest_style.fixture_parentheses
         {
             check_fixture_decorator_name(checker, decorator);
         }
 
-        if (checker.settings.rules.enabled(&RuleCode::PT004)
-            || checker.settings.rules.enabled(&RuleCode::PT005)
-            || checker.settings.rules.enabled(&RuleCode::PT022))
+        if (checker
+            .settings
+            .rules
+            .enabled(&Rule::MissingFixtureNameUnderscore)
+            || checker
+                .settings
+                .rules
+                .enabled(&Rule::IncorrectFixtureNameUnderscore)
+            || checker.settings.rules.enabled(&Rule::UselessYieldFixture))
             && !has_abstractmethod_decorator(decorators, checker)
         {
             check_fixture_returns(checker, func, func_name, body);
         }
 
-        if checker.settings.rules.enabled(&RuleCode::PT021) {
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::FixtureFinalizerCallback)
+        {
             check_fixture_addfinalizer(checker, args, body);
         }
 
-        if checker.settings.rules.enabled(&RuleCode::PT024)
-            || checker.settings.rules.enabled(&RuleCode::PT025)
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+            || checker
+                .settings
+                .rules
+                .enabled(&Rule::ErroneousUseFixturesOnFixture)
         {
             check_fixture_marks(checker, decorators);
         }
     }
 
-    if checker.settings.rules.enabled(&RuleCode::PT019) && func_name.starts_with("test_") {
+    if checker
+        .settings
+        .rules
+        .enabled(&Rule::FixtureParamWithoutValue)
+        && func_name.starts_with("test_")
+    {
         check_test_function_args(checker, args);
     }
 }

--- a/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/src/rules/flake8_pytest_style/rules/marks.rs
@@ -4,7 +4,7 @@ use super::helpers::{get_mark_decorators, get_mark_name};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 fn pytest_mark_parentheses(
@@ -84,8 +84,14 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr) {
 }
 
 pub fn marks(checker: &mut Checker, decorators: &[Expr]) {
-    let enforce_parentheses = checker.settings.rules.enabled(&RuleCode::PT023);
-    let enforce_useless_usefixtures = checker.settings.rules.enabled(&RuleCode::PT026);
+    let enforce_parentheses = checker
+        .settings
+        .rules
+        .enabled(&Rule::IncorrectMarkParenthesesStyle);
+    let enforce_useless_usefixtures = checker
+        .settings
+        .rules
+        .enabled(&Rule::UseFixturesWithoutParameters);
 
     for mark in get_mark_decorators(decorators) {
         if enforce_parentheses {

--- a/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/src/rules/flake8_pytest_style/rules/marks.rs
@@ -22,7 +22,7 @@ fn pytest_mark_parentheses(
         ),
         Range::from_located(decorator),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(fix);
     }
     checker.diagnostics.push(diagnostic);
@@ -75,7 +75,7 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr) {
             violations::UseFixturesWithoutParameters,
             Range::from_located(decorator),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             let at_start = Location::new(decorator.location.row(), decorator.location.column() - 1);
             diagnostic.amend(Fix::deletion(at_start, decorator.end_location.unwrap()));
         }

--- a/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -6,7 +6,7 @@ use crate::ast::helpers::create_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Generator;
 use crate::violations;
 
@@ -328,12 +328,20 @@ pub fn parametrize(checker: &mut Checker, decorators: &[Expr]) {
     let decorator = get_parametrize_decorator(checker, decorators);
     if let Some(decorator) = decorator {
         if let ExprKind::Call { args, .. } = &decorator.node {
-            if checker.settings.rules.enabled(&RuleCode::PT006) {
+            if checker
+                .settings
+                .rules
+                .enabled(&Rule::ParametrizeNamesWrongType)
+            {
                 if let Some(arg) = args.get(0) {
                     check_names(checker, arg);
                 }
             }
-            if checker.settings.rules.enabled(&RuleCode::PT007) {
+            if checker
+                .settings
+                .rules
+                .enabled(&Rule::ParametrizeValuesWrongType)
+            {
                 if let Some(arg) = args.get(1) {
                     check_values(checker, arg);
                 }

--- a/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -84,7 +84,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             let mut generator: Generator = checker.stylist.into();
                             generator.unparse_expr(
                                 &create_expr(ExprKind::Tuple {
@@ -114,7 +114,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             let mut generator: Generator = checker.stylist.into();
                             generator.unparse_expr(
                                 &create_expr(ExprKind::List {
@@ -156,7 +156,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             let mut generator: Generator = checker.stylist.into();
                             generator.unparse_expr(
                                 &create_expr(ExprKind::List {
@@ -178,7 +178,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
                                 diagnostic.amend(Fix::replacement(
                                     content,
@@ -205,7 +205,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             let mut generator: Generator = checker.stylist.into();
                             generator.unparse_expr(
                                 &create_expr(ExprKind::Tuple {
@@ -227,7 +227,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             violations::ParametrizeNamesWrongType(names_type),
                             Range::from_located(expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
                                 diagnostic.amend(Fix::replacement(
                                     content,
@@ -283,7 +283,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
         Range::from_located(expr),
     );
 
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let mut generator: Generator = checker.stylist.into();
         generator.unparse_expr(&create_expr(value.node.clone()), 0);
         diagnostic.amend(Fix::replacement(

--- a/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/src/rules/flake8_pytest_style/rules/raises.rs
@@ -4,7 +4,7 @@ use super::helpers::is_empty_or_null_string;
 use crate::ast::helpers::{format_call_path, to_call_path};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 fn is_pytest_raises(checker: &Checker, func: &Expr) -> bool {
@@ -25,7 +25,11 @@ fn is_non_trivial_with_body(body: &[Stmt]) -> bool {
 
 pub fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_raises(checker, func) {
-        if checker.settings.rules.enabled(&RuleCode::PT010) {
+        if checker
+            .settings
+            .rules
+            .enabled(&Rule::RaisesWithoutException)
+        {
             if args.is_empty() && keywords.is_empty() {
                 checker.diagnostics.push(Diagnostic::new(
                     violations::RaisesWithoutException,
@@ -34,7 +38,7 @@ pub fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: 
             }
         }
 
-        if checker.settings.rules.enabled(&RuleCode::PT011) {
+        if checker.settings.rules.enabled(&Rule::RaisesTooBroad) {
             let match_keyword = keywords
                 .iter()
                 .find(|kw| kw.node.arg == Some("match".to_string()));

--- a/src/rules/flake8_quotes/mod.rs
+++ b/src/rules/flake8_quotes/mod.rs
@@ -11,7 +11,7 @@ mod tests {
 
     use super::settings::Quote;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test_case(Path::new("doubles.py"))]
@@ -33,10 +33,10 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::Q000,
-                    RuleCode::Q001,
-                    RuleCode::Q002,
-                    RuleCode::Q003,
+                    Rule::BadQuotesInlineString,
+                    Rule::BadQuotesMultilineString,
+                    Rule::BadQuotesDocstring,
+                    Rule::AvoidQuoteEscape,
                 ])
             },
         )?;
@@ -63,10 +63,10 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::Q000,
-                    RuleCode::Q001,
-                    RuleCode::Q002,
-                    RuleCode::Q003,
+                    Rule::BadQuotesInlineString,
+                    Rule::BadQuotesMultilineString,
+                    Rule::BadQuotesDocstring,
+                    Rule::AvoidQuoteEscape,
                 ])
             },
         )?;
@@ -98,10 +98,10 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::Q000,
-                    RuleCode::Q001,
-                    RuleCode::Q002,
-                    RuleCode::Q003,
+                    Rule::BadQuotesInlineString,
+                    Rule::BadQuotesMultilineString,
+                    Rule::BadQuotesDocstring,
+                    Rule::AvoidQuoteEscape,
                 ])
             },
         )?;
@@ -133,10 +133,10 @@ mod tests {
                     avoid_escape: true,
                 },
                 ..Settings::for_rules(vec![
-                    RuleCode::Q000,
-                    RuleCode::Q001,
-                    RuleCode::Q002,
-                    RuleCode::Q003,
+                    Rule::BadQuotesInlineString,
+                    Rule::BadQuotesMultilineString,
+                    Rule::BadQuotesDocstring,
+                    Rule::AvoidQuoteEscape,
                 ])
             },
         )?;

--- a/src/rules/flake8_quotes/rules.rs
+++ b/src/rules/flake8_quotes/rules.rs
@@ -3,7 +3,7 @@ use rustpython_ast::Location;
 use super::settings::Quote;
 use crate::ast::types::Range;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violations;
@@ -80,7 +80,8 @@ pub fn quotes(
             violations::BadQuotesDocstring(quotes_settings.docstring_quotes.clone()),
             Range::new(start, end),
         );
-        if matches!(autofix, flags::Autofix::Enabled) && settings.rules.should_fix(&RuleCode::Q002)
+        if matches!(autofix, flags::Autofix::Enabled)
+            && settings.rules.should_fix(&Rule::BadQuotesDocstring)
         {
             let quote_count = if is_multiline { 3 } else { 1 };
             let string_contents = &raw_text[quote_count..raw_text.len() - quote_count];
@@ -110,7 +111,8 @@ pub fn quotes(
             Range::new(start, end),
         );
 
-        if matches!(autofix, flags::Autofix::Enabled) && settings.rules.should_fix(&RuleCode::Q001)
+        if matches!(autofix, flags::Autofix::Enabled)
+            && settings.rules.should_fix(&Rule::BadQuotesMultilineString)
         {
             let string_contents = &raw_text[3..raw_text.len() - 3];
             let quote = good_multiline(&quotes_settings.multiline_quotes);
@@ -137,7 +139,7 @@ pub fn quotes(
                 let mut diagnostic =
                     Diagnostic::new(violations::AvoidQuoteEscape, Range::new(start, end));
                 if matches!(autofix, flags::Autofix::Enabled)
-                    && settings.rules.should_fix(&RuleCode::Q003)
+                    && settings.rules.should_fix(&Rule::AvoidQuoteEscape)
                 {
                     let quote = bad_single(&quotes_settings.inline_quotes);
 
@@ -193,7 +195,7 @@ pub fn quotes(
                 Range::new(start, end),
             );
             if matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(&RuleCode::Q000)
+                && settings.rules.should_fix(&Rule::BadQuotesInlineString)
             {
                 let quote = good_single(&quotes_settings.inline_quotes);
                 let mut fixed_contents =

--- a/src/rules/flake8_return/mod.rs
+++ b/src/rules/flake8_return/mod.rs
@@ -11,18 +11,18 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
-    #[test_case(RuleCode::RET501, Path::new("RET501.py"); "RET501")]
-    #[test_case(RuleCode::RET502, Path::new("RET502.py"); "RET502")]
-    #[test_case(RuleCode::RET503, Path::new("RET503.py"); "RET503")]
-    #[test_case(RuleCode::RET504, Path::new("RET504.py"); "RET504")]
-    #[test_case(RuleCode::RET505, Path::new("RET505.py"); "RET505")]
-    #[test_case(RuleCode::RET506, Path::new("RET506.py"); "RET506")]
-    #[test_case(RuleCode::RET507, Path::new("RET507.py"); "RET507")]
-    #[test_case(RuleCode::RET508, Path::new("RET508.py"); "RET508")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UnnecessaryReturnNone, Path::new("RET501.py"); "RET501")]
+    #[test_case(Rule::ImplicitReturnValue, Path::new("RET502.py"); "RET502")]
+    #[test_case(Rule::ImplicitReturn, Path::new("RET503.py"); "RET503")]
+    #[test_case(Rule::UnnecessaryAssign, Path::new("RET504.py"); "RET504")]
+    #[test_case(Rule::SuperfluousElseReturn, Path::new("RET505.py"); "RET505")]
+    #[test_case(Rule::SuperfluousElseRaise, Path::new("RET506.py"); "RET506")]
+    #[test_case(Rule::SuperfluousElseContinue, Path::new("RET507.py"); "RET507")]
+    #[test_case(Rule::SuperfluousElseBreak, Path::new("RET508.py"); "RET508")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_return")

--- a/src/rules/flake8_return/mod.rs
+++ b/src/rules/flake8_return/mod.rs
@@ -23,7 +23,7 @@ mod tests {
     #[test_case(RuleCode::RET507, Path::new("RET507.py"); "RET507")]
     #[test_case(RuleCode::RET508, Path::new("RET508.py"); "RET508")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_return")
                 .join(path)

--- a/src/rules/flake8_simplify/mod.rs
+++ b/src/rules/flake8_simplify/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -39,7 +38,7 @@ mod tests {
     #[test_case(RuleCode::SIM300, Path::new("SIM300.py"); "SIM300")]
     #[test_case(RuleCode::SIM401, Path::new("SIM401.py"); "SIM401")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_simplify")
                 .join(path)

--- a/src/rules/flake8_simplify/mod.rs
+++ b/src/rules/flake8_simplify/mod.rs
@@ -9,35 +9,35 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::SIM101, Path::new("SIM101.py"); "SIM101")]
-    #[test_case(RuleCode::SIM102, Path::new("SIM102.py"); "SIM102")]
-    #[test_case(RuleCode::SIM103, Path::new("SIM103.py"); "SIM103")]
-    #[test_case(RuleCode::SIM105, Path::new("SIM105.py"); "SIM105")]
-    #[test_case(RuleCode::SIM107, Path::new("SIM107.py"); "SIM107")]
-    #[test_case(RuleCode::SIM108, Path::new("SIM108.py"); "SIM108")]
-    #[test_case(RuleCode::SIM109, Path::new("SIM109.py"); "SIM109")]
-    #[test_case(RuleCode::SIM110, Path::new("SIM110.py"); "SIM110")]
-    #[test_case(RuleCode::SIM111, Path::new("SIM111.py"); "SIM111")]
-    #[test_case(RuleCode::SIM112, Path::new("SIM112.py"); "SIM112")]
-    #[test_case(RuleCode::SIM115, Path::new("SIM115.py"); "SIM115")]
-    #[test_case(RuleCode::SIM117, Path::new("SIM117.py"); "SIM117")]
-    #[test_case(RuleCode::SIM118, Path::new("SIM118.py"); "SIM118")]
-    #[test_case(RuleCode::SIM201, Path::new("SIM201.py"); "SIM201")]
-    #[test_case(RuleCode::SIM202, Path::new("SIM202.py"); "SIM202")]
-    #[test_case(RuleCode::SIM208, Path::new("SIM208.py"); "SIM208")]
-    #[test_case(RuleCode::SIM210, Path::new("SIM210.py"); "SIM210")]
-    #[test_case(RuleCode::SIM211, Path::new("SIM211.py"); "SIM211")]
-    #[test_case(RuleCode::SIM212, Path::new("SIM212.py"); "SIM212")]
-    #[test_case(RuleCode::SIM220, Path::new("SIM220.py"); "SIM220")]
-    #[test_case(RuleCode::SIM221, Path::new("SIM221.py"); "SIM221")]
-    #[test_case(RuleCode::SIM222, Path::new("SIM222.py"); "SIM222")]
-    #[test_case(RuleCode::SIM223, Path::new("SIM223.py"); "SIM223")]
-    #[test_case(RuleCode::SIM300, Path::new("SIM300.py"); "SIM300")]
-    #[test_case(RuleCode::SIM401, Path::new("SIM401.py"); "SIM401")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::DuplicateIsinstanceCall, Path::new("SIM101.py"); "SIM101")]
+    #[test_case(Rule::NestedIfStatements, Path::new("SIM102.py"); "SIM102")]
+    #[test_case(Rule::ReturnBoolConditionDirectly, Path::new("SIM103.py"); "SIM103")]
+    #[test_case(Rule::UseContextlibSuppress, Path::new("SIM105.py"); "SIM105")]
+    #[test_case(Rule::ReturnInTryExceptFinally, Path::new("SIM107.py"); "SIM107")]
+    #[test_case(Rule::UseTernaryOperator, Path::new("SIM108.py"); "SIM108")]
+    #[test_case(Rule::CompareWithTuple, Path::new("SIM109.py"); "SIM109")]
+    #[test_case(Rule::ConvertLoopToAny, Path::new("SIM110.py"); "SIM110")]
+    #[test_case(Rule::ConvertLoopToAll, Path::new("SIM111.py"); "SIM111")]
+    #[test_case(Rule::UseCapitalEnvironmentVariables, Path::new("SIM112.py"); "SIM112")]
+    #[test_case(Rule::OpenFileWithContextHandler, Path::new("SIM115.py"); "SIM115")]
+    #[test_case(Rule::MultipleWithStatements, Path::new("SIM117.py"); "SIM117")]
+    #[test_case(Rule::KeyInDict, Path::new("SIM118.py"); "SIM118")]
+    #[test_case(Rule::NegateEqualOp, Path::new("SIM201.py"); "SIM201")]
+    #[test_case(Rule::NegateNotEqualOp, Path::new("SIM202.py"); "SIM202")]
+    #[test_case(Rule::DoubleNegation, Path::new("SIM208.py"); "SIM208")]
+    #[test_case(Rule::IfExprWithTrueFalse, Path::new("SIM210.py"); "SIM210")]
+    #[test_case(Rule::IfExprWithFalseTrue, Path::new("SIM211.py"); "SIM211")]
+    #[test_case(Rule::IfExprWithTwistedArms, Path::new("SIM212.py"); "SIM212")]
+    #[test_case(Rule::AAndNotA, Path::new("SIM220.py"); "SIM220")]
+    #[test_case(Rule::AOrNotA, Path::new("SIM221.py"); "SIM221")]
+    #[test_case(Rule::OrTrue, Path::new("SIM222.py"); "SIM222")]
+    #[test_case(Rule::AndFalse, Path::new("SIM223.py"); "SIM223")]
+    #[test_case(Rule::YodaConditions, Path::new("SIM300.py"); "SIM300")]
+    #[test_case(Rule::DictGetWithDefault, Path::new("SIM401.py"); "SIM401")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_simplify")

--- a/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -9,7 +9,7 @@ use crate::ast::helpers::{contains_effect, create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// Return `true` if two `Expr` instances are equivalent names.
@@ -66,7 +66,7 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 violations::DuplicateIsinstanceCall(arg_name.to_string()),
                 Range::from_located(expr),
             );
-            if checker.patch(&RuleCode::SIM101) {
+            if checker.patch(&Rule::DuplicateIsinstanceCall) {
                 // Grab the types used in each duplicate `isinstance` call.
                 let types: Vec<&Expr> = indices
                     .iter()
@@ -179,7 +179,7 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
             ),
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::SIM109) {
+        if checker.patch(&Rule::CompareWithTuple) {
             // Create a `x in (a, b)` compare expr.
             let in_expr = create_expr(ExprKind::Compare {
                 left: Box::new(create_expr(ExprKind::Name {
@@ -241,7 +241,7 @@ pub fn a_and_not_a(checker: &mut Checker, expr: &Expr) {
                     violations::AAndNotA(id.to_string()),
                     Range::from_located(expr),
                 );
-                if checker.patch(&RuleCode::SIM220) {
+                if checker.patch(&Rule::AAndNotA) {
                     diagnostic.amend(Fix::replacement(
                         "False".to_string(),
                         expr.location,
@@ -293,7 +293,7 @@ pub fn a_or_not_a(checker: &mut Checker, expr: &Expr) {
                     violations::AOrNotA(id.to_string()),
                     Range::from_located(expr),
                 );
-                if checker.patch(&RuleCode::SIM220) {
+                if checker.patch(&Rule::AAndNotA) {
                     diagnostic.amend(Fix::replacement(
                         "True".to_string(),
                         expr.location,
@@ -321,7 +321,7 @@ pub fn or_true(checker: &mut Checker, expr: &Expr) {
         } = &value.node
         {
             let mut diagnostic = Diagnostic::new(violations::OrTrue, Range::from_located(value));
-            if checker.patch(&RuleCode::SIM223) {
+            if checker.patch(&Rule::AndFalse) {
                 diagnostic.amend(Fix::replacement(
                     "True".to_string(),
                     expr.location,
@@ -348,7 +348,7 @@ pub fn and_false(checker: &mut Checker, expr: &Expr) {
         } = &value.node
         {
             let mut diagnostic = Diagnostic::new(violations::AndFalse, Range::from_located(value));
-            if checker.patch(&RuleCode::SIM223) {
+            if checker.patch(&Rule::AndFalse) {
                 diagnostic.amend(Fix::replacement(
                     "False".to_string(),
                     expr.location,

--- a/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -4,7 +4,7 @@ use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// SIM112
@@ -40,7 +40,7 @@ pub fn use_capital_environment_variables(checker: &mut Checker, expr: &Expr) {
         violations::UseCapitalEnvironmentVariables(capital_env_var.clone(), env_var.clone()),
         Range::from_located(arg),
     );
-    if checker.patch(&RuleCode::SIM112) {
+    if checker.patch(&Rule::UseCapitalEnvironmentVariables) {
         let new_env_var = create_expr(ExprKind::Constant {
             value: capital_env_var.into(),
             kind: kind.clone(),
@@ -79,7 +79,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
         violations::UseCapitalEnvironmentVariables(capital_env_var.clone(), env_var.clone()),
         Range::from_located(slice),
     );
-    if checker.patch(&RuleCode::SIM112) {
+    if checker.patch(&Rule::UseCapitalEnvironmentVariables) {
         let new_env_var = create_expr(ExprKind::Constant {
             value: capital_env_var.into(),
             kind: kind.clone(),

--- a/src/rules/flake8_simplify/rules/ast_for.rs
+++ b/src/rules/flake8_simplify/rules/ast_for.rs
@@ -6,7 +6,7 @@ use crate::ast::helpers::{create_expr, create_stmt};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::{Generator, Stylist};
 use crate::violations;
 
@@ -178,7 +178,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
         Some(sibling) => return_values_for_siblings(stmt, sibling),
     } {
         if loop_info.return_value && !loop_info.next_return_value {
-            if checker.settings.rules.enabled(&RuleCode::SIM110) {
+            if checker.settings.rules.enabled(&Rule::ConvertLoopToAny) {
                 let contents = return_stmt(
                     "any",
                     loop_info.test,
@@ -196,7 +196,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     violations::ConvertLoopToAny(contents.clone()),
                     Range::from_located(stmt),
                 );
-                if checker.patch(&RuleCode::SIM110) {
+                if checker.patch(&Rule::ConvertLoopToAny) {
                     diagnostic.amend(Fix::replacement(
                         contents,
                         stmt.location,
@@ -211,7 +211,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
         }
 
         if !loop_info.return_value && loop_info.next_return_value {
-            if checker.settings.rules.enabled(&RuleCode::SIM111) {
+            if checker.settings.rules.enabled(&Rule::ConvertLoopToAll) {
                 // Invert the condition.
                 let test = {
                     if let ExprKind::UnaryOp {
@@ -244,7 +244,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     violations::ConvertLoopToAll(contents.clone()),
                     Range::from_located(stmt),
                 );
-                if checker.patch(&RuleCode::SIM111) {
+                if checker.patch(&Rule::ConvertLoopToAll) {
                     diagnostic.amend(Fix::replacement(
                         contents,
                         stmt.location,

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -9,7 +9,7 @@ use crate::ast::helpers::{
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::flake8_simplify::rules::fix_if;
 use crate::violations;
 
@@ -67,7 +67,7 @@ pub fn nested_if_statements(checker: &mut Checker, stmt: &Stmt) {
     }
 
     let mut diagnostic = Diagnostic::new(violations::NestedIfStatements, Range::from_located(stmt));
-    if checker.patch(&RuleCode::SIM102) {
+    if checker.patch(&Rule::NestedIfStatements) {
         // The fixer preserves comments in the nested body, but removes comments between
         // the outer and inner if statements.
         let nested_if = &body[0];
@@ -118,7 +118,7 @@ pub fn return_bool_condition_directly(checker: &mut Checker, stmt: &Stmt) {
         violations::ReturnBoolConditionDirectly(condition),
         Range::from_located(stmt),
     );
-    if checker.patch(&RuleCode::SIM103)
+    if checker.patch(&Rule::ReturnBoolConditionDirectly)
         && !(has_comments_in(Range::from_located(stmt), checker.locator)
             || has_comments_in(Range::from_located(&orelse[0]), checker.locator))
     {
@@ -232,7 +232,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
         violations::UseTernaryOperator(contents.clone()),
         Range::from_located(stmt),
     );
-    if checker.patch(&RuleCode::SIM108) {
+    if checker.patch(&Rule::UseTernaryOperator) {
         diagnostic.amend(Fix::replacement(
             contents,
             stmt.location,
@@ -335,7 +335,7 @@ pub fn use_dict_get_with_default(
         violations::DictGetWithDefault(contents.clone()),
         Range::from_located(stmt),
     );
-    if checker.patch(&RuleCode::SIM401) {
+    if checker.patch(&Rule::DictGetWithDefault) {
         diagnostic.amend(Fix::replacement(
             contents,
             stmt.location,

--- a/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -32,7 +32,7 @@ pub fn explicit_true_false_in_ifexpr(
         violations::IfExprWithTrueFalse(unparse_expr(test, checker.stylist)),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(
                 &create_expr(ExprKind::Call {
@@ -77,7 +77,7 @@ pub fn explicit_false_true_in_ifexpr(
         violations::IfExprWithFalseTrue(unparse_expr(test, checker.stylist)),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(
                 &create_expr(ExprKind::UnaryOp {
@@ -126,7 +126,7 @@ pub fn twisted_arms_in_ifexpr(
         ),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(
                 &create_expr(ExprKind::IfExp {

--- a/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -42,7 +42,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
         ),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
@@ -86,7 +86,7 @@ pub fn negation_with_not_equal_op(
         ),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
@@ -119,7 +119,7 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
         violations::DoubleNegation(operand.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_expr(operand, checker.stylist),
             expr.location,

--- a/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/src/rules/flake8_simplify/rules/ast_with.rs
@@ -5,7 +5,7 @@ use super::fix_with;
 use crate::ast::helpers::{first_colon_range, has_comments_in};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
@@ -49,7 +49,7 @@ pub fn multiple_with_statements(
                 |colon| Range::new(with_stmt.location, colon.end_location),
             ),
         );
-        if checker.patch(&RuleCode::SIM117) {
+        if checker.patch(&Rule::MultipleWithStatements) {
             let nested_with = &with_body[0];
             if !has_comments_in(
                 Range::new(with_stmt.location, nested_with.location),

--- a/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -38,7 +38,7 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: Range) {
         violations::KeyInDict(left_content.to_string(), value_content.to_string()),
         range,
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             value_content.to_string(),
             right.location,

--- a/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/src/rules/flake8_tidy_imports/banned_api.rs
@@ -113,7 +113,7 @@ mod tests {
 
     use super::ApiBan;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test]
@@ -139,7 +139,7 @@ mod tests {
                     .into(),
                     ..Default::default()
                 },
-                ..Settings::for_rules(vec![RuleCode::TID251])
+                ..Settings::for_rules(vec![Rule::BannedApi])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -64,7 +64,7 @@ mod tests {
 
     use super::Strictness;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test]
@@ -76,7 +76,7 @@ mod tests {
                     ban_relative_imports: Strictness::Parents,
                     ..Default::default()
                 },
-                ..Settings::for_rules(vec![RuleCode::TID252])
+                ..Settings::for_rules(vec![Rule::RelativeImports])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -92,7 +92,7 @@ mod tests {
                     ban_relative_imports: Strictness::All,
                     ..Default::default()
                 },
-                ..Settings::for_rules(vec![RuleCode::TID252])
+                ..Settings::for_rules(vec![Rule::RelativeImports])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/flake8_unused_arguments/mod.rs
+++ b/src/rules/flake8_unused_arguments/mod.rs
@@ -12,15 +12,15 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::ARG001, Path::new("ARG.py"); "ARG001")]
-    #[test_case(RuleCode::ARG002, Path::new("ARG.py"); "ARG002")]
-    #[test_case(RuleCode::ARG003, Path::new("ARG.py"); "ARG003")]
-    #[test_case(RuleCode::ARG004, Path::new("ARG.py"); "ARG004")]
-    #[test_case(RuleCode::ARG005, Path::new("ARG.py"); "ARG005")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UnusedFunctionArgument, Path::new("ARG.py"); "ARG001")]
+    #[test_case(Rule::UnusedMethodArgument, Path::new("ARG.py"); "ARG002")]
+    #[test_case(Rule::UnusedClassMethodArgument, Path::new("ARG.py"); "ARG003")]
+    #[test_case(Rule::UnusedStaticMethodArgument, Path::new("ARG.py"); "ARG004")]
+    #[test_case(Rule::UnusedLambdaArgument, Path::new("ARG.py"); "ARG005")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_unused_arguments")
@@ -41,11 +41,11 @@ mod tests {
                     ignore_variadic_names: true,
                 },
                 ..settings::Settings::for_rules(vec![
-                    RuleCode::ARG001,
-                    RuleCode::ARG002,
-                    RuleCode::ARG003,
-                    RuleCode::ARG004,
-                    RuleCode::ARG005,
+                    Rule::UnusedFunctionArgument,
+                    Rule::UnusedMethodArgument,
+                    Rule::UnusedClassMethodArgument,
+                    Rule::UnusedStaticMethodArgument,
+                    Rule::UnusedLambdaArgument,
                 ])
             },
         )?;
@@ -62,11 +62,11 @@ mod tests {
                     ignore_variadic_names: false,
                 },
                 ..settings::Settings::for_rules(vec![
-                    RuleCode::ARG001,
-                    RuleCode::ARG002,
-                    RuleCode::ARG003,
-                    RuleCode::ARG004,
-                    RuleCode::ARG005,
+                    Rule::UnusedFunctionArgument,
+                    Rule::UnusedMethodArgument,
+                    Rule::UnusedClassMethodArgument,
+                    Rule::UnusedStaticMethodArgument,
+                    Rule::UnusedLambdaArgument,
                 ])
             },
         )?;

--- a/src/rules/flake8_unused_arguments/mod.rs
+++ b/src/rules/flake8_unused_arguments/mod.rs
@@ -6,7 +6,6 @@ mod types;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -22,7 +21,7 @@ mod tests {
     #[test_case(RuleCode::ARG004, Path::new("ARG.py"); "ARG004")]
     #[test_case(RuleCode::ARG005, Path::new("ARG.py"); "ARG005")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/flake8_unused_arguments")
                 .join(path)

--- a/src/rules/flake8_unused_arguments/types.rs
+++ b/src/rules/flake8_unused_arguments/types.rs
@@ -1,4 +1,4 @@
-use crate::registry::{DiagnosticKind, RuleCode};
+use crate::registry::{DiagnosticKind, Rule};
 use crate::violations;
 
 /// An AST node that can contain arguments.
@@ -21,13 +21,13 @@ impl Argumentable {
         }
     }
 
-    pub fn rule_code(&self) -> &RuleCode {
+    pub fn rule_code(&self) -> &Rule {
         match self {
-            Argumentable::Function => &RuleCode::ARG001,
-            Argumentable::Method => &RuleCode::ARG002,
-            Argumentable::ClassMethod => &RuleCode::ARG003,
-            Argumentable::StaticMethod => &RuleCode::ARG004,
-            Argumentable::Lambda => &RuleCode::ARG005,
+            Argumentable::Function => &Rule::UnusedFunctionArgument,
+            Argumentable::Method => &Rule::UnusedMethodArgument,
+            Argumentable::ClassMethod => &Rule::UnusedClassMethodArgument,
+            Argumentable::StaticMethod => &Rule::UnusedStaticMethodArgument,
+            Argumentable::Lambda => &Rule::UnusedLambdaArgument,
         }
     }
 }

--- a/src/rules/isort/mod.rs
+++ b/src/rules/isort/mod.rs
@@ -684,7 +684,7 @@ mod tests {
     use super::categorize::ImportType;
     use super::settings::RelatveImportsOrder;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test_case(Path::new("add_newline_before_comments.py"))]
@@ -737,7 +737,7 @@ mod tests {
                 .as_path(),
             &Settings {
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -757,7 +757,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -778,7 +778,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -798,7 +798,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -821,7 +821,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -841,7 +841,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
@@ -871,7 +871,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
@@ -903,7 +903,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
@@ -933,7 +933,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
@@ -954,7 +954,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
@@ -979,7 +979,7 @@ mod tests {
                     ]),
                     ..super::settings::Settings::default()
                 },
-                ..Settings::for_rule(RuleCode::I002)
+                ..Settings::for_rule(Rule::MissingRequiredImport)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -1004,7 +1004,7 @@ mod tests {
                     ]),
                     ..super::settings::Settings::default()
                 },
-                ..Settings::for_rule(RuleCode::I002)
+                ..Settings::for_rule(Rule::MissingRequiredImport)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -1028,7 +1028,7 @@ mod tests {
                         .to_string()]),
                     ..super::settings::Settings::default()
                 },
-                ..Settings::for_rule(RuleCode::I002)
+                ..Settings::for_rule(Rule::MissingRequiredImport)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -1050,7 +1050,7 @@ mod tests {
                     required_imports: BTreeSet::from(["import os".to_string()]),
                     ..super::settings::Settings::default()
                 },
-                ..Settings::for_rule(RuleCode::I002)
+                ..Settings::for_rule(Rule::MissingRequiredImport)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -1070,7 +1070,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -1096,7 +1096,7 @@ mod tests {
                     ..super::settings::Settings::default()
                 },
                 src: vec![Path::new("resources/test/fixtures/isort").to_path_buf()],
-                ..Settings::for_rule(RuleCode::I001)
+                ..Settings::for_rule(Rule::UnsortedImports)
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);

--- a/src/rules/isort/rules/add_required_imports.rs
+++ b/src/rules/isort/rules/add_required_imports.rs
@@ -8,7 +8,7 @@ use super::super::track::Block;
 use crate::ast::helpers::is_docstring_stmt;
 use crate::ast::types::Range;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violations;
@@ -125,7 +125,9 @@ fn add_required_import(
         violations::MissingRequiredImport(required_import.clone()),
         Range::new(Location::default(), Location::default()),
     );
-    if matches!(autofix, flags::Autofix::Enabled) && settings.rules.should_fix(&RuleCode::I002) {
+    if matches!(autofix, flags::Autofix::Enabled)
+        && settings.rules.should_fix(&Rule::MissingRequiredImport)
+    {
         // Determine the location at which the import should be inserted.
         let splice = helpers::find_splice_location(python_ast, locator);
 

--- a/src/rules/isort/rules/organize_imports.rs
+++ b/src/rules/isort/rules/organize_imports.rs
@@ -102,7 +102,7 @@ pub fn organize_imports(
     } else {
         let mut diagnostic = Diagnostic::new(violations::UnsortedImports, range);
         if matches!(autofix, flags::Autofix::Enabled)
-            && settings.rules.should_fix(diagnostic.kind.code())
+            && settings.rules.should_fix(diagnostic.kind.rule())
         {
             diagnostic.amend(Fix::replacement(
                 indent(&expected, indentation),

--- a/src/rules/mccabe/mod.rs
+++ b/src/rules/mccabe/mod.rs
@@ -10,7 +10,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings::Settings;
 
     #[test_case(0)]
@@ -22,7 +22,7 @@ mod tests {
             Path::new("./resources/test/fixtures/mccabe/C901.py"),
             &Settings {
                 mccabe: super::settings::Settings { max_complexity },
-                ..Settings::for_rules(vec![RuleCode::C901])
+                ..Settings::for_rules(vec![Rule::FunctionIsTooComplex])
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);

--- a/src/rules/pandas_vet/mod.rs
+++ b/src/rules/pandas_vet/mod.rs
@@ -41,7 +41,7 @@ mod tests {
         )?;
         let actual = diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.kind.code().clone())
+            .map(|diagnostic| diagnostic.kind.rule().clone())
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
         Ok(())

--- a/src/rules/pandas_vet/mod.rs
+++ b/src/rules/pandas_vet/mod.rs
@@ -12,12 +12,12 @@ mod tests {
     use textwrap::dedent;
 
     use crate::linter::check_path;
-    use crate::registry::{RuleCode, RuleCodePrefix};
+    use crate::registry::{Rule, RuleCodePrefix};
     use crate::settings::flags;
     use crate::source_code::{Indexer, Locator, Stylist};
     use crate::{directives, rustpython_helpers, settings};
 
-    fn rule_code(contents: &str, expected: &[RuleCode]) -> Result<()> {
+    fn rule_code(contents: &str, expected: &[Rule]) -> Result<()> {
         let contents = dedent(contents);
         let settings = settings::Settings::for_rules(RuleCodePrefix::PD.codes());
         let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);
@@ -56,7 +56,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         x.drop(['a'], axis=1, inplace=True)
-    "#, &[RuleCode::PD002]; "PD002_fail")]
+    "#, &[Rule::UseOfInplaceArgument]; "PD002_fail")]
     #[test_case(r#"
         import pandas as pd
         nas = pd.isna(val)
@@ -64,7 +64,7 @@ mod tests {
     #[test_case(r#"
         import pandas as pd
         nulls = pd.isnull(val)
-    "#, &[RuleCode::PD003]; "PD003_fail")]
+    "#, &[Rule::UseOfDotIsNull]; "PD003_fail")]
     #[test_case(r#"
         import pandas as pd
         print('bah humbug')
@@ -76,7 +76,7 @@ mod tests {
     #[test_case(r#"
         import pandas as pd
         not_nulls = pd.notnull(val)
-    "#, &[RuleCode::PD004]; "PD004_fail")]
+    "#, &[Rule::UseOfDotNotNull]; "PD004_fail")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -91,7 +91,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         y = x.ix[[0, 2], 'A']
-    "#, &[RuleCode::PD007]; "PD007_fail")]
+    "#, &[Rule::UseOfDotIx]; "PD007_fail")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -101,7 +101,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         index = x.at[:, ['B', 'A']]
-    "#, &[RuleCode::PD008]; "PD008_fail")]
+    "#, &[Rule::UseOfDotAt]; "PD008_fail")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -111,7 +111,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         index = x.iat[:, 1:3]
-    "#, &[RuleCode::PD009]; "PD009_fail")]
+    "#, &[Rule::UseOfDotIat]; "PD009_fail")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -133,7 +133,7 @@ mod tests {
             columns='bar',
             values='baz'
         )
-    "#, &[RuleCode::PD010]; "PD010_fail_pivot")]
+    "#, &[Rule::UseOfDotPivotOrUnstack]; "PD010_fail_pivot")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -148,7 +148,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         result = x.values
-    "#, &[RuleCode::PD011]; "PD011_fail_values")]
+    "#, &[Rule::UseOfDotValues]; "PD011_fail_values")]
     #[test_case(r#"
         import pandas as pd
         x = pd.DataFrame()
@@ -177,7 +177,7 @@ mod tests {
     #[test_case(r#"
         import pandas as pd
         employees = pd.read_table(input_file)
-    "#, &[RuleCode::PD012]; "PD012_fail_read_table")]
+    "#, &[Rule::UseOfDotReadTable]; "PD012_fail_read_table")]
     #[test_case(r#"
         import pandas as pd
         employees = read_table
@@ -204,7 +204,7 @@ mod tests {
         import pandas as pd
         x = pd.DataFrame()
         y = x.stack(level=-1, dropna=True)
-    "#, &[RuleCode::PD013]; "PD013_fail_stack")]
+    "#, &[Rule::UseOfDotStack]; "PD013_fail_stack")]
     #[test_case(r#"
         import pandas as pd
         pd.stack(
@@ -220,7 +220,7 @@ mod tests {
         x = pd.DataFrame()
         y = pd.DataFrame()
         pd.merge(x, y)
-    "#, &[RuleCode::PD015]; "PD015_fail_merge_on_pandas_object")]
+    "#, &[Rule::UseOfPdMerge]; "PD015_fail_merge_on_pandas_object")]
     #[test_case(
         "pd.to_datetime(timestamp * 10 ** 9).strftime('%Y-%m-%d %H:%M:%S.%f')",
         &[];
@@ -241,8 +241,8 @@ mod tests {
     #[test_case(r#"
         import pandas as pd
         df = pd.DataFrame()
-    "#, &[RuleCode::PD901]; "PD901_fail_df_var")]
-    fn test_pandas_vet(code: &str, expected: &[RuleCode]) -> Result<()> {
+    "#, &[Rule::DfIsABadVariableName]; "PD901_fail_df_var")]
+    fn test_pandas_vet(code: &str, expected: &[Rule]) -> Result<()> {
         rule_code(code, expected)?;
         Ok(())
     }

--- a/src/rules/pep8_naming/mod.rs
+++ b/src/rules/pep8_naming/mod.rs
@@ -5,7 +5,6 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -31,7 +30,7 @@ mod tests {
     #[test_case(RuleCode::N817, Path::new("N817.py"); "N817")]
     #[test_case(RuleCode::N818, Path::new("N818.py"); "N818")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pep8_naming")
                 .join(path)

--- a/src/rules/pep8_naming/mod.rs
+++ b/src/rules/pep8_naming/mod.rs
@@ -11,25 +11,25 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::N801, Path::new("N801.py"); "N801")]
-    #[test_case(RuleCode::N802, Path::new("N802.py"); "N802")]
-    #[test_case(RuleCode::N803, Path::new("N803.py"); "N803")]
-    #[test_case(RuleCode::N804, Path::new("N804.py"); "N804")]
-    #[test_case(RuleCode::N805, Path::new("N805.py"); "N805")]
-    #[test_case(RuleCode::N806, Path::new("N806.py"); "N806")]
-    #[test_case(RuleCode::N807, Path::new("N807.py"); "N807")]
-    #[test_case(RuleCode::N811, Path::new("N811.py"); "N811")]
-    #[test_case(RuleCode::N812, Path::new("N812.py"); "N812")]
-    #[test_case(RuleCode::N813, Path::new("N813.py"); "N813")]
-    #[test_case(RuleCode::N814, Path::new("N814.py"); "N814")]
-    #[test_case(RuleCode::N815, Path::new("N815.py"); "N815")]
-    #[test_case(RuleCode::N816, Path::new("N816.py"); "N816")]
-    #[test_case(RuleCode::N817, Path::new("N817.py"); "N817")]
-    #[test_case(RuleCode::N818, Path::new("N818.py"); "N818")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::InvalidClassName, Path::new("N801.py"); "N801")]
+    #[test_case(Rule::InvalidFunctionName, Path::new("N802.py"); "N802")]
+    #[test_case(Rule::InvalidArgumentName, Path::new("N803.py"); "N803")]
+    #[test_case(Rule::InvalidFirstArgumentNameForClassMethod, Path::new("N804.py"); "N804")]
+    #[test_case(Rule::InvalidFirstArgumentNameForMethod, Path::new("N805.py"); "N805")]
+    #[test_case(Rule::NonLowercaseVariableInFunction, Path::new("N806.py"); "N806")]
+    #[test_case(Rule::DunderFunctionName, Path::new("N807.py"); "N807")]
+    #[test_case(Rule::ConstantImportedAsNonConstant, Path::new("N811.py"); "N811")]
+    #[test_case(Rule::LowercaseImportedAsNonLowercase, Path::new("N812.py"); "N812")]
+    #[test_case(Rule::CamelcaseImportedAsLowercase, Path::new("N813.py"); "N813")]
+    #[test_case(Rule::CamelcaseImportedAsConstant, Path::new("N814.py"); "N814")]
+    #[test_case(Rule::MixedCaseVariableInClassScope, Path::new("N815.py"); "N815")]
+    #[test_case(Rule::MixedCaseVariableInGlobalScope, Path::new("N816.py"); "N816")]
+    #[test_case(Rule::CamelcaseImportedAsAcronym, Path::new("N817.py"); "N817")]
+    #[test_case(Rule::ErrorSuffixOnExceptionName, Path::new("N818.py"); "N818")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pep8_naming")

--- a/src/rules/pycodestyle/mod.rs
+++ b/src/rules/pycodestyle/mod.rs
@@ -11,32 +11,32 @@ mod tests {
 
     use super::settings::Settings;
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::E401, Path::new("E40.py"))]
-    #[test_case(RuleCode::E402, Path::new("E40.py"))]
-    #[test_case(RuleCode::E402, Path::new("E402.py"))]
-    #[test_case(RuleCode::E501, Path::new("E501.py"))]
-    #[test_case(RuleCode::E711, Path::new("E711.py"))]
-    #[test_case(RuleCode::E712, Path::new("E712.py"))]
-    #[test_case(RuleCode::E713, Path::new("E713.py"))]
-    #[test_case(RuleCode::E714, Path::new("E714.py"))]
-    #[test_case(RuleCode::E721, Path::new("E721.py"))]
-    #[test_case(RuleCode::E722, Path::new("E722.py"))]
-    #[test_case(RuleCode::E731, Path::new("E731.py"))]
-    #[test_case(RuleCode::E741, Path::new("E741.py"))]
-    #[test_case(RuleCode::E742, Path::new("E742.py"))]
-    #[test_case(RuleCode::E743, Path::new("E743.py"))]
-    #[test_case(RuleCode::E999, Path::new("E999.py"))]
-    #[test_case(RuleCode::W292, Path::new("W292_0.py"))]
-    #[test_case(RuleCode::W292, Path::new("W292_1.py"))]
-    #[test_case(RuleCode::W292, Path::new("W292_2.py"))]
-    #[test_case(RuleCode::W292, Path::new("W292_3.py"))]
-    #[test_case(RuleCode::W292, Path::new("W292_4.py"))]
-    #[test_case(RuleCode::W605, Path::new("W605_0.py"))]
-    #[test_case(RuleCode::W605, Path::new("W605_1.py"))]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::MultipleImportsOnOneLine, Path::new("E40.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E40.py"))]
+    #[test_case(Rule::ModuleImportNotAtTopOfFile, Path::new("E402.py"))]
+    #[test_case(Rule::LineTooLong, Path::new("E501.py"))]
+    #[test_case(Rule::NoneComparison, Path::new("E711.py"))]
+    #[test_case(Rule::TrueFalseComparison, Path::new("E712.py"))]
+    #[test_case(Rule::NotInTest, Path::new("E713.py"))]
+    #[test_case(Rule::NotIsTest, Path::new("E714.py"))]
+    #[test_case(Rule::TypeComparison, Path::new("E721.py"))]
+    #[test_case(Rule::DoNotUseBareExcept, Path::new("E722.py"))]
+    #[test_case(Rule::DoNotAssignLambda, Path::new("E731.py"))]
+    #[test_case(Rule::AmbiguousVariableName, Path::new("E741.py"))]
+    #[test_case(Rule::AmbiguousClassName, Path::new("E742.py"))]
+    #[test_case(Rule::AmbiguousFunctionName, Path::new("E743.py"))]
+    #[test_case(Rule::SyntaxError, Path::new("E999.py"))]
+    #[test_case(Rule::NoNewLineAtEndOfFile, Path::new("W292_0.py"))]
+    #[test_case(Rule::NoNewLineAtEndOfFile, Path::new("W292_1.py"))]
+    #[test_case(Rule::NoNewLineAtEndOfFile, Path::new("W292_2.py"))]
+    #[test_case(Rule::NoNewLineAtEndOfFile, Path::new("W292_3.py"))]
+    #[test_case(Rule::NoNewLineAtEndOfFile, Path::new("W292_4.py"))]
+    #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_0.py"))]
+    #[test_case(Rule::InvalidEscapeSequence, Path::new("W605_1.py"))]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pycodestyle")
@@ -52,7 +52,11 @@ mod tests {
     fn constant_literals() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pycodestyle/constant_literals.py"),
-            &settings::Settings::for_rules(vec![RuleCode::E711, RuleCode::E712, RuleCode::F632]),
+            &settings::Settings::for_rules(vec![
+                Rule::NoneComparison,
+                Rule::TrueFalseComparison,
+                Rule::IsLiteral,
+            ]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -69,7 +73,7 @@ mod tests {
                     ignore_overlong_task_comments,
                     ..Settings::default()
                 },
-                ..settings::Settings::for_rule(RuleCode::E501)
+                ..settings::Settings::for_rule(Rule::LineTooLong)
             },
         )?;
         insta::assert_yaml_snapshot!(snapshot, diagnostics);
@@ -85,7 +89,7 @@ mod tests {
                     max_doc_length: Some(50),
                     ..Settings::default()
                 },
-                ..settings::Settings::for_rule(RuleCode::W505)
+                ..settings::Settings::for_rule(Rule::DocLineTooLong)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/pycodestyle/mod.rs
+++ b/src/rules/pycodestyle/mod.rs
@@ -4,7 +4,6 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -38,7 +37,7 @@ mod tests {
     #[test_case(RuleCode::W605, Path::new("W605_0.py"))]
     #[test_case(RuleCode::W605, Path::new("W605_1.py"))]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pycodestyle")
                 .join(path)

--- a/src/rules/pycodestyle/rules.rs
+++ b/src/rules/pycodestyle/rules.rs
@@ -151,7 +151,7 @@ pub fn literal_comparisons(
                 violations::NoneComparison(op.into()),
                 Range::from_located(comparator),
             );
-            if checker.patch(diagnostic.kind.code()) && !helpers::is_constant_non_singleton(next) {
+            if checker.patch(diagnostic.kind.rule()) && !helpers::is_constant_non_singleton(next) {
                 bad_ops.insert(0, Cmpop::Is);
             }
             diagnostics.push(diagnostic);
@@ -161,7 +161,7 @@ pub fn literal_comparisons(
                 violations::NoneComparison(op.into()),
                 Range::from_located(comparator),
             );
-            if checker.patch(diagnostic.kind.code()) && !helpers::is_constant_non_singleton(next) {
+            if checker.patch(diagnostic.kind.rule()) && !helpers::is_constant_non_singleton(next) {
                 bad_ops.insert(0, Cmpop::IsNot);
             }
             diagnostics.push(diagnostic);
@@ -179,7 +179,7 @@ pub fn literal_comparisons(
                     violations::TrueFalseComparison(value, op.into()),
                     Range::from_located(comparator),
                 );
-                if checker.patch(diagnostic.kind.code())
+                if checker.patch(diagnostic.kind.rule())
                     && !helpers::is_constant_non_singleton(next)
                 {
                     bad_ops.insert(0, Cmpop::Is);
@@ -191,7 +191,7 @@ pub fn literal_comparisons(
                     violations::TrueFalseComparison(value, op.into()),
                     Range::from_located(comparator),
                 );
-                if checker.patch(diagnostic.kind.code())
+                if checker.patch(diagnostic.kind.rule())
                     && !helpers::is_constant_non_singleton(next)
                 {
                     bad_ops.insert(0, Cmpop::IsNot);
@@ -217,7 +217,7 @@ pub fn literal_comparisons(
                     violations::NoneComparison(op.into()),
                     Range::from_located(next),
                 );
-                if checker.patch(diagnostic.kind.code())
+                if checker.patch(diagnostic.kind.rule())
                     && !helpers::is_constant_non_singleton(comparator)
                 {
                     bad_ops.insert(idx, Cmpop::Is);
@@ -229,7 +229,7 @@ pub fn literal_comparisons(
                     violations::NoneComparison(op.into()),
                     Range::from_located(next),
                 );
-                if checker.patch(diagnostic.kind.code())
+                if checker.patch(diagnostic.kind.rule())
                     && !helpers::is_constant_non_singleton(comparator)
                 {
                     bad_ops.insert(idx, Cmpop::IsNot);
@@ -249,7 +249,7 @@ pub fn literal_comparisons(
                         violations::TrueFalseComparison(value, op.into()),
                         Range::from_located(next),
                     );
-                    if checker.patch(diagnostic.kind.code())
+                    if checker.patch(diagnostic.kind.rule())
                         && !helpers::is_constant_non_singleton(comparator)
                     {
                         bad_ops.insert(idx, Cmpop::Is);
@@ -261,7 +261,7 @@ pub fn literal_comparisons(
                         violations::TrueFalseComparison(value, op.into()),
                         Range::from_located(next),
                     );
-                    if checker.patch(diagnostic.kind.code())
+                    if checker.patch(diagnostic.kind.rule())
                         && !helpers::is_constant_non_singleton(comparator)
                     {
                         bad_ops.insert(idx, Cmpop::IsNot);
@@ -323,7 +323,7 @@ pub fn not_tests(
                                 violations::NotInTest,
                                 Range::from_located(operand),
                             );
-                            if checker.patch(diagnostic.kind.code()) && should_fix {
+                            if checker.patch(diagnostic.kind.rule()) && should_fix {
                                 diagnostic.amend(Fix::replacement(
                                     compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
                                     expr.location,
@@ -339,7 +339,7 @@ pub fn not_tests(
                                 violations::NotIsTest,
                                 Range::from_located(operand),
                             );
-                            if checker.patch(diagnostic.kind.code()) && should_fix {
+                            if checker.patch(diagnostic.kind.rule()) && should_fix {
                                 diagnostic.amend(Fix::replacement(
                                     compare(left, &[Cmpop::IsNot], comparators, checker.stylist),
                                     expr.location,
@@ -455,7 +455,7 @@ pub fn do_not_assign_lambda(checker: &mut Checker, target: &Expr, value: &Expr, 
                 violations::DoNotAssignLambda(id.to_string()),
                 Range::from_located(stmt),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 if !match_leading_content(stmt, checker.locator)
                     && !match_trailing_content(stmt, checker.locator)
                 {

--- a/src/rules/pydocstyle/mod.rs
+++ b/src/rules/pydocstyle/mod.rs
@@ -12,59 +12,59 @@ mod tests {
 
     use super::settings::{Convention, Settings};
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::D100, Path::new("D.py"); "D100")]
-    #[test_case(RuleCode::D101, Path::new("D.py"); "D101")]
-    #[test_case(RuleCode::D102, Path::new("D.py"); "D102_0")]
-    #[test_case(RuleCode::D102, Path::new("setter.py"); "D102_1")]
-    #[test_case(RuleCode::D103, Path::new("D.py"); "D103")]
-    #[test_case(RuleCode::D104, Path::new("D.py"); "D104")]
-    #[test_case(RuleCode::D105, Path::new("D.py"); "D105")]
-    #[test_case(RuleCode::D106, Path::new("D.py"); "D106")]
-    #[test_case(RuleCode::D107, Path::new("D.py"); "D107")]
-    #[test_case(RuleCode::D201, Path::new("D.py"); "D201")]
-    #[test_case(RuleCode::D202, Path::new("D.py"); "D202")]
-    #[test_case(RuleCode::D203, Path::new("D.py"); "D203")]
-    #[test_case(RuleCode::D204, Path::new("D.py"); "D204")]
-    #[test_case(RuleCode::D205, Path::new("D.py"); "D205")]
-    #[test_case(RuleCode::D206, Path::new("D.py"); "D206")]
-    #[test_case(RuleCode::D207, Path::new("D.py"); "D207")]
-    #[test_case(RuleCode::D208, Path::new("D.py"); "D208")]
-    #[test_case(RuleCode::D209, Path::new("D.py"); "D209")]
-    #[test_case(RuleCode::D210, Path::new("D.py"); "D210")]
-    #[test_case(RuleCode::D211, Path::new("D.py"); "D211")]
-    #[test_case(RuleCode::D212, Path::new("D.py"); "D212")]
-    #[test_case(RuleCode::D213, Path::new("D.py"); "D213")]
-    #[test_case(RuleCode::D214, Path::new("sections.py"); "D214")]
-    #[test_case(RuleCode::D215, Path::new("sections.py"); "D215")]
-    #[test_case(RuleCode::D300, Path::new("D.py"); "D300")]
-    #[test_case(RuleCode::D301, Path::new("D.py"); "D301")]
-    #[test_case(RuleCode::D400, Path::new("D.py"); "D400_0")]
-    #[test_case(RuleCode::D400, Path::new("D400.py"); "D400_1")]
-    #[test_case(RuleCode::D402, Path::new("D.py"); "D402")]
-    #[test_case(RuleCode::D403, Path::new("D.py"); "D403")]
-    #[test_case(RuleCode::D404, Path::new("D.py"); "D404")]
-    #[test_case(RuleCode::D405, Path::new("sections.py"); "D405")]
-    #[test_case(RuleCode::D406, Path::new("sections.py"); "D406")]
-    #[test_case(RuleCode::D407, Path::new("sections.py"); "D407")]
-    #[test_case(RuleCode::D408, Path::new("sections.py"); "D408")]
-    #[test_case(RuleCode::D409, Path::new("sections.py"); "D409")]
-    #[test_case(RuleCode::D410, Path::new("sections.py"); "D410")]
-    #[test_case(RuleCode::D411, Path::new("sections.py"); "D411")]
-    #[test_case(RuleCode::D412, Path::new("sections.py"); "D412")]
-    #[test_case(RuleCode::D413, Path::new("sections.py"); "D413")]
-    #[test_case(RuleCode::D414, Path::new("sections.py"); "D414")]
-    #[test_case(RuleCode::D415, Path::new("D.py"); "D415")]
-    #[test_case(RuleCode::D416, Path::new("D.py"); "D416")]
-    #[test_case(RuleCode::D417, Path::new("canonical_google_examples.py"); "D417_2")]
-    #[test_case(RuleCode::D417, Path::new("canonical_numpy_examples.py"); "D417_1")]
-    #[test_case(RuleCode::D417, Path::new("sections.py"); "D417_0")]
-    #[test_case(RuleCode::D418, Path::new("D.py"); "D418")]
-    #[test_case(RuleCode::D419, Path::new("D.py"); "D419")]
-    #[test_case(RuleCode::D104, Path::new("D104/__init__.py"); "D104_1")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::PublicModule, Path::new("D.py"); "D100")]
+    #[test_case(Rule::PublicClass, Path::new("D.py"); "D101")]
+    #[test_case(Rule::PublicMethod, Path::new("D.py"); "D102_0")]
+    #[test_case(Rule::PublicMethod, Path::new("setter.py"); "D102_1")]
+    #[test_case(Rule::PublicFunction, Path::new("D.py"); "D103")]
+    #[test_case(Rule::PublicPackage, Path::new("D.py"); "D104")]
+    #[test_case(Rule::MagicMethod, Path::new("D.py"); "D105")]
+    #[test_case(Rule::PublicNestedClass, Path::new("D.py"); "D106")]
+    #[test_case(Rule::PublicInit, Path::new("D.py"); "D107")]
+    #[test_case(Rule::NoBlankLineBeforeFunction, Path::new("D.py"); "D201")]
+    #[test_case(Rule::NoBlankLineAfterFunction, Path::new("D.py"); "D202")]
+    #[test_case(Rule::OneBlankLineBeforeClass, Path::new("D.py"); "D203")]
+    #[test_case(Rule::OneBlankLineAfterClass, Path::new("D.py"); "D204")]
+    #[test_case(Rule::BlankLineAfterSummary, Path::new("D.py"); "D205")]
+    #[test_case(Rule::IndentWithSpaces, Path::new("D.py"); "D206")]
+    #[test_case(Rule::NoUnderIndentation, Path::new("D.py"); "D207")]
+    #[test_case(Rule::NoOverIndentation, Path::new("D.py"); "D208")]
+    #[test_case(Rule::NewLineAfterLastParagraph, Path::new("D.py"); "D209")]
+    #[test_case(Rule::NoSurroundingWhitespace, Path::new("D.py"); "D210")]
+    #[test_case(Rule::NoBlankLineBeforeClass, Path::new("D.py"); "D211")]
+    #[test_case(Rule::MultiLineSummaryFirstLine, Path::new("D.py"); "D212")]
+    #[test_case(Rule::MultiLineSummarySecondLine, Path::new("D.py"); "D213")]
+    #[test_case(Rule::SectionNotOverIndented, Path::new("sections.py"); "D214")]
+    #[test_case(Rule::SectionUnderlineNotOverIndented, Path::new("sections.py"); "D215")]
+    #[test_case(Rule::UsesTripleQuotes, Path::new("D.py"); "D300")]
+    #[test_case(Rule::UsesRPrefixForBackslashedContent, Path::new("D.py"); "D301")]
+    #[test_case(Rule::EndsInPeriod, Path::new("D.py"); "D400_0")]
+    #[test_case(Rule::EndsInPeriod, Path::new("D400.py"); "D400_1")]
+    #[test_case(Rule::NoSignature, Path::new("D.py"); "D402")]
+    #[test_case(Rule::FirstLineCapitalized, Path::new("D.py"); "D403")]
+    #[test_case(Rule::NoThisPrefix, Path::new("D.py"); "D404")]
+    #[test_case(Rule::CapitalizeSectionName, Path::new("sections.py"); "D405")]
+    #[test_case(Rule::NewLineAfterSectionName, Path::new("sections.py"); "D406")]
+    #[test_case(Rule::DashedUnderlineAfterSection, Path::new("sections.py"); "D407")]
+    #[test_case(Rule::SectionUnderlineAfterName, Path::new("sections.py"); "D408")]
+    #[test_case(Rule::SectionUnderlineMatchesSectionLength, Path::new("sections.py"); "D409")]
+    #[test_case(Rule::BlankLineAfterSection, Path::new("sections.py"); "D410")]
+    #[test_case(Rule::BlankLineBeforeSection, Path::new("sections.py"); "D411")]
+    #[test_case(Rule::NoBlankLinesBetweenHeaderAndContent, Path::new("sections.py"); "D412")]
+    #[test_case(Rule::BlankLineAfterLastSection, Path::new("sections.py"); "D413")]
+    #[test_case(Rule::NonEmptySection, Path::new("sections.py"); "D414")]
+    #[test_case(Rule::EndsInPunctuation, Path::new("D.py"); "D415")]
+    #[test_case(Rule::SectionNameEndsInColon, Path::new("D.py"); "D416")]
+    #[test_case(Rule::DocumentAllArguments, Path::new("canonical_google_examples.py"); "D417_2")]
+    #[test_case(Rule::DocumentAllArguments, Path::new("canonical_numpy_examples.py"); "D417_1")]
+    #[test_case(Rule::DocumentAllArguments, Path::new("sections.py"); "D417_0")]
+    #[test_case(Rule::SkipDocstring, Path::new("D.py"); "D418")]
+    #[test_case(Rule::NonEmpty, Path::new("D.py"); "D419")]
+    #[test_case(Rule::PublicPackage, Path::new("D104/__init__.py"); "D104_1")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pydocstyle")
@@ -84,7 +84,7 @@ mod tests {
                 // When inferring the convention, we'll see a few false negatives.
                 // See: https://github.com/PyCQA/pydocstyle/issues/459.
                 pydocstyle: Settings { convention: None },
-                ..settings::Settings::for_rule(RuleCode::D417)
+                ..settings::Settings::for_rule(Rule::DocumentAllArguments)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -100,7 +100,7 @@ mod tests {
                 pydocstyle: Settings {
                     convention: Some(Convention::Google),
                 },
-                ..settings::Settings::for_rule(RuleCode::D417)
+                ..settings::Settings::for_rule(Rule::DocumentAllArguments)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -116,7 +116,7 @@ mod tests {
                 pydocstyle: Settings {
                     convention: Some(Convention::Numpy),
                 },
-                ..settings::Settings::for_rule(RuleCode::D417)
+                ..settings::Settings::for_rule(Rule::DocumentAllArguments)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/pydocstyle/mod.rs
+++ b/src/rules/pydocstyle/mod.rs
@@ -5,7 +5,6 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -66,7 +65,7 @@ mod tests {
     #[test_case(RuleCode::D419, Path::new("D.py"); "D419")]
     #[test_case(RuleCode::D104, Path::new("D104/__init__.py"); "D104_1")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pydocstyle")
                 .join(path)

--- a/src/rules/pydocstyle/rules.rs
+++ b/src/rules/pydocstyle/rules.rs
@@ -180,7 +180,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
                 violations::NoBlankLineBeforeFunction(blank_lines_before),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
                 diagnostic.amend(Fix::deletion(
                     Location::new(docstring.expr.location.row() - blank_lines_before, 0),
@@ -221,7 +221,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
                 violations::NoBlankLineAfterFunction(blank_lines_after),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
                 diagnostic.amend(Fix::deletion(
                     Location::new(docstring.expr.end_location.unwrap().row() + 1, 0),
@@ -262,7 +262,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                     violations::NoBlankLineBeforeClass(blank_lines_before),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
                     diagnostic.amend(Fix::deletion(
                         Location::new(docstring.expr.location.row() - blank_lines_before, 0),
@@ -278,7 +278,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                     violations::OneBlankLineBeforeClass(blank_lines_before),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
                     diagnostic.amend(Fix::replacement(
                         "\n".to_string(),
@@ -315,7 +315,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 violations::OneBlankLineAfterClass(blank_lines_after),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
                 diagnostic.amend(Fix::replacement(
                     "\n".to_string(),
@@ -350,7 +350,7 @@ pub fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
             violations::BlankLineAfterSummary(blanks_count),
             Range::from_located(docstring.expr),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             if blanks_count > 1 {
                 // Find the "summary" line (defined as the first non-blank line).
                 let mut summary_line = 0;
@@ -422,7 +422,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                         Location::new(docstring.expr.location.row() + i, 0),
                     ),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         whitespace::clean(docstring.indentation),
                         Location::new(docstring.expr.location.row() + i, 0),
@@ -472,7 +472,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                             Location::new(docstring.expr.location.row() + i, 0),
                         ),
                     );
-                    if checker.patch(diagnostic.kind.code()) {
+                    if checker.patch(diagnostic.kind.rule()) {
                         diagnostic.amend(Fix::replacement(
                             whitespace::clean(docstring.indentation),
                             Location::new(docstring.expr.location.row() + i, 0),
@@ -496,7 +496,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                         Location::new(docstring.expr.location.row() + i, 0),
                     ),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         whitespace::clean(docstring.indentation),
                         Location::new(docstring.expr.location.row() + i, 0),
@@ -526,7 +526,7 @@ pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring
                         violations::NewLineAfterLastParagraph,
                         Range::from_located(docstring.expr),
                     );
-                    if checker.patch(diagnostic.kind.code()) {
+                    if checker.patch(diagnostic.kind.rule()) {
                         // Insert a newline just before the end-quote(s).
                         let num_trailing_quotes = "'''".len();
                         let num_trailing_spaces = last_line
@@ -578,7 +578,7 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
         violations::NoSurroundingWhitespace,
         Range::from_located(docstring.expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         if let Some(pattern) = leading_quote(contents) {
             if let Some(quote) = pattern.chars().last() {
                 // If removing whitespace would lead to an invalid string of quote
@@ -988,7 +988,7 @@ fn blanks_and_section_underline(
                 violations::DashedUnderlineAfterSection(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Add a dashed line (of the appropriate length) under the section header.
                 let content = format!(
                     "{}{}\n",
@@ -1026,7 +1026,7 @@ fn blanks_and_section_underline(
                     violations::SectionUnderlineAfterName(context.section_name.to_string()),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and the underline.
                     diagnostic.amend(Fix::deletion(
                         Location::new(
@@ -1060,7 +1060,7 @@ fn blanks_and_section_underline(
                     ),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Replace the existing underline with a line of the appropriate length.
                     let content = format!(
                         "{}{}\n",
@@ -1097,7 +1097,7 @@ fn blanks_and_section_underline(
                     violations::SectionUnderlineNotOverIndented(context.section_name.to_string()),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Replace the existing indentation with whitespace of the appropriate length.
                     diagnostic.amend(Fix::replacement(
                         whitespace::clean(docstring.indentation),
@@ -1146,7 +1146,7 @@ fn blanks_and_section_underline(
                             ),
                             Range::from_located(docstring.expr),
                         );
-                        if checker.patch(diagnostic.kind.code()) {
+                        if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
                             diagnostic.amend(Fix::deletion(
                                 Location::new(
@@ -1184,7 +1184,7 @@ fn blanks_and_section_underline(
                 violations::DashedUnderlineAfterSection(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Add a dashed line (of the appropriate length) under the section header.
                 let content = format!(
                     "{}{}\n",
@@ -1209,7 +1209,7 @@ fn blanks_and_section_underline(
                     ),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and content.
                     diagnostic.amend(Fix::deletion(
                         Location::new(
@@ -1248,7 +1248,7 @@ fn common_section(
                     violations::CapitalizeSectionName(context.section_name.to_string()),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Replace the section title with the capitalized variant. This requires
                     // locating the start and end of the section name.
                     if let Some(index) = context.line.find(context.section_name) {
@@ -1280,7 +1280,7 @@ fn common_section(
                 violations::SectionNotOverIndented(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Replace the existing indentation with whitespace of the appropriate length.
                 diagnostic.amend(Fix::replacement(
                     whitespace::clean(docstring.indentation),
@@ -1306,7 +1306,7 @@ fn common_section(
                     violations::BlankLineAfterLastSection(context.section_name.to_string()),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
                     diagnostic.amend(Fix::insertion(
                         "\n".to_string(),
@@ -1327,7 +1327,7 @@ fn common_section(
                     violations::BlankLineAfterSection(context.section_name.to_string()),
                     Range::from_located(docstring.expr),
                 );
-                if checker.patch(diagnostic.kind.code()) {
+                if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
                     diagnostic.amend(Fix::insertion(
                         "\n".to_string(),
@@ -1351,7 +1351,7 @@ fn common_section(
                 violations::BlankLineBeforeSection(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
                 diagnostic.amend(Fix::insertion(
                     "\n".to_string(),
@@ -1540,7 +1540,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
                 violations::NewLineAfterSectionName(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Delete the suffix. This requires locating the end of the section name.
                 if let Some(index) = context.line.find(context.section_name) {
                     // Map from bytes to characters.
@@ -1586,7 +1586,7 @@ fn google_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 violations::SectionNameEndsInColon(context.section_name.to_string()),
                 Range::from_located(docstring.expr),
             );
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix. This requires locating the end of the section name.
                 if let Some(index) = context.line.find(context.section_name) {
                     // Map from bytes to characters.

--- a/src/rules/pyflakes/mod.rs
+++ b/src/rules/pyflakes/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -106,7 +105,7 @@ mod tests {
     #[test_case(RuleCode::F842, Path::new("F842.py"); "F842")]
     #[test_case(RuleCode::F901, Path::new("F901.py"); "F901")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes")
                 .join(path)

--- a/src/rules/pyflakes/mod.rs
+++ b/src/rules/pyflakes/mod.rs
@@ -233,7 +233,7 @@ mod tests {
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
         let actual = diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.kind.code().clone())
+            .map(|diagnostic| diagnostic.kind.rule().clone())
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
         Ok(())

--- a/src/rules/pyflakes/mod.rs
+++ b/src/rules/pyflakes/mod.rs
@@ -15,96 +15,96 @@ mod tests {
     use textwrap::dedent;
 
     use crate::linter::{check_path, test_path};
-    use crate::registry::{RuleCode, RuleCodePrefix};
+    use crate::registry::{Rule, RuleCodePrefix};
     use crate::settings::flags;
     use crate::source_code::{Indexer, Locator, Stylist};
     use crate::{directives, rustpython_helpers, settings};
 
-    #[test_case(RuleCode::F401, Path::new("F401_0.py"); "F401_0")]
-    #[test_case(RuleCode::F401, Path::new("F401_1.py"); "F401_1")]
-    #[test_case(RuleCode::F401, Path::new("F401_2.py"); "F401_2")]
-    #[test_case(RuleCode::F401, Path::new("F401_3.py"); "F401_3")]
-    #[test_case(RuleCode::F401, Path::new("F401_4.py"); "F401_4")]
-    #[test_case(RuleCode::F401, Path::new("F401_5.py"); "F401_5")]
-    #[test_case(RuleCode::F401, Path::new("F401_6.py"); "F401_6")]
-    #[test_case(RuleCode::F401, Path::new("F401_7.py"); "F401_7")]
-    #[test_case(RuleCode::F402, Path::new("F402.py"); "F402")]
-    #[test_case(RuleCode::F403, Path::new("F403.py"); "F403")]
-    #[test_case(RuleCode::F404, Path::new("F404.py"); "F404")]
-    #[test_case(RuleCode::F405, Path::new("F405.py"); "F405")]
-    #[test_case(RuleCode::F406, Path::new("F406.py"); "F406")]
-    #[test_case(RuleCode::F407, Path::new("F407.py"); "F407")]
-    #[test_case(RuleCode::F501, Path::new("F50x.py"); "F501")]
-    #[test_case(RuleCode::F502, Path::new("F502.py"); "F502_1")]
-    #[test_case(RuleCode::F502, Path::new("F50x.py"); "F502_0")]
-    #[test_case(RuleCode::F503, Path::new("F503.py"); "F503_1")]
-    #[test_case(RuleCode::F503, Path::new("F50x.py"); "F503_0")]
-    #[test_case(RuleCode::F504, Path::new("F504.py"); "F504_1")]
-    #[test_case(RuleCode::F504, Path::new("F50x.py"); "F504_0")]
-    #[test_case(RuleCode::F505, Path::new("F504.py"); "F505_1")]
-    #[test_case(RuleCode::F505, Path::new("F50x.py"); "F505_0")]
-    #[test_case(RuleCode::F506, Path::new("F50x.py"); "F506")]
-    #[test_case(RuleCode::F507, Path::new("F50x.py"); "F507")]
-    #[test_case(RuleCode::F508, Path::new("F50x.py"); "F508")]
-    #[test_case(RuleCode::F509, Path::new("F50x.py"); "F509")]
-    #[test_case(RuleCode::F521, Path::new("F521.py"); "F521")]
-    #[test_case(RuleCode::F522, Path::new("F522.py"); "F522")]
-    #[test_case(RuleCode::F523, Path::new("F523.py"); "F523")]
-    #[test_case(RuleCode::F524, Path::new("F524.py"); "F524")]
-    #[test_case(RuleCode::F525, Path::new("F525.py"); "F525")]
-    #[test_case(RuleCode::F541, Path::new("F541.py"); "F541")]
-    #[test_case(RuleCode::F601, Path::new("F601.py"); "F601")]
-    #[test_case(RuleCode::F602, Path::new("F602.py"); "F602")]
-    #[test_case(RuleCode::F622, Path::new("F622.py"); "F622")]
-    #[test_case(RuleCode::F631, Path::new("F631.py"); "F631")]
-    #[test_case(RuleCode::F632, Path::new("F632.py"); "F632")]
-    #[test_case(RuleCode::F633, Path::new("F633.py"); "F633")]
-    #[test_case(RuleCode::F634, Path::new("F634.py"); "F634")]
-    #[test_case(RuleCode::F701, Path::new("F701.py"); "F701")]
-    #[test_case(RuleCode::F702, Path::new("F702.py"); "F702")]
-    #[test_case(RuleCode::F704, Path::new("F704.py"); "F704")]
-    #[test_case(RuleCode::F706, Path::new("F706.py"); "F706")]
-    #[test_case(RuleCode::F707, Path::new("F707.py"); "F707")]
-    #[test_case(RuleCode::F722, Path::new("F722.py"); "F722")]
-    #[test_case(RuleCode::F811, Path::new("F811_0.py"); "F811_0")]
-    #[test_case(RuleCode::F811, Path::new("F811_1.py"); "F811_1")]
-    #[test_case(RuleCode::F811, Path::new("F811_2.py"); "F811_2")]
-    #[test_case(RuleCode::F811, Path::new("F811_3.py"); "F811_3")]
-    #[test_case(RuleCode::F811, Path::new("F811_4.py"); "F811_4")]
-    #[test_case(RuleCode::F811, Path::new("F811_5.py"); "F811_5")]
-    #[test_case(RuleCode::F811, Path::new("F811_6.py"); "F811_6")]
-    #[test_case(RuleCode::F811, Path::new("F811_7.py"); "F811_7")]
-    #[test_case(RuleCode::F811, Path::new("F811_8.py"); "F811_8")]
-    #[test_case(RuleCode::F811, Path::new("F811_9.py"); "F811_9")]
-    #[test_case(RuleCode::F811, Path::new("F811_10.py"); "F811_10")]
-    #[test_case(RuleCode::F811, Path::new("F811_11.py"); "F811_11")]
-    #[test_case(RuleCode::F811, Path::new("F811_12.py"); "F811_12")]
-    #[test_case(RuleCode::F811, Path::new("F811_13.py"); "F811_13")]
-    #[test_case(RuleCode::F811, Path::new("F811_14.py"); "F811_14")]
-    #[test_case(RuleCode::F811, Path::new("F811_15.py"); "F811_15")]
-    #[test_case(RuleCode::F811, Path::new("F811_16.py"); "F811_16")]
-    #[test_case(RuleCode::F811, Path::new("F811_17.py"); "F811_17")]
-    #[test_case(RuleCode::F811, Path::new("F811_18.py"); "F811_18")]
-    #[test_case(RuleCode::F811, Path::new("F811_19.py"); "F811_19")]
-    #[test_case(RuleCode::F811, Path::new("F811_20.py"); "F811_20")]
-    #[test_case(RuleCode::F821, Path::new("F821_0.py"); "F821_0")]
-    #[test_case(RuleCode::F821, Path::new("F821_1.py"); "F821_1")]
-    #[test_case(RuleCode::F821, Path::new("F821_2.py"); "F821_2")]
-    #[test_case(RuleCode::F821, Path::new("F821_3.py"); "F821_3")]
-    #[test_case(RuleCode::F821, Path::new("F821_4.py"); "F821_4")]
-    #[test_case(RuleCode::F821, Path::new("F821_5.py"); "F821_5")]
-    #[test_case(RuleCode::F821, Path::new("F821_6.py"); "F821_6")]
-    #[test_case(RuleCode::F821, Path::new("F821_7.py"); "F821_7")]
-    #[test_case(RuleCode::F821, Path::new("F821_8.pyi"); "F821_8")]
-    #[test_case(RuleCode::F822, Path::new("F822.py"); "F822")]
-    #[test_case(RuleCode::F823, Path::new("F823.py"); "F823")]
-    #[test_case(RuleCode::F841, Path::new("F841_0.py"); "F841_0")]
-    #[test_case(RuleCode::F841, Path::new("F841_1.py"); "F841_1")]
-    #[test_case(RuleCode::F841, Path::new("F841_2.py"); "F841_2")]
-    #[test_case(RuleCode::F841, Path::new("F841_3.py"); "F841_3")]
-    #[test_case(RuleCode::F842, Path::new("F842.py"); "F842")]
-    #[test_case(RuleCode::F901, Path::new("F901.py"); "F901")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UnusedImport, Path::new("F401_0.py"); "F401_0")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_1.py"); "F401_1")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_2.py"); "F401_2")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_3.py"); "F401_3")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_4.py"); "F401_4")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_5.py"); "F401_5")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_6.py"); "F401_6")]
+    #[test_case(Rule::UnusedImport, Path::new("F401_7.py"); "F401_7")]
+    #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"); "F402")]
+    #[test_case(Rule::ImportStarUsed, Path::new("F403.py"); "F403")]
+    #[test_case(Rule::LateFutureImport, Path::new("F404.py"); "F404")]
+    #[test_case(Rule::ImportStarUsage, Path::new("F405.py"); "F405")]
+    #[test_case(Rule::ImportStarNotPermitted, Path::new("F406.py"); "F406")]
+    #[test_case(Rule::FutureFeatureNotDefined, Path::new("F407.py"); "F407")]
+    #[test_case(Rule::PercentFormatInvalidFormat, Path::new("F50x.py"); "F501")]
+    #[test_case(Rule::PercentFormatExpectedMapping, Path::new("F502.py"); "F502_1")]
+    #[test_case(Rule::PercentFormatExpectedMapping, Path::new("F50x.py"); "F502_0")]
+    #[test_case(Rule::PercentFormatExpectedSequence, Path::new("F503.py"); "F503_1")]
+    #[test_case(Rule::PercentFormatExpectedSequence, Path::new("F50x.py"); "F503_0")]
+    #[test_case(Rule::PercentFormatExtraNamedArguments, Path::new("F504.py"); "F504_1")]
+    #[test_case(Rule::PercentFormatExtraNamedArguments, Path::new("F50x.py"); "F504_0")]
+    #[test_case(Rule::PercentFormatMissingArgument, Path::new("F504.py"); "F505_1")]
+    #[test_case(Rule::PercentFormatMissingArgument, Path::new("F50x.py"); "F505_0")]
+    #[test_case(Rule::PercentFormatMixedPositionalAndNamed, Path::new("F50x.py"); "F506")]
+    #[test_case(Rule::PercentFormatPositionalCountMismatch, Path::new("F50x.py"); "F507")]
+    #[test_case(Rule::PercentFormatStarRequiresSequence, Path::new("F50x.py"); "F508")]
+    #[test_case(Rule::PercentFormatUnsupportedFormatCharacter, Path::new("F50x.py"); "F509")]
+    #[test_case(Rule::StringDotFormatInvalidFormat, Path::new("F521.py"); "F521")]
+    #[test_case(Rule::StringDotFormatExtraNamedArguments, Path::new("F522.py"); "F522")]
+    #[test_case(Rule::StringDotFormatExtraPositionalArguments, Path::new("F523.py"); "F523")]
+    #[test_case(Rule::StringDotFormatMissingArguments, Path::new("F524.py"); "F524")]
+    #[test_case(Rule::StringDotFormatMixingAutomatic, Path::new("F525.py"); "F525")]
+    #[test_case(Rule::FStringMissingPlaceholders, Path::new("F541.py"); "F541")]
+    #[test_case(Rule::MultiValueRepeatedKeyLiteral, Path::new("F601.py"); "F601")]
+    #[test_case(Rule::MultiValueRepeatedKeyVariable, Path::new("F602.py"); "F602")]
+    #[test_case(Rule::TwoStarredExpressions, Path::new("F622.py"); "F622")]
+    #[test_case(Rule::AssertTuple, Path::new("F631.py"); "F631")]
+    #[test_case(Rule::IsLiteral, Path::new("F632.py"); "F632")]
+    #[test_case(Rule::InvalidPrintSyntax, Path::new("F633.py"); "F633")]
+    #[test_case(Rule::IfTuple, Path::new("F634.py"); "F634")]
+    #[test_case(Rule::BreakOutsideLoop, Path::new("F701.py"); "F701")]
+    #[test_case(Rule::ContinueOutsideLoop, Path::new("F702.py"); "F702")]
+    #[test_case(Rule::YieldOutsideFunction, Path::new("F704.py"); "F704")]
+    #[test_case(Rule::ReturnOutsideFunction, Path::new("F706.py"); "F706")]
+    #[test_case(Rule::DefaultExceptNotLast, Path::new("F707.py"); "F707")]
+    #[test_case(Rule::ForwardAnnotationSyntaxError, Path::new("F722.py"); "F722")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_0.py"); "F811_0")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_1.py"); "F811_1")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_2.py"); "F811_2")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_3.py"); "F811_3")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_4.py"); "F811_4")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_5.py"); "F811_5")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_6.py"); "F811_6")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_7.py"); "F811_7")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_8.py"); "F811_8")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_9.py"); "F811_9")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_10.py"); "F811_10")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_11.py"); "F811_11")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_12.py"); "F811_12")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_13.py"); "F811_13")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_14.py"); "F811_14")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_15.py"); "F811_15")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_16.py"); "F811_16")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_17.py"); "F811_17")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_18.py"); "F811_18")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_19.py"); "F811_19")]
+    #[test_case(Rule::RedefinedWhileUnused, Path::new("F811_20.py"); "F811_20")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_0.py"); "F821_0")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_1.py"); "F821_1")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_2.py"); "F821_2")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_3.py"); "F821_3")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_4.py"); "F821_4")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_5.py"); "F821_5")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_6.py"); "F821_6")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_7.py"); "F821_7")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_8.pyi"); "F821_8")]
+    #[test_case(Rule::UndefinedExport, Path::new("F822.py"); "F822")]
+    #[test_case(Rule::UndefinedLocal, Path::new("F823.py"); "F823")]
+    #[test_case(Rule::UnusedVariable, Path::new("F841_0.py"); "F841_0")]
+    #[test_case(Rule::UnusedVariable, Path::new("F841_1.py"); "F841_1")]
+    #[test_case(Rule::UnusedVariable, Path::new("F841_2.py"); "F841_2")]
+    #[test_case(Rule::UnusedVariable, Path::new("F841_3.py"); "F841_3")]
+    #[test_case(Rule::UnusedAnnotation, Path::new("F842.py"); "F842")]
+    #[test_case(Rule::RaiseNotImplemented, Path::new("F901.py"); "F901")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes")
@@ -122,7 +122,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyflakes/F841_0.py"),
             &settings::Settings {
                 dummy_variable_rgx: Regex::new(r"^z$").unwrap().into(),
-                ..settings::Settings::for_rule(RuleCode::F841)
+                ..settings::Settings::for_rule(Rule::UnusedVariable)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -133,7 +133,7 @@ mod tests {
     fn init() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes/__init__.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F821, RuleCode::F822]),
+            &settings::Settings::for_rules(vec![Rule::UndefinedName, Rule::UndefinedExport]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -143,7 +143,7 @@ mod tests {
     fn default_builtins() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes/builtins.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F821]),
+            &settings::Settings::for_rules(vec![Rule::UndefinedName]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -155,7 +155,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyflakes/builtins.py"),
             &settings::Settings {
                 builtins: vec!["_".to_string()],
-                ..settings::Settings::for_rules(vec![RuleCode::F821])
+                ..settings::Settings::for_rules(vec![Rule::UndefinedName])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -166,7 +166,7 @@ mod tests {
     fn default_typing_modules() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes/typing_modules.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F821]),
+            &settings::Settings::for_rules(vec![Rule::UndefinedName]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -178,7 +178,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyflakes/typing_modules.py"),
             &settings::Settings {
                 typing_modules: vec!["airflow.typing_compat".to_string()],
-                ..settings::Settings::for_rules(vec![RuleCode::F821])
+                ..settings::Settings::for_rules(vec![Rule::UndefinedName])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -189,7 +189,7 @@ mod tests {
     fn future_annotations() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes/future_annotations.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F401, RuleCode::F821]),
+            &settings::Settings::for_rules(vec![Rule::UnusedImport, Rule::UndefinedName]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -199,7 +199,7 @@ mod tests {
     fn multi_statement_lines() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyflakes/multi_statement_lines.py"),
-            &settings::Settings::for_rule(RuleCode::F401),
+            &settings::Settings::for_rule(Rule::UnusedImport),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -207,7 +207,7 @@ mod tests {
 
     /// A re-implementation of the Pyflakes test runner.
     /// Note that all tests marked with `#[ignore]` should be considered TODOs.
-    fn flakes(contents: &str, expected: &[RuleCode]) -> Result<()> {
+    fn flakes(contents: &str, expected: &[Rule]) -> Result<()> {
         let contents = dedent(contents);
         let settings = settings::Settings::for_rules(RuleCodePrefix::F.codes());
         let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);
@@ -241,7 +241,7 @@ mod tests {
     /// See: <https://github.com/PyCQA/pyflakes/blob/04ecb0c324ef3b61124e2f80f9e1af6c3a4c7b26/pyflakes/test/test_undefined_names.py>
     #[test]
     fn undefined() -> Result<()> {
-        flakes("bar", &[RuleCode::F821])?;
+        flakes("bar", &[Rule::UndefinedName])?;
         Ok(())
     }
 
@@ -258,7 +258,7 @@ mod tests {
         [a for a in range(10)]
         a
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )
     }
 
@@ -275,7 +275,7 @@ mod tests {
             pass
         exc
         "#,
-            &[RuleCode::F841, RuleCode::F821],
+            &[Rule::UnusedVariable, Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -314,7 +314,7 @@ mod tests {
         print(exc)
         exc = 'Original value'
         "#,
-            &[RuleCode::F841, RuleCode::F821],
+            &[Rule::UnusedVariable, Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -398,7 +398,7 @@ mod tests {
     fn magic_module_in_class_scope() -> Result<()> {
         // Use of the C{__module__} magic builtin should not emit an undefined
         // name warning if used in class scope.
-        flakes("__module__", &[RuleCode::F821])?;
+        flakes("__module__", &[Rule::UndefinedName])?;
         flakes(
             r#"
         class Foo:
@@ -412,7 +412,7 @@ mod tests {
             def bar(self):
                 __module__
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -421,7 +421,7 @@ mod tests {
     fn magic_qualname_in_class_scope() -> Result<()> {
         // Use of the C{__qualname__} magic builtin should not emit an undefined
         // name warning if used in class scope.
-        flakes("__qualname__", &[RuleCode::F821])?;
+        flakes("__qualname__", &[Rule::UndefinedName])?;
         flakes(
             r#"
         class Foo:
@@ -435,7 +435,7 @@ mod tests {
             def bar(self):
                 __qualname__
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -443,7 +443,10 @@ mod tests {
     #[test]
     fn global_import_star() -> Result<()> {
         // Can't find undefined names with import *.
-        flakes("from fu import *; bar", &[RuleCode::F403, RuleCode::F405])?;
+        flakes(
+            "from fu import *; bar",
+            &[Rule::ImportStarUsed, Rule::ImportStarUsage],
+        )?;
         Ok(())
     }
 
@@ -473,7 +476,7 @@ mod tests {
             def b():
                 global bar; bar = 1
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -500,7 +503,7 @@ mod tests {
         def foo():
             print(x)
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -516,7 +519,7 @@ mod tests {
         def f2():
             global m
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -524,7 +527,7 @@ mod tests {
     #[test]
     fn del() -> Result<()> {
         // Del deletes bindings.
-        flakes("a = 1; del a; a", &[RuleCode::F821])?;
+        flakes("a = 1; del a; a", &[Rule::UndefinedName])?;
         Ok(())
     }
 
@@ -547,7 +550,7 @@ mod tests {
     #[test]
     fn del_undefined() -> Result<()> {
         // Del an undefined name.
-        flakes("del a", &[RuleCode::F821])?;
+        flakes("del a", &[Rule::UndefinedName])?;
         Ok(())
     }
 
@@ -666,7 +669,7 @@ mod tests {
             a = 2
             return a
         "#,
-            &[RuleCode::F823],
+            &[Rule::UndefinedLocal],
         )?;
         Ok(())
     }
@@ -686,7 +689,7 @@ mod tests {
                     a = 2
                     return a
         "#,
-            &[RuleCode::F823],
+            &[Rule::UndefinedLocal],
         )?;
         Ok(())
     }
@@ -708,7 +711,7 @@ mod tests {
                     print(x, a)
             print(x)
         "#,
-            &[RuleCode::F823],
+            &[Rule::UndefinedLocal],
         )?;
         Ok(())
     }
@@ -727,7 +730,7 @@ mod tests {
                     return a
                 return a
         "#,
-            &[RuleCode::F823],
+            &[Rule::UndefinedLocal],
         )?;
         Ok(())
     }
@@ -746,11 +749,11 @@ mod tests {
                 e[any] = 5
             "#,
             &[
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F841,
-                RuleCode::F821,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UnusedVariable,
+                Rule::UndefinedName,
             ],
         )?;
         Ok(())
@@ -787,7 +790,7 @@ mod tests {
             return foo
         f()
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -888,7 +891,7 @@ mod tests {
         def f(*, a, b=default_c):
             print(a, b)
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -947,12 +950,12 @@ mod tests {
         // not defined in the other generator.
         flakes(
             "(b for b in (a for a in [1, 2, 3] if b) if b)",
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         flakes(
             "(b for b in (a for a in [1, 2, 3] if a) if a)",
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -987,7 +990,7 @@ mod tests {
         except:
             socket_map = {}
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -996,7 +999,7 @@ mod tests {
         except Exception:
             socket_map = {}
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -1052,19 +1055,19 @@ mod tests {
         for i in range(i):
             print(i)
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         [42 for i in range(i)]
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         (42 for i in range(i))
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -1103,7 +1106,7 @@ mod tests {
             r#"
         {lambda: id(y) for x in range(10)}
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -1116,7 +1119,7 @@ mod tests {
             r#"
         any(lambda: id(y) for x in range(10))
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -1140,22 +1143,25 @@ mod tests {
     /// See: <https://github.com/PyCQA/pyflakes/blob/04ecb0c324ef3b61124e2f80f9e1af6c3a4c7b26/pyflakes/test/test_imports.py>
     #[test]
     fn unused_import() -> Result<()> {
-        flakes("import fu, bar", &[RuleCode::F401, RuleCode::F401])?;
-        flakes("from baz import fu, bar", &[RuleCode::F401, RuleCode::F401])?;
+        flakes("import fu, bar", &[Rule::UnusedImport, Rule::UnusedImport])?;
+        flakes(
+            "from baz import fu, bar",
+            &[Rule::UnusedImport, Rule::UnusedImport],
+        )?;
         Ok(())
     }
 
     #[test]
     fn unused_import_relative() -> Result<()> {
-        flakes("from . import fu", &[RuleCode::F401])?;
-        flakes("from . import fu as baz", &[RuleCode::F401])?;
-        flakes("from .. import fu", &[RuleCode::F401])?;
-        flakes("from ... import fu", &[RuleCode::F401])?;
-        flakes("from .. import fu as baz", &[RuleCode::F401])?;
-        flakes("from .bar import fu", &[RuleCode::F401])?;
-        flakes("from ..bar import fu", &[RuleCode::F401])?;
-        flakes("from ...bar import fu", &[RuleCode::F401])?;
-        flakes("from ...bar import fu as baz", &[RuleCode::F401])?;
+        flakes("from . import fu", &[Rule::UnusedImport])?;
+        flakes("from . import fu as baz", &[Rule::UnusedImport])?;
+        flakes("from .. import fu", &[Rule::UnusedImport])?;
+        flakes("from ... import fu", &[Rule::UnusedImport])?;
+        flakes("from .. import fu as baz", &[Rule::UnusedImport])?;
+        flakes("from .bar import fu", &[Rule::UnusedImport])?;
+        flakes("from ..bar import fu", &[Rule::UnusedImport])?;
+        flakes("from ...bar import fu", &[Rule::UnusedImport])?;
+        flakes("from ...bar import fu as baz", &[Rule::UnusedImport])?;
 
         Ok(())
     }
@@ -1164,11 +1170,19 @@ mod tests {
     fn aliased_import() -> Result<()> {
         flakes(
             "import fu as FU, bar as FU",
-            &[RuleCode::F401, RuleCode::F811, RuleCode::F401],
+            &[
+                Rule::UnusedImport,
+                Rule::RedefinedWhileUnused,
+                Rule::UnusedImport,
+            ],
         )?;
         flakes(
             "from moo import fu as FU, bar as FU",
-            &[RuleCode::F401, RuleCode::F811, RuleCode::F401],
+            &[
+                Rule::UnusedImport,
+                Rule::RedefinedWhileUnused,
+                Rule::UnusedImport,
+            ],
         )?;
 
         Ok(())
@@ -1205,11 +1219,17 @@ mod tests {
 
     #[test]
     fn redefined_while_unused() -> Result<()> {
-        flakes("import fu; fu = 3", &[RuleCode::F401, RuleCode::F811])?;
-        flakes("import fu; fu, bar = 3", &[RuleCode::F401, RuleCode::F811])?;
+        flakes(
+            "import fu; fu = 3",
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+        )?;
+        flakes(
+            "import fu; fu, bar = 3",
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+        )?;
         flakes(
             "import fu; [fu, bar] = 3",
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1227,7 +1247,7 @@ mod tests {
             import os
         os.path
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1265,7 +1285,7 @@ mod tests {
             pass
         os.path
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1341,7 +1361,7 @@ mod tests {
             from bb import mixer
         mixer(123)
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1413,7 +1433,7 @@ mod tests {
         def fu():
             pass
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1431,7 +1451,7 @@ mod tests {
                 def fu():
                     pass
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1451,10 +1471,10 @@ mod tests {
                     pass
         "#,
             &[
-                RuleCode::F401,
-                RuleCode::F811,
-                RuleCode::F401,
-                RuleCode::F811,
+                Rule::UnusedImport,
+                Rule::RedefinedWhileUnused,
+                Rule::UnusedImport,
+                Rule::RedefinedWhileUnused,
             ],
         )?;
 
@@ -1491,7 +1511,7 @@ mod tests {
         class fu:
             pass
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1548,7 +1568,7 @@ mod tests {
 
         fu
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         Ok(())
@@ -1576,7 +1596,7 @@ mod tests {
         def fun(fu):
             print(fu)
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         flakes(
@@ -1602,7 +1622,7 @@ mod tests {
     #[test]
     fn used_in_getattr() -> Result<()> {
         flakes("import fu; fu.bar.baz", &[])?;
-        flakes("import fu; \"bar\".fu.baz", &[RuleCode::F401])?;
+        flakes("import fu; \"bar\".fu.baz", &[Rule::UnusedImport])?;
 
         Ok(())
     }
@@ -1755,7 +1775,7 @@ mod tests {
         for fu in range(2):
             pass
         "#,
-            &[RuleCode::F401, RuleCode::F402],
+            &[Rule::UnusedImport, Rule::ImportShadowedByLoopVar],
         )?;
 
         Ok(())
@@ -1772,7 +1792,7 @@ mod tests {
         for fu in ():
             pass
         "#,
-            &[RuleCode::F402],
+            &[Rule::ImportShadowedByLoopVar],
         )?;
 
         Ok(())
@@ -1789,7 +1809,7 @@ mod tests {
         for (x, y, z, (a, b, c, (fu,))) in ():
             pass
         "#,
-            &[RuleCode::F402],
+            &[Rule::ImportShadowedByLoopVar],
         )?;
         flakes(
             r#"
@@ -1798,7 +1818,7 @@ mod tests {
         for [x, y, z, (a, b, c, (fu,))] in ():
             pass
         "#,
-            &[RuleCode::F402],
+            &[Rule::ImportShadowedByLoopVar],
         )?;
 
         Ok(())
@@ -1912,7 +1932,11 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[RuleCode::F401, RuleCode::F811, RuleCode::F841],
+            &[
+                Rule::UnusedImport,
+                Rule::RedefinedWhileUnused,
+                Rule::UnusedVariable,
+            ],
         )?;
 
         Ok(())
@@ -2051,7 +2075,7 @@ mod tests {
         import fu
         def f(): global fu
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -2111,7 +2135,7 @@ mod tests {
     fn shadowed_by_lambda() -> Result<()> {
         flakes(
             "import fu; lambda fu: fu",
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
         flakes("import fu; lambda fu: fu\nfu()", &[])?;
 
@@ -2138,7 +2162,7 @@ mod tests {
             import fu
         fu
         "#,
-            &[RuleCode::F401, RuleCode::F821],
+            &[Rule::UnusedImport, Rule::UndefinedName],
         )?;
 
         Ok(())
@@ -2153,7 +2177,7 @@ mod tests {
             def fun(self):
                 fu
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         Ok(())
@@ -2208,7 +2232,7 @@ mod tests {
     fn unused_package_import() -> Result<()> {
         // If a dotted name is imported and not used, an unused import warning is
         // reported.
-        flakes("import fu.bar", &[RuleCode::F401])?;
+        flakes("import fu.bar", &[Rule::UnusedImport])?;
 
         Ok(())
     }
@@ -2222,7 +2246,7 @@ mod tests {
         import fu.bar, fu.bar
         fu.bar
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
         flakes(
             r#"
@@ -2230,7 +2254,7 @@ mod tests {
         import fu.bar
         fu.bar
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -2315,7 +2339,7 @@ mod tests {
         import fu
         import fu.bar
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -2386,7 +2410,7 @@ mod tests {
             fu
         fu
         "#,
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -2455,7 +2479,7 @@ mod tests {
         x = 5
         from __future__ import division
         "#,
-            &[RuleCode::F404],
+            &[Rule::LateFutureImport],
         )?;
         flakes(
             r#"
@@ -2463,7 +2487,7 @@ mod tests {
         from __future__ import division
         bar
         "#,
-            &[RuleCode::F404],
+            &[Rule::LateFutureImport],
         )?;
 
         Ok(())
@@ -2492,7 +2516,7 @@ mod tests {
             r#"
         from __future__ import print_statement
         "#,
-            &[RuleCode::F407],
+            &[Rule::FutureFeatureNotDefined],
         )?;
 
         Ok(())
@@ -2505,7 +2529,7 @@ mod tests {
             r#"
         from __future__ import *
         "#,
-            &[RuleCode::F407],
+            &[Rule::FutureFeatureNotDefined],
         )?;
 
         Ok(())
@@ -2521,7 +2545,7 @@ mod tests {
             import bar
             __all__ = ["bar"]
         "#,
-            &[RuleCode::F401, RuleCode::F841],
+            &[Rule::UnusedImport, Rule::UnusedVariable],
         )?;
 
         Ok(())
@@ -2536,7 +2560,7 @@ mod tests {
         class foo:
             __all__ = ["bar"]
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -2549,7 +2573,7 @@ mod tests {
         import bar
         (__all__,) = ("foo",)
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -2589,7 +2613,7 @@ mod tests {
         if 1 < 3:
             __all__ += ['c', 'd']
         "#,
-            &[RuleCode::F822, RuleCode::F822],
+            &[Rule::UndefinedExport, Rule::UndefinedExport],
         )?;
 
         Ok(())
@@ -2604,10 +2628,10 @@ mod tests {
         __all__ = ['a'] + ['b'] + ['c']
         "#,
             &[
-                RuleCode::F401,
-                RuleCode::F822,
-                RuleCode::F822,
-                RuleCode::F822,
+                Rule::UnusedImport,
+                Rule::UndefinedExport,
+                Rule::UndefinedExport,
+                Rule::UndefinedExport,
             ],
         )?;
 
@@ -2623,10 +2647,10 @@ mod tests {
         __all__ = ('a',) + ('b',) + ('c',)
         "#,
             &[
-                RuleCode::F401,
-                RuleCode::F822,
-                RuleCode::F822,
-                RuleCode::F822,
+                Rule::UnusedImport,
+                Rule::UndefinedExport,
+                Rule::UndefinedExport,
+                Rule::UndefinedExport,
             ],
         )?;
 
@@ -2694,7 +2718,7 @@ mod tests {
             r#"
         __all__ = ["foo"]
         "#,
-            &[RuleCode::F822],
+            &[Rule::UndefinedExport],
         )?;
 
         Ok(())
@@ -2710,10 +2734,10 @@ mod tests {
         csc(1)
         "#,
             &[
-                RuleCode::F403,
-                RuleCode::F405,
-                RuleCode::F405,
-                RuleCode::F405,
+                Rule::ImportStarUsed,
+                Rule::ImportStarUsage,
+                Rule::ImportStarUsage,
+                Rule::ImportStarUsage,
             ],
         )?;
 
@@ -2730,7 +2754,7 @@ mod tests {
         a = 1
         __all__ = ['a']
         "#,
-            &[RuleCode::F403, RuleCode::F401],
+            &[Rule::ImportStarUsed, Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -2751,7 +2775,7 @@ mod tests {
         // expression results in a redefinition warning.
         flakes(
             "import fu; (1 for fu in range(1))",
-            &[RuleCode::F401, RuleCode::F811],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -2788,7 +2812,7 @@ mod tests {
         def f():
             return "hello"
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         Ok(())
@@ -2825,7 +2849,7 @@ mod tests {
         class foo:
             pass
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         Ok(())
@@ -3010,7 +3034,7 @@ mod tests {
             def bar():
                 pass
         "#,
-            &[RuleCode::F811],
+            &[Rule::RedefinedWhileUnused],
         )?;
         Ok(())
     }
@@ -3053,7 +3077,7 @@ mod tests {
             name: str
             age: int
         "#,
-            &[RuleCode::F842, RuleCode::F842],
+            &[Rule::UnusedAnnotation, Rule::UnusedAnnotation],
         )?;
         flakes(
             r#"
@@ -3063,10 +3087,10 @@ mod tests {
             foo: not_a_real_type = None
         "#,
             &[
-                RuleCode::F841,
-                RuleCode::F841,
-                RuleCode::F841,
-                RuleCode::F821,
+                Rule::UnusedVariable,
+                Rule::UnusedVariable,
+                Rule::UnusedVariable,
+                Rule::UndefinedName,
             ],
         )?;
         flakes(
@@ -3075,7 +3099,7 @@ mod tests {
             name: str
             print(name)
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3083,33 +3107,33 @@ mod tests {
         def f():
             a: Any
         "#,
-            &[RuleCode::F842],
+            &[Rule::UnusedAnnotation],
         )?;
         flakes(
             r#"
         foo: not_a_real_type
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         foo: not_a_real_type = None
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         class C:
             foo: not_a_real_type
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         class C:
             foo: not_a_real_type = None
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3117,7 +3141,7 @@ mod tests {
             class C:
                 foo: not_a_real_type
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3125,7 +3149,7 @@ mod tests {
             class C:
                 foo: not_a_real_type = None
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3187,34 +3211,34 @@ mod tests {
             r#"
         bar: 'Bar'
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         bar: 'foo.Bar'
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
         from foo import Bar
         bar: str
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
         flakes(
             r#"
         from foo import Bar
         def f(bar: str): pass
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
         flakes(
             r#"
         def f(a: A) -> A: pass
         class A: pass
         "#,
-            &[RuleCode::F821, RuleCode::F821],
+            &[Rule::UndefinedName, Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3228,7 +3252,7 @@ mod tests {
         a: A
         class A: pass
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3242,7 +3266,7 @@ mod tests {
         T: object
         def f(t: T): pass
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         flakes(
             r#"
@@ -3255,13 +3279,13 @@ mod tests {
             r#"
         a: 'A B'
         "#,
-            &[RuleCode::F722],
+            &[Rule::ForwardAnnotationSyntaxError],
         )?;
         flakes(
             r#"
         a: 'A; B'
         "#,
-            &[RuleCode::F722],
+            &[Rule::ForwardAnnotationSyntaxError],
         )?;
         flakes(
             r#"
@@ -3273,7 +3297,7 @@ mod tests {
             r#"
         a: 'a: "A"'
         "#,
-            &[RuleCode::F722],
+            &[Rule::ForwardAnnotationSyntaxError],
         )?;
         Ok(())
     }
@@ -3284,7 +3308,7 @@ mod tests {
             r#"
         x: int = x
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -3344,7 +3368,7 @@ mod tests {
 
         bar: TypeAlias
         "#,
-            &[RuleCode::F401],
+            &[Rule::UnusedImport],
         )?;
         Ok(())
     }
@@ -3378,7 +3402,7 @@ mod tests {
         def f():
             x: int
         "#,
-            &[RuleCode::F842],
+            &[Rule::UnusedAnnotation],
         )?;
         // This should only print one UnusedVariable message.
         flakes(
@@ -3387,7 +3411,7 @@ mod tests {
             x: int
             x = 3
         "#,
-            &[RuleCode::F841],
+            &[Rule::UnusedVariable],
         )?;
         Ok(())
     }
@@ -3399,7 +3423,7 @@ mod tests {
         name: str
         print(name)
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -3437,7 +3461,7 @@ mod tests {
             b: Undefined
         class B: pass
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
 
         flakes(
@@ -3495,7 +3519,7 @@ mod tests {
                 Y = 2
                 return Y
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -3662,7 +3686,7 @@ mod tests {
         def f(x: Annotated['integer', 1]) -> None:
             return None
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -3690,7 +3714,7 @@ mod tests {
         def f(x: Union[Annotated['int', '>0'], 'integer']) -> None:
             return None
         "#,
-            &[RuleCode::F821],
+            &[Rule::UndefinedName],
         )?;
         Ok(())
     }
@@ -3870,13 +3894,13 @@ mod tests {
             List[TypeVar("A", List["C"])]
         "#,
             &[
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
-                RuleCode::F821,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
             ],
         )?;
         flakes(

--- a/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::helpers::find_useless_f_strings;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// F541
@@ -14,7 +14,7 @@ pub fn f_string_missing_placeholders(expr: &Expr, values: &[Expr], checker: &mut
     {
         for (prefix_range, tok_range) in find_useless_f_strings(expr, checker.locator) {
             let mut diagnostic = Diagnostic::new(violations::FStringMissingPlaceholders, tok_range);
-            if checker.patch(&RuleCode::F541) {
+            if checker.patch(&Rule::FStringMissingPlaceholders) {
                 diagnostic.amend(Fix::deletion(
                     prefix_range.location,
                     prefix_range.end_location,

--- a/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -26,7 +26,7 @@ pub fn invalid_literal_comparison(
                 || helpers::is_constant_non_singleton(right))
         {
             let mut diagnostic = Diagnostic::new(violations::IsLiteral(op.into()), location);
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 if let Some(located_op) = &located.get(index) {
                     assert_eq!(&located_op.node, op);
                     if let Some(content) = match &located_op.node {

--- a/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -32,7 +32,7 @@ pub fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     };
     let mut diagnostic =
         Diagnostic::new(violations::RaiseNotImplemented, Range::from_located(expr));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             "NotImplementedError".to_string(),
             expr.location,

--- a/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/src/rules/pyflakes/rules/repeated_keys.rs
@@ -8,7 +8,7 @@ use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
@@ -37,7 +37,11 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Expr], values: &[Expr]) {
             if let Some(seen_values) = seen.get_mut(&key) {
                 match key {
                     DictionaryKey::Constant(..) => {
-                        if checker.settings.rules.enabled(&RuleCode::F601) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MultiValueRepeatedKeyLiteral)
+                        {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);
                             let mut diagnostic = Diagnostic::new(
@@ -48,7 +52,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Expr], values: &[Expr]) {
                                 Range::from_located(&keys[i]),
                             );
                             if is_duplicate_value {
-                                if checker.patch(&RuleCode::F601) {
+                                if checker.patch(&Rule::MultiValueRepeatedKeyLiteral) {
                                     diagnostic.amend(Fix::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),
@@ -61,7 +65,11 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Expr], values: &[Expr]) {
                         }
                     }
                     DictionaryKey::Variable(key) => {
-                        if checker.settings.rules.enabled(&RuleCode::F602) {
+                        if checker
+                            .settings
+                            .rules
+                            .enabled(&Rule::MultiValueRepeatedKeyVariable)
+                        {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);
                             let mut diagnostic = Diagnostic::new(
@@ -72,7 +80,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Expr], values: &[Expr]) {
                                 Range::from_located(&keys[i]),
                             );
                             if is_duplicate_value {
-                                if checker.patch(&RuleCode::F602) {
+                                if checker.patch(&Rule::MultiValueRepeatedKeyVariable) {
                                     diagnostic.amend(Fix::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),

--- a/src/rules/pyflakes/rules/strings.rs
+++ b/src/rules/pyflakes/rules/strings.rs
@@ -116,7 +116,7 @@ pub(crate) fn percent_format_extra_named_arguments(
         ),
         location,
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         match remove_unused_format_arguments_from_dict(&missing, right, checker.locator) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -274,7 +274,7 @@ pub(crate) fn string_dot_format_extra_named_arguments(
         ),
         location,
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         match remove_unused_keyword_arguments_from_format_call(&missing, location, checker.locator)
         {
             Ok(fix) => {

--- a/src/rules/pyflakes/rules/unused_variable.rs
+++ b/src/rules/pyflakes/rules/unused_variable.rs
@@ -9,7 +9,7 @@ use crate::ast::types::{BindingKind, Range, RefEquality, ScopeKind};
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 use crate::violations;
 
@@ -167,7 +167,7 @@ pub fn unused_variable(checker: &mut Checker, scope: usize) {
                 violations::UnusedVariable((*name).to_string()),
                 binding.range,
             );
-            if checker.patch(&RuleCode::F841) {
+            if checker.patch(&Rule::UnusedVariable) {
                 if let Some(stmt) = binding.source.as_ref().map(std::convert::Into::into) {
                     if let Some((kind, fix)) = remove_unused_variable(stmt, &binding.range, checker)
                     {

--- a/src/rules/pygrep_hooks/mod.rs
+++ b/src/rules/pygrep_hooks/mod.rs
@@ -3,7 +3,6 @@ pub(crate) mod rules;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -20,7 +19,7 @@ mod tests {
     #[test_case(RuleCode::PGH003, Path::new("PGH003_0.py"); "PGH003_0")]
     #[test_case(RuleCode::PGH004, Path::new("PGH004_0.py"); "PGH004_0")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pygrep-hooks")
                 .join(path)

--- a/src/rules/pygrep_hooks/mod.rs
+++ b/src/rules/pygrep_hooks/mod.rs
@@ -9,16 +9,16 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
 
-    #[test_case(RuleCode::PGH001, Path::new("PGH001_0.py"); "PGH001_0")]
-    #[test_case(RuleCode::PGH001, Path::new("PGH001_1.py"); "PGH001_1")]
-    #[test_case(RuleCode::PGH002, Path::new("PGH002_0.py"); "PGH002_0")]
-    #[test_case(RuleCode::PGH002, Path::new("PGH002_1.py"); "PGH002_1")]
-    #[test_case(RuleCode::PGH003, Path::new("PGH003_0.py"); "PGH003_0")]
-    #[test_case(RuleCode::PGH004, Path::new("PGH004_0.py"); "PGH004_0")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::NoEval, Path::new("PGH001_0.py"); "PGH001_0")]
+    #[test_case(Rule::NoEval, Path::new("PGH001_1.py"); "PGH001_1")]
+    #[test_case(Rule::DeprecatedLogWarn, Path::new("PGH002_0.py"); "PGH002_0")]
+    #[test_case(Rule::DeprecatedLogWarn, Path::new("PGH002_1.py"); "PGH002_1")]
+    #[test_case(Rule::BlanketTypeIgnore, Path::new("PGH003_0.py"); "PGH003_0")]
+    #[test_case(Rule::BlanketNOQA, Path::new("PGH004_0.py"); "PGH004_0")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pygrep-hooks")

--- a/src/rules/pylint/mod.rs
+++ b/src/rules/pylint/mod.rs
@@ -34,7 +34,7 @@ mod tests {
     #[test_case(RuleCode::PLW0120, Path::new("useless_else_on_loop.py"); "PLW0120")]
     #[test_case(RuleCode::PLW0602, Path::new("global_variable_not_assigned.py"); "PLW0602")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pylint")
                 .join(path)

--- a/src/rules/pylint/mod.rs
+++ b/src/rules/pylint/mod.rs
@@ -10,30 +10,30 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::rules::pylint;
     use crate::settings::Settings;
 
-    #[test_case(RuleCode::PLC0414, Path::new("import_aliasing.py"); "PLC0414")]
-    #[test_case(RuleCode::PLC3002, Path::new("unnecessary_direct_lambda_call.py"); "PLC3002")]
-    #[test_case(RuleCode::PLE0117, Path::new("nonlocal_without_binding.py"); "PLE0117")]
-    #[test_case(RuleCode::PLE0118, Path::new("used_prior_global_declaration.py"); "PLE0118")]
-    #[test_case(RuleCode::PLE1142, Path::new("await_outside_async.py"); "PLE1142")]
-    #[test_case(RuleCode::PLR0133, Path::new("constant_comparison.py"); "PLR0133")]
-    #[test_case(RuleCode::PLR0206, Path::new("property_with_parameters.py"); "PLR0206")]
-    #[test_case(RuleCode::PLR0402, Path::new("import_aliasing.py"); "PLR0402")]
-    #[test_case(RuleCode::PLR1701, Path::new("consider_merging_isinstance.py"); "PLR1701")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_0.py"); "PLR1722_0")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_1.py"); "PLR1722_1")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_2.py"); "PLR1722_2")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_3.py"); "PLR1722_3")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_4.py"); "PLR1722_4")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_5.py"); "PLR1722_5")]
-    #[test_case(RuleCode::PLR1722, Path::new("consider_using_sys_exit_6.py"); "PLR1722_6")]
-    #[test_case(RuleCode::PLR2004, Path::new("magic_value_comparison.py"); "PLR2004")]
-    #[test_case(RuleCode::PLW0120, Path::new("useless_else_on_loop.py"); "PLW0120")]
-    #[test_case(RuleCode::PLW0602, Path::new("global_variable_not_assigned.py"); "PLW0602")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UselessImportAlias, Path::new("import_aliasing.py"); "PLC0414")]
+    #[test_case(Rule::UnnecessaryDirectLambdaCall, Path::new("unnecessary_direct_lambda_call.py"); "PLC3002")]
+    #[test_case(Rule::NonlocalWithoutBinding, Path::new("nonlocal_without_binding.py"); "PLE0117")]
+    #[test_case(Rule::UsedPriorGlobalDeclaration, Path::new("used_prior_global_declaration.py"); "PLE0118")]
+    #[test_case(Rule::AwaitOutsideAsync, Path::new("await_outside_async.py"); "PLE1142")]
+    #[test_case(Rule::ConstantComparison, Path::new("constant_comparison.py"); "PLR0133")]
+    #[test_case(Rule::PropertyWithParameters, Path::new("property_with_parameters.py"); "PLR0206")]
+    #[test_case(Rule::ConsiderUsingFromImport, Path::new("import_aliasing.py"); "PLR0402")]
+    #[test_case(Rule::ConsiderMergingIsinstance, Path::new("consider_merging_isinstance.py"); "PLR1701")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_0.py"); "PLR1722_0")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_1.py"); "PLR1722_1")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_2.py"); "PLR1722_2")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_3.py"); "PLR1722_3")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_4.py"); "PLR1722_4")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_5.py"); "PLR1722_5")]
+    #[test_case(Rule::UseSysExit, Path::new("consider_using_sys_exit_6.py"); "PLR1722_6")]
+    #[test_case(Rule::MagicValueComparison, Path::new("magic_value_comparison.py"); "PLR2004")]
+    #[test_case(Rule::UselessElseOnLoop, Path::new("useless_else_on_loop.py"); "PLW0120")]
+    #[test_case(Rule::GlobalVariableNotAssigned, Path::new("global_variable_not_assigned.py"); "PLW0602")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pylint")
@@ -53,7 +53,7 @@ mod tests {
                 pylint: pylint::settings::Settings {
                     allow_magic_value_types: vec![pylint::settings::ConstantType::Int],
                 },
-                ..Settings::for_rules(vec![RuleCode::PLR2004])
+                ..Settings::for_rules(vec![Rule::MagicValueComparison])
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/pylint/rules/use_sys_exit.rs
+++ b/src/rules/pylint/rules/use_sys_exit.rs
@@ -95,7 +95,7 @@ pub fn use_sys_exit(checker: &mut Checker, func: &Expr) {
             violations::UseSysExit(name.to_string()),
             Range::from_located(func),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             if let Some(content) = get_member_import_name_alias(checker, "sys", "exit") {
                 diagnostic.amend(Fix::replacement(
                     content,

--- a/src/rules/pylint/rules/useless_import_alias.rs
+++ b/src/rules/pylint/rules/useless_import_alias.rs
@@ -20,7 +20,7 @@ pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic =
         Diagnostic::new(violations::UselessImportAlias, Range::from_located(alias));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             asname.to_string(),
             alias.location,

--- a/src/rules/pyupgrade/mod.rs
+++ b/src/rules/pyupgrade/mod.rs
@@ -6,7 +6,6 @@ pub(crate) mod types;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::AsRef;
     use std::path::Path;
 
     use anyhow::Result;
@@ -56,7 +55,7 @@ mod tests {
     #[test_case(RuleCode::UP032, Path::new("UP032.py"); "UP032")]
     #[test_case(RuleCode::UP033, Path::new("UP033.py"); "UP033")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyupgrade")
                 .join(path)

--- a/src/rules/pyupgrade/mod.rs
+++ b/src/rules/pyupgrade/mod.rs
@@ -12,49 +12,49 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
     use crate::settings::types::PythonVersion;
 
-    #[test_case(RuleCode::UP001, Path::new("UP001.py"); "UP001")]
-    #[test_case(RuleCode::UP003, Path::new("UP003.py"); "UP003")]
-    #[test_case(RuleCode::UP004, Path::new("UP004.py"); "UP004")]
-    #[test_case(RuleCode::UP005, Path::new("UP005.py"); "UP005")]
-    #[test_case(RuleCode::UP006, Path::new("UP006.py"); "UP006")]
-    #[test_case(RuleCode::UP007, Path::new("UP007.py"); "UP007")]
-    #[test_case(RuleCode::UP008, Path::new("UP008.py"); "UP008")]
-    #[test_case(RuleCode::UP009, Path::new("UP009_0.py"); "UP009_0")]
-    #[test_case(RuleCode::UP009, Path::new("UP009_1.py"); "UP009_1")]
-    #[test_case(RuleCode::UP009, Path::new("UP009_2.py"); "UP009_2")]
-    #[test_case(RuleCode::UP009, Path::new("UP009_3.py"); "UP009_3")]
-    #[test_case(RuleCode::UP009, Path::new("UP009_4.py"); "UP009_4")]
-    #[test_case(RuleCode::UP010, Path::new("UP010.py"); "UP010")]
-    #[test_case(RuleCode::UP011, Path::new("UP011.py"); "UP011")]
-    #[test_case(RuleCode::UP012, Path::new("UP012.py"); "UP012")]
-    #[test_case(RuleCode::UP013, Path::new("UP013.py"); "UP013")]
-    #[test_case(RuleCode::UP014, Path::new("UP014.py"); "UP014")]
-    #[test_case(RuleCode::UP015, Path::new("UP015.py"); "UP015")]
-    #[test_case(RuleCode::UP016, Path::new("UP016.py"); "UP016")]
-    #[test_case(RuleCode::UP018, Path::new("UP018.py"); "UP018")]
-    #[test_case(RuleCode::UP019, Path::new("UP019.py"); "UP019")]
-    #[test_case(RuleCode::UP021, Path::new("UP021.py"); "UP021")]
-    #[test_case(RuleCode::UP022, Path::new("UP022.py"); "UP022")]
-    #[test_case(RuleCode::UP023, Path::new("UP023.py"); "UP023")]
-    #[test_case(RuleCode::UP024, Path::new("UP024_0.py"); "UP024_0")]
-    #[test_case(RuleCode::UP024, Path::new("UP024_1.py"); "UP024_1")]
-    #[test_case(RuleCode::UP024, Path::new("UP024_2.py"); "UP024_2")]
-    #[test_case(RuleCode::UP024, Path::new("UP024_3.py"); "UP024_3")]
-    #[test_case(RuleCode::UP025, Path::new("UP025.py"); "UP025")]
-    #[test_case(RuleCode::UP026, Path::new("UP026.py"); "UP026")]
-    #[test_case(RuleCode::UP027, Path::new("UP027.py"); "UP027")]
-    #[test_case(RuleCode::UP028, Path::new("UP028_0.py"); "UP028_0")]
-    #[test_case(RuleCode::UP028, Path::new("UP028_1.py"); "UP028_1")]
-    #[test_case(RuleCode::UP029, Path::new("UP029.py"); "UP029")]
-    #[test_case(RuleCode::UP030, Path::new("UP030_0.py"); "UP030_0")]
-    #[test_case(RuleCode::UP030, Path::new("UP030_1.py"); "UP030_1")]
-    #[test_case(RuleCode::UP032, Path::new("UP032.py"); "UP032")]
-    #[test_case(RuleCode::UP033, Path::new("UP033.py"); "UP033")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::UselessMetaclassType, Path::new("UP001.py"); "UP001")]
+    #[test_case(Rule::TypeOfPrimitive, Path::new("UP003.py"); "UP003")]
+    #[test_case(Rule::UselessObjectInheritance, Path::new("UP004.py"); "UP004")]
+    #[test_case(Rule::DeprecatedUnittestAlias, Path::new("UP005.py"); "UP005")]
+    #[test_case(Rule::UsePEP585Annotation, Path::new("UP006.py"); "UP006")]
+    #[test_case(Rule::UsePEP604Annotation, Path::new("UP007.py"); "UP007")]
+    #[test_case(Rule::SuperCallWithParameters, Path::new("UP008.py"); "UP008")]
+    #[test_case(Rule::PEP3120UnnecessaryCodingComment, Path::new("UP009_0.py"); "UP009_0")]
+    #[test_case(Rule::PEP3120UnnecessaryCodingComment, Path::new("UP009_1.py"); "UP009_1")]
+    #[test_case(Rule::PEP3120UnnecessaryCodingComment, Path::new("UP009_2.py"); "UP009_2")]
+    #[test_case(Rule::PEP3120UnnecessaryCodingComment, Path::new("UP009_3.py"); "UP009_3")]
+    #[test_case(Rule::PEP3120UnnecessaryCodingComment, Path::new("UP009_4.py"); "UP009_4")]
+    #[test_case(Rule::UnnecessaryFutureImport, Path::new("UP010.py"); "UP010")]
+    #[test_case(Rule::LRUCacheWithoutParameters, Path::new("UP011.py"); "UP011")]
+    #[test_case(Rule::UnnecessaryEncodeUTF8, Path::new("UP012.py"); "UP012")]
+    #[test_case(Rule::ConvertTypedDictFunctionalToClass, Path::new("UP013.py"); "UP013")]
+    #[test_case(Rule::ConvertNamedTupleFunctionalToClass, Path::new("UP014.py"); "UP014")]
+    #[test_case(Rule::RedundantOpenModes, Path::new("UP015.py"); "UP015")]
+    #[test_case(Rule::RemoveSixCompat, Path::new("UP016.py"); "UP016")]
+    #[test_case(Rule::NativeLiterals, Path::new("UP018.py"); "UP018")]
+    #[test_case(Rule::TypingTextStrAlias, Path::new("UP019.py"); "UP019")]
+    #[test_case(Rule::ReplaceUniversalNewlines, Path::new("UP021.py"); "UP021")]
+    #[test_case(Rule::ReplaceStdoutStderr, Path::new("UP022.py"); "UP022")]
+    #[test_case(Rule::RewriteCElementTree, Path::new("UP023.py"); "UP023")]
+    #[test_case(Rule::OSErrorAlias, Path::new("UP024_0.py"); "UP024_0")]
+    #[test_case(Rule::OSErrorAlias, Path::new("UP024_1.py"); "UP024_1")]
+    #[test_case(Rule::OSErrorAlias, Path::new("UP024_2.py"); "UP024_2")]
+    #[test_case(Rule::OSErrorAlias, Path::new("UP024_3.py"); "UP024_3")]
+    #[test_case(Rule::RewriteUnicodeLiteral, Path::new("UP025.py"); "UP025")]
+    #[test_case(Rule::RewriteMockImport, Path::new("UP026.py"); "UP026")]
+    #[test_case(Rule::RewriteListComprehension, Path::new("UP027.py"); "UP027")]
+    #[test_case(Rule::RewriteYieldFrom, Path::new("UP028_0.py"); "UP028_0")]
+    #[test_case(Rule::RewriteYieldFrom, Path::new("UP028_1.py"); "UP028_1")]
+    #[test_case(Rule::UnnecessaryBuiltinImport, Path::new("UP029.py"); "UP029")]
+    #[test_case(Rule::FormatLiterals, Path::new("UP030_0.py"); "UP030_0")]
+    #[test_case(Rule::FormatLiterals, Path::new("UP030_1.py"); "UP030_1")]
+    #[test_case(Rule::FString, Path::new("UP032.py"); "UP032")]
+    #[test_case(Rule::FunctoolsCache, Path::new("UP033.py"); "UP033")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/pyupgrade")
@@ -72,7 +72,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyupgrade/future_annotations.py"),
             &settings::Settings {
                 target_version: PythonVersion::Py37,
-                ..settings::Settings::for_rule(RuleCode::UP006)
+                ..settings::Settings::for_rule(Rule::UsePEP585Annotation)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -85,7 +85,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyupgrade/future_annotations.py"),
             &settings::Settings {
                 target_version: PythonVersion::Py310,
-                ..settings::Settings::for_rule(RuleCode::UP006)
+                ..settings::Settings::for_rule(Rule::UsePEP585Annotation)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -98,7 +98,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyupgrade/future_annotations.py"),
             &settings::Settings {
                 target_version: PythonVersion::Py37,
-                ..settings::Settings::for_rule(RuleCode::UP007)
+                ..settings::Settings::for_rule(Rule::UsePEP604Annotation)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -111,7 +111,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyupgrade/future_annotations.py"),
             &settings::Settings {
                 target_version: PythonVersion::Py310,
-                ..settings::Settings::for_rule(RuleCode::UP007)
+                ..settings::Settings::for_rule(Rule::UsePEP604Annotation)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -124,7 +124,7 @@ mod tests {
             Path::new("./resources/test/fixtures/pyupgrade/UP017.py"),
             &settings::Settings {
                 target_version: PythonVersion::Py311,
-                ..settings::Settings::for_rule(RuleCode::UP017)
+                ..settings::Settings::for_rule(Rule::DatetimeTimezoneUTC)
             },
         )?;
         insta::assert_yaml_snapshot!(diagnostics);

--- a/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -157,7 +157,7 @@ pub fn convert_named_tuple_functional_to_class(
         violations::ConvertNamedTupleFunctionalToClass(typename.to_string()),
         Range::from_located(stmt),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         match match_defaults(keywords)
             .and_then(|defaults| create_properties_from_args(args, defaults))
         {

--- a/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -200,7 +200,7 @@ pub fn convert_typed_dict_functional_to_class(
         violations::ConvertTypedDictFunctionalToClass(class_name.to_string()),
         Range::from_located(stmt),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         match match_properties_and_total(args, keywords) {
             Ok((body, total_keyword)) => {
                 diagnostic.amend(convert_to_class(

--- a/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -4,7 +4,7 @@ use crate::ast::helpers::collect_call_path;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// UP017
@@ -17,7 +17,7 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
             violations::DatetimeTimezoneUTC { straight_import },
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::UP017) {
+        if checker.patch(&Rule::DatetimeTimezoneUTC) {
             if straight_import {
                 diagnostic.amend(Fix::replacement(
                     "datetime.UTC".to_string(),

--- a/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -46,7 +46,7 @@ pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         violations::DeprecatedUnittestAlias(attr.to_string(), target.to_string()),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             format!("self.{target}"),
             expr.location,

--- a/src/rules/pyupgrade/rules/f_strings.rs
+++ b/src/rules/pyupgrade/rules/f_strings.rs
@@ -9,7 +9,7 @@ use rustpython_parser::lexer::Tok;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::violations;
@@ -263,7 +263,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
     }
 
     let mut diagnostic = Diagnostic::new(violations::FString, Range::from_located(expr));
-    if checker.patch(&RuleCode::UP032) {
+    if checker.patch(&Rule::FString) {
         diagnostic.amend(Fix::replacement(
             contents,
             expr.location,

--- a/src/rules/pyupgrade/rules/format_literals.rs
+++ b/src/rules/pyupgrade/rules/format_literals.rs
@@ -98,7 +98,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
     }
 
     let mut diagnostic = Diagnostic::new(violations::FormatLiterals, Range::from_located(expr));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         // Currently, the only issue we know of is in LibCST:
         // https://github.com/Instagram/LibCST/issues/846
         if let Ok(contents) = generate_call(

--- a/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/src/rules/pyupgrade/rules/functools_cache.rs
@@ -5,7 +5,7 @@ use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// UP033
@@ -40,7 +40,7 @@ pub fn functools_cache(checker: &mut Checker, decorator_list: &[Expr]) {
                     violations::FunctoolsCache,
                     Range::new(func.end_location.unwrap(), expr.end_location.unwrap()),
                 );
-                if checker.patch(&RuleCode::UP033) {
+                if checker.patch(&Rule::FunctoolsCache) {
                     if let ExprKind::Attribute { value, ctx, .. } = &func.node {
                         diagnostic.amend(Fix::replacement(
                             unparse_expr(

--- a/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -5,7 +5,7 @@ use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// UP011
@@ -30,7 +30,7 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
                 violations::LRUCacheWithoutParameters,
                 Range::new(func.end_location.unwrap(), expr.end_location.unwrap()),
             );
-            if checker.patch(&RuleCode::UP011) {
+            if checker.patch(&Rule::LRUCacheWithoutParameters) {
                 diagnostic.amend(Fix::replacement(
                     unparse_expr(func, checker.stylist),
                     expr.location,

--- a/src/rules/pyupgrade/rules/native_literals.rs
+++ b/src/rules/pyupgrade/rules/native_literals.rs
@@ -5,7 +5,7 @@ use rustpython_parser::lexer::Tok;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 use crate::violations::LiteralType;
 
@@ -30,7 +30,7 @@ pub fn native_literals(
             } else {
                 LiteralType::Bytes
             }), Range::from_located(expr));
-            if checker.patch(&RuleCode::UP018) {
+            if checker.patch(&Rule::NativeLiterals) {
                 diagnostic.amend(Fix::replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
@@ -101,7 +101,7 @@ pub fn native_literals(
             }),
             Range::from_located(expr),
         );
-        if checker.patch(&RuleCode::UP018) {
+        if checker.patch(&Rule::NativeLiterals) {
             diagnostic.amend(Fix::replacement(
                 arg_code.to_string(),
                 expr.location,

--- a/src/rules/pyupgrade/rules/open_alias.rs
+++ b/src/rules/pyupgrade/rules/open_alias.rs
@@ -3,7 +3,7 @@ use rustpython_ast::Expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// UP020
@@ -13,7 +13,7 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
     {
         let mut diagnostic = Diagnostic::new(violations::OpenAlias, Range::from_located(expr));
-        if checker.patch(&RuleCode::UP020) {
+        if checker.patch(&Rule::OpenAlias) {
             diagnostic.amend(Fix::replacement(
                 "open".to_string(),
                 func.location,

--- a/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -148,7 +148,7 @@ fn handle_making_changes(
             violations::OSErrorAlias(compose_call_path(target)),
             Range::from_located(target),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 final_str,
                 target.location,

--- a/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -10,7 +10,7 @@ use crate::ast::helpers::find_keyword;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 use crate::violations;
 
@@ -164,7 +164,7 @@ pub fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                         &keyword.node.value,
                         mode.replacement_value(),
                         checker.locator,
-                        checker.patch(&RuleCode::UP015),
+                        checker.patch(&Rule::RedundantOpenModes),
                     ));
                 }
             }
@@ -181,7 +181,7 @@ pub fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                     mode_param,
                     mode.replacement_value(),
                     checker.locator,
-                    checker.patch(&RuleCode::UP015),
+                    checker.patch(&Rule::RedundantOpenModes),
                 ));
             }
         }

--- a/src/rules/pyupgrade/rules/remove_six_compat.rs
+++ b/src/rules/pyupgrade/rules/remove_six_compat.rs
@@ -4,7 +4,7 @@ use crate::ast::helpers::{create_expr, create_stmt};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::{Generator, Locator, Stylist};
 use crate::violations;
 
@@ -405,7 +405,7 @@ fn handle_next_on_six_dict(expr: &Expr, patch: bool, checker: &Checker) -> Optio
 /// UP016
 pub fn remove_six_compat(checker: &mut Checker, expr: &Expr) {
     if let Some(diagnostic) =
-        handle_next_on_six_dict(expr, checker.patch(&RuleCode::UP016), checker)
+        handle_next_on_six_dict(expr, checker.patch(&Rule::RemoveSixCompat), checker)
     {
         checker.diagnostics.push(diagnostic);
         return;
@@ -415,7 +415,7 @@ pub fn remove_six_compat(checker: &mut Checker, expr: &Expr) {
         .resolve_call_path(expr)
         .map_or(false, |call_path| is_module_member(&call_path, "six"))
     {
-        let patch = checker.patch(&RuleCode::UP016);
+        let patch = checker.patch(&Rule::RemoveSixCompat);
         let diagnostic = match &expr.node {
             ExprKind::Call {
                 func,

--- a/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -108,7 +108,7 @@ pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keywo
 
         let mut diagnostic =
             Diagnostic::new(violations::ReplaceStdoutStderr, Range::from_located(expr));
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             if let Some(fix) = generate_fix(checker.locator, stdout, stderr) {
                 diagnostic.amend(fix);
             };

--- a/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -21,7 +21,7 @@ pub fn replace_universal_newlines(checker: &mut Checker, expr: &Expr, kwargs: &[
             ),
         );
         let mut diagnostic = Diagnostic::new(violations::ReplaceUniversalNewlines, range);
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "text".to_string(),
                 range.location,

--- a/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -9,7 +9,7 @@ use crate::violations;
 fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic =
         Diagnostic::new(violations::RewriteCElementTree, Range::from_located(node));
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let contents = checker
             .locator
             .slice_source_code_range(&Range::from_located(node));

--- a/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -12,7 +12,7 @@ use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_import, match_import_from, match_module};
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::{Locator, Stylist};
 use crate::violations;
 use crate::violations::MockReference;
@@ -204,7 +204,7 @@ pub fn rewrite_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 violations::RewriteMockImport(MockReference::Attribute),
                 Range::from_located(value),
             );
-            if checker.patch(&RuleCode::UP026) {
+            if checker.patch(&Rule::RewriteMockImport) {
                 diagnostic.amend(Fix::replacement(
                     "mock".to_string(),
                     value.location,
@@ -226,7 +226,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                 .any(|name| name.node.name == "mock" || name.node.name == "mock.mock")
             {
                 // Generate the fix, if needed, which is shared between all `mock` imports.
-                let content = if checker.patch(&RuleCode::UP026) {
+                let content = if checker.patch(&Rule::RewriteMockImport) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         match format_import(stmt, &indent, checker.locator, checker.stylist) {
                             Ok(content) => Some(content),
@@ -275,7 +275,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     violations::RewriteMockImport(MockReference::Import),
                     Range::from_located(stmt),
                 );
-                if checker.patch(&RuleCode::UP026) {
+                if checker.patch(&Rule::RewriteMockImport) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         match format_import_from(stmt, &indent, checker.locator, checker.stylist) {
                             Ok(content) => {

--- a/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
+++ b/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
@@ -12,7 +12,7 @@ pub fn rewrite_unicode_literal(checker: &mut Checker, expr: &Expr, kind: Option<
         if const_kind.to_lowercase() == "u" {
             let mut diagnostic =
                 Diagnostic::new(violations::RewriteUnicodeLiteral, Range::from_located(expr));
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::deletion(
                     expr.location,
                     Location::new(expr.location.row(), expr.location.column() + 1),

--- a/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -159,7 +159,7 @@ pub fn rewrite_yield_from(checker: &mut Checker, stmt: &Stmt) {
 
             let mut diagnostic =
                 Diagnostic::new(violations::RewriteYieldFrom, Range::from_located(item.stmt));
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 let contents = checker
                     .locator
                     .slice_source_code_range(&Range::from_located(item.iter));

--- a/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -20,7 +20,7 @@ pub fn super_call_with_parameters(checker: &mut Checker, expr: &Expr, func: &Exp
     let Some(mut diagnostic) = super::super_args(scope, &parents, expr, func, args) else {
         return;
     };
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         if let Some(fix) = fixes::remove_super_arguments(checker.locator, expr) {
             diagnostic.amend(fix);
         }

--- a/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -28,7 +28,7 @@ pub fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr, args: 
         violations::TypeOfPrimitive(primitive),
         Range::from_located(expr),
     );
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             primitive.builtin(),
             expr.location,

--- a/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -13,7 +13,7 @@ pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     }) {
         let mut diagnostic =
             Diagnostic::new(violations::TypingTextStrAlias, Range::from_located(expr));
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "str".to_string(),
                 expr.location,

--- a/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -79,7 +79,7 @@ pub fn unnecessary_builtin_import(
         Range::from_located(stmt),
     );
 
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker
             .deletions
             .iter()

--- a/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 use crate::violations;
 
@@ -130,7 +130,7 @@ pub fn unnecessary_encode_utf8(
                         expr,
                         variable,
                         checker.locator,
-                        checker.patch(&RuleCode::UP012),
+                        checker.patch(&Rule::UnnecessaryEncodeUTF8),
                     ));
                 } else {
                     // "unicode text©".encode("utf-8")
@@ -138,7 +138,7 @@ pub fn unnecessary_encode_utf8(
                         expr,
                         args,
                         kwargs,
-                        checker.patch(&RuleCode::UP012),
+                        checker.patch(&Rule::UnnecessaryEncodeUTF8),
                     ) {
                         checker.diagnostics.push(diagnostic);
                     }
@@ -152,7 +152,7 @@ pub fn unnecessary_encode_utf8(
                     expr,
                     args,
                     kwargs,
-                    checker.patch(&RuleCode::UP012),
+                    checker.patch(&Rule::UnnecessaryEncodeUTF8),
                 ) {
                     checker.diagnostics.push(diagnostic);
                 }

--- a/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -64,7 +64,7 @@ pub fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, names: &[Lo
         Range::from_located(stmt),
     );
 
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker
             .deletions
             .iter()

--- a/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, RuleCode};
+use crate::registry::{Diagnostic, Rule};
 use crate::violations;
 
 /// Returns `true` if `expr` contains an `ExprKind::Await`.
@@ -79,7 +79,7 @@ pub fn unpack_list_comprehension(checker: &mut Checker, targets: &[Expr], value:
                 violations::RewriteListComprehension,
                 Range::from_located(value),
             );
-            if checker.patch(&RuleCode::UP027) {
+            if checker.patch(&Rule::RewriteListComprehension) {
                 let existing = checker
                     .locator
                     .slice_source_code_range(&Range::from_located(value));

--- a/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -16,7 +16,7 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
             violations::UsePEP585Annotation(binding.to_string()),
             Range::from_located(expr),
         );
-        if checker.patch(diagnostic.kind.code()) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 binding.to_lowercase(),
                 expr.location,

--- a/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -82,7 +82,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
         TypingMember::Optional => {
             let mut diagnostic =
                 Diagnostic::new(violations::UsePEP604Annotation, Range::from_located(expr));
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 let mut generator: Generator = checker.stylist.into();
                 generator.unparse_expr(&optional(slice), 0);
                 diagnostic.amend(Fix::replacement(
@@ -96,7 +96,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
         TypingMember::Union => {
             let mut diagnostic =
                 Diagnostic::new(violations::UsePEP604Annotation, Range::from_located(expr));
-            if checker.patch(diagnostic.kind.code()) {
+            if checker.patch(diagnostic.kind.rule()) {
                 match &slice.node {
                     ExprKind::Slice { .. } => {
                         // Invalid type annotation.

--- a/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -32,7 +32,7 @@ pub fn useless_metaclass_type(checker: &mut Checker, stmt: &Stmt, value: &Expr, 
         rule(targets, value, Range::from_located(stmt)) else {
             return;
         };
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker
             .deletions
             .iter()

--- a/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -46,7 +46,7 @@ pub fn useless_object_inheritance(
     let Some(mut diagnostic) = rule(name, bases, checker.current_scope(), &checker.bindings) else {
         return;
     };
-    if checker.patch(diagnostic.kind.code()) {
+    if checker.patch(diagnostic.kind.rule()) {
         if let Some(fix) = fixes::remove_class_def_base(
             checker.locator,
             stmt.location,

--- a/src/rules/ruff/mod.rs
+++ b/src/rules/ruff/mod.rs
@@ -15,7 +15,7 @@ mod tests {
     use crate::settings;
     #[test_case(RuleCode::RUF004, Path::new("RUF004.py"); "RUF004")]
     fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
-        let snapshot = format!("{}_{}", rule_code.as_ref(), path.to_string_lossy());
+        let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff")
                 .join(path)

--- a/src/rules/ruff/mod.rs
+++ b/src/rules/ruff/mod.rs
@@ -11,10 +11,10 @@ mod tests {
     use test_case::test_case;
 
     use crate::linter::test_path;
-    use crate::registry::RuleCode;
+    use crate::registry::Rule;
     use crate::settings;
-    #[test_case(RuleCode::RUF004, Path::new("RUF004.py"); "RUF004")]
-    fn rules(rule_code: RuleCode, path: &Path) -> Result<()> {
+    #[test_case(Rule::KeywordArgumentBeforeStarArgument, Path::new("RUF004.py"); "RUF004")]
+    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff")
@@ -33,9 +33,9 @@ mod tests {
             &settings::Settings {
                 allowed_confusables: FxHashSet::from_iter(['−', 'ρ', '∗']).into(),
                 ..settings::Settings::for_rules(vec![
-                    RuleCode::RUF001,
-                    RuleCode::RUF002,
-                    RuleCode::RUF003,
+                    Rule::AmbiguousUnicodeCharacterString,
+                    Rule::AmbiguousUnicodeCharacterDocstring,
+                    Rule::AmbiguousUnicodeCharacterComment,
                 ])
             },
         )?;
@@ -48,10 +48,10 @@ mod tests {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/RUF100_0.py"),
             &settings::Settings::for_rules(vec![
-                RuleCode::RUF100,
-                RuleCode::E501,
-                RuleCode::F401,
-                RuleCode::F841,
+                Rule::UnusedNOQA,
+                Rule::LineTooLong,
+                Rule::UnusedImport,
+                Rule::UnusedVariable,
             ]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
@@ -62,7 +62,7 @@ mod tests {
     fn ruf100_1() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/RUF100_1.py"),
-            &settings::Settings::for_rules(vec![RuleCode::RUF100, RuleCode::F401]),
+            &settings::Settings::for_rules(vec![Rule::UnusedNOQA, Rule::UnusedImport]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -72,7 +72,7 @@ mod tests {
     fn flake8_noqa() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/flake8_noqa.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F401, RuleCode::F841]),
+            &settings::Settings::for_rules(vec![Rule::UnusedImport, Rule::UnusedVariable]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -82,7 +82,7 @@ mod tests {
     fn ruff_noqa() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/ruff_noqa.py"),
-            &settings::Settings::for_rules(vec![RuleCode::F401, RuleCode::F841]),
+            &settings::Settings::for_rules(vec![Rule::UnusedImport, Rule::UnusedVariable]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())
@@ -92,7 +92,7 @@ mod tests {
     fn redirects() -> Result<()> {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/redirects.py"),
-            &settings::Settings::for_rules(vec![RuleCode::UP007]),
+            &settings::Settings::for_rules(vec![Rule::UsePEP604Annotation]),
         )?;
         insta::assert_yaml_snapshot!(diagnostics);
         Ok(())

--- a/src/rules/ruff/rules.rs
+++ b/src/rules/ruff/rules.rs
@@ -1650,9 +1650,9 @@ pub fn ambiguous_unicode_character(
                         },
                         Range::new(location, end_location),
                     );
-                    if settings.rules.enabled(diagnostic.kind.code()) {
+                    if settings.rules.enabled(diagnostic.kind.rule()) {
                         if matches!(autofix, flags::Autofix::Enabled)
-                            && settings.rules.should_fix(diagnostic.kind.code())
+                            && settings.rules.should_fix(diagnostic.kind.rule())
                         {
                             diagnostic.amend(Fix::replacement(
                                 representant.to_string(),

--- a/src/settings/rule_table.rs
+++ b/src/settings/rule_table.rs
@@ -3,14 +3,14 @@ use std::collections::hash_map;
 use rustc_hash::FxHashMap;
 
 use super::hashable::HashableHashMap;
-use crate::registry::RuleCode;
+use crate::registry::Rule;
 
 /// A table to keep track of which rules are enabled
 /// and whether or not they should be autofixed.
 #[derive(Debug, Hash)]
 pub struct RuleTable {
     /// Maps rule codes to a boolean indicating if the rule should be autofixed.
-    enabled: HashableHashMap<RuleCode, bool>,
+    enabled: HashableHashMap<Rule, bool>,
 }
 
 impl RuleTable {
@@ -22,27 +22,27 @@ impl RuleTable {
     }
 
     /// Returns whether the given rule should be checked.
-    pub fn enabled(&self, code: &RuleCode) -> bool {
+    pub fn enabled(&self, code: &Rule) -> bool {
         self.enabled.contains_key(code)
     }
 
     /// Returns whether violations of the given rule should be autofixed.
-    pub fn should_fix(&self, code: &RuleCode) -> bool {
+    pub fn should_fix(&self, code: &Rule) -> bool {
         *self.enabled.get(code).unwrap_or(&false)
     }
 
     /// Returns an iterator over all enabled rules.
-    pub fn iter_enabled(&self) -> hash_map::Keys<RuleCode, bool> {
+    pub fn iter_enabled(&self) -> hash_map::Keys<Rule, bool> {
         self.enabled.keys()
     }
 
     /// Enables the given rule.
-    pub fn enable(&mut self, code: RuleCode, should_fix: bool) {
+    pub fn enable(&mut self, code: Rule, should_fix: bool) {
         self.enabled.insert(code, should_fix);
     }
 }
 
-impl<I: IntoIterator<Item = RuleCode>> From<I> for RuleTable {
+impl<I: IntoIterator<Item = Rule>> From<I> for RuleTable {
     fn from(codes: I) -> Self {
         let mut enabled = FxHashMap::default();
         for code in codes {

--- a/src/settings/types.rs
+++ b/src/settings/types.rs
@@ -12,7 +12,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 
 use super::hashable::HashableHashSet;
 use crate::fs;
-use crate::registry::{RuleCode, RuleCodePrefix};
+use crate::registry::{Rule, RuleCodePrefix};
 
 #[derive(
     Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize, Hash, JsonSchema,
@@ -89,7 +89,7 @@ impl FromStr for FilePattern {
 pub struct PerFileIgnore {
     pub basename: String,
     pub absolute: PathBuf,
-    pub codes: HashableHashSet<RuleCode>,
+    pub codes: HashableHashSet<Rule>,
 }
 
 impl PerFileIgnore {


### PR DESCRIPTION
Rules often exist in several linters for example UselessObjectInheritance is known as:

* UP004 in pyupgrade
* R0205 in pylint
* PIE792 in flake8-pie

Ruff currently only supports one code per rule (aside from "prefix redirects" which aren't documented at all), so basically the first code used ends up being the code promoted by ruff which is very arbitrary.

I think we should rather have a proper many to many mapping, allowing many codes to be mapped to one ruff rule or one code to several ruff rules (e.g. C0103 from pylint encompasses N801, N802 and N803 from pep8-naming). This would also allow flake8_to_ruff to be expanded to support e.g. pylint.

To cleanly implement this we have to decouple "rules" from "rule codes". This is the first PR for that epic task ... it doesn't yet change the mapping, only which variant names we use in our codebase.

Added benefits: The code is no longer littered with cryptic numeric codes and thus more readable and we get a big step closer to #1773.