### PR TITLE
feat: update scripts to new rules structure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,9 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/add_rule.py --name DoTheThing --code PLC999 --linter pylint
       - run: cargo check
-      - run: ./scripts/add_plugin.py test --url https://pypi.org/project/-test/0.1.0/
+      - run: |
+         ./scripts/add_plugin.py test --url https://pypi.org/project/-test/0.1.0/ --prefix TST
+         ./scripts/add_rule.py --name FirstRule --code TST001 --linter test
       - run: cargo check
 
 # TODO(charlie): Re-enable the `wasm-pack` tests.


### PR DESCRIPTION
- optional `prefix` argument for `add_plugin.py`
- rules directory instead of `rules.rs`
- pathlib syntax
- fix test case where code was added instead of name

Example:
```
python scripts/add_plugin.py --url https://pypi.org/project/example/1.0.0/ example --prefix EXA
python scripts/add_rule.py --name SecondRule --code EXA002 --linter example
python scripts/add_rule.py --name FirstRule --code EXA001 --linter example
python scripts/add_rule.py --name ThirdRule --code EXA003 --linter example
 ```

Note that it breaks compatibility with 'old style' plugins (generation works fine, but namespaces need to be changed):
```
python scripts/add_rule.py --name DoTheThing --code PLC999 --linter pylint
```