### PR TITLE
Run cargo fmt in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,11 @@ repos:
     rev: v0.10.1
     hooks:
       - id: validate-pyproject
+
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --
+        language: rust
+        types: [rust]


### PR DESCRIPTION
Since `cargo fmt` is a required CI check, we could just as well run it in `pre-commit`.