### PR TITLE
Added pylint formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2121,8 +2121,8 @@ force-exclude = true
 The style in which violation messages should be formatted: `"text"`
 (default), `"grouped"` (group messages by file), `"json"`
 (machine-readable), `"junit"` (machine-readable XML), `"github"`
-(GitHub Actions annotations) or `"gitlab"`
-(GitLab CI code quality report).
+(GitHub Actions annotations), `"gitlab"`
+(GitLab CI code quality report) or `\"pylint\"` (Pylint text format).
 
 **Default value**: `"text"`
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -227,7 +227,7 @@
       ]
     },
     "format": {
-      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations) or `\"gitlab\"` (GitLab CI code quality report).",
+      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report) or `\"pylint\"` (Pylint text format).",
       "anyOf": [
         {
           "$ref": "#/definitions/SerializationFormat"
@@ -1804,7 +1804,8 @@
         "junit",
         "grouped",
         "github",
-        "gitlab"
+        "gitlab",
+        "pylint"
       ]
     },
     "Strictness": {

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -319,6 +319,9 @@ pub fn explain(rule: &Rule, format: SerializationFormat) -> Result<()> {
         SerializationFormat::Gitlab => {
             bail!("`--explain` does not support GitLab format")
         }
+        SerializationFormat::Pylint => {
+            bail!("`--explain` does not support pylint format")
+        }
     };
     Ok(())
 }

--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -312,6 +312,24 @@ impl<'a> Printer<'a> {
                     )?
                 )?;
             }
+            SerializationFormat::Pylint => {
+                // Generate error workflow command in pylint format.
+                // See: https://flake8.pycqa.org/en/latest/internal/formatters.html#pylint-formatter
+                for message in &diagnostics.messages {
+                    let label = format!(
+                        "{}{}{}{} {}{}{} {}",
+                        relativize_path(Path::new(&message.filename)),
+                        ":",
+                        message.location.row(),
+                        ":",
+                        "[",
+                        message.kind.rule().code(),
+                        "]",
+                        message.kind.body(),
+                    );
+                    writeln!(stdout, "{label}")?;
+                }
+            }
         }
 
         stdout.flush()?;

--- a/src/settings/types.rs
+++ b/src/settings/types.rs
@@ -156,6 +156,7 @@ pub enum SerializationFormat {
     Grouped,
     Github,
     Gitlab,
+    Pylint,
 }
 
 impl Default for SerializationFormat {


### PR DESCRIPTION
Fixes: #1953

@charliermarsh thank you for the tips in the issue.

I'm not very familiar with Rust, so please excuse if my string formatting syntax is messy.

In terms of testing, I compared output of `flake8 --format=pylint ` and `cargo run --format=pylint` on the same code and the output syntax seems to check out.
