### PR TITLE
fix(pydocstyle): Avoid trimming docstring if starts with leading quote

### DIFF
--- a/resources/test/fixtures/pydocstyle/D.py
+++ b/resources/test/fixtures/pydocstyle/D.py
@@ -615,3 +615,12 @@ def one_liner():
     """Wrong."
 
     """
+
+
+@expect('D200: One-line docstring should fit on one line with quotes '
+        '(found 3)')
+@expect('D212: Multi-line docstring summary should start at the first line')
+def one_liner():
+    """
+
+    "Wrong."""

--- a/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -32,7 +32,9 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
         if let Some(pattern) = leading_quote(contents) {
             // If removing whitespace would lead to an invalid string of quote
             // characters, avoid applying the fix.
-            if !trimmed.ends_with(pattern.chars().last().unwrap()) {
+            if !trimmed.ends_with(pattern.chars().last().unwrap())
+                && !trimmed.starts_with(pattern.chars().last().unwrap())
+            {
                 diagnostic.amend(Fix::replacement(
                     trimmed.to_string(),
                     Location::new(

--- a/src/rules/pydocstyle/rules/one_liner.rs
+++ b/src/rules/pydocstyle/rules/one_liner.rs
@@ -34,7 +34,9 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                 // If removing whitespace would lead to an invalid string of quote
                 // characters, avoid applying the fix.
                 let trimmed = docstring.body.trim();
-                if !trimmed.ends_with(trailing.chars().last().unwrap()) {
+                if !trimmed.ends_with(trailing.chars().last().unwrap())
+                    && !trimmed.starts_with(leading.chars().last().unwrap())
+                {
                     diagnostic.amend(Fix::replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.expr.location,

--- a/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
+++ b/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
@@ -63,4 +63,14 @@ expression: diagnostics
     column: 7
   fix: ~
   parent: ~
+- kind:
+    FitsOnOneLine: ~
+  location:
+    row: 624
+    column: 4
+  end_location:
+    row: 626
+    column: 14
+  fix: ~
+  parent: ~
 

--- a/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D212_D.py.snap
+++ b/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D212_D.py.snap
@@ -22,4 +22,14 @@ expression: diagnostics
     column: 13
   fix: ~
   parent: ~
+- kind:
+    MultiLineSummaryFirstLine: ~
+  location:
+    row: 624
+    column: 4
+  end_location:
+    row: 626
+    column: 14
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
Fixes: #2017

looks like the other way round is also possible to break:

```""" "foo"""`