### PR TITLE
Update RustPython to fix `Dict.keys` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4f38cb68e4a97aeea9eb19673803a0bd5f655383#4f38cb68e4a97aeea9eb19673803a0bd5f655383"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4f38cb68e4a97aeea9eb19673803a0bd5f655383#4f38cb68e4a97aeea9eb19673803a0bd5f655383"
 dependencies = [
  "ascii",
  "bitflags",
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4f38cb68e4a97aeea9eb19673803a0bd5f655383#4f38cb68e4a97aeea9eb19673803a0bd5f655383"
 dependencies = [
  "bincode",
  "bitflags",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=62aa942bf506ea3d41ed0503b947b84141fdaa3c#62aa942bf506ea3d41ed0503b947b84141fdaa3c"
+source = "git+https://github.com/RustPython/RustPython.git?rev=4f38cb68e4a97aeea9eb19673803a0bd5f655383#4f38cb68e4a97aeea9eb19673803a0bd5f655383"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ path-absolutize = { version = "3.0.14", features = ["once_cell_cache", "use_unix
 regex = { version = "1.6.0" }
 ruff_macros = { version = "0.0.229", path = "ruff_macros" }
 rustc-hash = { version = "1.1.0" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
 schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/resources/test/fixtures/pyupgrade/UP013.py
+++ b/resources/test/fixtures/pyupgrade/UP013.py
@@ -31,3 +31,7 @@ MyType10 = TypedDict("MyType10", {"key": Literal["value"]})
 
 # using namespace TypedDict
 MyType11 = typing.TypedDict("MyType11", {"key": int})
+
+# unpacking
+c = {"c": float}
+MyType12 = TypedDict("MyType1", {"a": int, "b": str, **c})

--- a/resources/test/fixtures/pyupgrade/UP031_0.py
+++ b/resources/test/fixtures/pyupgrade/UP031_0.py
@@ -62,6 +62,12 @@ print(
     "bar %(bar)s" % {"foo": x, "bar": y}
 )
 
+bar = {"bar": y}
+print(
+    "foo %(foo)s "
+    "bar %(bar)s" % {"foo": x, **bar}
+)
+
 print("%s \N{snowman}" % (a,))
 
 print("%(foo)s \N{snowman}" % {"foo": 1})

--- a/ruff_dev/Cargo.toml
+++ b/ruff_dev/Cargo.toml
@@ -11,9 +11,9 @@ libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a87
 once_cell = { version = "1.16.0" }
 ruff = { path = ".." }
 ruff_cli = { path = "../ruff_cli" }
-rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "62aa942bf506ea3d41ed0503b947b84141fdaa3c" }
+rustpython-ast = { features = ["unparse"], git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "4f38cb68e4a97aeea9eb19673803a0bd5f655383" }
 schemars = { version = "0.8.11" }
 serde_json = {version="1.0.91"}
 strum = { version = "0.24.1", features = ["strum_macros"] }

--- a/src/ast/comparable.rs
+++ b/src/ast/comparable.rs
@@ -424,7 +424,11 @@ impl<'a> From<&'a Expr> for ComparableExpr<'a> {
                 orelse: orelse.into(),
             },
             ExprKind::Dict { keys, values } => Self::Dict {
-                keys: keys.iter().map(std::convert::Into::into).collect(),
+                keys: keys
+                    .iter()
+                    .flatten()
+                    .map(std::convert::Into::into)
+                    .collect(),
                 values: values.iter().map(std::convert::Into::into).collect(),
             },
             ExprKind::Set { elts } => Self::Set {

--- a/src/ast/comparable.rs
+++ b/src/ast/comparable.rs
@@ -295,7 +295,7 @@ pub enum ComparableExpr<'a> {
         orelse: Box<ComparableExpr<'a>>,
     },
     Dict {
-        keys: Vec<ComparableExpr<'a>>,
+        keys: Vec<Option<ComparableExpr<'a>>>,
         values: Vec<ComparableExpr<'a>>,
     },
     Set {
@@ -426,8 +426,7 @@ impl<'a> From<&'a Expr> for ComparableExpr<'a> {
             ExprKind::Dict { keys, values } => Self::Dict {
                 keys: keys
                     .iter()
-                    .flatten()
-                    .map(std::convert::Into::into)
+                    .map(|expr| expr.as_ref().map(std::convert::Into::into))
                     .collect(),
                 values: values.iter().map(std::convert::Into::into).collect(),
             },

--- a/src/ast/helpers.rs
+++ b/src/ast/helpers.rs
@@ -161,7 +161,7 @@ where
         }
         ExprKind::Dict { keys, values } => values
             .iter()
-            .chain(keys.iter())
+            .chain(keys.iter().flatten())
             .any(|expr| any_over_expr(expr, func)),
         ExprKind::Set { elts } | ExprKind::List { elts, .. } | ExprKind::Tuple { elts, .. } => {
             elts.iter().any(|expr| any_over_expr(expr, func))

--- a/src/ast/relocate.rs
+++ b/src/ast/relocate.rs
@@ -39,7 +39,7 @@ pub fn relocate_expr(expr: &mut Expr, location: Range) {
             relocate_expr(orelse, location);
         }
         ExprKind::Dict { keys, values } => {
-            for expr in keys {
+            for expr in keys.iter_mut().flatten() {
                 relocate_expr(expr, location);
             }
             for expr in values {

--- a/src/ast/visitor.rs
+++ b/src/ast/visitor.rs
@@ -288,7 +288,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             visitor.visit_expr(orelse);
         }
         ExprKind::Dict { keys, values } => {
-            for expr in keys {
+            for expr in keys.iter().flatten() {
                 visitor.visit_expr(expr);
             }
             for expr in values {

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -3155,7 +3155,7 @@ where
                         // Ex) TypedDict("a", {"a": int})
                         if args.len() > 1 {
                             if let ExprKind::Dict { keys, values } = &args[1].node {
-                                for key in keys {
+                                for key in keys.iter().flatten() {
                                     self.in_type_definition = false;
                                     self.visit_expr(key);
                                     self.in_type_definition = prev_in_type_definition;

--- a/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -78,14 +78,18 @@ fn create_class_def_stmt(
     })
 }
 
-fn properties_from_dict_literal(keys: &[Expr], values: &[Expr]) -> Result<Vec<Stmt>> {
+fn properties_from_dict_literal(keys: &[Option<Expr>], values: &[Expr]) -> Result<Vec<Stmt>> {
     keys.iter()
         .zip(values.iter())
-        .map(|(key, value)| match &key.node {
-            ExprKind::Constant {
-                value: Constant::Str(property),
+        .map(|(key, value)| match key {
+            Some(Expr {
+                node:
+                    ExprKind::Constant {
+                        value: Constant::Str(property),
+                        ..
+                    },
                 ..
-            } => {
+            }) => {
                 if is_identifier(property) && !KWLIST.contains(&property.as_str()) {
                     Ok(create_property_assignment_stmt(property, &value.node))
                 } else {

--- a/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -18,7 +18,11 @@ fn contains_await(expr: &Expr) -> bool {
         ExprKind::IfExp { test, body, orelse } => {
             contains_await(test) || contains_await(body) || contains_await(orelse)
         }
-        ExprKind::Dict { keys, values } => keys.iter().chain(values.iter()).any(contains_await),
+        ExprKind::Dict { keys, values } => keys
+            .iter()
+            .flatten()
+            .chain(values.iter())
+            .any(contains_await),
         ExprKind::Set { elts } => elts.iter().any(contains_await),
         ExprKind::ListComp { elt, .. } => contains_await(elt),
         ExprKind::SetComp { elt, .. } => contains_await(elt),

--- a/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP013_UP013.py.snap
+++ b/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP013_UP013.py.snap
@@ -182,4 +182,14 @@ expression: diagnostics
       row: 33
       column: 53
   parent: ~
+- kind:
+    ConvertTypedDictFunctionalToClass: MyType12
+  location:
+    row: 37
+    column: 0
+  end_location:
+    row: 37
+    column: 58
+  fix: ~
+  parent: ~
 

--- a/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP031_UP031_0.py.snap
+++ b/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP031_UP031_0.py.snap
@@ -430,52 +430,69 @@ expression: diagnostics
 - kind:
     PrintfStringFormatting: ~
   location:
-    row: 65
+    row: 67
+    column: 4
+  end_location:
+    row: 68
+    column: 37
+  fix:
+    content: "\"foo {foo} \"\n    \"bar {bar}\".format(foo=x, **bar)"
+    location:
+      row: 67
+      column: 4
+    end_location:
+      row: 68
+      column: 37
+  parent: ~
+- kind:
+    PrintfStringFormatting: ~
+  location:
+    row: 71
     column: 6
   end_location:
-    row: 65
+    row: 71
     column: 29
   fix:
     content: "\"{} \\N{snowman}\".format(a)"
     location:
-      row: 65
+      row: 71
       column: 6
     end_location:
-      row: 65
+      row: 71
       column: 29
   parent: ~
 - kind:
     PrintfStringFormatting: ~
   location:
-    row: 67
+    row: 73
     column: 6
   end_location:
-    row: 67
+    row: 73
     column: 40
   fix:
     content: "\"{foo} \\N{snowman}\".format(foo=1)"
     location:
-      row: 67
+      row: 73
       column: 6
     end_location:
-      row: 67
+      row: 73
       column: 40
   parent: ~
 - kind:
     PrintfStringFormatting: ~
   location:
-    row: 69
+    row: 75
     column: 6
   end_location:
-    row: 69
+    row: 75
     column: 35
   fix:
     content: "(\"foo {} \" \"bar {}\").format(x, y)"
     location:
-      row: 69
+      row: 75
       column: 6
     end_location:
-      row: 69
+      row: 75
       column: 35
   parent: ~
 

--- a/src/source_code/generator.rs
+++ b/src/source_code/generator.rs
@@ -678,17 +678,16 @@ impl<'a> Generator<'a> {
             ExprKind::Dict { keys, values } => {
                 self.p("{");
                 let mut first = true;
-                let (packed, unpacked) = values.split_at(keys.len());
-                for (k, v) in keys.iter().zip(packed) {
+                for (k, v) in keys.iter().zip(values) {
                     self.p_delim(&mut first, ", ");
-                    self.unparse_expr(k, precedence::TEST);
-                    self.p(": ");
-                    self.unparse_expr(v, precedence::TEST);
-                }
-                for d in unpacked {
-                    self.p_delim(&mut first, ", ");
-                    self.p("**");
-                    self.unparse_expr(d, precedence::EXPR);
+                    if let Some(k) = k {
+                        self.unparse_expr(k, precedence::TEST);
+                        self.p(": ");
+                        self.unparse_expr(v, precedence::TEST);
+                    } else {
+                        self.p("**");
+                        self.unparse_expr(v, precedence::EXPR);
+                    }
                 }
                 self.p("}");
             }


### PR DESCRIPTION
This PR upgrades RustPython to fix the type of `Dict.keys` to `Vec<Option<Expr>>` (see https://github.com/RustPython/RustPython/pull/4449 for why this change was needed) and unblock #1884.