### PR TITLE
Move compare to helpers file

### DIFF
--- a/src/rules/pycodestyle/helpers.rs
+++ b/src/rules/pycodestyle/helpers.rs
@@ -1,3 +1,19 @@
+use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
+
+use crate::ast::helpers::{create_expr, unparse_expr};
+use crate::source_code::Stylist;
+
 pub fn is_ambiguous_name(name: &str) -> bool {
     name == "l" || name == "I" || name == "O"
+}
+
+pub fn compare(left: &Expr, ops: &[Cmpop], comparators: &[Expr], stylist: &Stylist) -> String {
+    unparse_expr(
+        &create_expr(ExprKind::Compare {
+            left: Box::new(left.clone()),
+            ops: ops.to_vec(),
+            comparators: comparators.to_vec(),
+        }),
+        stylist,
+    )
 }

--- a/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -4,12 +4,11 @@ use rustpython_ast::Constant;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
 use crate::ast::helpers;
-use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
-use crate::source_code::Stylist;
+use crate::rules::pycodestyle::helpers::compare;
 use crate::violations;
 
 /// E711, E712
@@ -192,15 +191,4 @@ pub fn literal_comparisons(
     }
 
     checker.diagnostics.extend(diagnostics);
-}
-
-pub fn compare(left: &Expr, ops: &[Cmpop], comparators: &[Expr], stylist: &Stylist) -> String {
-    unparse_expr(
-        &create_expr(ExprKind::Compare {
-            left: Box::new(left.clone()),
-            ops: ops.to_vec(),
-            comparators: comparators.to_vec(),
-        }),
-        stylist,
-    )
 }

--- a/src/rules/pycodestyle/rules/not_tests.rs
+++ b/src/rules/pycodestyle/rules/not_tests.rs
@@ -1,12 +1,11 @@
 use rustpython_ast::Unaryop;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
-use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
-use crate::source_code::Stylist;
+use crate::rules::pycodestyle::helpers::compare;
 use crate::violations;
 
 /// E713, E714
@@ -66,15 +65,4 @@ pub fn not_tests(
             }
         }
     }
-}
-
-pub fn compare(left: &Expr, ops: &[Cmpop], comparators: &[Expr], stylist: &Stylist) -> String {
-    unparse_expr(
-        &create_expr(ExprKind::Compare {
-            left: Box::new(left.clone()),
-            ops: ops.to_vec(),
-            comparators: comparators.to_vec(),
-        }),
-        stylist,
-    )
 }


### PR DESCRIPTION
From discussion on https://github.com/charliermarsh/ruff/pull/2123

I didn't originally have a helpers file so I put the function in both places but now that a helpers file exists it seems logical for it to be there.