### PR TITLE
refactor CLI (2/3): Group options in `--help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,80 +352,71 @@ Arguments:
   [FILES]...
 
 Options:
-      --config <CONFIG>
-          Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
-  -v, --verbose
-          Enable verbose logging
-  -q, --quiet
-          Print lint violations, but nothing else
-  -s, --silent
-          Disable all logging (but still exit with status code "1" upon detecting lint violations)
-  -e, --exit-zero
-          Exit with status code "0", even upon detecting lint violations
-  -w, --watch
-          Run in watch mode by re-running whenever files change
-      --fix
-          Attempt to automatically fix lint violations
-      --fix-only
-          Fix any fixable lint violations, but don't report on leftover violations. Implies `--fix`
-      --diff
-          Avoid writing any fixed files back; instead, output a diff for each changed file to stdout
-  -n, --no-cache
-          Disable cache reads
-      --isolated
-          Ignore all configuration files
+      --fix              Attempt to automatically fix lint violations
+      --show-source      Show violations with source code
+      --diff             Avoid writing any fixed files back; instead, output a diff for each changed file to stdout
+  -w, --watch            Run in watch mode by re-running whenever files change
+      --fix-only         Fix any fixable lint violations, but don't report on leftover violations. Implies `--fix`
+      --format <FORMAT>  Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint]
+      --config <CONFIG>  Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
+      --add-noqa         Enable automatic additions of `noqa` directives to failing lines
+      --show-files       See the files Ruff will be run against with the current settings
+      --show-settings    See the settings Ruff will use to lint a given Python file
+  -h, --help             Print help
+  -V, --version          Print version
+
+Rule selection:
       --select <RULE_CODE>
           Comma-separated list of rule codes to enable (or ALL, to enable all rules)
-      --extend-select <RULE_CODE>
-          Like --select, but adds additional rule codes on top of the selected ones
       --ignore <RULE_CODE>
           Comma-separated list of rule codes to disable
+      --extend-select <RULE_CODE>
+          Like --select, but adds additional rule codes on top of the selected ones
       --extend-ignore <RULE_CODE>
           Like --ignore, but adds additional rule codes on top of the ignored ones
-      --exclude <FILE_PATTERN>
-          List of paths, used to omit files and/or directories from analysis
-      --extend-exclude <FILE_PATTERN>
-          Like --exclude, but adds additional files and directories on top of those already excluded
+      --per-file-ignores <PER_FILE_IGNORES>
+          List of mappings from file pattern to code to exclude
       --fixable <RULE_CODE>
           List of rule codes to treat as eligible for autofix. Only applicable when autofix itself is enabled (e.g., via `--fix`)
       --unfixable <RULE_CODE>
           List of rule codes to treat as ineligible for autofix. Only applicable when autofix itself is enabled (e.g., via `--fix`)
-      --per-file-ignores <PER_FILE_IGNORES>
-          List of mappings from file pattern to code to exclude
-      --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint]
-      --stdin-filename <STDIN_FILENAME>
-          The name of the file when passing it through stdin
-      --cache-dir <CACHE_DIR>
-          Path to the cache directory [env: RUFF_CACHE_DIR=]
-      --show-source
-          Show violations with source code
-      --respect-gitignore
-          Respect file exclusions via `.gitignore` and other standard ignore files
-      --force-exclude
-          Enforce exclusions, even for paths passed to Ruff directly on the command-line
-      --update-check
-          Enable or disable automatic update checks
-      --dummy-variable-rgx <DUMMY_VARIABLE_RGX>
-          Regular expression matching the name of dummy variables
+
+File selection:
+      --exclude <FILE_PATTERN>         List of paths, used to omit files and/or directories from analysis
+      --extend-exclude <FILE_PATTERN>  Like --exclude, but adds additional files and directories on top of those already excluded
+      --respect-gitignore              Respect file exclusions via `.gitignore` and other standard ignore files
+      --force-exclude                  Enforce exclusions, even for paths passed to Ruff directly on the command-line
+
+Rule configuration:
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported
       --line-length <LINE_LENGTH>
           Set the line-length for length-associated rules and automatic formatting
-      --add-noqa
-          Enable automatic additions of `noqa` directives to failing lines
-      --clean
-          Clear any caches in the current directory or any subdirectories
-      --explain <EXPLAIN>
-          Explain a rule
-      --show-files
-          See the files Ruff will be run against with the current settings
-      --show-settings
-          See the settings Ruff will use to lint a given Python file
-  -h, --help
-          Print help
-  -V, --version
-          Print version
+      --dummy-variable-rgx <DUMMY_VARIABLE_RGX>
+          Regular expression matching the name of dummy variables
+
+Miscellaneous:
+  -n, --no-cache
+          Disable cache reads
+      --isolated
+          Ignore all configuration files
+      --cache-dir <CACHE_DIR>
+          Path to the cache directory [env: RUFF_CACHE_DIR=]
+      --stdin-filename <STDIN_FILENAME>
+          The name of the file when passing it through stdin
+  -e, --exit-zero
+          Exit with status code "0", even upon detecting lint violations
+      --update-check
+          Enable or disable automatic update checks
+
+Subcommands:
+      --explain <EXPLAIN>  Explain a rule
+      --clean              Clear any caches in the current directory or any subdirectories
+
+Log levels:
+  -v, --verbose  Enable verbose logging
+  -q, --quiet    Print lint violations, but nothing else
+  -s, --silent   Disable all logging (but still exit with status code "1" upon detecting lint violations)
 ```
 <!-- End auto-generated cli help. -->
 

