### PR TITLE
ICN001 check from imports that have no alias

### DIFF
--- a/resources/test/fixtures/flake8_import_conventions/from_imports.py
+++ b/resources/test/fixtures/flake8_import_conventions/from_imports.py
@@ -1,11 +1,21 @@
 # Test absolute imports
+# Violation cases
+import xml.dom.minidom
 import xml.dom.minidom as wrong
 from xml.dom import minidom as wrong
+from xml.dom import minidom
 from xml.dom.minidom import parseString as wrong  # Ensure ICN001 throws on function import.
+from xml.dom.minidom import parseString
+from xml.dom.minidom import parse, parseString
+from xml.dom.minidom import parse as ps, parseString as wrong
 
+# No ICN001 violations
 import xml.dom.minidom as md
 from xml.dom import minidom as md
 from xml.dom.minidom import parseString as pstr
+from xml.dom.minidom import parse, parseString as pstr
+from xml.dom.minidom import parse as ps, parseString as pstr
+
 
 # Test relative imports
 from ..xml.dom import minidom as okay  # Ensure config "xml.dom.minidom" doesn't catch relative imports

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1230,29 +1230,29 @@ where
                         }
                     }
 
-                    if let Some(asname) = &alias.node.asname {
-                        if self
-                            .settings
-                            .rules
-                            .enabled(&Rule::ImportAliasIsNotConventional)
+                    if self
+                        .settings
+                        .rules
+                        .enabled(&Rule::ImportAliasIsNotConventional)
+                    {
+                        let full_name = helpers::format_import_from_member(
+                            level.as_ref(),
+                            module.as_deref(),
+                            &alias.node.name,
+                        );
+                        if let Some(diagnostic) =
+                            flake8_import_conventions::rules::check_conventional_import(
+                                stmt,
+                                &full_name,
+                                alias.node.asname.as_deref(),
+                                &self.settings.flake8_import_conventions.aliases,
+                            )
                         {
-                            let full_name = helpers::format_import_from_member(
-                                level.as_ref(),
-                                module.as_deref(),
-                                &alias.node.name,
-                            );
-                            if let Some(diagnostic) =
-                                flake8_import_conventions::rules::check_conventional_import(
-                                    stmt,
-                                    &full_name,
-                                    alias.node.asname.as_deref(),
-                                    &self.settings.flake8_import_conventions.aliases,
-                                )
-                            {
-                                self.diagnostics.push(diagnostic);
-                            }
+                            self.diagnostics.push(diagnostic);
                         }
+                    }
 
+                    if let Some(asname) = &alias.node.asname {
                         if self
                             .settings
                             .rules

--- a/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
+++ b/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__from_imports.snap
@@ -7,10 +7,22 @@ expression: diagnostics
       - xml.dom.minidom
       - md
   location:
-    row: 2
+    row: 3
     column: 0
   end_location:
-    row: 2
+    row: 3
+    column: 22
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - xml.dom.minidom
+      - md
+  location:
+    row: 4
+    column: 0
+  end_location:
+    row: 4
     column: 31
   fix: ~
   parent: ~
@@ -19,11 +31,23 @@ expression: diagnostics
       - xml.dom.minidom
       - md
   location:
-    row: 3
+    row: 5
     column: 0
   end_location:
-    row: 3
+    row: 5
     column: 36
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - xml.dom.minidom
+      - md
+  location:
+    row: 6
+    column: 0
+  end_location:
+    row: 6
+    column: 27
   fix: ~
   parent: ~
 - kind:
@@ -31,11 +55,47 @@ expression: diagnostics
       - xml.dom.minidom.parseString
       - pstr
   location:
-    row: 4
+    row: 7
     column: 0
   end_location:
-    row: 4
+    row: 7
     column: 48
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - xml.dom.minidom.parseString
+      - pstr
+  location:
+    row: 8
+    column: 0
+  end_location:
+    row: 8
+    column: 39
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - xml.dom.minidom.parseString
+      - pstr
+  location:
+    row: 9
+    column: 0
+  end_location:
+    row: 9
+    column: 46
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - xml.dom.minidom.parseString
+      - pstr
+  location:
+    row: 10
+    column: 0
+  end_location:
+    row: 10
+    column: 61
   fix: ~
   parent: ~
 


### PR DESCRIPTION
Add tests.

Ensure that these cases are caught by ICN001:
```python
from xml.dom import minidom
from xml.dom.minidom import parseString
```

with config:
```toml
[tool.ruff.flake8-import-conventions.extend-aliases]
"dask.dataframe" = "dd"
"xml.dom.minidom" = "md"
"xml.dom.minidom.parseString" = "pstr"
```