### PR TITLE
Escape curly braces when converting .format() strings

### DIFF
--- a/resources/test/fixtures/pyupgrade/UP032.py
+++ b/resources/test/fixtures/pyupgrade/UP032.py
@@ -44,6 +44,8 @@ print("foo {} ".format(x))
 
 "{}".format(a)
 
+'({}={{0!e}})'.format(a)
+
 ###
 # Non-errors
 ###

--- a/src/rules/pyupgrade/rules/f_strings.rs
+++ b/src/rules/pyupgrade/rules/f_strings.rs
@@ -12,6 +12,7 @@ use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyflakes::format::FormatSummary;
+use crate::rules::pyupgrade::helpers::curly_escape;
 use crate::violations;
 
 /// Like [`FormatSummary`], but maps positional and keyword arguments to their
@@ -217,13 +218,7 @@ fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
                 converted.push('}');
             }
             FormatPart::Literal(value) => {
-                if value.starts_with('{') {
-                    converted.push('{');
-                }
-                converted.push_str(&value);
-                if value.ends_with('}') {
-                    converted.push('}');
-                }
+                converted.push_str(&curly_escape(&value));
             }
         }
     }

--- a/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_UP032.py.snap
+++ b/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_UP032.py.snap
@@ -359,4 +359,21 @@ expression: diagnostics
       row: 45
       column: 14
   parent: ~
+- kind:
+    FString: ~
+  location:
+    row: 47
+    column: 0
+  end_location:
+    row: 47
+    column: 24
+  fix:
+    content: "f'({a}={{0!e}})'"
+    location:
+      row: 47
+      column: 0
+    end_location:
+      row: 47
+      column: 24
+  parent: ~
 


### PR DESCRIPTION
Closes #2111.