### PR TITLE
Fix S101 range to only highlight `assert`

### DIFF
--- a/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/src/rules/flake8_bandit/rules/assert_used.rs
@@ -6,5 +6,8 @@ use crate::violations;
 
 /// S101
 pub fn assert_used(stmt: &Located<StmtKind>) -> Diagnostic {
-    Diagnostic::new(violations::AssertUsed, Range::from_located(stmt))
+    Diagnostic::new(
+        violations::AssertUsed,
+        Range::new(stmt.location, stmt.location.with_col_offset("assert".len())),
+    )
 }

--- a/src/rules/flake8_bandit/snapshots/ruff__rules__flake8_bandit__tests__S101_S101.py.snap
+++ b/src/rules/flake8_bandit/snapshots/ruff__rules__flake8_bandit__tests__S101_S101.py.snap
@@ -9,7 +9,7 @@ expression: diagnostics
     column: 0
   end_location:
     row: 2
-    column: 11
+    column: 6
   fix: ~
   parent: ~
 - kind:
@@ -19,7 +19,7 @@ expression: diagnostics
     column: 4
   end_location:
     row: 8
-    column: 17
+    column: 10
   fix: ~
   parent: ~
 - kind:
@@ -29,7 +29,7 @@ expression: diagnostics
     column: 4
   end_location:
     row: 11
-    column: 17
+    column: 10
   fix: ~
   parent: ~
 


### PR DESCRIPTION
Fix:

```
resources/test/fixtures/flake8_bandit/S101.py:2:1: S101 Use of `assert` detected
  |
2 | assert True
  | ^^^^^^^^^^^ S101
  |

resources/test/fixtures/flake8_bandit/S101.py:8:5: S101 Use of `assert` detected
  |
8 |     assert x == 1
  |     ^^^^^^^^^^^^^ S101
  |

resources/test/fixtures/flake8_bandit/S101.py:11:5: S101 Use of `assert` detected
   |
11 |     assert x == 2
   |     ^^^^^^^^^^^^^ S101
   |

Found 3 error(s).
```

to:

```
resources/test/fixtures/flake8_bandit/S101.py:2:1: S101 Use of `assert` detected
  |
2 | assert True
  | ^^^^^^ S101
  |

resources/test/fixtures/flake8_bandit/S101.py:8:5: S101 Use of `assert` detected
  |
8 |     assert x == 1
  |     ^^^^^^ S101
  |

resources/test/fixtures/flake8_bandit/S101.py:11:5: S101 Use of `assert` detected
   |
11 |     assert x == 2
   |     ^^^^^^ S101
   |
```