--- a/ruff_cli/src/args.rs
+++ b/ruff_cli/src/args.rs
@@ -22,113 +22,163 @@ use rustc_hash::FxHashMap;
 pub struct Args {
     #[arg(required_unless_present_any = ["clean", "explain", "generate_shell_completion"])]
     pub files: Vec<PathBuf>,
-    /// Path to the `pyproject.toml` or `ruff.toml` file to use for
-    /// configuration.
-    #[arg(long, conflicts_with = "isolated")]
-    pub config: Option<PathBuf>,
-    #[clap(flatten)]
-    pub log_level_args: LogLevelArgs,
-    /// Exit with status code "0", even upon detecting lint violations.
-    #[arg(short, long)]
-    pub exit_zero: bool,
-    /// Run in watch mode by re-running whenever files change.
-    #[arg(short, long)]
-    pub watch: bool,
     /// Attempt to automatically fix lint violations.
     #[arg(long, overrides_with("no_fix"))]
     fix: bool,
     #[clap(long, overrides_with("fix"), hide = true)]
     no_fix: bool,
+    /// Show violations with source code.
+    #[arg(long, overrides_with("no_show_source"))]
+    show_source: bool,
+    #[clap(long, overrides_with("show_source"), hide = true)]
+    no_show_source: bool,
+    /// Avoid writing any fixed files back; instead, output a diff for each
+    /// changed file to stdout.
+    #[arg(long)]
+    pub diff: bool,
+    /// Run in watch mode by re-running whenever files change.
+    #[arg(short, long)]
+    pub watch: bool,
     /// Fix any fixable lint violations, but don't report on leftover
     /// violations. Implies `--fix`.
     #[arg(long, overrides_with("no_fix_only"))]
     fix_only: bool,
     #[clap(long, overrides_with("fix_only"), hide = true)]
     no_fix_only: bool,
-    /// Avoid writing any fixed files back; instead, output a diff for each
-    /// changed file to stdout.
-    #[arg(long)]
-    pub diff: bool,
-    /// Disable cache reads.
-    #[arg(short, long)]
-    pub no_cache: bool,
-    /// Ignore all configuration files.
-    #[arg(long, conflicts_with = "config")]
-    pub isolated: bool,
-    /// Comma-separated list of rule codes to enable (or ALL, to enable all
-    /// rules).
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub select: Option<Vec<RuleSelector>>,
-    /// Like --select, but adds additional rule codes on top of the selected
-    /// ones.
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub extend_select: Option<Vec<RuleSelector>>,
-    /// Comma-separated list of rule codes to disable.
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub ignore: Option<Vec<RuleSelector>>,
-    /// Like --ignore, but adds additional rule codes on top of the ignored
-    /// ones.
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub extend_ignore: Option<Vec<RuleSelector>>,
-    /// List of paths, used to omit files and/or directories from analysis.
-    #[arg(long, value_delimiter = ',', value_name = "FILE_PATTERN")]
-    pub exclude: Option<Vec<FilePattern>>,
-    /// Like --exclude, but adds additional files and directories on top of
-    /// those already excluded.
-    #[arg(long, value_delimiter = ',', value_name = "FILE_PATTERN")]
-    pub extend_exclude: Option<Vec<FilePattern>>,
-    /// List of rule codes to treat as eligible for autofix. Only applicable
-    /// when autofix itself is enabled (e.g., via `--fix`).
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub fixable: Option<Vec<RuleSelector>>,
-    /// List of rule codes to treat as ineligible for autofix. Only applicable
-    /// when autofix itself is enabled (e.g., via `--fix`).
-    #[arg(long, value_delimiter = ',', value_name = "RULE_CODE")]
-    pub unfixable: Option<Vec<RuleSelector>>,
-    /// List of mappings from file pattern to code to exclude
-    #[arg(long, value_delimiter = ',')]
-    pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
     /// Output serialization format for violations.
     #[arg(long, value_enum, env = "RUFF_FORMAT")]
     pub format: Option<SerializationFormat>,
-    /// The name of the file when passing it through stdin.
-    #[arg(long)]
-    pub stdin_filename: Option<PathBuf>,
-    /// Path to the cache directory.
-    #[arg(long, env = "RUFF_CACHE_DIR")]
-    pub cache_dir: Option<PathBuf>,
-    /// Show violations with source code.
-    #[arg(long, overrides_with("no_show_source"))]
-    show_source: bool,
-    #[clap(long, overrides_with("show_source"), hide = true)]
-    no_show_source: bool,
+    /// Path to the `pyproject.toml` or `ruff.toml` file to use for
+    /// configuration.
+    #[arg(long, conflicts_with = "isolated")]
+    pub config: Option<PathBuf>,
+    /// Comma-separated list of rule codes to enable (or ALL, to enable all
+    /// rules).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub select: Option<Vec<RuleSelector>>,
+    /// Comma-separated list of rule codes to disable.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub ignore: Option<Vec<RuleSelector>>,
+    /// Like --select, but adds additional rule codes on top of the selected
+    /// ones.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub extend_select: Option<Vec<RuleSelector>>,
+    /// Like --ignore, but adds additional rule codes on top of the ignored
+    /// ones.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub extend_ignore: Option<Vec<RuleSelector>>,
+    /// List of mappings from file pattern to code to exclude
+    #[arg(long, value_delimiter = ',', help_heading = "Rule selection")]
+    pub per_file_ignores: Option<Vec<PatternPrefixPair>>,
+    /// List of paths, used to omit files and/or directories from analysis.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub exclude: Option<Vec<FilePattern>>,
+    /// Like --exclude, but adds additional files and directories on top of
+    /// those already excluded.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub extend_exclude: Option<Vec<FilePattern>>,
+    /// List of rule codes to treat as eligible for autofix. Only applicable
+    /// when autofix itself is enabled (e.g., via `--fix`).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub fixable: Option<Vec<RuleSelector>>,
+    /// List of rule codes to treat as ineligible for autofix. Only applicable
+    /// when autofix itself is enabled (e.g., via `--fix`).
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "RULE_CODE",
+        help_heading = "Rule selection"
+    )]
+    pub unfixable: Option<Vec<RuleSelector>>,
     /// Respect file exclusions via `.gitignore` and other standard ignore
     /// files.
