### PR TITLE
Avoid nested-if violations when outer-if has else clause

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM102.py
+++ b/resources/test/fixtures/flake8_simplify/SIM102.py
@@ -92,3 +92,40 @@ if node.module:
         "multiprocessing."
     ):
         print("Bad module!")
+
+
+# OK
+if a:
+    if b:
+        print("foo")
+else:
+    print("bar")
+
+# OK
+if a:
+    if b:
+        if c:
+            print("foo")
+        else:
+            print("bar")
+else:
+    print("bar")
+
+# OK
+if a:
+    # SIM 102
+    if b:
+        if c:
+            print("foo")
+else:
+    print("bar")
+
+
+# OK
+if a:
+    if b:
+        if c:
+            print("foo")
+        print("baz")
+else:
+    print("bar")

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1386,6 +1386,7 @@ where
                         stmt,
                         test,
                         body,
+                        orelse,
                         self.current_stmt_parent().map(Into::into),
                     );
                 }

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -148,4 +148,21 @@ expression: diagnostics
       row: 95
       column: 0
   parent: ~
+- kind:
+    NestedIfStatements: ~
+  location:
+    row: 117
+    column: 4
+  end_location:
+    row: 118
+    column: 13
+  fix:
+    content: "    if b and c:\n        print(\"foo\")\n"
+    location:
+      row: 117
+      column: 0
+    end_location:
+      row: 120
+      column: 0
+  parent: ~
 


### PR DESCRIPTION
It looks like we need `do`-`while`-like semantics here with an additional outer check.

Closes #2094.