### PR TITLE
flake8_executable: Only match shebang at beginning of line

### DIFF
--- a/src/rules/flake8_executable/helpers.rs
+++ b/src/rules/flake8_executable/helpers.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 static SHEBANG_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?P<spaces>\s*)#!(?P<directive>.*)").unwrap());
+    Lazy::new(|| Regex::new(r"^(?P<spaces>\s*)#!(?P<directive>.*)").unwrap());
 
 #[derive(Debug)]
 pub enum ShebangDirective<'a> {
@@ -67,7 +67,7 @@ mod tests {
         ));
         assert!(matches!(
             extract_shebang("print('test')  #!/usr/bin/python"),
-            ShebangDirective::Match(2, 17, 32, "/usr/bin/python")
+            ShebangDirective::None
         ));
     }
 }

--- a/src/rules/flake8_executable/snapshots/ruff__rules__flake8_executable__tests__EXE004_3.py.snap
+++ b/src/rules/flake8_executable/snapshots/ruff__rules__flake8_executable__tests__EXE004_3.py.snap
@@ -2,5 +2,14 @@
 source: src/rules/flake8_executable/mod.rs
 expression: diagnostics
 ---
-[]
+- kind:
+    ShebangMissingExecutableFile: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 1
+    column: 0
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
The Python implementation [uses `re.match`](https://github.com/xuhdev/flake8-executable/blob/v2.1.3/flake8_executable/__init__.py#L124) for this, which only matches at the beginning of a line.

We could use `Regex::captures_read_at`, but that’s a more complicated API; it’s easier to anchor the regex with `^`.

(Cc @sbrugman)