### PR TITLE
Use `smallvec` for call path representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,6 +1946,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "shellexpand",
+ "smallvec",
  "strum",
  "strum_macros",
  "test-case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }
 shellexpand = { version = "3.0.0" }
+smallvec = "1.10.0"
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }
 shellexpand = { version = "3.0.0" }
-smallvec = "1.10.0"
+smallvec = { version = "1.10.0" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }

--- a/src/ast/function_type.rs
+++ b/src/ast/function_type.rs
@@ -33,7 +33,7 @@ pub fn classify(
             checker.resolve_call_path(expr).map_or(false, |call_path| {
                 METACLASS_BASES
                     .iter()
-                    .any(|(module, member)| call_path == [*module, *member])
+                    .any(|(module, member)| call_path.as_slice() == [*module, *member])
             })
         })
         || decorator_list.iter().any(|expr| {

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -10,7 +10,7 @@ use rustpython_ast::{
 use rustpython_parser::lexer;
 use rustpython_parser::lexer::Tok;
 use rustpython_parser::token::StringKind;
-use smallvec::{smallvec, SmallVec};
+use smallvec::smallvec;
 
 use crate::ast::types::{Binding, BindingKind, CallPath, Range};
 use crate::checkers::ast::Checker;
@@ -110,11 +110,11 @@ pub fn format_call_path(call_path: &[&str]) -> String {
 }
 
 /// Return `true` if the `Expr` contains a reference to `${module}.${target}`.
-pub fn contains_call_path(checker: &Checker, expr: &Expr, target: CallPath) -> bool {
+pub fn contains_call_path(checker: &Checker, expr: &Expr, target: &[&str]) -> bool {
     any_over_expr(expr, &|expr| {
         checker
             .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path == target)
+            .map_or(false, |call_path| call_path.as_slice() == target)
     })
 }
 

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -10,8 +10,9 @@ use rustpython_ast::{
 use rustpython_parser::lexer;
 use rustpython_parser::lexer::Tok;
 use rustpython_parser::token::StringKind;
+use smallvec::{smallvec, SmallVec};
 
-use crate::ast::types::{Binding, BindingKind, Range};
+use crate::ast::types::{Binding, BindingKind, CallPath, Range};
 use crate::checkers::ast::Checker;
 use crate::source_code::{Generator, Indexer, Locator, Stylist};
 
@@ -62,6 +63,29 @@ pub fn collect_call_path(expr: &Expr) -> Vec<&str> {
     segments
 }
 
+fn collect_small_path_inner<'a>(expr: &'a Expr, parts: &mut CallPath<'a>) {
+    match &expr.node {
+        ExprKind::Call { func, .. } => {
+            collect_small_path_inner(func, parts);
+        }
+        ExprKind::Attribute { value, attr, .. } => {
+            collect_small_path_inner(value, parts);
+            parts.push(attr);
+        }
+        ExprKind::Name { id, .. } => {
+            parts.push(id);
+        }
+        _ => {}
+    }
+}
+
+/// Convert an `Expr` to its call path segments (like ["typing", "List"]).
+pub fn collect_small_path(expr: &Expr) -> CallPath {
+    let mut segments = smallvec![];
+    collect_small_path_inner(expr, &mut segments);
+    segments
+}
+
 /// Convert an `Expr` to its call path (like `List`, or `typing.List`).
 pub fn compose_call_path(expr: &Expr) -> Option<String> {
     let call_path = collect_call_path(expr);
@@ -86,7 +110,7 @@ pub fn format_call_path(call_path: &[&str]) -> String {
 }
 
 /// Return `true` if the `Expr` contains a reference to `${module}.${target}`.
-pub fn contains_call_path(checker: &Checker, expr: &Expr, target: &[&str]) -> bool {
+pub fn contains_call_path(checker: &Checker, expr: &Expr, target: CallPath) -> bool {
     any_over_expr(expr, &|expr| {
         checker
             .resolve_call_path(expr)
@@ -415,11 +439,11 @@ pub fn format_import_from_member(
 }
 
 /// Split a target string (like `typing.List`) into (`typing`, `List`).
-pub fn to_call_path(target: &str) -> Vec<&str> {
+pub fn to_call_path(target: &str) -> CallPath {
     if target.contains('.') {
         target.split('.').collect()
     } else {
-        vec!["", target]
+        smallvec!["", target]
     }
 }
 

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -243,4 +243,4 @@ impl<'a> From<&RefEquality<'a, Expr>> for &'a Expr {
     }
 }
 
-pub type CallPath<'a> = smallvec::SmallVec<[&'a str; 4]>;
+pub type CallPath<'a> = smallvec::SmallVec<[&'a str; 8]>;

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -242,3 +242,5 @@ impl<'a> From<&RefEquality<'a, Expr>> for &'a Expr {
         r.0
     }
 }
+
+pub type CallPath<'a> = smallvec::SmallVec<[&'a str; 4]>;

--- a/src/python/typing.rs
+++ b/src/python/typing.rs
@@ -249,3 +249,13 @@ pub fn is_pep585_builtin(checker: &Checker, expr: &Expr) -> bool {
         PEP_585_BUILTINS_ELIGIBLE.contains(&call_path.as_slice())
     })
 }
+
+pub enum Callable {
+    ForwardRef,
+    Cast,
+    NewType,
+    TypeVar,
+    NamedTuple,
+    TypedDict,
+    MypyExtension,
+}

--- a/src/rules/flake8_2020/rules.rs
+++ b/src/rules/flake8_2020/rules.rs
@@ -9,7 +9,7 @@ use crate::violations;
 fn is_sys(checker: &Checker, expr: &Expr, target: &str) -> bool {
     checker
         .resolve_call_path(expr)
-        .map_or(false, |path| path == ["sys", target])
+        .map_or(false, |call_path| call_path.as_slice() == ["sys", target])
 }
 
 /// YTT101, YTT102, YTT301, YTT303
