### PR TITLE
Fix typo in src option docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2442,7 +2442,7 @@ my_package/
       bar.py
 ```
 
-The `src` directory should be included in `source` (e.g., `source =
+The `src` directory should be included in the `src` option (e.g., `src =
 ["src"]`), such that when resolving imports, `my_package.foo` is
 considered a first-party import.
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -421,7 +421,7 @@
       ]
     },
     "src": {
-      "description": "The source code paths to consider, e.g., when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_package/ pyproject.toml src/ my_package/ __init__.py foo.py bar.py ```\n\nThe `src` directory should be included in `source` (e.g., `source = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
+      "description": "The source code paths to consider, e.g., when resolving first- vs. third-party imports.\n\nAs an example: given a Python package structure like:\n\n```text my_package/ pyproject.toml src/ my_package/ __init__.py foo.py bar.py ```\n\nThe `src` directory should be included in the `src` option (e.g., `src = [\"src\"]`), such that when resolving imports, `my_package.foo` is considered a first-party import.\n\nThis field supports globs. For example, if you have a series of Python packages in a `python_modules` directory, `src = [\"python_modules/*\"]` would expand to incorporate all of the packages in that directory. User home directory and environment variables will also be expanded.",
       "type": [
         "array",
         "null"

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -342,7 +342,7 @@ pub struct Options {
     ///       bar.py
     /// ```
     ///
-    /// The `src` directory should be included in `source` (e.g., `source =
+    /// The `src` directory should be included in the `src` option (e.g., `src =
     /// ["src"]`), such that when resolving imports, `my_package.foo` is
     /// considered a first-party import.
     ///


### PR DESCRIPTION
As far as I can tell, `source` is not a valid option, so this is probably a typo. This PR fixes it