### PR TITLE
Move readme dev details to CONTRIBUTING.md and fix contradictions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,16 @@ After cloning the repository, run Ruff locally with:
 cargo run resources/test/fixtures --no-cache
 ```
 
-Prior to opening a pull request, ensure that your code has been auto-formatted, and that it passes
-both the lint and test validation checks:
+Prior to opening a pull request, ensure that your code has been auto-formatted,
+and that it passes both the lint and test validation checks.
+
+For rustfmt and Clippy, we use [nightly Rust][nightly], as it is stricter than stable Rust.
+(However, tests and builds use stable Rust.)
 
 ```shell
 cargo +nightly fmt --all     # Auto-formatting...
-cargo +nightly clippy --all  # Linting...
-cargo +nightly test --all    # Testing...
+cargo +nightly clippy --fix --workspace --all-targets --all-features -- -W clippy::pedantic  # Linting...
+cargo test --all    # Testing...
 ```
 
 These checks will run on GitHub Actions when you open your Pull Request, but running them locally
@@ -127,3 +130,5 @@ them to [PyPI](https://pypi.org/project/ruff/).
 
 Ruff follows the [semver](https://semver.org/) versioning standard. However, as pre-1.0 software,
 even patch releases may contain [non-backwards-compatible changes](https://semver.org/#spec-item-4).
+
+[nightly]: https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ developer of [Zulip](https://github.com/zulip/zulip):
 1. [Benchmarks](#benchmarks)
 1. [Reference](#reference)
 1. [License](#license)
-1. [Contributing](#contributing)
 
 ## Installation and Usage
 
@@ -1643,7 +1642,8 @@ Run `ruff /path/to/code.py --show-settings` to view the resolved settings for a 
 
 ## Development
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Ruff.
+Contributions are welcome and hugely appreciated. To get started, check out the
+[contributing guidelines](https://github.com/charliermarsh/ruff/blob/main/CONTRIBUTING.md).
 
 ## Releases
 
@@ -3443,8 +3443,3 @@ keep-runtime-typing = true
 ## License
 
 MIT
-
-## Contributing
-
-Contributions are welcome and hugely appreciated. To get started, check out the
-[contributing guidelines](https://github.com/charliermarsh/ruff/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1643,22 +1643,7 @@ Run `ruff /path/to/code.py --show-settings` to view the resolved settings for a 
 
 ## Development
 
-Ruff is written in Rust (1.65.0). You'll need to install the [Rust toolchain](https://www.rust-lang.org/tools/install)
-for development.
-
-Assuming you have `cargo` installed, you can run:
-
-```shell
-cargo run resources/test/fixtures
-```
-
-For rustfmt and Clippy, we use [nightly Rust](https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust):
-
-```shell
-cargo +nightly fmt
-cargo +nightly clippy --fix --workspace --all-targets --all-features -- -W clippy::pedantic
-cargo test --all
-```
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Ruff.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ developer of [Zulip](https://github.com/zulip/zulip):
    1. [Ruff-specific rules (RUF)](#ruff-specific-rules-ruf)<!-- End auto-generated table of contents. -->
 1. [Editor Integrations](#editor-integrations)
 1. [FAQ](#faq)
-1. [Development](#development)
+1. [Contributing](#contributing)
 1. [Releases](#releases)
 1. [Benchmarks](#benchmarks)
 1. [Reference](#reference)
@@ -1640,7 +1640,7 @@ matter how they're provided, which avoids accidental incompatibilities and simpl
 
 Run `ruff /path/to/code.py --show-settings` to view the resolved settings for a given file.
 
-## Development
+## Contributing
 
 Contributions are welcome and hugely appreciated. To get started, check out the
 [contributing guidelines](https://github.com/charliermarsh/ruff/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Following up on #2018/#2019 discussion, this moves the readme's development-related bits to `CONTRIBUTING.md` to avoid duplication, and fixes up the commands accordingly 😄 