### PR TITLE
Avoid SIM401 in `elif` blocks

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM401.py
+++ b/resources/test/fixtures/flake8_simplify/SIM401.py
@@ -91,3 +91,20 @@ if key in a_dict:
     var = a_dict[key]
 else:
     var = a_dict["fallback"]
+
+# OK (false negative for elif)
+if foo():
+    pass
+elif key in a_dict:
+    vars[idx] = a_dict[key]
+else:
+    vars[idx] = "default"
+
+# OK (false negative for nested else)
+if foo():
+    pass
+else:
+    if key in a_dict:
+        vars[idx] = a_dict[key]
+    else:
+        vars[idx] = "default"

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1369,12 +1369,17 @@ where
                     flake8_simplify::rules::use_ternary_operator(
                         self,
                         stmt,
-                        self.current_stmt_parent().map(|parent| parent.0),
+                        self.current_stmt_parent().map(std::convert::Into::into),
                     );
                 }
                 if self.settings.rules.enabled(&Rule::DictGetWithDefault) {
                     flake8_simplify::rules::use_dict_get_with_default(
-                        self, stmt, test, body, orelse,
+                        self,
+                        stmt,
+                        test,
+                        body,
+                        orelse,
+                        self.current_stmt_parent().map(std::convert::Into::into),
                     );
                 }
             }

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -253,6 +253,7 @@ pub fn use_dict_get_with_default(
     test: &Expr,
     body: &Vec<Stmt>,
     orelse: &Vec<Stmt>,
+    parent: Option<&Stmt>,
 ) {
     if body.len() != 1 || orelse.len() != 1 {
         return;
@@ -299,6 +300,36 @@ pub fn use_dict_get_with_default(
     // Check that the default value is not "complex".
     if contains_effect(checker, default_val) {
         return;
+    }
+
+    // It's part of a bigger if-elif block:
+    // https://github.com/MartinThoma/flake8-simplify/issues/115
+    if let Some(StmtKind::If {
+        orelse: parent_orelse,
+        ..
+    }) = parent.map(|parent| &parent.node)
+    {
+        if parent_orelse.len() == 1 && stmt == &parent_orelse[0] {
+            // TODO(charlie): These two cases have the same AST:
+            //
+            // if True:
+            //     pass
+            // elif a:
+            //     b = 1
+            // else:
+            //     b = 2
+            //
+            // if True:
+            //     pass
+            // else:
+            //     if a:
+            //         b = 1
+            //     else:
+            //         b = 2
+            //
+            // We want to flag the latter, but not the former. Right now, we flag neither.
+            return;
+        }
     }
 
     let contents = unparse_stmt(


### PR DESCRIPTION
For now, we're just gonna avoid flagging this for `elif` blocks, following the same reasoning as for ternaries. We can handle all of these cases, but we'll knock out the TODOs as a pair, and this avoids broken code.

Closes #2007.