@@ -182,7 +182,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
 pub fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     if checker
         .resolve_call_path(expr)
-        .map_or(false, |path| path == ["six", "PY3"])
+        .map_or(false, |call_path| call_path.as_slice() == ["six", "PY3"])
     {
         checker.diagnostics.push(Diagnostic::new(
             violations::SixPY3Referenced,

--- a/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -94,7 +94,7 @@ pub fn bad_file_permissions(
 ) {
     if checker
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["os", "chmod"])
+        .map_or(false, |call_path| call_path.as_slice() == ["os", "chmod"])
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(mode_arg) = call_args.get_argument("mode", Some(1)) {

--- a/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -30,7 +30,7 @@ pub fn hashlib_insecure_hash_functions(
     keywords: &[Keyword],
 ) {
     if let Some(call_path) = checker.resolve_call_path(func) {
-        if call_path == ["hashlib", "new"] {
+        if call_path.as_slice() == ["hashlib", "new"] {
             let call_args = SimpleCallArgs::new(args, keywords);
 
             if !is_used_for_security(&call_args) {
@@ -49,7 +49,7 @@ pub fn hashlib_insecure_hash_functions(
             }
         } else {
             for func_name in &WEAK_HASHES {
-                if call_path == ["hashlib", func_name] {
+                if call_path.as_slice() == ["hashlib", func_name] {
                     let call_args = SimpleCallArgs::new(args, keywords);
 
                     if !is_used_for_security(&call_args) {

--- a/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -22,6 +22,11 @@ fn is_used_for_security(call_args: &SimpleCallArgs) -> bool {
     }
 }
 
+enum HashlibCall {
+    New,
+    WeakHash(&'static str),
+}
+
 /// S324
 pub fn hashlib_insecure_hash_functions(
     checker: &mut Checker,
@@ -29,39 +34,46 @@ pub fn hashlib_insecure_hash_functions(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if let Some(call_path) = checker.resolve_call_path(func) {
+    if let Some(hashlib_call) = checker.resolve_call_path(func).and_then(|call_path| {
         if call_path.as_slice() == ["hashlib", "new"] {
-            let call_args = SimpleCallArgs::new(args, keywords);
-
-            if !is_used_for_security(&call_args) {
-                return;
-            }
-
-            if let Some(name_arg) = call_args.get_argument("name", Some(0)) {
-                if let Some(hash_func_name) = string_literal(name_arg) {
-                    if WEAK_HASHES.contains(&hash_func_name.to_lowercase().as_str()) {
-                        checker.diagnostics.push(Diagnostic::new(
-                            violations::HashlibInsecureHashFunction(hash_func_name.to_string()),
-                            Range::from_located(name_arg),
-                        ));
-                    }
-                }
-            }
+            Some(HashlibCall::New)
         } else {
-            for func_name in &WEAK_HASHES {
-                if call_path.as_slice() == ["hashlib", func_name] {
-                    let call_args = SimpleCallArgs::new(args, keywords);
+            WEAK_HASHES
+                .iter()
+                .find(|hash| call_path.as_slice() == ["hashlib", hash])
+                .map(|hash| HashlibCall::WeakHash(hash))
+        }
+    }) {
+        match hashlib_call {
+            HashlibCall::New => {
+                let call_args = SimpleCallArgs::new(args, keywords);
 
-                    if !is_used_for_security(&call_args) {
-                        return;
-                    }
-
-                    checker.diagnostics.push(Diagnostic::new(
-                        violations::HashlibInsecureHashFunction((*func_name).to_string()),
-                        Range::from_located(func),
-                    ));
+                if !is_used_for_security(&call_args) {
                     return;
                 }
+
+                if let Some(name_arg) = call_args.get_argument("name", Some(0)) {
+                    if let Some(hash_func_name) = string_literal(name_arg) {
+                        if WEAK_HASHES.contains(&hash_func_name.to_lowercase().as_str()) {
+                            checker.diagnostics.push(Diagnostic::new(
+                                violations::HashlibInsecureHashFunction(hash_func_name.to_string()),
+                                Range::from_located(name_arg),
+                            ));
+                        }
+                    }
+                }
+            }
+            HashlibCall::WeakHash(func_name) => {
+                let call_args = SimpleCallArgs::new(args, keywords);
+
+                if !is_used_for_security(&call_args) {
+                    return;
+                }
+
+                checker.diagnostics.push(Diagnostic::new(
+                    violations::HashlibInsecureHashFunction((*func_name).to_string()),
+                    Range::from_located(func),
+                ));
             }
         }
     }

--- a/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -14,10 +14,9 @@ pub fn jinja2_autoescape_false(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["jinja2", "Environment"])
-    {
+    if checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["jinja2", "Environment"]
+    }) {
         let call_args = SimpleCallArgs::new(args, keywords);
 
         if let Some(autoescape_arg) = call_args.get_argument("autoescape", None) {

--- a/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -29,6 +29,11 @@ pub fn request_with_no_cert_validation(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
+    if let Some(target) = checker.resolve_call_path(func).and_then(|call_path| {
+        REQUESTS_HTTP_VERBS
+            .iter()
+            .find(|target| call_path.as_slice() == ["requests", target)
+    }) {}
     if let Some(call_path) = checker.resolve_call_path(func) {
         let call_args = SimpleCallArgs::new(args, keywords);
         for func_name in &REQUESTS_HTTP_VERBS {

--- a/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -30,44 +30,27 @@ pub fn request_with_no_cert_validation(
     keywords: &[Keyword],
 ) {
     if let Some(target) = checker.resolve_call_path(func).and_then(|call_path| {
-        REQUESTS_HTTP_VERBS
-            .iter()
-            .find(|target| call_path.as_slice() == ["requests", target)
-    }) {}
-    if let Some(call_path) = checker.resolve_call_path(func) {
-        let call_args = SimpleCallArgs::new(args, keywords);
-        for func_name in &REQUESTS_HTTP_VERBS {
-            if call_path.as_slice() == ["requests", func_name] {
-                if let Some(verify_arg) = call_args.get_argument("verify", None) {
-                    if let ExprKind::Constant {
-                        value: Constant::Bool(false),
-                        ..
-                    } = &verify_arg.node
-                    {
-                        checker.diagnostics.push(Diagnostic::new(
-                            violations::RequestWithNoCertValidation("requests".to_string()),
-                            Range::from_located(verify_arg),
-                        ));
-                    }
-                }
-                return;
+        if call_path.len() == 2 {
+            if call_path[0] == "requests" && REQUESTS_HTTP_VERBS.contains(&call_path[1]) {
+                return Some("requests");
+            }
+            if call_path[0] == "httpx" && HTTPX_METHODS.contains(&call_path[1]) {
+                return Some("httpx");
             }
         }
-        for func_name in &HTTPX_METHODS {
-            if call_path.as_slice() == ["httpx", func_name] {
-                if let Some(verify_arg) = call_args.get_argument("verify", None) {
-                    if let ExprKind::Constant {
-                        value: Constant::Bool(false),
-                        ..
-                    } = &verify_arg.node
-                    {
-                        checker.diagnostics.push(Diagnostic::new(
-                            violations::RequestWithNoCertValidation("httpx".to_string()),
-                            Range::from_located(verify_arg),
-                        ));
-                    }
-                }
-                return;
+        None
+    }) {
+        let call_args = SimpleCallArgs::new(args, keywords);
+        if let Some(verify_arg) = call_args.get_argument("verify", None) {
+            if let ExprKind::Constant {
+                value: Constant::Bool(false),
+                ..
+            } = &verify_arg.node
+            {
+                checker.diagnostics.push(Diagnostic::new(
+                    violations::RequestWithNoCertValidation(target.to_string()),
+                    Range::from_located(verify_arg),
+                ));
             }
         }
     }

--- a/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -32,7 +32,7 @@ pub fn request_with_no_cert_validation(
     if let Some(call_path) = checker.resolve_call_path(func) {
         let call_args = SimpleCallArgs::new(args, keywords);
         for func_name in &REQUESTS_HTTP_VERBS {
-            if call_path == ["requests", func_name] {
+            if call_path.as_slice() == ["requests", func_name] {
                 if let Some(verify_arg) = call_args.get_argument("verify", None) {
                     if let ExprKind::Constant {
                         value: Constant::Bool(false),
@@ -49,7 +49,7 @@ pub fn request_with_no_cert_validation(
             }
         }
         for func_name in &HTTPX_METHODS {
-            if call_path == ["httpx", func_name] {
+            if call_path.as_slice() == ["httpx", func_name] {
                 if let Some(verify_arg) = call_args.get_argument("verify", None) {
                     if let ExprKind::Constant {
                         value: Constant::Bool(false),

--- a/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -19,7 +19,7 @@ pub fn request_without_timeout(
     if checker.resolve_call_path(func).map_or(false, |call_path| {
         HTTP_VERBS
             .iter()
-            .any(|func_name| call_path == ["requests", func_name])
+            .any(|func_name| call_path.as_slice() == ["requests", func_name])
     }) {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(timeout_arg) = call_args.get_argument("timeout", None) {

--- a/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -16,7 +16,7 @@ pub fn snmp_insecure_version(
     keywords: &[Keyword],
 ) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["pysnmp", "hlapi", "CommunityData"]
+        call_path.as_slice() == ["pysnmp", "hlapi", "CommunityData"]
     }) {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(mp_model_arg) = call_args.get_argument("mpModel", None) {

--- a/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -14,7 +14,7 @@ pub fn snmp_weak_cryptography(
     keywords: &[Keyword],
 ) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["pysnmp", "hlapi", "UsmUserData"]
+        call_path.as_slice() == ["pysnmp", "hlapi", "UsmUserData"]
     }) {
         let call_args = SimpleCallArgs::new(args, keywords);
         if call_args.len() < 3 {

--- a/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -10,14 +10,15 @@ use crate::violations;
 pub fn unsafe_yaml_load(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if checker
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["yaml", "load"])
+        .map_or(false, |call_path| call_path.as_slice() == ["yaml", "load"])
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(loader_arg) = call_args.get_argument("Loader", Some(1)) {
             if !checker
                 .resolve_call_path(loader_arg)
                 .map_or(false, |call_path| {
-                    call_path == ["yaml", "SafeLoader"] || call_path == ["yaml", "CSafeLoader"]
+                    call_path.as_slice() == ["yaml", "SafeLoader"]
+                        || call_path.as_slice() == ["yaml", "CSafeLoader"]
                 })
             {
                 let loader = match &loader_arg.node {

--- a/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -15,11 +15,13 @@ fn is_abc_class(checker: &Checker, bases: &[Expr], keywords: &[Keyword]) -> bool
             .map_or(false, |arg| arg == "metaclass")
             && checker
                 .resolve_call_path(&keyword.node.value)
-                .map_or(false, |call_path| call_path == ["abc", "ABCMeta"])
+                .map_or(false, |call_path| {
+                    call_path.as_slice() == ["abc", "ABCMeta"]
+                })
     }) || bases.iter().any(|base| {
         checker
             .resolve_call_path(base)
-            .map_or(false, |call_path| call_path == ["abc", "ABC"])
+            .map_or(false, |call_path| call_path.as_slice() == ["abc", "ABC"])
     })
 }
 

--- a/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -25,7 +25,7 @@ pub fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items: &[With
     }
     if !checker
         .resolve_call_path(args.first().unwrap())
-        .map_or(false, |call_path| call_path == ["", "Exception"])
+        .map_or(false, |call_path| call_path.as_slice() == ["", "Exception"])
     {
         return;
     }

--- a/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -7,7 +7,8 @@ use crate::violations;
 
 fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
     checker.resolve_call_path(expr).map_or(false, |call_path| {
-        call_path == ["functools", "lru_cache"] || call_path == ["functools", "cache"]
+        call_path.as_slice() == ["functools", "lru_cache"]
+            || call_path.as_slice() == ["functools", "cache"]
     })
 }
 

--- a/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -58,7 +58,9 @@ const IMMUTABLE_GENERIC_TYPES: &[&[&str]] = &[
 
 pub fn is_mutable_func(checker: &Checker, expr: &Expr) -> bool {
     checker.resolve_call_path(expr).map_or(false, |call_path| {
-        MUTABLE_FUNCS.iter().any(|target| call_path == *target)
+        MUTABLE_FUNCS
+            .iter()
+            .any(|target| call_path.as_slice() == *target)
     })
 }
 
@@ -82,25 +84,25 @@ fn is_immutable_annotation(checker: &Checker, expr: &Expr) -> bool {
                 IMMUTABLE_TYPES
                     .iter()
                     .chain(IMMUTABLE_GENERIC_TYPES)
-                    .any(|target| call_path == *target)
+                    .any(|target| call_path.as_slice() == *target)
             })
         }
         ExprKind::Subscript { value, slice, .. } => {
             checker.resolve_call_path(value).map_or(false, |call_path| {
                 if IMMUTABLE_GENERIC_TYPES
                     .iter()
-                    .any(|target| call_path == *target)
+                    .any(|target| call_path.as_slice() == *target)
                 {
                     true
-                } else if call_path == ["typing", "Union"] {
+                } else if call_path.as_slice() == ["typing", "Union"] {
                     if let ExprKind::Tuple { elts, .. } = &slice.node {
                         elts.iter().all(|elt| is_immutable_annotation(checker, elt))
                     } else {
                         false
                     }
-                } else if call_path == ["typing", "Optional"] {
+                } else if call_path.as_slice() == ["typing", "Optional"] {
                     is_immutable_annotation(checker, slice)
-                } else if call_path == ["typing", "Annotated"] {
+                } else if call_path.as_slice() == ["typing", "Annotated"] {
                     if let ExprKind::Tuple { elts, .. } = &slice.node {
                         elts.first()
                             .map_or(false, |elt| is_immutable_annotation(checker, elt))

--- a/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -8,9 +8,9 @@ use crate::violations;
 /// B005
 pub fn useless_contextlib_suppress(checker: &mut Checker, expr: &Expr, args: &[Expr]) {
     if args.is_empty()
-        && checker
-            .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path == ["contextlib", "suppress"])
+        && checker.resolve_call_path(expr).map_or(false, |call_path| {
+            call_path.as_slice() == ["contextlib", "suppress"]
+        })
     {
         checker.diagnostics.push(Diagnostic::new(
             violations::UselessContextlibSuppress,

--- a/src/rules/flake8_datetimez/rules.rs
+++ b/src/rules/flake8_datetimez/rules.rs
@@ -13,10 +13,9 @@ pub fn call_datetime_without_tzinfo(
     keywords: &[Keyword],
     location: Range,
 ) {
-    if !checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["datetime", "datetime"])
-    {
+    if !checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["datetime", "datetime"]
+    }) {
         return;
     }
 
@@ -41,7 +40,7 @@ pub fn call_datetime_without_tzinfo(
 /// DTZ002
 pub fn call_datetime_today(checker: &mut Checker, func: &Expr, location: Range) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "today"]
+        call_path.as_slice() == ["datetime", "datetime", "today"]
     }) {
         checker
             .diagnostics
@@ -52,7 +51,7 @@ pub fn call_datetime_today(checker: &mut Checker, func: &Expr, location: Range) 
 /// DTZ003
 pub fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location: Range) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "utcnow"]
+        call_path.as_slice() == ["datetime", "datetime", "utcnow"]
     }) {
         checker
             .diagnostics
@@ -63,7 +62,7 @@ pub fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location: Range)
 /// DTZ004
 pub fn call_datetime_utcfromtimestamp(checker: &mut Checker, func: &Expr, location: Range) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "utcfromtimestamp"]
+        call_path.as_slice() == ["datetime", "datetime", "utcfromtimestamp"]
     }) {
         checker.diagnostics.push(Diagnostic::new(
             violations::CallDatetimeUtcfromtimestamp,
@@ -81,7 +80,7 @@ pub fn call_datetime_now_without_tzinfo(
     location: Range,
 ) {
     if !checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "now"]
+        call_path.as_slice() == ["datetime", "datetime", "now"]
     }) {
         return;
     }
@@ -122,7 +121,7 @@ pub fn call_datetime_fromtimestamp(
     location: Range,
 ) {
     if !checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "fromtimestamp"]
+        call_path.as_slice() == ["datetime", "datetime", "fromtimestamp"]
     }) {
         return;
     }
@@ -162,7 +161,7 @@ pub fn call_datetime_strptime_without_zone(
     location: Range,
 ) {
     if !checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "datetime", "strptime"]
+        call_path.as_slice() == ["datetime", "datetime", "strptime"]
     }) {
         return;
     }
@@ -211,7 +210,7 @@ pub fn call_datetime_strptime_without_zone(
 /// DTZ011
 pub fn call_date_today(checker: &mut Checker, func: &Expr, location: Range) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "date", "today"]
+        call_path.as_slice() == ["datetime", "date", "today"]
     }) {
         checker
             .diagnostics
@@ -222,7 +221,7 @@ pub fn call_date_today(checker: &mut Checker, func: &Expr, location: Range) {
 /// DTZ012
 pub fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, location: Range) {
     if checker.resolve_call_path(func).map_or(false, |call_path| {
-        call_path == ["datetime", "date", "fromtimestamp"]
+        call_path.as_slice() == ["datetime", "date", "fromtimestamp"]
     }) {
         checker
             .diagnostics

--- a/src/rules/flake8_debugger/rules.rs
+++ b/src/rules/flake8_debugger/rules.rs
@@ -33,7 +33,7 @@ pub fn debugger_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
             .find(|target| call_path.as_slice() == **target)
     }) {
         checker.diagnostics.push(Diagnostic::new(
-            violations::Debugger(DebuggerUsingType::Call(format_call_path(&target))),
+            violations::Debugger(DebuggerUsingType::Call(format_call_path(target))),
             Range::from_located(expr),
         ));
     }

--- a/src/rules/flake8_debugger/rules.rs
+++ b/src/rules/flake8_debugger/rules.rs
@@ -28,7 +28,10 @@ const DEBUGGERS: &[&[&str]] = &[
 /// Checks for the presence of a debugger call.
 pub fn debugger_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if let Some(call_path) = checker.resolve_call_path(func) {
-        if DEBUGGERS.iter().any(|target| call_path == *target) {
+        if DEBUGGERS
+            .iter()
+            .any(|target| call_path.as_slice() == *target)
+        {
             checker.diagnostics.push(Diagnostic::new(
                 violations::Debugger(DebuggerUsingType::Call(format_call_path(&call_path))),
                 Range::from_located(expr),

--- a/src/rules/flake8_debugger/rules.rs
+++ b/src/rules/flake8_debugger/rules.rs
@@ -27,16 +27,15 @@ const DEBUGGERS: &[&[&str]] = &[
 
 /// Checks for the presence of a debugger call.
 pub fn debugger_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
-    if let Some(call_path) = checker.resolve_call_path(func) {
-        if DEBUGGERS
+    if let Some(target) = checker.resolve_call_path(func).and_then(|call_path| {
+        DEBUGGERS
             .iter()
-            .any(|target| call_path.as_slice() == *target)
-        {
-            checker.diagnostics.push(Diagnostic::new(
-                violations::Debugger(DebuggerUsingType::Call(format_call_path(&call_path))),
-                Range::from_located(expr),
-            ));
-        }
+            .find(|target| call_path.as_slice() == **target)
+    }) {
+        checker.diagnostics.push(Diagnostic::new(
+            violations::Debugger(DebuggerUsingType::Call(format_call_path(&target))),
+            Range::from_located(expr),
+        ));
     }
 }
 

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -120,7 +120,7 @@ where
     if !bases.iter().any(|expr| {
         checker
             .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path == ["enum", "Enum"])
+            .map_or(false, |call_path| call_path.as_slice() == ["enum", "Enum"])
     }) {
         return;
     }
@@ -134,7 +134,7 @@ where
         if let ExprKind::Call { func, .. } = &value.node {
             if checker
                 .resolve_call_path(func)
-                .map_or(false, |call_path| call_path == ["enum", "auto"])
+                .map_or(false, |call_path| call_path.as_slice() == ["enum", "auto"])
             {
                 continue;
             }

--- a/src/rules/flake8_print/rules/print_call.rs
+++ b/src/rules/flake8_print/rules/print_call.rs
@@ -14,7 +14,7 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
         let call_path = checker.resolve_call_path(func);
         if call_path
             .as_ref()
-            .map_or(false, |call_path| *call_path == ["", "print"])
+            .map_or(false, |call_path| *call_path.as_slice() == ["", "print"])
         {
             // If the print call has a `file=` argument (that isn't `None`, `"sys.stdout"`,
             // or `"sys.stderr"`), don't trigger T201.
@@ -26,7 +26,8 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
                     if checker
                         .resolve_call_path(&keyword.node.value)
                         .map_or(true, |call_path| {
-                            call_path != ["sys", "stdout"] && call_path != ["sys", "stderr"]
+                            call_path.as_slice() != ["sys", "stdout"]
+                                && call_path.as_slice() != ["sys", "stderr"]
                         })
                     {
                         return;
@@ -34,10 +35,9 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
                 }
             }
             Diagnostic::new(violations::PrintFound, Range::from_located(func))
-        } else if call_path
-            .as_ref()
-            .map_or(false, |call_path| *call_path == ["pprint", "pprint"])
-        {
+        } else if call_path.as_ref().map_or(false, |call_path| {
+            *call_path.as_slice() == ["pprint", "pprint"]
+        }) {
             Diagnostic::new(violations::PPrintFound, Range::from_located(func))
         } else {
             return;

--- a/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -18,15 +18,17 @@ pub fn get_mark_name(decorator: &Expr) -> &str {
 }
 
 pub fn is_pytest_fail(call: &Expr, checker: &Checker) -> bool {
-    checker
-        .resolve_call_path(call)
-        .map_or(false, |call_path| call_path == ["pytest", "fail"])
+    checker.resolve_call_path(call).map_or(false, |call_path| {
+        call_path.as_slice() == ["pytest", "fail"]
+    })
 }
 
 pub fn is_pytest_fixture(decorator: &Expr, checker: &Checker) -> bool {
     checker
         .resolve_call_path(decorator)
-        .map_or(false, |call_path| call_path == ["pytest", "fixture"])
+        .map_or(false, |call_path| {
+            call_path.as_slice() == ["pytest", "fixture"]
+        })
 }
 
 pub fn is_pytest_mark(decorator: &Expr) -> bool {
@@ -41,13 +43,17 @@ pub fn is_pytest_mark(decorator: &Expr) -> bool {
 pub fn is_pytest_yield_fixture(decorator: &Expr, checker: &Checker) -> bool {
     checker
         .resolve_call_path(decorator)
-        .map_or(false, |call_path| call_path == ["pytest", "yield_fixture"])
+        .map_or(false, |call_path| {
+            call_path.as_slice() == ["pytest", "yield_fixture"]
+        })
 }
 
 pub fn is_abstractmethod_decorator(decorator: &Expr, checker: &Checker) -> bool {
     checker
         .resolve_call_path(decorator)
-        .map_or(false, |call_path| call_path == ["abc", "abstractmethod"])
+        .map_or(false, |call_path| {
+            call_path.as_slice() == ["abc", "abstractmethod"]
+        })
 }
 
 /// Check if the expression is a constant that evaluates to false.
@@ -96,7 +102,7 @@ pub fn is_pytest_parametrize(decorator: &Expr, checker: &Checker) -> bool {
     checker
         .resolve_call_path(decorator)
         .map_or(false, |call_path| {
-            call_path == ["pytest", "mark", "parametrize"]
+            call_path.as_slice() == ["pytest", "mark", "parametrize"]
         })
 }
 

--- a/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/src/rules/flake8_pytest_style/rules/raises.rs
@@ -8,9 +8,9 @@ use crate::registry::{Diagnostic, RuleCode};
 use crate::violations;
 
 fn is_pytest_raises(checker: &Checker, func: &Expr) -> bool {
-    checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["pytest", "raises"])
+    checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["pytest", "raises"]
+    })
 }
 
 fn is_non_trivial_with_body(body: &[Stmt]) -> bool {

--- a/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -17,7 +17,7 @@ pub fn use_capital_environment_variables(checker: &mut Checker, expr: &Expr) {
 
     // check `os.environ.get('foo')` and `os.getenv('foo')``
     if !checker.resolve_call_path(expr).map_or(false, |call_path| {
-        call_path == ["os", "environ", "get"] || call_path == ["os", "getenv"]
+        call_path.as_slice() == ["os", "environ", "get"] || call_path.as_slice() == ["os", "getenv"]
     }) {
         return;
     }

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -1,5 +1,6 @@
 use log::error;
 use rustpython_ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
+use smallvec::smallvec;
 
 use crate::ast::comparable::ComparableExpr;
 use crate::ast::helpers::{
@@ -174,13 +175,13 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
     }
 
     // Avoid suggesting ternary for `if sys.version_info >= ...`-style checks.
-    if contains_call_path(checker, test, &["sys", "version_info"]) {
+    if contains_call_path(checker, test, smallvec!["sys", "version_info"]) {
         return;
     }
 
     // Avoid suggesting ternary for `if sys.platform.startswith("...")`-style
     // checks.
-    if contains_call_path(checker, test, &["sys", "platform"]) {
+    if contains_call_path(checker, test, smallvec!["sys", "platform"]) {
         return;
     }
 

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -1,6 +1,5 @@
 use log::error;
 use rustpython_ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
-use smallvec::smallvec;
 
 use crate::ast::comparable::ComparableExpr;
 use crate::ast::helpers::{
@@ -175,13 +174,13 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
     }
 
     // Avoid suggesting ternary for `if sys.version_info >= ...`-style checks.
-    if contains_call_path(checker, test, smallvec!["sys", "version_info"]) {
+    if contains_call_path(checker, test, &["sys", "version_info"]) {
         return;
     }
 
     // Avoid suggesting ternary for `if sys.platform.startswith("...")`-style
     // checks.
-    if contains_call_path(checker, test, smallvec!["sys", "platform"]) {
+    if contains_call_path(checker, test, &["sys", "platform"]) {
         return;
     }
 

--- a/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -29,7 +29,7 @@ fn match_async_exit_stack(checker: &Checker) -> bool {
             for item in items {
                 if let ExprKind::Call { func, .. } = &item.context_expr.node {
                     if checker.resolve_call_path(func).map_or(false, |call_path| {
-                        call_path == ["contextlib", "AsyncExitStack"]
+                        call_path.as_slice() == ["contextlib", "AsyncExitStack"]
                     }) {
                         return true;
                     }
@@ -59,10 +59,9 @@ fn match_exit_stack(checker: &Checker) -> bool {
         if let StmtKind::With { items, .. } = &parent.node {
             for item in items {
                 if let ExprKind::Call { func, .. } = &item.context_expr.node {
-                    if checker
-                        .resolve_call_path(func)
-                        .map_or(false, |call_path| call_path == ["contextlib", "ExitStack"])
-                    {
+                    if checker.resolve_call_path(func).map_or(false, |call_path| {
+                        call_path.as_slice() == ["contextlib", "ExitStack"]
+                    }) {
                         return true;
                     }
                 }
@@ -76,7 +75,7 @@ fn match_exit_stack(checker: &Checker) -> bool {
 pub fn open_file_with_context_handler(checker: &mut Checker, func: &Expr) {
     if checker
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["", "open"])
+        .map_or(false, |call_path| call_path.as_slice() == ["", "open"])
     {
         if checker.is_builtin("open") {
             // Ex) `with open("foo.txt") as f: ...`

--- a/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/src/rules/flake8_tidy_imports/banned_api.rs
@@ -86,19 +86,21 @@ pub fn name_or_parent_is_banned<T>(
 
 /// TID251
 pub fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
-    if let Some(call_path) = checker.resolve_call_path(expr) {
-        for (banned_path, ban) in checker.settings.flake8_tidy_imports.banned_api.iter() {
-            if call_path == banned_path.split('.').collect::<CallPath>() {
-                checker.diagnostics.push(Diagnostic::new(
-                    BannedApi {
-                        name: banned_path.to_string(),
-                        message: ban.msg.to_string(),
-                    },
-                    Range::from_located(expr),
-                ));
-                return;
-            }
-        }
+    if let Some((banned_path, ban)) = checker.resolve_call_path(expr).and_then(|call_path| {
+        checker
+            .settings
+            .flake8_tidy_imports
+            .banned_api
+            .iter()
+            .find(|(banned_path, ..)| call_path == banned_path.split('.').collect::<CallPath>())
+    }) {
+        checker.diagnostics.push(Diagnostic::new(
+            BannedApi {
+                name: banned_path.to_string(),
+                message: ban.msg.to_string(),
+            },
+            Range::from_located(expr),
+        ));
     }
 }
 

--- a/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/src/rules/flake8_tidy_imports/banned_api.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Alias, Expr, Located};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::ast::types::Range;
+use crate::ast::types::{CallPath, Range};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
@@ -88,7 +88,7 @@ pub fn name_or_parent_is_banned<T>(
 pub fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
     if let Some(call_path) = checker.resolve_call_path(expr) {
         for (banned_path, ban) in checker.settings.flake8_tidy_imports.banned_api.iter() {
-            if call_path == banned_path.split('.').collect::<Vec<_>>() {
+            if call_path == banned_path.split('.').collect::<CallPath>() {
                 checker.diagnostics.push(Diagnostic::new(
                     BannedApi {
                         name: banned_path.to_string(),

--- a/src/rules/pep8_naming/helpers.rs
+++ b/src/rules/pep8_naming/helpers.rs
@@ -27,7 +27,7 @@ pub fn is_namedtuple_assignment(checker: &Checker, stmt: &Stmt) -> bool {
         return false;
     };
     checker.resolve_call_path(value).map_or(false, |call_path| {
-        call_path == ["collections", "namedtuple"]
+        call_path.as_slice() == ["collections", "namedtuple"]
     })
 }
 

--- a/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -7,10 +7,9 @@ use crate::violations;
 
 /// PGH002 - deprecated use of logging.warn
 pub fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {
-    if checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["logging", "warn"])
-    {
+    if checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["logging", "warn"]
+    }) {
         checker.diagnostics.push(Diagnostic::new(
             violations::DeprecatedLogWarn,
             Range::from_located(func),

--- a/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -29,10 +29,9 @@ fn match_named_tuple_assign<'a>(
     } = &value.node else {
         return None;
     };
-    if !checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["typing", "NamedTuple"])
-    {
+    if !checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["typing", "NamedTuple"]
+    }) {
         return None;
     }
     Some((typename, args, keywords, func))

--- a/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -30,10 +30,9 @@ fn match_typed_dict_assign<'a>(
     } = &value.node else {
         return None;
     };
-    if !checker
-        .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["typing", "TypedDict"])
-    {
+    if !checker.resolve_call_path(func).map_or(false, |call_path| {
+        call_path.as_slice() == ["typing", "TypedDict"]
+    }) {
         return None;
     }
     Some((class_name, args, keywords, func))

--- a/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -10,7 +10,7 @@ use crate::violations;
 /// UP017
 pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
     if checker.resolve_call_path(expr).map_or(false, |call_path| {
-        call_path == ["datetime", "timezone", "utc"]
+        call_path.as_slice() == ["datetime", "timezone", "utc"]
     }) {
         let straight_import = collect_call_path(expr) == ["datetime", "timezone", "utc"];
         let mut diagnostic = Diagnostic::new(

--- a/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/src/rules/pyupgrade/rules/functools_cache.rs
@@ -22,9 +22,9 @@ pub fn functools_cache(checker: &mut Checker, decorator_list: &[Expr]) {
         // Look for, e.g., `import functools; @functools.lru_cache(maxsize=None)`.
         if args.is_empty()
             && keywords.len() == 1
-            && checker
-                .resolve_call_path(func)
-                .map_or(false, |call_path| call_path == ["functools", "lru_cache"])
+            && checker.resolve_call_path(func).map_or(false, |call_path| {
+                call_path.as_slice() == ["functools", "lru_cache"]
+            })
         {
             let KeywordData { arg, value } = &keywords[0].node;
             if arg.as_ref().map_or(false, |arg| arg == "maxsize")

--- a/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -22,9 +22,9 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
         // Look for, e.g., `import functools; @functools.lru_cache()`.
         if args.is_empty()
             && keywords.is_empty()
-            && checker
-                .resolve_call_path(func)
-                .map_or(false, |call_path| call_path == ["functools", "lru_cache"])
+            && checker.resolve_call_path(func).map_or(false, |call_path| {
+                call_path.as_slice() == ["functools", "lru_cache"]
+            })
         {
             let mut diagnostic = Diagnostic::new(
                 violations::LRUCacheWithoutParameters,

--- a/src/rules/pyupgrade/rules/open_alias.rs
+++ b/src/rules/pyupgrade/rules/open_alias.rs
@@ -10,7 +10,7 @@ use crate::violations;
 pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
         .resolve_call_path(func)
-        .map_or(false, |call_path| call_path == ["io", "open"])
+        .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
     {
         let mut diagnostic = Diagnostic::new(violations::OpenAlias, Range::from_located(expr));
         if checker.patch(&RuleCode::UP020) {

--- a/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -39,7 +39,7 @@ fn check_module(checker: &Checker, expr: &Expr) -> (Vec<String>, Vec<String>) {
     let mut before_replace: Vec<String> = vec![];
     if let Some(call_path) = checker.resolve_call_path(expr) {
         for module in ERROR_MODULES.iter() {
-            if call_path == [module, "error"] {
+            if call_path.as_slice() == [module, "error"] {
                 replacements.push("OSError".to_string());
                 before_replace.push(format!("{module}.error"));
                 break;

--- a/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -80,10 +80,9 @@ fn generate_fix(locator: &Locator, stdout: &Keyword, stderr: &Keyword) -> Option
 
 /// UP022
 pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keyword]) {
-    if checker
-        .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path == ["subprocess", "run"])
-    {
+    if checker.resolve_call_path(expr).map_or(false, |call_path| {
+        call_path.as_slice() == ["subprocess", "run"]
+    }) {
         // Find `stdout` and `stderr` kwargs.
         let Some(stdout) = find_keyword(kwargs, "stdout") else {
             return;
@@ -95,10 +94,14 @@ pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, kwargs: &[Keywo
         // Verify that they're both set to `subprocess.PIPE`.
         if !checker
             .resolve_call_path(&stdout.node.value)
-            .map_or(false, |call_path| call_path == ["subprocess", "PIPE"])
+            .map_or(false, |call_path| {
+                call_path.as_slice() == ["subprocess", "PIPE"]
+            })
             || !checker
                 .resolve_call_path(&stderr.node.value)
-                .map_or(false, |call_path| call_path == ["subprocess", "PIPE"])
+                .map_or(false, |call_path| {
+                    call_path.as_slice() == ["subprocess", "PIPE"]
+                })
         {
             return;
         }

--- a/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -9,10 +9,9 @@ use crate::violations;
 
 /// UP021
 pub fn replace_universal_newlines(checker: &mut Checker, expr: &Expr, kwargs: &[Keyword]) {
-    if checker
-        .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path == ["subprocess", "run"])
-    {
+    if checker.resolve_call_path(expr).map_or(false, |call_path| {
+        call_path.as_slice() == ["subprocess", "run"]
+    }) {
         let Some(kwarg) = find_keyword(kwargs, "universal_newlines") else { return; };
         let range = Range::new(
             kwarg.location,

--- a/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -8,10 +8,9 @@ use crate::violations;
 
 /// UP019
 pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
-    if checker
-        .resolve_call_path(expr)
-        .map_or(false, |call_path| call_path == ["typing", "Text"])
-    {
+    if checker.resolve_call_path(expr).map_or(false, |call_path| {
+        call_path.as_slice() == ["typing", "Text"]
+    }) {
         let mut diagnostic =
             Diagnostic::new(violations::TypingTextStrAlias, Range::from_located(expr));
         if checker.patch(diagnostic.kind.code()) {

--- a/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -8,14 +8,17 @@ use crate::violations;
 
 /// UP006
 pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
-    if let Some(call_path) = checker.resolve_call_path(expr) {
+    if let Some(binding) = checker
+        .resolve_call_path(expr)
+        .and_then(|call_path| call_path.last().copied())
+    {
         let mut diagnostic = Diagnostic::new(
-            violations::UsePEP585Annotation(call_path[call_path.len() - 1].to_string()),
+            violations::UsePEP585Annotation(binding.to_string()),
             Range::from_located(expr),
         );
         if checker.patch(diagnostic.kind.code()) {
             diagnostic.amend(Fix::replacement(
-                call_path[call_path.len() - 1].to_lowercase(),
+                binding.to_lowercase(),
                 expr.location,
                 expr.end_location.unwrap(),
             ));

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -31,18 +31,18 @@ pub struct VisibleScope {
 /// Returns `true` if a function is a "static method".
 pub fn is_staticmethod(checker: &Checker, decorator_list: &[Expr]) -> bool {
     decorator_list.iter().any(|expr| {
-        checker
-            .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path == ["", "staticmethod"])
+        checker.resolve_call_path(expr).map_or(false, |call_path| {
+            call_path.as_slice() == ["", "staticmethod"]
+        })
     })
 }
 
 /// Returns `true` if a function is a "class method".
 pub fn is_classmethod(checker: &Checker, decorator_list: &[Expr]) -> bool {
     decorator_list.iter().any(|expr| {
-        checker
-            .resolve_call_path(expr)
-            .map_or(false, |call_path| call_path == ["", "classmethod"])
+        checker.resolve_call_path(expr).map_or(false, |call_path| {
+            call_path.as_slice() == ["", "classmethod"]
+        })
     })
 }
 
@@ -64,7 +64,8 @@ pub fn is_override(checker: &Checker, decorator_list: &[Expr]) -> bool {
 pub fn is_abstract(checker: &Checker, decorator_list: &[Expr]) -> bool {
     decorator_list.iter().any(|expr| {
         checker.resolve_call_path(expr).map_or(false, |call_path| {
-            call_path == ["abc", "abstractmethod"] || call_path == ["abc", "abstractproperty"]
+            call_path.as_slice() == ["abc", "abstractmethod"]
+                || call_path.as_slice() == ["abc", "abstractproperty"]
         })
     })
 }


### PR DESCRIPTION
This provides a ~10% speed-up for large codebases with `--select ALL`:

![Screen Shot 2023-01-18 at 11 28 20 AM](https://user-images.githubusercontent.com/1309177/213236389-cff50840-6e55-47a3-9164-2e40cbc885f6.png)
