### PR TITLE
Revert "Upgrade to toml v0.5.11"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,7 +733,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1267,6 +1267,15 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1877,7 +1886,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "titlecase",
- "toml",
+ "toml_edit",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -2488,11 +2497,33 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
+dependencies = [
+ "indexmap",
+ "itertools",
+ "nom8",
+ "serde",
+ "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ strum_macros = { version = "0.24.3" }
 textwrap = { version = "0.16.0" }
 thiserror = { version = "1.0" }
 titlecase = { version = "2.2.1" }
-toml = { version = "0.5.11" }
+toml_edit = { version = "0.17.1", features = ["easy"] }
 
 # https://docs.rs/getrandom/0.2.7/getrandom/#webassembly-support
 # For (future) wasm-pack support

--- a/flake8_to_ruff/Cargo.toml
+++ b/flake8_to_ruff/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.87" }
 strum = { version = "0.24.1", features = ["strum_macros"] }
 strum_macros = { version = "0.24.3" }
-toml = { version = "0.5.11" }
+toml_edit = { version = "0.17.1", features = ["easy"] }
 
 [dev-dependencies]
 

--- a/flake8_to_ruff/src/main.rs
+++ b/flake8_to_ruff/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
 
     // Create Ruff's pyproject.toml section.
     let pyproject = flake8_to_ruff::convert(&config, black.as_ref(), cli.plugin)?;
-    println!("{}", toml::to_string_pretty(&pyproject)?);
+    println!("{}", toml_edit::easy::to_string_pretty(&pyproject)?);
 
     Ok(())
 }

--- a/src/flake8_to_ruff/black.rs
+++ b/src/flake8_to_ruff/black.rs
@@ -27,7 +27,7 @@ struct Pyproject {
 
 pub fn parse_black_options<P: AsRef<Path>>(path: P) -> Result<Option<Black>> {
     let contents = std::fs::read_to_string(path)?;
-    Ok(toml::from_str::<Pyproject>(&contents)?
+    Ok(toml_edit::easy::from_str::<Pyproject>(&contents)?
         .tool
         .and_then(|tool| tool.black))
 }

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -31,13 +31,13 @@ impl Pyproject {
 /// Parse a `ruff.toml` file.
 fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
     let contents = fs::read_file(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    toml_edit::easy::from_str(&contents).map_err(Into::into)
 }
 
 /// Parse a `pyproject.toml` file.
 fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
     let contents = fs::read_file(path)?;
-    toml::from_str(&contents).map_err(Into::into)
+    toml_edit::easy::from_str(&contents).map_err(Into::into)
 }
 
 /// Return `true` if a `pyproject.toml` contains a `[tool.ruff]` section.
@@ -144,17 +144,17 @@ mod tests {
 
     #[test]
     fn deserialize() -> Result<()> {
-        let pyproject: Pyproject = toml::from_str(r#""#)?;
+        let pyproject: Pyproject = toml_edit::easy::from_str(r#""#)?;
         assert_eq!(pyproject.tool, None);
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 "#,
         )?;
         assert_eq!(pyproject.tool, Some(Tools { ruff: None }));
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -214,7 +214,7 @@ mod tests {
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -275,7 +275,7 @@ line-length = 79
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -336,7 +336,7 @@ exclude = ["foo.py"]
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -397,7 +397,7 @@ select = ["E501"]
             })
         );
 
-        let pyproject: Pyproject = toml::from_str(
+        let pyproject: Pyproject = toml_edit::easy::from_str(
             r#"
 [tool.black]
 [tool.ruff]
@@ -459,7 +459,7 @@ ignore = ["E501"]
             })
         );
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]
@@ -468,7 +468,7 @@ line_length = 79
         )
         .is_err());
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]
@@ -477,7 +477,7 @@ select = ["E123"]
         )
         .is_err());
 
-        assert!(toml::from_str::<Pyproject>(
+        assert!(toml_edit::easy::from_str::<Pyproject>(
             r#"
 [tool.black]
 [tool.ruff]


### PR DESCRIPTION
This _did_ fix https://github.com/charliermarsh/ruff/issues/1894, but was a little premature. `toml` doesn't actually depend on `toml-edit` yet, and `v0.5.11` was mostly about deprecations AFAICT. So upgrading might solve that issue, but could introduce other incompatibilities, and I'd like to minimize churn. I expect that `toml` will have a new release soon, so we can revert this revert.

Reverts charliermarsh/ruff#2040.
