### PR TITLE
Fix that --explain panics

### DIFF
--- a/ruff_cli/src/cli.rs
+++ b/ruff_cli/src/cli.rs
@@ -181,7 +181,7 @@ pub struct Cli {
         conflicts_with = "stdin_filename",
         conflicts_with = "watch",
     )]
-    pub explain: Option<Rule>,
+    pub explain: Option<&'static Rule>,
     /// Generate shell completion
     #[arg(
         long,
@@ -303,7 +303,7 @@ pub struct Arguments {
     pub config: Option<PathBuf>,
     pub diff: bool,
     pub exit_zero: bool,
-    pub explain: Option<Rule>,
+    pub explain: Option<&'static Rule>,
     pub files: Vec<PathBuf>,
     pub generate_shell_completion: Option<clap_complete_command::Shell>,
     pub isolated: bool,

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -158,7 +158,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
     };
 
     if let Some(rule) = cli.explain {
-        commands::explain(&rule, format)?;
+        commands::explain(rule, format)?;
         return Ok(ExitCode::SUCCESS);
     }
     if cli.show_settings {

--- a/ruff_cli/tests/integration_test.rs
+++ b/ruff_cli/tests/integration_test.rs
@@ -151,3 +151,12 @@ fn test_show_source() -> Result<()> {
     assert!(str::from_utf8(&output.get_output().stdout)?.contains("l = 1"));
     Ok(())
 }
+
+#[test]
+fn explain_status_codes() -> Result<()> {
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.args(["-", "--explain", "F401"]).assert().success();
+    let mut cmd = Command::cargo_bin(BIN_NAME)?;
+    cmd.args(["-", "--explain", "RUF404"]).assert().failure();
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes a bug accidentally introduced in 6cf770a6924e6c2b00f53a52492bdffe80015552,
which resulted every `ruff --explain <code>` invocation to fail with:

    thread 'main' panicked at 'Mismatch between definition and access of `explain`.
    Could not downcast to ruff::registry::Rule, need to downcast to &ruff::registry::Rule',
    ruff_cli/src/cli.rs:184:18

We also add an integration test for --explain to prevent such bugs from going by unnoticed in the future.