### PR TITLE
Change CI to use MSRV for cargo test and build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-11-01
+          toolchain: 1.65.0
           override: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo install cargo-insta
@@ -122,7 +122,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-11-01
+          toolchain: 1.65.0
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -1651,12 +1651,12 @@ Assuming you have `cargo` installed, you can run:
 cargo run resources/test/fixtures
 ```
 
-For development, we use [nightly Rust](https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust):
+For rustfmt and Clippy, we use [nightly Rust](https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust):
 
 ```shell
 cargo +nightly fmt
 cargo +nightly clippy --fix --workspace --all-targets --all-features -- -W clippy::pedantic
-cargo +nightly test --all
+cargo test --all
 ```
 
 ## Releases


### PR DESCRIPTION
This was apparently accidentally changed in
79ca66ace5ebba10e94cda9925d19fdfc50ac327.