### PR TITLE
docs(readme): add featuretools

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Ruff is extremely actively developed and used in major open-source projects like
 - [cibuildwheel (PyPA)](https://github.com/pypa/cibuildwheel)
 - [build (PyPA)](https://github.com/pypa/build)
 - [Babel](https://github.com/python-babel/babel)
+- [featuretools](https://github.com/alteryx/featuretools)
 
 Read the [launch blog post](https://notes.crmarsh.com/python-tooling-could-be-much-much-faster).
 


### PR DESCRIPTION
The list is getting long, which is a good thing. 
What about turning it into an alphabetically sorted paragraph, like [kedro](https://github.com/kedro-org/kedro#who-likes-kedro) has? 