### PR TITLE
[`pep8-naming`][`N806`] Don't mark `TypeVar` & `NewType` Assignment as Errors

### DIFF
--- a/resources/test/fixtures/pep8_naming/N806.py
+++ b/resources/test/fixtures/pep8_naming/N806.py
@@ -1,5 +1,7 @@
 import collections
 from collections import namedtuple
+from typing import TypeVar
+from typing import NewType
 
 GLOBAL: str = "foo"
 
@@ -11,5 +13,9 @@ def f():
     Camel = 0
     CONSTANT = 0
     _ = 0
+
     MyObj1 = collections.namedtuple("MyObj1", ["a", "b"])
     MyObj2 = namedtuple("MyObj12", ["a", "b"])
+
+    T = TypeVar("T")
+    UserId = NewType('UserId', int)

--- a/src/rules/pep8_naming/helpers.rs
+++ b/src/rules/pep8_naming/helpers.rs
@@ -31,6 +31,16 @@ pub fn is_namedtuple_assignment(checker: &Checker, stmt: &Stmt) -> bool {
     })
 }
 
+pub fn is_type_var_assignment(checker: &Checker, stmt: &Stmt) -> bool {
+    let StmtKind::Assign { value, .. } = &stmt.node else {
+        return false;
+    };
+    checker.resolve_call_path(value).map_or(false, |call_path| {
+        call_path.as_slice() == ["typing", "TypeVar"]
+            || call_path.as_slice() == ["typing", "NewType"]
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::{is_acronym, is_camelcase, is_mixed_case};

--- a/src/rules/pep8_naming/rules.rs
+++ b/src/rules/pep8_naming/rules.rs
@@ -126,7 +126,10 @@ pub fn non_lowercase_variable_in_function(
     stmt: &Stmt,
     name: &str,
 ) {
-    if name.to_lowercase() != name && !helpers::is_namedtuple_assignment(checker, stmt) {
+    if name.to_lowercase() != name
+        && !helpers::is_namedtuple_assignment(checker, stmt)
+        && !helpers::is_type_var_assignment(checker, stmt)
+    {
         checker.diagnostics.push(Diagnostic::new(
             violations::NonLowercaseVariableInFunction(name.to_string()),
             Range::from_located(expr),

--- a/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N806_N806.py.snap
+++ b/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N806_N806.py.snap
@@ -5,20 +5,20 @@ expression: diagnostics
 - kind:
     NonLowercaseVariableInFunction: Camel
   location:
-    row: 11
+    row: 13
     column: 4
   end_location:
-    row: 11
+    row: 13
     column: 9
   fix: ~
   parent: ~
 - kind:
     NonLowercaseVariableInFunction: CONSTANT
   location:
-    row: 12
+    row: 14
     column: 4
   end_location:
-    row: 12
+    row: 14
     column: 12
   fix: ~
   parent: ~


### PR DESCRIPTION
closes https://github.com/charliermarsh/ruff/issues/1985