### PR TITLE
Fix D404 NoThisPrefix not working with whitespace.

### DIFF
--- a/resources/test/fixtures/pydocstyle/D.py
+++ b/resources/test/fixtures/pydocstyle/D.py
@@ -624,3 +624,13 @@ def one_liner():
     """
 
     "Wrong."""
+
+
+@expect('D404: First word of the docstring should not be "This"')
+def starts_with_this():
+    """This is a docstring."""
+
+
+@expect('D404: First word of the docstring should not be "This"')
+def starts_with_space_then_this():
+    """ This is a docstring that starts with a space."""  # noqa: D210

--- a/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -14,7 +14,7 @@ pub fn starts_with_this(checker: &mut Checker, docstring: &Docstring) {
         return;
     }
 
-    let Some(first_word) = body.split(' ').next() else {
+    let Some(first_word) = trimmed.split(' ').next() else {
         return
     };
     if normalize_word(first_word) != "this" {

--- a/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D404_D.py.snap
+++ b/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D404_D.py.snap
@@ -2,5 +2,24 @@
 source: src/rules/pydocstyle/mod.rs
 expression: diagnostics
 ---
-[]
+- kind:
+    NoThisPrefix: ~
+  location:
+    row: 631
+    column: 4
+  end_location:
+    row: 631
+    column: 30
+  fix: ~
+  parent: ~
+- kind:
+    NoThisPrefix: ~
+  location:
+    row: 636
+    column: 4
+  end_location:
+    row: 636
+    column: 56
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
D404 should trigger for """ This is a docstring."""

Add a few tests to ensure the fix worked.