### PR TITLE
Suggest input format in error case

### DIFF
--- a/src/settings/types.rs
+++ b/src/settings/types.rs
@@ -44,7 +44,7 @@ impl FromStr for PythonVersion {
             "py39" => Ok(PythonVersion::Py39),
             "py310" => Ok(PythonVersion::Py310),
             "py311" => Ok(PythonVersion::Py311),
-            _ => Err(anyhow!("Unknown version: {string}")),
+            _ => Err(anyhow!("Unknown version: {string}, try \"py37\"")),
         }
     }
 }

--- a/src/settings/types.rs
+++ b/src/settings/types.rs
@@ -44,7 +44,7 @@ impl FromStr for PythonVersion {
             "py39" => Ok(PythonVersion::Py39),
             "py310" => Ok(PythonVersion::Py310),
             "py311" => Ok(PythonVersion::Py311),
-            _ => Err(anyhow!("Unknown version: {string}, try \"py37\"")),
+            _ => Err(anyhow!("Unknown version: {string} (try: \"py37\")")),
         }
     }
 }


### PR DESCRIPTION
`ruff --target-version 3.7` tells now:
`error: Invalid value '3.7' for '--target-version <TARGET_VERSION>': Unknown version: 3.7, try "py37"`