-    #[arg(long, overrides_with("no_respect_gitignore"))]
+    #[arg(
+        long,
+        overrides_with("no_respect_gitignore"),
+        help_heading = "File selection"
+    )]
     respect_gitignore: bool,
     #[clap(long, overrides_with("respect_gitignore"), hide = true)]
     no_respect_gitignore: bool,
     /// Enforce exclusions, even for paths passed to Ruff directly on the
     /// command-line.
-    #[arg(long, overrides_with("no_force_exclude"))]
+    #[arg(
+        long,
+        overrides_with("no_force_exclude"),
+        help_heading = "File selection"
+    )]
     force_exclude: bool,
     #[clap(long, overrides_with("force_exclude"), hide = true)]
     no_force_exclude: bool,
-    /// Enable or disable automatic update checks.
-    #[arg(long, overrides_with("no_update_check"))]
-    update_check: bool,
-    #[clap(long, overrides_with("update_check"), hide = true)]
-    no_update_check: bool,
-    /// Regular expression matching the name of dummy variables.
-    #[arg(long)]
-    pub dummy_variable_rgx: Option<Regex>,
     /// The minimum Python version that should be supported.
-    #[arg(long)]
+    #[arg(long, help_heading = "Rule configuration")]
     pub target_version: Option<PythonVersion>,
     /// Set the line-length for length-associated rules and automatic
     /// formatting.
