### PR TITLE
Ignore generators in flake8-return rules

### DIFF
--- a/resources/test/fixtures/flake8_return/RET503.py
+++ b/resources/test/fixtures/flake8_return/RET503.py
@@ -114,3 +114,12 @@ def bar3(x, y, z):
         else:
             return z
         return None
+
+
+def prompts(self, foo):
+    if not foo:
+        return []
+
+    for x in foo:
+        yield x
+        yield x + 1

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -325,6 +325,11 @@ pub fn function(checker: &mut Checker, body: &[Stmt]) {
         visitor.stack
     };
 
+    // Avoid false positives for generators.
+    if !stack.yields.is_empty() {
+        return;
+    }
+
     if checker.settings.rules.enabled(&Rule::SuperfluousElseReturn)
         || checker.settings.rules.enabled(&Rule::SuperfluousElseRaise)
         || checker


### PR DESCRIPTION
We could do a better job of handling them, but they cause too many false-positives right now.

Closes #2119.