### PR TITLE
Restrict SIM105 to try blocks with a body of one simple statement

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM105.py
+++ b/resources/test/fixtures/flake8_simplify/SIM105.py
@@ -41,3 +41,21 @@ except ValueError:
     pass
 finally:
     print('bar')
+
+try:
+    foo()
+    foo()
+except ValueError:
+    pass
+
+try:
+    for i in range(3):
+        foo()
+except ValueError:
+    pass
+
+def bar():
+    try:
+        return foo()
+    except ValueError:
+        pass

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1384,7 +1384,7 @@ where
                 }
                 if self.settings.rules.enabled(&RuleCode::SIM105) {
                     flake8_simplify::rules::use_contextlib_suppress(
-                        self, stmt, handlers, orelse, finalbody,
+                        self, stmt, body, handlers, orelse, finalbody,
                     );
                 }
                 if self.settings.rules.enabled(&RuleCode::SIM107) {


### PR DESCRIPTION
If a `try` block has multiple statements, a compound statement, or control flow, rewriting it with `contextlib.suppress` would obfuscate the fact that the exception still short-circuits further statements in the block.

Fixes #1947.