### PR TITLE
De-duplicate SIM102

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM102.py
+++ b/resources/test/fixtures/flake8_simplify/SIM102.py
@@ -5,6 +5,12 @@ if a:
 
 # SIM102
 if a:
+    if b:
+        if c:
+            d
+
+# SIM102
+if a:
     pass
 elif b:
     if c:

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1356,7 +1356,13 @@ where
                     pyflakes::rules::if_tuple(self, stmt, test);
                 }
                 if self.settings.rules.enabled(&Rule::NestedIfStatements) {
-                    flake8_simplify::rules::nested_if_statements(self, stmt);
+                    flake8_simplify::rules::nested_if_statements(
+                        self,
+                        stmt,
+                        test,
+                        body,
+                        self.current_stmt_parent().map(Into::into),
+                    );
                 }
                 if self
                     .settings

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -53,10 +53,12 @@ fn find_last_nested_if(body: &[Stmt]) -> Option<(&Expr, &Stmt)> {
     if !(orelse.is_empty() && body.len() == 1) {
         return None;
     }
-    find_last_nested_if(inner_body).or(Some((
-        test,
-        inner_body.last().expect("Expected body to be non-empty"),
-    )))
+    find_last_nested_if(inner_body).or_else(|| {
+        Some((
+            test,
+            inner_body.last().expect("Expected body to be non-empty"),
+        ))
+    })
 }
 
 /// SIM102

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -54,7 +54,7 @@ fn find_last_nested_if(body: &[Stmt]) -> Option<(&Expr, &Stmt)> {
     }
     find_last_nested_if(inner_body).or(Some((
         test,
-        inner_body.last().expect("Expect body to be non-empty"),
+        inner_body.last().expect("Expected body to be non-empty"),
     )))
 }
 

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -37,6 +37,16 @@ fn is_main_check(expr: &Expr) -> bool {
     false
 }
 
+/// Find the last nested if statement and return the test expression and the first statement.
+///
+/// ```python
+/// if xxx:
+///     if yyy:
+///      # ^^^ returns this expression
+///         z = 1
+///       # ^^^^^ and this statement
+///         ...
+/// ```
 fn find_last_nested_if(body: &[Stmt]) -> Option<(&Expr, &Stmt)> {
     let [Stmt { node: StmtKind::If { test, body: inner_body, orelse }, ..}] = body else { return None };
     if !(orelse.is_empty() && body.len() == 1) {

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -37,7 +37,8 @@ fn is_main_check(expr: &Expr) -> bool {
     false
 }
 
-/// Find the last nested if statement and return the test expression and the first statement.
+/// Find the last nested if statement and return the test expression and the
+/// first statement.
 ///
 /// ```python
 /// if xxx:

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -8,7 +8,7 @@ expression: diagnostics
     row: 2
     column: 0
   end_location:
-    row: 4
+    row: 3
     column: 9
   fix:
     content: "if a and b:\n    c\n"
@@ -22,29 +22,36 @@ expression: diagnostics
 - kind:
     NestedIfStatements: ~
   location:
-    row: 9
+    row: 7
     column: 0
   end_location:
-    row: 11
-    column: 9
+    row: 9
+    column: 13
   fix:
-    content: "elif b and c:\n    d\n"
+    content: "if a and b:\n    if c:\n        d\n"
     location:
-      row: 9
+      row: 7
       column: 0
     end_location:
-      row: 12
+      row: 11
       column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 14
+    row: 15
     column: 0
   end_location:
-    row: 17
+    row: 16
     column: 9
-  fix: ~
+  fix:
+    content: "elif b and c:\n    d\n"
+    location:
+      row: 15
+      column: 0
+    end_location:
+      row: 18
+      column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
@@ -52,83 +59,93 @@ expression: diagnostics
     row: 20
     column: 0
   end_location:
-    row: 23
+    row: 22
+    column: 9
+  fix: ~
+  parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 26
+    column: 0
+  end_location:
+    row: 27
     column: 9
   fix:
     content: "if a and b:\n    # Fixable due to placement of this comment.\n    c\n"
     location:
-      row: 20
+      row: 26
       column: 0
     end_location:
-      row: 24
+      row: 30
       column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 45
+    row: 51
     column: 4
   end_location:
-    row: 57
-    column: 23
+    row: 52
+    column: 16
   fix:
     content: "    if True and True:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
     location:
-      row: 45
+      row: 51
       column: 0
     end_location:
-      row: 58
+      row: 64
       column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 61
+    row: 67
     column: 0
   end_location:
-    row: 73
-    column: 23
+    row: 68
+    column: 12
   fix:
     content: "if True and True:\n    \"\"\"this\nis valid\"\"\"\n\n    \"\"\"the indentation on\n        this line is significant\"\"\"\n\n    \"this is\" \\\n\"allowed too\"\n\n    (\"so is\"\n\"this for some reason\")\n"
     location:
-      row: 61
+      row: 67
       column: 0
     end_location:
-      row: 74
+      row: 80
       column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 77
+    row: 83
     column: 4
   end_location:
-    row: 81
-    column: 32
+    row: 86
+    column: 10
   fix:
     content: "    if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n        \"multiprocessing.\"\n    )):\n        print(\"Bad module!\")\n"
     location:
-      row: 77
+      row: 83
       column: 0
     end_location:
-      row: 82
+      row: 88
       column: 0
   parent: ~
 - kind:
     NestedIfStatements: ~
   location:
-    row: 84
+    row: 90
     column: 0
   end_location:
-    row: 88
-    column: 28
+    row: 93
+    column: 6
   fix:
     content: "if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n    \"multiprocessing.\"\n)):\n    print(\"Bad module!\")\n"
     location:
-      row: 84
+      row: 90
       column: 0
     end_location:
-      row: 89
+      row: 95
       column: 0
   parent: ~
 


### PR DESCRIPTION
The idea is the same as #1867. Avoids emitting `SIM102` twice for the following code:

```python
if a:
    if b:
        if c:
            d
```

```
resources/test/fixtures/flake8_simplify/SIM102.py:1:1: SIM102 Use a single `if` statement instead of nested `if` statements
resources/test/fixtures/flake8_simplify/SIM102.py:2:5: SIM102 Use a single `if` statement instead of nested `if` statements
```