-    #[arg(long)]
+    #[arg(long, help_heading = "Rule configuration")]
     pub line_length: Option<usize>,
+    /// Regular expression matching the name of dummy variables.
+    #[arg(long, help_heading = "Rule configuration")]
+    pub dummy_variable_rgx: Option<Regex>,
+    /// Disable cache reads.
+    #[arg(short, long, help_heading = "Miscellaneous")]
+    pub no_cache: bool,
+    /// Ignore all configuration files.
+    #[arg(long, conflicts_with = "config", help_heading = "Miscellaneous")]
+    pub isolated: bool,
+    /// Path to the cache directory.
+    #[arg(long, env = "RUFF_CACHE_DIR", help_heading = "Miscellaneous")]
+    pub cache_dir: Option<PathBuf>,
+    /// The name of the file when passing it through stdin.
+    #[arg(long, help_heading = "Miscellaneous")]
+    pub stdin_filename: Option<PathBuf>,
+    /// Exit with status code "0", even upon detecting lint violations.
+    #[arg(short, long, help_heading = "Miscellaneous")]
+    pub exit_zero: bool,
+    /// Enable or disable automatic update checks.
+    #[arg(
+        long,
+        overrides_with("no_update_check"),
+        help_heading = "Miscellaneous"
+    )]
+    update_check: bool,
+    #[clap(long, overrides_with("update_check"), hide = true)]
+    no_update_check: bool,
     /// Enable automatic additions of `noqa` directives to failing lines.
     #[arg(
         long,
@@ -143,25 +193,11 @@ pub struct Args {
         conflicts_with = "watch",
     )]
     pub add_noqa: bool,
-    /// Clear any caches in the current directory or any subdirectories.
-    #[arg(
-        long,
-        // Fake subcommands.
-        conflicts_with = "add_noqa",
-        // conflicts_with = "clean",
-        conflicts_with = "explain",
-        conflicts_with = "generate_shell_completion",
-        conflicts_with = "show_files",
-        conflicts_with = "show_settings",
-        // Unsupported default-command arguments.
-        conflicts_with = "stdin_filename",
-        conflicts_with = "watch",
-    )]
-    pub clean: bool,
     /// Explain a rule.
     #[arg(
         long,
         value_parser=Rule::from_code,
+        help_heading="Subcommands",
         // Fake subcommands.
         conflicts_with = "add_noqa",
         conflicts_with = "clean",
@@ -174,6 +210,22 @@ pub struct Args {
         conflicts_with = "watch",
     )]
     pub explain: Option<&'static Rule>,
+    /// Clear any caches in the current directory or any subdirectories.
+    #[arg(
+        long,
+        help_heading="Subcommands",
+        // Fake subcommands.
+        conflicts_with = "add_noqa",
+        // conflicts_with = "clean",
+        conflicts_with = "explain",
+        conflicts_with = "generate_shell_completion",
+        conflicts_with = "show_files",
+        conflicts_with = "show_settings",
+        // Unsupported default-command arguments.
+        conflicts_with = "stdin_filename",
+        conflicts_with = "watch",
+    )]
+    pub clean: bool,
     /// Generate shell completion
     #[arg(
         long,
@@ -221,20 +273,22 @@ pub struct Args {
         conflicts_with = "watch",
     )]
     pub show_settings: bool,
+    #[clap(flatten)]
+    pub log_level_args: LogLevelArgs,
 }
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, clap::Args)]
 pub struct LogLevelArgs {
     /// Enable verbose logging.
-    #[arg(short, long, group = "verbosity")]
+    #[arg(short, long, group = "verbosity", help_heading = "Log levels")]
     pub verbose: bool,
     /// Print lint violations, but nothing else.
-    #[arg(short, long, group = "verbosity")]
+    #[arg(short, long, group = "verbosity", help_heading = "Log levels")]
     pub quiet: bool,
     /// Disable all logging (but still exit with status code "1" upon detecting
     /// lint violations).
-    #[arg(short, long, group = "verbosity")]
+    #[arg(short, long, group = "verbosity", help_heading = "Log levels")]
     pub silent: bool,
 }
 

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -49,9 +49,6 @@ pub fn run(
         return Ok(Diagnostics::default());
     }
 
