### PR TITLE
Treat attribute constants as constant for yoda-conditions

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM300.py
+++ b/resources/test/fixtures/flake8_simplify/SIM300.py
@@ -9,6 +9,7 @@
 YODA == age  # SIM300
 YODA > age  # SIM300
 YODA >= age  # SIM300
+JediOrder.YODA == age  # SIM300
 
 # OK
 compare == "yoda"
@@ -22,3 +23,4 @@ age == YODA
 age < YODA
 age <= YODA
 YODA == YODA
+age == JediOrder.YODA

--- a/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -10,6 +10,7 @@ use crate::violations;
 /// Return `true` if an [`Expr`] is a constant or a constant-like name.
 fn is_constant_like(expr: &Expr) -> bool {
     match &expr.node {
+        ExprKind::Attribute { attr, .. } => string::is_upper(attr),
         ExprKind::Constant { .. } => true,
         ExprKind::Tuple { elts, .. } => elts.iter().all(is_constant_like),
         ExprKind::Name { id, .. } => string::is_upper(id),

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
@@ -192,4 +192,23 @@ expression: diagnostics
       row: 11
       column: 11
   parent: ~
+- kind:
+    YodaConditions:
+      suggestion: age == JediOrder.YODA
+  location:
+    row: 12
+    column: 0
+  end_location:
+    row: 12
+    column: 21
+  fix:
+    content:
+      - age == JediOrder.YODA
+    location:
+      row: 12
+      column: 0
+    end_location:
+      row: 12
+      column: 21
+  parent: ~
 


### PR DESCRIPTION
Accessed attributes that are Python constants should be considered for yoda-conditions


```py
## Error
JediOrder.YODA == age  # SIM300

## OK
age == JediOrder.YODA
```

~~PS: This PR will fail CI, as the `main` branch currently failing.~~