### PR TITLE
Fix singular and plural for "error(s)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Check spelling of file.txt
       uses: crate-ci/typos@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/flake8-to-ruff.yaml
+++ b/.github/workflows/flake8-to-ruff.yaml
@@ -12,6 +12,7 @@ env:
   PYTHON_VERSION: "3.7" # to build abi3 wheels
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/flake8-to-ruff.yaml
+++ b/.github/workflows/flake8-to-ruff.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           pip install dist/${{ env.CRATE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -64,7 +64,7 @@ jobs:
         run: |
           pip install dist/${{ env.CRATE_NAME }}-*universal2.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -96,7 +96,7 @@ jobs:
         run: |
           python -m pip install dist/${{ env.CRATE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -123,7 +123,7 @@ jobs:
         run: |
           pip install dist/${{ env.CRATE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -144,7 +144,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           args: --no-default-features --release --out dist -m ./${{ env.CRATE_NAME }}/Cargo.toml
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.5.0
         if: matrix.target != 'ppc64'
         name: Install built wheel
         with:
@@ -158,7 +158,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -192,7 +192,7 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -228,7 +228,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -262,7 +262,7 @@ jobs:
         run: |
           pip install dist/${{ env.CRATE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -280,7 +280,7 @@ jobs:
       - musllinux-cross
       - pypy
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
       - uses: actions/setup-python@v4

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -8,6 +8,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -13,6 +13,7 @@ env:
   PYTHON_VERSION: "3.7" # to build abi3 wheels
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -39,7 +39,7 @@ jobs:
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -65,7 +65,7 @@ jobs:
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -124,7 +124,7 @@ jobs:
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -145,7 +145,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           args: --no-default-features --release --out dist
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.5.0
         if: matrix.target != 'ppc64'
         name: Install built wheel
         with:
@@ -159,7 +159,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -193,7 +193,7 @@ jobs:
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -229,7 +229,7 @@ jobs:
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -263,7 +263,7 @@ jobs:
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
       - name: Upload wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist
@@ -282,7 +282,7 @@ jobs:
       - pypy
     if: "startsWith(github.ref, 'refs/tags/')"
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: wheels
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -1696,7 +1696,7 @@ After installing `ruff` and `nbqa`, you can run Ruff over a notebook like so:
 Untitled.ipynb:cell_1:2:5: F841 Local variable `x` is assigned to but never used
 Untitled.ipynb:cell_2:1:1: E402 Module level import not at top of file
 Untitled.ipynb:cell_2:1:8: F401 `os` imported but unused
-Found 3 error(s).
+Found 3 errors.
 1 potentially fixable with the --fix option.
 ```
 

--- a/resources/test/project/README.md
+++ b/resources/test/project/README.md
@@ -16,7 +16,7 @@ resources/test/project/examples/docs/docs/file.py:1:1: I001 Import block is un-s
 resources/test/project/examples/docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 resources/test/project/project/file.py:1:8: F401 `os` imported but unused
 resources/test/project/project/import_file.py:1:1: I001 Import block is un-sorted or un-formatted
-Found 7 error(s).
+Found 7 errors.
 7 potentially fixable with the --fix option.
 ```
 
@@ -31,7 +31,7 @@ examples/docs/docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 examples/docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 project/file.py:1:8: F401 `os` imported but unused
 project/import_file.py:1:1: I001 Import block is un-sorted or un-formatted
-Found 7 error(s).
+Found 7 errors.
 7 potentially fixable with the --fix option.
 ```
 
@@ -42,7 +42,7 @@ files:
 ∴ (cd resources/test/project/examples/docs && cargo run .)
 docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
-Found 2 error(s).
+Found 2 errors.
 2 potentially fixable with the --fix option.
 ```
 
@@ -60,7 +60,7 @@ resources/test/project/examples/docs/docs/file.py:3:8: F401 `numpy` imported but
 resources/test/project/examples/docs/docs/file.py:4:27: F401 `docs.concepts.file` imported but unused
 resources/test/project/examples/excluded/script.py:1:8: F401 `os` imported but unused
 resources/test/project/project/file.py:1:8: F401 `os` imported but unused
-Found 9 error(s).
+Found 9 errors.
 9 potentially fixable with the --fix option.
 ```
 
@@ -73,7 +73,7 @@ docs/docs/concepts/file.py:5:5: F841 Local variable `x` is assigned to but never
 docs/docs/file.py:1:1: I001 Import block is un-sorted or un-formatted
 docs/docs/file.py:8:5: F841 Local variable `x` is assigned to but never used
 excluded/script.py:5:5: F841 Local variable `x` is assigned to but never used
-Found 4 error(s).
+Found 4 errors.
 4 potentially fixable with the --fix option.
 ```
 
@@ -82,7 +82,7 @@ Passing an excluded directory directly should report errors in the contained fil
 ```
 ∴ cargo run resources/test/project/examples/excluded/
 resources/test/project/examples/excluded/script.py:1:8: F401 `os` imported but unused
-Found 1 error(s).
+Found 1 error.
 1 potentially fixable with the --fix option.
 ```
 

--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -96,12 +96,14 @@ impl<'a> Printer<'a> {
                     let remaining = diagnostics.messages.len();
                     let total = fixed + remaining;
                     if fixed > 0 {
+                        let s = if total == 1 { "" } else { "s" };
                         writeln!(
                             stdout,
-                            "Found {total} error(s) ({fixed} fixed, {remaining} remaining)."
+                            "Found {total} error{s}) ({fixed} fixed, {remaining} remaining)."
                         )?;
                     } else if remaining > 0 {
-                        writeln!(stdout, "Found {remaining} error(s).")?;
+                        let s = if remaining == 1 { "" } else { "s" };
+                        writeln!(stdout, "Found {remaining} error{s}.")?;
                     }
 
                     if !matches!(self.autofix, fix::FixMode::Apply) {
@@ -121,10 +123,11 @@ impl<'a> Printer<'a> {
                 Violations::Hide => {
                     let fixed = diagnostics.fixed;
                     if fixed > 0 {
+                        let s = if fixed == 1 { "" } else { "s" };
                         if matches!(self.autofix, fix::FixMode::Apply) {
-                            writeln!(stdout, "Fixed {fixed} error(s).")?;
+                            writeln!(stdout, "Fixed {fixed} error{s}.")?;
                         } else if matches!(self.autofix, fix::FixMode::Diff) {
-                            writeln!(stdout, "Would fix {fixed} error(s).")?;
+                            writeln!(stdout, "Would fix {fixed} error{s}.")?;
                         }
                     }
                 }
@@ -339,8 +342,13 @@ impl<'a> Printer<'a> {
         }
 
         if self.log_level >= &LogLevel::Default {
+            let s = if diagnostics.messages.len() == 1 {
+                ""
+            } else {
+                "s"
+            };
             notify_user!(
-                "Found {} error(s). Watching for file changes.",
+                "Found {} error{s}. Watching for file changes.",
                 diagnostics.messages.len()
             );
         }

--- a/ruff_cli/tests/integration_test.rs
+++ b/ruff_cli/tests/integration_test.rs
@@ -28,7 +28,7 @@ fn test_stdin_error() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        "-:1:8: F401 `os` imported but unused\nFound 1 error(s).\n1 potentially fixable with the \
+        "-:1:8: F401 `os` imported but unused\nFound 1 error.\n1 potentially fixable with the \
          --fix option.\n"
     );
     Ok(())
@@ -44,8 +44,8 @@ fn test_stdin_filename() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        "F401.py:1:8: F401 `os` imported but unused\nFound 1 error(s).\n1 potentially fixable \
-         with the --fix option.\n"
+        "F401.py:1:8: F401 `os` imported but unused\nFound 1 error.\n1 potentially fixable with \
+         the --fix option.\n"
     );
     Ok(())
 }


### PR DESCRIPTION
Computers are really bad at some things, but one thing they're really good at is counting :)

So let's replace:

```console
$ ruff 1.py
1.py:1:89: E501 Line too long (115 > 88 characters)
Found 1 error(s).
$ ruff 2.py
2.py:1:89: E501 Line too long (115 > 88 characters)
2.py:2:89: E501 Line too long (115 > 88 characters)
Found 2 error(s).
```

With:

```console
$ target/debug/ruff 1.py
warning: debug build without --no-cache.
1.py:1:89: E501 Line too long (115 > 88 characters)
Found 1 error.
$ target/debug/ruff 2.py
warning: debug build without --no-cache.
2.py:1:89: E501 Line too long (115 > 88 characters)
2.py:2:89: E501 Line too long (115 > 88 characters)
Found 2 errors.
```

---

Also some CI updates: 

* Let contributors test feature branches, so we can properly test our code on the CI _before_ opening PRs
* Bump GitHub Actions
* Enable colour on the CI logs for readability, because GitHub Actions isn't a tty: https://github.com/actions/runner/issues/241. Compare:
  * https://github.com/charliermarsh/ruff/actions/runs/4003221441/jobs/6871125904
  * https://github.com/hugovk/ruff/actions/runs/4007012752/jobs/6879284777
