### PR TITLE
add clippy and rust_dev to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,9 @@ repos:
         entry: cargo +nightly clippy --workspace --all-targets --all-features
         language: rust
         pass_filenames: false
-
+      - id: dev-generate-all
+        name: dev-generate-all
+        entry: cargo +nightly dev generate-all
+        language: rust
+        pass_filenames: false
+        exclude: target

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
         types: [rust]
       - id: clippy
         name: clippy
-        entry: cargo +nightly clippy --workspace --all-targets --all-features
+        entry: cargo clippy --workspace --all-targets --all-features
         language: rust
         pass_filenames: false
       - id: dev-generate-all
         name: dev-generate-all
-        entry: cargo +nightly dev generate-all
+        entry: cargo dev generate-all
         language: rust
         pass_filenames: false
         exclude: target

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,9 @@ repos:
         entry: cargo +nightly fmt --
         language: rust
         types: [rust]
+      - id: clippy
+        name: clippy
+        entry: cargo +nightly clippy --workspace --all-targets --all-features
+        language: rust
+        pass_filenames: false
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ cargo test --all    # Testing...
 These checks will run on GitHub Actions when you open your Pull Request, but running them locally
 will save you time and expedite the merge process.
 
+If you have `pre-commit` [installed](https://pre-commit.com/#installation) then you can use it to 
+assist with formatting and linting. The following command will run the `pre-commit` hooks:
+
+```shell
+pre-commit run --all-files
+```
+
 Your Pull Request will be reviewed by a maintainer, which may involve a few rounds of iteration
 prior to merging.
 


### PR DESCRIPTION
I presume the reasoning for not including clippy in `pre-commit` was that it passes all files. This can be turned off with `pass_filenames`, in which case it only runs once.

`cargo +nightly dev generate-all` is also added (when excluding `target` is does not give false positives).

(The overhead of these commands is not much when the build is there. People can always choose to run only certain hooks with `pre-commit run [hook] --all-files`)