-    // Validate the `Settings` and return any errors.
-    resolver.validate(pyproject_strategy)?;
-
     // Initialize the cache.
     if matches!(cache, flags::Cache::Enabled) {
         match &pyproject_strategy {
@@ -197,9 +194,6 @@ pub fn add_noqa(
         return Ok(0);
     }
 
-    // Validate the `Settings` and return any errors.
-    resolver.validate(pyproject_strategy)?;
-
     let start = Instant::now();
     let modifications: usize = par_iter(&paths)
         .flatten()
@@ -233,9 +227,6 @@ pub fn show_settings(
     let (paths, resolver) =
         resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
 
-    // Validate the `Settings` and return any errors.
-    resolver.validate(pyproject_strategy)?;
-
     // Print the list of files.
     let Some(entry) = paths
         .iter()
@@ -259,16 +250,13 @@ pub fn show_files(
     overrides: &Overrides,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
-    let (paths, resolver) =
+    let (paths, _resolver) =
         resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
 
     if paths.is_empty() {
         warn_user_once!("No Python files found under the given path(s)");
         return Ok(());
     }
-
-    // Validate the `Settings` and return any errors.
-    resolver.validate(pyproject_strategy)?;
 
     // Print the list of files.
     for entry in paths

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -16,7 +16,7 @@ use ruff::linter::add_noqa_to_path;
 use ruff::logging::LogLevel;
 use ruff::message::{Location, Message};
 use ruff::registry::{Linter, Rule, RuleNamespace};
-use ruff::resolver::{FileDiscovery, PyprojectDiscovery};
+use ruff::resolver::PyprojectDiscovery;
 use ruff::settings::flags;
 use ruff::settings::types::SerializationFormat;
 use ruff::{fix, fs, packaging, resolver, warn_user_once, AutofixAvailability, IOError};
@@ -32,15 +32,13 @@ use crate::iterators::par_iter;
 pub fn run(
     files: &[PathBuf],
     pyproject_strategy: &PyprojectDiscovery,
-    file_strategy: &FileDiscovery,
     overrides: &Overrides,
     cache: flags::Cache,
     autofix: fix::FixMode,
 ) -> Result<Diagnostics> {
     // Collect all the Python files to check.
     let start = Instant::now();
-    let (paths, resolver) =
-        resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
+    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
     let duration = start.elapsed();
     debug!("Identified files to lint in: {:?}", duration);
 
@@ -153,12 +151,11 @@ fn read_from_stdin() -> Result<String> {
 pub fn run_stdin(
     filename: Option<&Path>,
     pyproject_strategy: &PyprojectDiscovery,
-    file_strategy: &FileDiscovery,
     overrides: &Overrides,
     autofix: fix::FixMode,
 ) -> Result<Diagnostics> {
     if let Some(filename) = filename {
-        if !resolver::python_file_at_path(filename, pyproject_strategy, file_strategy, overrides)? {
+        if !resolver::python_file_at_path(filename, pyproject_strategy, overrides)? {
             return Ok(Diagnostics::default());
         }
     }
@@ -179,13 +176,11 @@ pub fn run_stdin(
 pub fn add_noqa(
     files: &[PathBuf],
     pyproject_strategy: &PyprojectDiscovery,
-    file_strategy: &FileDiscovery,
     overrides: &Overrides,
 ) -> Result<usize> {
     // Collect all the files to check.
     let start = Instant::now();
-    let (paths, resolver) =
-        resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
+    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
     let duration = start.elapsed();
     debug!("Identified files to lint in: {:?}", duration);
 
@@ -220,12 +215,10 @@ pub fn add_noqa(
 pub fn show_settings(
     files: &[PathBuf],
     pyproject_strategy: &PyprojectDiscovery,
-    file_strategy: &FileDiscovery,
     overrides: &Overrides,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
-    let (paths, resolver) =
-        resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
+    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
 
     // Print the list of files.
     let Some(entry) = paths
@@ -246,12 +239,10 @@ pub fn show_settings(
 pub fn show_files(
     files: &[PathBuf],
     pyproject_strategy: &PyprojectDiscovery,
-    file_strategy: &FileDiscovery,
     overrides: &Overrides,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
-    let (paths, _resolver) =
-        resolver::python_files_in_path(files, pyproject_strategy, file_strategy, overrides)?;
+    let (paths, _resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
 
     if paths.is_empty() {
         warn_user_once!("No Python files found under the given path(s)");

--- a/ruff_cli/src/diagnostics.rs
+++ b/ruff_cli/src/diagnostics.rs
@@ -42,9 +42,6 @@ pub fn lint_path(
     cache: flags::Cache,
     autofix: fix::FixMode,
 ) -> Result<Diagnostics> {
-    // Validate the `Settings` and return any errors.
-    settings.lib.validate()?;
-
     // Check the cache.
     // TODO(charlie): `fixer::Mode::Apply` and `fixer::Mode::Diff` both have
     // side-effects that aren't captured in the cache. (In practice, it's fine
@@ -116,9 +113,6 @@ pub fn lint_stdin(
     settings: &Settings,
     autofix: fix::FixMode,
 ) -> Result<Diagnostics> {
-    // Validate the `Settings` and return any errors.
-    settings.validate()?;
-
     // Lint the inputs.
     let (messages, fixed) = if matches!(autofix, fix::FixMode::Apply | fix::FixMode::Diff) {
         let (transformed, fixed, messages) = lint_fix(

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -36,7 +36,7 @@ pub mod updates;
 
 fn inner_main() -> Result<ExitCode> {
     // Extract command-line arguments.
-    let (cli, overrides) = Args::parse().partition();
+    let args = Args::parse();
 
     let default_panic_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -52,6 +52,8 @@ quoting the executed command, along with the relevant file contents and `pyproje
         );
         default_panic_hook(info);
     }));
+
+    let (cli, overrides) = args.partition();
 
     let log_level = extract_log_level(&cli);
     set_up_logging(&log_level)?;

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -17,7 +17,7 @@ use ::ruff::resolver::{FileDiscovery, PyprojectDiscovery};
 use ::ruff::settings::types::SerializationFormat;
 use ::ruff::{fix, fs, warn_user_once};
 use anyhow::Result;
-use args::{extract_log_level, Args};
+use args::Args;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
@@ -53,10 +53,10 @@ quoting the executed command, along with the relevant file contents and `pyproje
         default_panic_hook(info);
     }));
 
-    let (cli, overrides) = args.partition();
-
-    let log_level = extract_log_level(&cli);
+    let log_level: LogLevel = (&args.log_level_args).into();
     set_up_logging(&log_level)?;
+
+    let (cli, overrides) = args.partition();
 
     if let Some(shell) = cli.generate_shell_completion {
         shell.generate(&mut Args::command(), &mut io::stdout());

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -13,7 +13,7 @@ use std::process::ExitCode;
 use std::sync::mpsc::channel;
 
 use ::ruff::logging::{set_up_logging, LogLevel};
-use ::ruff::resolver::{FileDiscovery, PyprojectDiscovery};
+use ::ruff::resolver::PyprojectDiscovery;
 use ::ruff::settings::types::SerializationFormat;
 use ::ruff::{fix, fs, warn_user_once};
 use anyhow::Result;
@@ -78,16 +78,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
 
     // Extract options that are included in `Settings`, but only apply at the top
     // level.
-    let file_strategy = FileDiscovery {
-        force_exclude: match &pyproject_strategy {
-            PyprojectDiscovery::Fixed(settings) => settings.lib.force_exclude,
-            PyprojectDiscovery::Hierarchical(settings) => settings.lib.force_exclude,
-        },
-        respect_gitignore: match &pyproject_strategy {
-            PyprojectDiscovery::Fixed(settings) => settings.lib.respect_gitignore,
-            PyprojectDiscovery::Hierarchical(settings) => settings.lib.respect_gitignore,
-        },
-    };
     let CliSettings {
         fix,
         fix_only,
@@ -104,11 +94,11 @@ quoting the executed command, along with the relevant file contents and `pyproje
         return Ok(ExitCode::SUCCESS);
     }
     if cli.show_settings {
-        commands::show_settings(&cli.files, &pyproject_strategy, &file_strategy, &overrides)?;
+        commands::show_settings(&cli.files, &pyproject_strategy, &overrides)?;
         return Ok(ExitCode::SUCCESS);
     }
     if cli.show_files {
-        commands::show_files(&cli.files, &pyproject_strategy, &file_strategy, &overrides)?;
+        commands::show_files(&cli.files, &pyproject_strategy, &overrides)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -161,7 +151,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
         let messages = commands::run(
             &cli.files,
             &pyproject_strategy,
-            &file_strategy,
             &overrides,
             cache.into(),
             fix::FixMode::None,
@@ -191,7 +180,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
                         let messages = commands::run(
                             &cli.files,
                             &pyproject_strategy,
-                            &file_strategy,
                             &overrides,
                             cache.into(),
                             fix::FixMode::None,
@@ -203,8 +191,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
             }
         }
     } else if cli.add_noqa {
-        let modifications =
-            commands::add_noqa(&cli.files, &pyproject_strategy, &file_strategy, &overrides)?;
+        let modifications = commands::add_noqa(&cli.files, &pyproject_strategy, &overrides)?;
         if modifications > 0 && log_level >= LogLevel::Default {
             println!("Added {modifications} noqa directives.");
         }
@@ -216,7 +203,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
             commands::run_stdin(
                 cli.stdin_filename.map(fs::normalize_path).as_deref(),
                 &pyproject_strategy,
-                &file_strategy,
                 &overrides,
                 autofix,
             )?
@@ -224,7 +210,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
             commands::run(
                 &cli.files,
                 &pyproject_strategy,
-                &file_strategy,
                 &overrides,
                 cache.into(),
                 autofix,

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -76,12 +76,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
         cli.stdin_filename.as_deref(),
     )?;
 
-    // Validate the `Settings` and return any errors.
-    match &pyproject_strategy {
-        PyprojectDiscovery::Fixed(settings) => settings.lib.validate()?,
-        PyprojectDiscovery::Hierarchical(settings) => settings.lib.validate()?,
-    };
-
     // Extract options that are included in `Settings`, but only apply at the top
     // level.
     let file_strategy = FileDiscovery {

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -136,7 +136,13 @@ quoting the executed command, along with the relevant file contents and `pyproje
     }
 
     let printer = Printer::new(&format, &log_level, &autofix, &violations);
-    if cli.watch {
+
+    if cli.add_noqa {
+        let modifications = commands::add_noqa(&cli.files, &pyproject_strategy, &overrides)?;
+        if modifications > 0 && log_level >= LogLevel::Default {
+            println!("Added {modifications} noqa directives.");
+        }
+    } else if cli.watch {
         if !matches!(autofix, fix::FixMode::None) {
             warn_user_once!("--fix is not enabled in watch mode.");
         }
@@ -189,11 +195,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
                 }
                 Err(err) => return Err(err.into()),
             }
-        }
-    } else if cli.add_noqa {
-        let modifications = commands::add_noqa(&cli.files, &pyproject_strategy, &overrides)?;
-        if modifications > 0 && log_level >= LogLevel::Default {
-            println!("Added {modifications} noqa directives.");
         }
     } else {
         let is_stdin = cli.files == vec![PathBuf::from("-")];

--- a/src/lib_native.rs
+++ b/src/lib_native.rs
@@ -32,9 +32,6 @@ pub fn check(path: &Path, contents: &str, autofix: bool) -> Result<Vec<Diagnosti
     // Load the relevant `Settings` for the given `Path`.
     let settings = resolve(path)?;
 
-    // Validate the `Settings` and return any errors.
-    settings.validate()?;
-
     // Tokenize once.
     let tokens: Vec<LexResult> = tokenize(contents);
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -42,9 +42,6 @@ pub fn check_path(
     autofix: flags::Autofix,
     noqa: flags::Noqa,
 ) -> Result<Vec<Diagnostic>> {
-    // Validate the `Settings` and return any errors.
-    settings.validate()?;
-
     // Aggregate all diagnostics.
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
@@ -187,9 +184,6 @@ const MAX_ITERATIONS: usize = 100;
 
 /// Add any missing `#noqa` pragmas to the source code at the given `Path`.
 pub fn add_noqa_to_path(path: &Path, settings: &Settings) -> Result<usize> {
-    // Validate the `Settings` and return any errors.
-    settings.validate()?;
-
     // Read the file from disk.
     let contents = fs::read_file(path)?;
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -98,26 +98,6 @@ impl Resolver {
     pub fn iter(&self) -> impl Iterator<Item = &AllSettings> {
         self.settings.values()
     }
-
-    /// Validate all resolved `Settings` in this `Resolver`.
-    pub fn validate(&self, strategy: &PyprojectDiscovery) -> Result<()> {
-        // TODO(charlie): This risks false positives (but not false negatives), since
-        // some of the `Settings` in the path may ultimately be unused (or, e.g., they
-        // could have their `required_version` overridden by other `Settings` in
-        // the path). It'd be preferable to validate once we've determined the
-        // `Settings` for each path, but that's more expensive.
-        match &strategy {
-            PyprojectDiscovery::Fixed(settings) => {
-                settings.lib.validate()?;
-            }
-            PyprojectDiscovery::Hierarchical(default) => {
-                for settings in std::iter::once(default).chain(self.iter()) {
-                    settings.lib.validate()?;
-                }
-            }
-        }
-        Ok(())
-    }
 }
 
 pub trait ConfigProcessor: Copy + Send + Sync {

--- a/src/settings/defaults.rs
+++ b/src/settings/defaults.rs
@@ -68,7 +68,6 @@ impl Default for Settings {
             line_length: LINE_LENGTH,
             namespace_packages: vec![],
             per_file_ignores: vec![],
-            required_version: None,
             respect_gitignore: true,
             show_source: false,
             src: vec![path_dedot::CWD.clone()],


### PR DESCRIPTION
This is the followup PR for #2145.

New `ruff --help` output:

```
Ruff: An extremely fast Python linter.

Usage: ruff [OPTIONS] [FILES]...

Arguments:
  [FILES]...  

Options:
      --fix              Attempt to automatically fix lint violations
      --show-source      Show violations with source code
      --diff             Avoid writing any fixed files back; instead, output a diff for each changed file to stdout
  -w, --watch            Run in watch mode by re-running whenever files change
      --fix-only         Fix any fixable lint violations, but don't report on leftover violations. Implies `--fix`
      --format <FORMAT>  Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint]
      --config <CONFIG>  Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
      --add-noqa         Enable automatic additions of `noqa` directives to failing lines
      --show-files       See the files Ruff will be run against with the current settings
      --show-settings    See the settings Ruff will use to lint a given Python file
  -h, --help             Print help
  -V, --version          Print version

Rule selection:
      --select <RULE_CODE>
          Comma-separated list of rule codes to enable (or ALL, to enable all rules)
      --ignore <RULE_CODE>
          Comma-separated list of rule codes to disable
      --extend-select <RULE_CODE>
          Like --select, but adds additional rule codes on top of the selected ones
      --extend-ignore <RULE_CODE>
          Like --ignore, but adds additional rule codes on top of the ignored ones
      --per-file-ignores <PER_FILE_IGNORES>
          List of mappings from file pattern to code to exclude
      --fixable <RULE_CODE>
          List of rule codes to treat as eligible for autofix. Only applicable when autofix itself is enabled (e.g., via `--fix`)
      --unfixable <RULE_CODE>
          List of rule codes to treat as ineligible for autofix. Only applicable when autofix itself is enabled (e.g., via `--fix`)

File selection:
      --exclude <FILE_PATTERN>         List of paths, used to omit files and/or directories from analysis
      --extend-exclude <FILE_PATTERN>  Like --exclude, but adds additional files and directories on top of those already excluded
      --respect-gitignore              Respect file exclusions via `.gitignore` and other standard ignore files
      --force-exclude                  Enforce exclusions, even for paths passed to Ruff directly on the command-line

Rule configuration:
      --target-version <TARGET_VERSION>
          The minimum Python version that should be supported
      --line-length <LINE_LENGTH>
          Set the line-length for length-associated rules and automatic formatting
      --dummy-variable-rgx <DUMMY_VARIABLE_RGX>
          Regular expression matching the name of dummy variables

Miscellaneous:
  -n, --no-cache
          Disable cache reads
      --isolated
          Ignore all configuration files
      --cache-dir <CACHE_DIR>
          Path to the cache directory [env: RUFF_CACHE_DIR=]
      --stdin-filename <STDIN_FILENAME>
          The name of the file when passing it through stdin
  -e, --exit-zero
          Exit with status code "0", even upon detecting lint violations
      --update-check
          Enable or disable automatic update checks

Subcommands:
      --explain <EXPLAIN>  Explain a rule
      --clean              Clear any caches in the current directory or any subdirectories

Log levels:
  -v, --verbose  Enable verbose logging
  -q, --quiet    Print lint violations, but nothing else
  -s, --silent   Disable all logging (but still exit with status code "1" upon detecting lint violations)
```