### PR TITLE
Avoid checking row types for single-name @parametrize decorators

### DIFF
--- a/resources/test/fixtures/flake8_pytest_style/PT007.py
+++ b/resources/test/fixtures/flake8_pytest_style/PT007.py
@@ -53,3 +53,25 @@ def test_list_of_tuples(param1, param2):
 )
 def test_list_of_lists(param1, param2):
     ...
+
+
+@pytest.mark.parametrize(
+    "param1,param2",
+    [
+        [1, 2],
+        [3, 4],
+    ],
+)
+def test_csv_name_list_of_lists(param1, param2):
+    ...
+
+
+@pytest.mark.parametrize(
+    "param",
+    [
+        [1, 2],
+        [3, 4],
+    ],
+)
+def test_single_list_of_lists(param):
+    ...

--- a/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -132,3 +132,19 @@ pub fn is_empty_or_null_string(expr: &Expr) -> bool {
         _ => false,
     }
 }
+
+pub fn split_names(names: &str) -> Vec<&str> {
+    // Match the following pytest code:
+    //    [x.strip() for x in argnames.split(",") if x.strip()]
+    names
+        .split(',')
+        .filter_map(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+        .collect::<Vec<&str>>()
+}

--- a/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
+++ b/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_list_of_tuples.snap
@@ -86,4 +86,28 @@ expression: diagnostics
     column: 14
   fix: ~
   parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - list
+      - tuple
+  location:
+    row: 61
+    column: 8
+  end_location:
+    row: 61
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - list
+      - tuple
+  location:
+    row: 62
+    column: 8
+  end_location:
+    row: 62
+    column: 14
+  fix: ~
+  parent: ~
 

--- a/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
+++ b/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_tuple_of_lists.snap
@@ -86,4 +86,28 @@ expression: diagnostics
     column: 5
   fix: ~
   parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - list
+  location:
+    row: 60
+    column: 4
+  end_location:
+    row: 63
+    column: 5
+  fix: ~
+  parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - list
+  location:
+    row: 71
+    column: 4
+  end_location:
+    row: 74
+    column: 5
+  fix: ~
+  parent: ~
 

--- a/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
+++ b/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT007_tuple_of_tuples.snap
@@ -86,4 +86,52 @@ expression: diagnostics
     column: 14
   fix: ~
   parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - tuple
+  location:
+    row: 60
+    column: 4
+  end_location:
+    row: 63
+    column: 5
+  fix: ~
+  parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - tuple
+  location:
+    row: 61
+    column: 8
+  end_location:
+    row: 61
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - tuple
+  location:
+    row: 62
+    column: 8
+  end_location:
+    row: 62
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
+    ParametrizeValuesWrongType:
+      - tuple
+      - tuple
+  location:
+    row: 71
+    column: 4
+  end_location:
+    row: 74
+    column: 5
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
Closes #2008.