### PR TITLE
Avoid flagging redefined imports as unused in same-scope

### DIFF
--- a/resources/test/fixtures/pyflakes/multi_statement_lines.py
+++ b/resources/test/fixtures/pyflakes/multi_statement_lines.py
@@ -1,51 +1,51 @@
 
 if True:
-    import foo; x = 1
-    import foo;     x = 1
+    import foo1; x = 1
+    import foo2;     x = 1
 
 if True:
-    import foo; \
+    import foo3; \
 x = 1
 
 if True:
-    import foo \
+    import foo4 \
         ; x = 1
 
 
 if True:
-    x = 1; import foo
+    x = 1; import foo5
 
 
 if True:
     x = 1; \
-         import foo
+         import foo6
 
 
 if True:
     x = 1 \
-        ; import foo
+        ; import foo7
 
 
 if True:
-    x = 1; import foo; x = 1
-    x = 1;     import foo;     x = 1
+    x = 1; import foo8; x = 1
+    x = 1;     import foo9;     x = 1
 
 if True:
     x = 1; \
-        import foo; \
+        import foo10; \
     x = 1
 
 if True:
     x = 1 \
-        ;import foo \
+        ;import foo11 \
         ;x = 1
 
 
 # Continuation, but not as the last content in the file.
 x = 1; \
-import foo
+import foo12
 
 # Continuation, followed by end-of-file. (Removing `import foo` would cause a syntax
 # error.)
 x = 1; \
-import foo
+import foo13

--- a/resources/test/fixtures/ruff/RUF100_1.py
+++ b/resources/test/fixtures/ruff/RUF100_1.py
@@ -1,64 +1,89 @@
-# This should ignore both errors.
-from typing import (  # noqa: F401
-    List,
-    Sequence,
-)
+def f():
+    # This should ignore both errors.
+    from typing import (  # noqa: F401
+        List,
+        Sequence,
+    )
 
-# This should ignore both errors.
-from typing import (  # noqa
-    List,
-    Sequence,
-)
 
-# This should ignore both errors.
-from typing import (
-    List,  # noqa: F401
-    Sequence,  # noqa: F401
-)
+def f():
+    # This should ignore both errors.
+    from typing import (  # noqa
+        List,
+        Sequence,
+    )
 
-# This should ignore both errors.
-from typing import (
-    List,  # noqa
-    Sequence,  # noqa
-)
 
-# This should ignore the first error.
-from typing import (
-    Mapping,  # noqa: F401
-    Union,
-)
+def f():
+    # This should ignore both errors.
+    from typing import (
+        List,  # noqa: F401
+        Sequence,  # noqa: F401
+    )
 
-# This should ignore both errors.
-from typing import (  # noqa
-    List,
-    Sequence,
-)
 
-# This should ignore the error, but the inner noqa should be marked as unused.
-from typing import (  # noqa: F401
-    Optional,  # noqa: F401
-)
+def f():
+    # This should ignore both errors.
+    from typing import (
+        List,  # noqa
+        Sequence,  # noqa
+    )
 
-# This should ignore the error, but the inner noqa should be marked as unused.
-from typing import (  # noqa
-    Optional,  # noqa: F401
-)
 
-# This should ignore the error, but mark F501 as unused.
-from typing import (  # noqa: F401
-    Dict,  # noqa: F501
-)
+def f():
+    # This should ignore the first error.
+    from typing import (
+        Mapping,  # noqa: F401
+        Union,
+    )
 
-# This should ignore the error, but mark F501 as unused.
-from typing import (  # noqa: F501
-    Tuple,  # noqa: F401
-)
 
-# This should ignore both errors.
-from typing import Any, AnyStr  # noqa: F401
+def f():
+    # This should ignore both errors.
+    from typing import (  # noqa
+        List,
+        Sequence,
+    )
 
-# This should ignore both errors.
-from typing import AsyncIterable, AsyncGenerator  # noqa
 
