### PR TITLE
Fix SIM300 to take Python constants into account

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM300.py
+++ b/resources/test/fixtures/flake8_simplify/SIM300.py
@@ -5,6 +5,9 @@
 "yoda" <= compare  # SIM300
 'yoda' < compare  # SIM300
 42 > age  # SIM300
+YODA == age  # SIM300
+YODA > age  # SIM300
+YODA >= age  # SIM300
 
 # OK
 compare == "yoda"
@@ -13,3 +16,7 @@ x == y
 "yoda" == compare == 1
 "yoda" == compare == someothervar
 "yoda" == "yoda"
+age == YODA
+age < YODA
+age <= YODA
+

--- a/resources/test/fixtures/flake8_simplify/SIM300.py
+++ b/resources/test/fixtures/flake8_simplify/SIM300.py
@@ -19,4 +19,4 @@ x == y
 age == YODA
 age < YODA
 age <= YODA
-
+YODA == YODA

--- a/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -3,6 +3,7 @@ use rustpython_ast::{Cmpop, Expr, ExprKind};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
+use crate::python::string::{self};
 use crate::registry::Diagnostic;
 use crate::violations;
 
@@ -24,12 +25,6 @@ pub fn yoda_conditions(
     ) {
         return;
     }
-    if !matches!(&left.node, &ExprKind::Constant { .. }) {
-        return;
-    }
-    if matches!(&right.node, &ExprKind::Constant { .. }) {
-        return;
-    }
 
     // Slice exact content to preserve formatting.
     let constant = checker
@@ -38,6 +33,13 @@ pub fn yoda_conditions(
     let variable = checker
         .locator
         .slice_source_code_range(&Range::from_located(right));
+
+    if !matches!(&left.node, &ExprKind::Constant { .. }) && !string::is_upper(constant) {
+        return;
+    }
+    if matches!(&right.node, &ExprKind::Constant { .. }) || string::is_upper(variable) {
+        return;
+    }
 
     // Reverse the operation.
     let reversed_op = match op {

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
@@ -116,4 +116,61 @@ expression: diagnostics
       row: 7
       column: 8
   parent: ~
+- kind:
+    YodaConditions:
+      suggestion: age == YODA
+  location:
+    row: 8
+    column: 0
+  end_location:
+    row: 8
+    column: 11
+  fix:
+    content:
+      - age == YODA
+    location:
+      row: 8
+      column: 0
+    end_location:
+      row: 8
+      column: 11
+  parent: ~
+- kind:
+    YodaConditions:
+      suggestion: age < YODA
+  location:
+    row: 9
+    column: 0
+  end_location:
+    row: 9
+    column: 10
+  fix:
+    content:
+      - age < YODA
+    location:
+      row: 9
+      column: 0
+    end_location:
+      row: 9
+      column: 10
+  parent: ~
+- kind:
+    YodaConditions:
+      suggestion: age <= YODA
+  location:
+    row: 10
+    column: 0
+  end_location:
+    row: 10
+    column: 11
+  fix:
+    content:
+      - age <= YODA
+    location:
+      row: 10
+      column: 0
+    end_location:
+      row: 10
+      column: 11
+  parent: ~
 


### PR DESCRIPTION
SIM300 currently doesn't take Python constants into account when looking for Yoda conditions, this PR fixes that behavior.

```python
# Errors
YODA == age  # SIM300
YODA > age  # SIM300
YODA >= age  # SIM300

# OK
age == YODA
age < YODA
age <= YODA
```

Ref: <https://github.com/home-assistant/core/pull/86793>