### PR TITLE
README: `--force-exclude` is already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ Ruff also works with [pre-commit](https://pre-commit.com):
   rev: 'v0.0.228'
   hooks:
     - id: ruff
-      # Respect `exclude` and `extend-exclude` settings.
-      args: ["--force-exclude"]
 ```
 
 ## Configuration


### PR DESCRIPTION
Re: https://github.com/charliermarsh/ruff-pre-commit/issues/19 / https://github.com/charliermarsh/ruff-pre-commit/pull/20

This is now always set, no need to include it in the README example.