-# This should mark F501 as unused.
-from typing import Awaitable, AwaitableGenerator  # noqa: F501
+def f():
+    # This should ignore the error, but the inner noqa should be marked as unused.
+    from typing import (  # noqa: F401
+        Optional,  # noqa: F401
+    )
+
+
+def f():
+    # This should ignore the error, but the inner noqa should be marked as unused.
+    from typing import (  # noqa
+        Optional,  # noqa: F401
+    )
+
+
+def f():
+    # This should ignore the error, but mark F501 as unused.
+    from typing import (  # noqa: F401
+        Dict,  # noqa: F501
+    )
+
+
+def f():
+    # This should ignore the error, but mark F501 as unused.
+    from typing import (  # noqa: F501
+        Tuple,  # noqa: F401
+    )
+
+
+def f():
+    # This should ignore both errors.
+    from typing import Any, AnyStr  # noqa: F401
+
+
+def f():
+    # This should ignore both errors.
+    from typing import AsyncIterable, AsyncGenerator  # noqa
+
+
+def f():
+    # This should mark F501 as unused.
+    from typing import Awaitable, AwaitableGenerator  # noqa: F501

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -3587,7 +3587,6 @@ impl<'a> Checker<'a> {
     {
         let binding_index = self.bindings.len();
 
-        let mut overridden = None;
         if let Some((stack_index, scope_index)) = self
             .scope_stack
             .iter()
@@ -3619,7 +3618,6 @@ impl<'a> Checker<'a> {
                         | BindingKind::FutureImportation
                 );
                 if matches!(binding.kind, BindingKind::LoopVar) && existing_is_import {
-                    overridden = Some((*scope_index, *existing_binding_index));
                     if self.settings.rules.enabled(&Rule::ImportShadowedByLoopVar) {
                         self.diagnostics.push(Diagnostic::new(
                             violations::ImportShadowedByLoopVar(
@@ -3639,7 +3637,6 @@ impl<'a> Checker<'a> {
                                 cast::decorator_list(existing.source.as_ref().unwrap()),
                             ))
                     {
-                        overridden = Some((*scope_index, *existing_binding_index));
                         if self.settings.rules.enabled(&Rule::RedefinedWhileUnused) {
                             self.diagnostics.push(Diagnostic::new(
                                 violations::RedefinedWhileUnused(
@@ -3657,13 +3654,6 @@ impl<'a> Checker<'a> {
                         .push(binding_index);
                 }
             }
-        }
-
-        // If we're about to lose the binding, store it as overridden.
-        if let Some((scope_index, binding_index)) = overridden {
-            self.scopes[scope_index]
-                .overridden
-                .push((name, binding_index));
         }
 
         // Assume the rebound name is used as a global or within a loop.

--- a/src/rules/pyflakes/mod.rs
+++ b/src/rules/pyflakes/mod.rs
@@ -1170,19 +1170,11 @@ mod tests {
     fn aliased_import() -> Result<()> {
         flakes(
             "import fu as FU, bar as FU",
-            &[
-                Rule::UnusedImport,
-                Rule::RedefinedWhileUnused,
-                Rule::UnusedImport,
-            ],
+            &[Rule::RedefinedWhileUnused, Rule::UnusedImport],
         )?;
         flakes(
             "from moo import fu as FU, bar as FU",
-            &[
-                Rule::UnusedImport,
-                Rule::RedefinedWhileUnused,
-                Rule::UnusedImport,
-            ],
+            &[Rule::RedefinedWhileUnused, Rule::UnusedImport],
         )?;
 
         Ok(())
@@ -1219,18 +1211,9 @@ mod tests {
 
     #[test]
     fn redefined_while_unused() -> Result<()> {
-        flakes(
-            "import fu; fu = 3",
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
-        )?;
-        flakes(
-            "import fu; fu, bar = 3",
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
-        )?;
-        flakes(
-            "import fu; [fu, bar] = 3",
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
-        )?;
+        flakes("import fu; fu = 3", &[Rule::RedefinedWhileUnused])?;
+        flakes("import fu; fu, bar = 3", &[Rule::RedefinedWhileUnused])?;
+        flakes("import fu; [fu, bar] = 3", &[Rule::RedefinedWhileUnused])?;
 
         Ok(())
     }
@@ -1247,7 +1230,7 @@ mod tests {
             import os
         os.path
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1285,7 +1268,7 @@ mod tests {
             pass
         os.path
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1361,7 +1344,7 @@ mod tests {
             from bb import mixer
         mixer(123)
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1433,7 +1416,7 @@ mod tests {
         def fu():
             pass
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1511,7 +1494,7 @@ mod tests {
         class fu:
             pass
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -1775,7 +1758,7 @@ mod tests {
         for fu in range(2):
             pass
         "#,
-            &[Rule::UnusedImport, Rule::ImportShadowedByLoopVar],
+            &[Rule::ImportShadowedByLoopVar],
         )?;
 
         Ok(())
@@ -1932,11 +1915,7 @@ mod tests {
         try: pass
         except Exception as fu: pass
         "#,
-            &[
-                Rule::UnusedImport,
-                Rule::RedefinedWhileUnused,
-                Rule::UnusedVariable,
-            ],
+            &[Rule::RedefinedWhileUnused, Rule::UnusedVariable],
         )?;
 
         Ok(())
@@ -2246,7 +2225,7 @@ mod tests {
         import fu.bar, fu.bar
         fu.bar
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
         flakes(
             r#"
@@ -2254,7 +2233,7 @@ mod tests {
         import fu.bar
         fu.bar
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())
@@ -2410,7 +2389,7 @@ mod tests {
             fu
         fu
         "#,
-            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
+            &[Rule::RedefinedWhileUnused],
         )?;
 
         Ok(())

--- a/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__multi_statement_lines.snap
+++ b/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__multi_statement_lines.snap
@@ -4,7 +4,7 @@ expression: diagnostics
 ---
 - kind:
     UnusedImport:
-      - foo
+      - foo1
       - false
       - false
   location:
@@ -12,7 +12,7 @@ expression: diagnostics
     column: 11
   end_location:
     row: 3
-    column: 14
+    column: 15
   fix:
     content: ""
     location:
@@ -20,11 +20,11 @@ expression: diagnostics
       column: 4
     end_location:
       row: 3
-      column: 16
+      column: 17
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo2
       - false
       - false
   location:
@@ -32,7 +32,7 @@ expression: diagnostics
     column: 11
   end_location:
     row: 4
-    column: 14
+    column: 15
   fix:
     content: ""
     location:
@@ -40,11 +40,11 @@ expression: diagnostics
       column: 4
     end_location:
       row: 4
-      column: 20
+      column: 21
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo3
       - false
       - false
   location:
@@ -52,7 +52,7 @@ expression: diagnostics
     column: 11
   end_location:
     row: 7
-    column: 14
+    column: 15
   fix:
     content: ""
     location:
@@ -64,7 +64,7 @@ expression: diagnostics
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo4
       - false
       - false
   location:
@@ -72,7 +72,7 @@ expression: diagnostics
     column: 11
   end_location:
     row: 11
-    column: 14
+    column: 15
   fix:
     content: ""
     location:
@@ -84,7 +84,7 @@ expression: diagnostics
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo5
       - false
       - false
   location:
@@ -92,7 +92,7 @@ expression: diagnostics
     column: 18
   end_location:
     row: 16
-    column: 21
+    column: 22
   fix:
     content: ""
     location:
@@ -100,11 +100,11 @@ expression: diagnostics
       column: 11
     end_location:
       row: 16
-      column: 21
+      column: 22
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo6
       - false
       - false
   location:
@@ -112,7 +112,7 @@ expression: diagnostics
     column: 16
   end_location:
     row: 21
-    column: 19
+    column: 20
   fix:
     content: ""
     location:
@@ -120,11 +120,11 @@ expression: diagnostics
       column: 9
     end_location:
       row: 21
-      column: 19
+      column: 20
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo7
       - false
       - false
   location:
@@ -132,7 +132,7 @@ expression: diagnostics
     column: 17
   end_location:
     row: 26
-    column: 20
+    column: 21
   fix:
     content: ""
     location:
@@ -140,11 +140,11 @@ expression: diagnostics
       column: 10
     end_location:
       row: 26
-      column: 20
+      column: 21
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo8
       - false
       - false
   location:
@@ -152,7 +152,7 @@ expression: diagnostics
     column: 18
   end_location:
     row: 30
-    column: 21
+    column: 22
   fix:
     content: ""
     location:
@@ -160,11 +160,11 @@ expression: diagnostics
       column: 11
     end_location:
       row: 30
-      column: 23
+      column: 24
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo9
       - false
       - false
   location:
@@ -172,7 +172,7 @@ expression: diagnostics
     column: 22
   end_location:
     row: 31
-    column: 25
+    column: 26
   fix:
     content: ""
     location:
@@ -180,11 +180,11 @@ expression: diagnostics
       column: 15
     end_location:
       row: 31
-      column: 31
+      column: 32
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo10
       - false
       - false
   location:
@@ -192,7 +192,7 @@ expression: diagnostics
     column: 15
   end_location:
     row: 35
-    column: 18
+    column: 20
   fix:
     content: ""
     location:
@@ -204,7 +204,7 @@ expression: diagnostics
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo11
       - false
       - false
   location:
@@ -212,7 +212,7 @@ expression: diagnostics
     column: 16
   end_location:
     row: 40
-    column: 19
+    column: 21
   fix:
     content: ""
     location:
@@ -224,7 +224,7 @@ expression: diagnostics
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo12
       - false
       - false
   location:
@@ -232,7 +232,7 @@ expression: diagnostics
     column: 7
   end_location:
     row: 46
-    column: 10
+    column: 12
   fix:
     content: ""
     location:
@@ -240,11 +240,11 @@ expression: diagnostics
       column: 0
     end_location:
       row: 46
-      column: 10
+      column: 12
   parent: ~
 - kind:
     UnusedImport:
-      - foo
+      - foo13
       - false
       - false
   location:
@@ -252,14 +252,14 @@ expression: diagnostics
     column: 7
   end_location:
     row: 51
-    column: 10
+    column: 12
   fix:
-    content: "\n"
+    content: ""
     location:
       row: 51
       column: 0
     end_location:
       row: 51
-      column: 10
+      column: 12
   parent: ~
 

--- a/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
+++ b/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
@@ -8,22 +8,22 @@ expression: diagnostics
       - false
       - false
   location:
-    row: 28
-    column: 4
+    row: 37
+    column: 8
   end_location:
-    row: 28
-    column: 9
+    row: 37
+    column: 13
   fix:
-    content: "from typing import (\n    Mapping,  # noqa: F401\n    )"
+    content: "from typing import (\n        Mapping,  # noqa: F401\n        )"
     location:
-      row: 26
-      column: 0
+      row: 35
+      column: 4
     end_location:
-      row: 29
-      column: 1
+      row: 38
+      column: 5
   parent:
-    row: 26
-    column: 0
+    row: 35
+    column: 4
 - kind:
     UnusedNOQA:
       unknown: []
@@ -31,19 +31,19 @@ expression: diagnostics
       unmatched:
         - F401
   location:
-    row: 39
-    column: 15
+    row: 52
+    column: 19
   end_location:
-    row: 39
-    column: 27
+    row: 52
+    column: 31
   fix:
     content: ""
     location:
-      row: 39
-      column: 13
+      row: 52
+      column: 17
     end_location:
-      row: 39
-      column: 27
+      row: 52
+      column: 31
   parent: ~
 - kind:
     UnusedNOQA:
@@ -52,18 +52,39 @@ expression: diagnostics
       unmatched:
         - F401
   location:
-    row: 44
+    row: 59
+    column: 19
+  end_location:
+    row: 59
+    column: 31
+  fix:
+    content: ""
+    location:
+      row: 59
+      column: 17
+    end_location:
+      row: 59
+      column: 31
+  parent: ~
+- kind:
+    UnusedNOQA:
+      unknown: []
+      disabled:
+        - F501
+      unmatched: []
+  location:
+    row: 66
     column: 15
   end_location:
-    row: 44
+    row: 66
     column: 27
   fix:
     content: ""
     location:
-      row: 44
+      row: 66
       column: 13
     end_location:
-      row: 44
+      row: 66
       column: 27
   parent: ~
 - kind:
@@ -73,40 +94,19 @@ expression: diagnostics
         - F501
       unmatched: []
   location:
-    row: 49
-    column: 11
+    row: 72
+    column: 26
   end_location:
-    row: 49
-    column: 23
+    row: 72
+    column: 38
   fix:
     content: ""
     location:
-      row: 49
-      column: 9
+      row: 72
+      column: 24
     end_location:
-      row: 49
-      column: 23
-  parent: ~
-- kind:
-    UnusedNOQA:
-      unknown: []
-      disabled:
-        - F501
-      unmatched: []
-  location:
-    row: 53
-    column: 22
-  end_location:
-    row: 53
-    column: 34
-  fix:
-    content: ""
-    location:
-      row: 53
-      column: 20
-    end_location:
-      row: 53
-      column: 34
+      row: 72
+      column: 38
   parent: ~
 - kind:
     UnusedImport:
@@ -114,19 +114,19 @@ expression: diagnostics
       - false
       - true
   location:
-    row: 64
-    column: 19
+    row: 89
+    column: 23
   end_location:
-    row: 64
-    column: 28
+    row: 89
+    column: 32
   fix:
-    content: ""
+    content: pass
     location:
-      row: 64
-      column: 0
+      row: 89
+      column: 4
     end_location:
-      row: 65
-      column: 0
+      row: 89
+      column: 52
   parent: ~
 - kind:
     UnusedImport:
@@ -134,19 +134,19 @@ expression: diagnostics
       - false
       - true
   location:
-    row: 64
-    column: 30
+    row: 89
+    column: 34
   end_location:
-    row: 64
-    column: 48
+    row: 89
+    column: 52
   fix:
-    content: ""
+    content: pass
     location:
-      row: 64
-      column: 0
+      row: 89
+      column: 4
     end_location:
-      row: 65
-      column: 0
+      row: 89
+      column: 52
   parent: ~
 - kind:
     UnusedNOQA:
@@ -155,18 +155,18 @@ expression: diagnostics
         - F501
       unmatched: []
   location:
-    row: 64
-    column: 50
+    row: 89
+    column: 54
   end_location:
-    row: 64
-    column: 62
+    row: 89
+    column: 66
   fix:
     content: ""
     location:
-      row: 64
-      column: 48
+      row: 89
+      column: 52
     end_location:
-      row: 64
-      column: 62
+      row: 89
+      column: 66
   parent: ~
 


### PR DESCRIPTION
This is effectively a revert of #1173, to favor false-negatives over false-positives in the same-scope case.

Closes #2044.