### PR TITLE
fix: pin rustpython to the same revision to fix cargo vendor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,9 +1871,9 @@ dependencies = [
  "ropey",
  "ruff_macros",
  "rustc-hash",
- "rustpython-ast 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
- "rustpython-common 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
- "rustpython-parser 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
+ "rustpython-ast",
+ "rustpython-common",
+ "rustpython-parser",
  "schemars",
  "semver",
  "serde",
@@ -1939,9 +1939,9 @@ dependencies = [
  "once_cell",
  "ruff",
  "ruff_cli",
- "rustpython-ast 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
- "rustpython-common 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
- "rustpython-parser 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
+ "rustpython-ast",
+ "rustpython-common",
+ "rustpython-parser",
  "schemars",
  "serde_json",
  "strum",
@@ -2008,49 +2008,14 @@ version = "0.2.0"
 source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
 dependencies = [
  "num-bigint",
- "rustpython-common 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
- "rustpython-compiler-core 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
-]
-
-[[package]]
-name = "rustpython-ast"
-version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa#ff90fe52eea578c8ebdd9d95e078cc041a5959fa"
-dependencies = [
- "num-bigint",
- "rustpython-common 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
- "rustpython-compiler-core 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
+ "rustpython-common",
+ "rustpython-compiler-core",
 ]
 
 [[package]]
 name = "rustpython-common"
 version = "0.2.0"
 source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
-dependencies = [
- "ascii",
- "bitflags",
- "cfg-if",
- "hexf-parse",
- "itertools",
- "lexical-parse-float",
- "libc",
- "lock_api",
- "num-bigint",
- "num-complex",
- "num-traits",
- "once_cell",
- "radium",
- "rand",
- "siphasher",
- "unic-ucd-category",
- "volatile",
- "widestring",
-]
-
-[[package]]
-name = "rustpython-common"
-version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa#ff90fe52eea578c8ebdd9d95e078cc041a5959fa"
 dependencies = [
  "ascii",
  "bitflags",
@@ -2090,23 +2055,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustpython-compiler-core"
-version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa#ff90fe52eea578c8ebdd9d95e078cc041a5959fa"
-dependencies = [
- "bincode",
- "bitflags",
- "bstr 0.2.17",
- "itertools",
- "lz4_flex",
- "num-bigint",
- "num-complex",
- "num_enum",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "rustpython-parser"
 version = "0.2.0"
 source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
@@ -2122,33 +2070,8 @@ dependencies = [
  "phf 0.10.1",
  "phf_codegen 0.10.0",
  "rustc-hash",
- "rustpython-ast 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
- "rustpython-compiler-core 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c)",
- "thiserror",
- "tiny-keccak",
- "unic-emoji-char",
- "unic-ucd-ident",
- "unicode_names2",
-]
-
-[[package]]
-name = "rustpython-parser"
-version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa#ff90fe52eea578c8ebdd9d95e078cc041a5959fa"
-dependencies = [
- "ahash",
- "anyhow",
- "itertools",
- "lalrpop",
- "lalrpop-util",
- "log",
- "num-bigint",
- "num-traits",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
- "rustc-hash",
- "rustpython-ast 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
- "rustpython-compiler-core 0.2.0 (git+https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa)",
+ "rustpython-ast",
+ "rustpython-compiler-core",
  "thiserror",
  "tiny-keccak",
  "unic-emoji-char",

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,9 +11,9 @@ libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a87
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
 ruff_cli = { path = "../ruff_cli" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "ff90fe52eea578c8ebdd9d95e078cc041a5959fa" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "ff90fe52eea578c8ebdd9d95e078cc041a5959fa" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "ff90fe52eea578c8ebdd9d95e078cc041a5959fa" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
 schemars = { version = "0.8.11" }
 serde_json = {version="1.0.91"}
 strum = { version = "0.24.1", features = ["strum_macros"] }


### PR DESCRIPTION
I was trying to update ruff in nixpkgs and ran into this error when it was running `cargo vendor`
```
error: failed to sync

Caused by:
  found duplicate version of package `rustpython-ast v0.2.0` vendored from two sources:

        source 1: https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942b
        source 2: https://github.com/RustPython/RustPython.git?rev=ff90fe52eea578c8ebdd9d95e078cc041a5959fa#ff90fe52
```