### PR TITLE
Track type-checking blocks during tree traversal

### DIFF
--- a/src/rules/flake8_type_checking/helpers.rs
+++ b/src/rules/flake8_type_checking/helpers.rs
@@ -1,6 +1,6 @@
-use rustpython_ast::{Expr, Stmt};
+use rustpython_ast::Expr;
 
-use crate::ast::types::{Binding, BindingKind, Range};
+use crate::ast::types::{Binding, BindingKind, ExecutionContext};
 use crate::checkers::ast::Checker;
 
 pub fn is_type_checking_block(checker: &Checker, test: &Expr) -> bool {
@@ -9,18 +9,15 @@ pub fn is_type_checking_block(checker: &Checker, test: &Expr) -> bool {
     })
 }
 
-pub fn is_valid_runtime_import(binding: &Binding, blocks: &[&Stmt]) -> bool {
+pub fn is_valid_runtime_import(binding: &Binding) -> bool {
     if matches!(
         binding.kind,
         BindingKind::Importation(..)
             | BindingKind::FromImportation(..)
             | BindingKind::SubmoduleImportation(..)
     ) {
-        if binding.runtime_usage.is_some() {
-            return !blocks
-                .iter()
-                .any(|block| Range::from_located(block).contains(&binding.range));
-        }
+        binding.runtime_usage.is_some() && matches!(binding.context, ExecutionContext::Runtime)
+    } else {
+        false
     }
-    false
 }

--- a/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -1,7 +1,6 @@
 use ruff_macros::derive_message_formats;
-use rustpython_ast::Stmt;
 
-use crate::ast::types::{Binding, BindingKind, Range};
+use crate::ast::types::{Binding, BindingKind, ExecutionContext};
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
@@ -23,10 +22,7 @@ impl Violation for RuntimeImportInTypeCheckingBlock {
 }
 
 /// TCH004
-pub fn runtime_import_in_type_checking_block(
-    binding: &Binding,
-    blocks: &[&Stmt],
-) -> Option<Diagnostic> {
+pub fn runtime_import_in_type_checking_block(binding: &Binding) -> Option<Diagnostic> {
     let full_name = match &binding.kind {
         BindingKind::Importation(.., full_name) => full_name,
         BindingKind::FromImportation(.., full_name) => full_name.as_str(),
@@ -34,19 +30,14 @@ pub fn runtime_import_in_type_checking_block(
         _ => return None,
     };
 
-    let defined_in_type_checking = blocks
-        .iter()
-        .any(|block| Range::from_located(block).contains(&binding.range));
-    if defined_in_type_checking {
-        if binding.runtime_usage.is_some() {
-            return Some(Diagnostic::new(
-                RuntimeImportInTypeCheckingBlock {
-                    full_name: full_name.to_string(),
-                },
-                binding.range,
-            ));
-        }
+    if matches!(binding.context, ExecutionContext::Typing) && binding.runtime_usage.is_some() {
+        Some(Diagnostic::new(
+            RuntimeImportInTypeCheckingBlock {
+                full_name: full_name.to_string(),
+            },
+            binding.range,
+        ))
+    } else {
+        None
     }
-
-    None
 }


### PR DESCRIPTION
This is more efficient, as we don't have to go back and check if every statement is bounded by the existing blocks.