### PR TITLE
isort: support forced_separate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3464,6 +3464,24 @@ combine-as-imports = true
 
 ---
 
+#### [`forced-separate`](#forced-separate)
+
+A list of modules to separate into auxiliary block(s) of imports,
+in the order specified.
+
+**Default value**: `[]`
+
+**Type**: `Vec<String>`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+forced-separate = ["tests"]
+```
+
+---
+
 #### [`known-first-party`](#known-first-party)
 
 A list of modules to consider first-party, regardless of whether they

--- a/resources/test/fixtures/isort/forced_separate.py
+++ b/resources/test/fixtures/isort/forced_separate.py
@@ -1,0 +1,8 @@
+# office_helper and tests are both first-party,
+# but we want tests and experiments to be separated, in that order
+from office_helper.core import CoreState
+import tests.common.foo as tcf
+from tests.common import async_mock_service
+from experiments.starry import *
+from experiments.weird import varieties
+from office_helper.assistants import entity_registry as er

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -937,6 +937,16 @@
             "null"
           ]
         },
+        "forced-separate": {
+          "description": "A list of modules to separate into auxiliary block(s) of imports, in the order specified.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "known-first-party": {
           "description": "A list of modules to consider first-party, regardless of whether they can be identified as such via introspection of the local filesystem.",
           "type": [

--- a/src/rules/isort/mod.rs
+++ b/src/rules/isort/mod.rs
@@ -17,6 +17,7 @@ use track::{Block, Trailer};
 use types::EitherImport::{Import, ImportFrom};
 use types::{AliasData, CommentSet, EitherImport, OrderedImportBlock, TrailingComma};
 
+use crate::rules::isort::types::ImportBlock;
 use crate::source_code::{Locator, Stylist};
 
 mod annotate;
@@ -29,6 +30,7 @@ mod order;
 pub(crate) mod rules;
 pub mod settings;
 mod sorting;
+mod split;
 pub(crate) mod track;
 mod types;
 
@@ -129,6 +131,7 @@ pub fn format_imports(
     variables: &BTreeSet<String>,
     no_lines_before: &BTreeSet<ImportType>,
     lines_after_imports: isize,
+    forced_separate: &[String],
 ) -> String {
     let trailer = &block.trailer;
     let block = annotate_imports(&block.imports, comments, locator, split_on_trailing_comma);
@@ -136,6 +139,86 @@ pub fn format_imports(
     // Normalize imports (i.e., deduplicate, aggregate `from` imports).
     let block = normalize_imports(block, combine_as_imports);
 
+    let mut output = String::new();
+
+    for block in split::split_by_forced_separate(block, forced_separate) {
+        let block_output = format_import_block(
+            block,
+            line_length,
+            stylist,
+            src,
+            package,
+            extra_standard_library,
+            force_single_line,
+            force_sort_within_sections,
+            force_wrap_aliases,
+            known_first_party,
+            known_third_party,
+            order_by_type,
+            relative_imports_order,
+            single_line_exclusions,
+            split_on_trailing_comma,
+            classes,
+            constants,
+            variables,
+            no_lines_before,
+        );
+
+        if !block_output.is_empty() && !output.is_empty() {
+            // If we are about to output something, and had already
+            // output a block, separate them.
+            output.push_str(stylist.line_ending());
+        }
+        output.push_str(block_output.as_str());
+    }
+
+    match trailer {
+        None => {}
+        Some(Trailer::Sibling) => {
+            if lines_after_imports >= 0 {
+                for _ in 0..lines_after_imports {
+                    output.push_str(stylist.line_ending());
+                }
+            } else {
+                output.push_str(stylist.line_ending());
+            }
+        }
+        Some(Trailer::FunctionDef | Trailer::ClassDef) => {
+            if lines_after_imports >= 0 {
+                for _ in 0..lines_after_imports {
+                    output.push_str(stylist.line_ending());
+                }
+            } else {
+                output.push_str(stylist.line_ending());
+                output.push_str(stylist.line_ending());
+            }
+        }
+    }
+    output
+}
+
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+fn format_import_block(
+    block: ImportBlock,
+    line_length: usize,
+    stylist: &Stylist,
+    src: &[PathBuf],
+    package: Option<&Path>,
+    extra_standard_library: &BTreeSet<String>,
+    force_single_line: bool,
+    force_sort_within_sections: bool,
+    force_wrap_aliases: bool,
+    known_first_party: &BTreeSet<String>,
+    known_third_party: &BTreeSet<String>,
+    order_by_type: bool,
+    relative_imports_order: RelativeImportsOrder,
+    single_line_exclusions: &BTreeSet<String>,
+    split_on_trailing_comma: bool,
+    classes: &BTreeSet<String>,
+    constants: &BTreeSet<String>,
+    variables: &BTreeSet<String>,
+    no_lines_before: &BTreeSet<ImportType>,
+) -> String {
     // Categorize by type (e.g., first-party vs. third-party).
     let block_by_type = categorize_imports(
         block,
@@ -211,28 +294,6 @@ pub fn format_imports(
                 }
             }
             is_first_statement = false;
-        }
-    }
-    match trailer {
-        None => {}
-        Some(Trailer::Sibling) => {
-            if lines_after_imports >= 0 {
-                for _ in 0..lines_after_imports {
-                    output.push_str(stylist.line_ending());
-                }
-            } else {
-                output.push_str(stylist.line_ending());
-            }
-        }
-        Some(Trailer::FunctionDef | Trailer::ClassDef) => {
-            if lines_after_imports >= 0 {
-                for _ in 0..lines_after_imports {
-                    output.push_str(stylist.line_ending());
-                }
-            } else {
-                output.push_str(stylist.line_ending());
-                output.push_str(stylist.line_ending());
-            }
         }
     }
     output
@@ -674,6 +735,29 @@ mod tests {
             },
         )?;
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
+        assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("forced_separate.py"))]
+    fn forced_separate(path: &Path) -> Result<()> {
+        let snapshot = format!("{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &Settings {
+                src: vec![test_resource_path("fixtures/isort")],
+                isort: super::settings::Settings {
+                    forced_separate: vec![
+                        // The order will be retained by the split mechanism.
+                        "tests".to_string(),
+                        "not_there".to_string(), // doesn't appear, shouldn't matter
+                        "experiments".to_string(),
+                    ],
+                    ..super::settings::Settings::default()
+                },
+                ..Settings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
         assert_yaml_snapshot!(snapshot, diagnostics);
         Ok(())
     }

--- a/src/rules/isort/rules/organize_imports.rs
+++ b/src/rules/isort/rules/organize_imports.rs
@@ -119,6 +119,7 @@ pub fn organize_imports(
         &settings.isort.variables,
         &settings.isort.no_lines_before,
         settings.isort.lines_after_imports,
+        &settings.isort.forced_separate,
     );
 
     // Expand the span the entire range, including leading and trailing space.

--- a/src/rules/isort/settings.rs
+++ b/src/rules/isort/settings.rs
@@ -224,6 +224,16 @@ pub struct Options {
     /// The number of blank lines to place after imports.
     /// -1 for automatic determination.
     pub lines_after_imports: Option<isize>,
+    #[option(
+        default = r#"[]"#,
+        value_type = "Vec<String>",
+        example = r#"
+            forced-separate = ["tests"]
+        "#
+    )]
+    /// A list of modules to separate into auxiliary block(s) of imports,
+    /// in the order specified.
+    pub forced_separate: Option<Vec<String>>,
 }
 
 #[derive(Debug, Hash)]
@@ -246,6 +256,7 @@ pub struct Settings {
     pub variables: BTreeSet<String>,
     pub no_lines_before: BTreeSet<ImportType>,
     pub lines_after_imports: isize,
+    pub forced_separate: Vec<String>,
 }
 
 impl Default for Settings {
@@ -268,6 +279,7 @@ impl Default for Settings {
             variables: BTreeSet::new(),
             no_lines_before: BTreeSet::new(),
             lines_after_imports: -1,
+            forced_separate: Vec::new(),
         }
     }
 }
@@ -296,6 +308,7 @@ impl From<Options> for Settings {
             variables: BTreeSet::from_iter(options.variables.unwrap_or_default()),
             no_lines_before: BTreeSet::from_iter(options.no_lines_before.unwrap_or_default()),
             lines_after_imports: options.lines_after_imports.unwrap_or(-1),
+            forced_separate: Vec::from_iter(options.forced_separate.unwrap_or_default()),
         }
     }
 }
@@ -320,6 +333,7 @@ impl From<Settings> for Options {
             variables: Some(settings.variables.into_iter().collect()),
             no_lines_before: Some(settings.no_lines_before.into_iter().collect()),
             lines_after_imports: Some(settings.lines_after_imports),
+            forced_separate: Some(settings.forced_separate.into_iter().collect()),
         }
     }
 }

--- a/src/rules/isort/snapshots/ruff__rules__isort__tests__forced_separate.py.snap
+++ b/src/rules/isort/snapshots/ruff__rules__isort__tests__forced_separate.py.snap
@@ -1,0 +1,31 @@
+---
+source: src/rules/isort/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnsortedImports: ~
+  location:
+    row: 3
+    column: 0
+  end_location:
+    row: 9
+    column: 0
+  fix:
+    content:
+      - from office_helper.assistants import entity_registry as er
+      - from office_helper.core import CoreState
+      - ""
+      - import tests.common.foo as tcf
+      - from tests.common import async_mock_service
+      - ""
+      - from experiments.starry import *
+      - from experiments.weird import varieties
+      - ""
+    location:
+      row: 3
+      column: 0
+    end_location:
+      row: 9
+      column: 0
+  parent: ~
+

--- a/src/rules/isort/split.rs
+++ b/src/rules/isort/split.rs
@@ -1,0 +1,57 @@
+use crate::rules::isort::types::{ImportBlock, Importable};
+
+/// Find the index of the block that the import should be placed in.
+/// The index is the position of the pattern in `forced_separate` plus one.
+/// If the import is not matched by any of the patterns, return 0 (the first block).
+fn find_block_index(forced_separate: &[String], imp: &dyn Importable) -> usize {
+    forced_separate
+        .iter()
+        .position(|pattern| imp.module_base().starts_with(pattern))
+        .map_or(0, |position| position + 1)
+}
+
+/// Split the import block into multiple blocks, where the first block is the imports that are not
+/// matched by any of the patterns in `forced_separate`, and the rest of the blocks are the imports
+/// that _are_ matched by the patterns in `forced_separate`, in the order they appear in the
+/// `forced_separate` set. Empty blocks are retained for patterns that do not match any imports.
+pub fn split_by_forced_separate<'a>(
+    block: ImportBlock<'a>,
+    forced_separate: &[String],
+) -> Vec<ImportBlock<'a>> {
+    if forced_separate.is_empty() {
+        // Nothing to do here.
+        return vec![block];
+    }
+    let mut blocks = vec![ImportBlock::default()]; // The zeroth block is for non-forced-separate imports.
+    for _ in forced_separate {
+        // Populate the blocks with empty blocks for each forced_separate pattern.
+        blocks.push(ImportBlock::default());
+    }
+    let ImportBlock {
+        import,
+        import_from,
+        import_from_as,
+        import_from_star,
+    } = block;
+    for (imp, comment_set) in import {
+        blocks[find_block_index(forced_separate, &imp)]
+            .import
+            .insert(imp, comment_set);
+    }
+    for (imp, val) in import_from {
+        blocks[find_block_index(forced_separate, &imp)]
+            .import_from
+            .insert(imp, val);
+    }
+    for ((imp, alias), comment_set) in import_from_as {
+        blocks[find_block_index(forced_separate, &imp)]
+            .import_from_as
+            .insert((imp, alias), comment_set);
+    }
+    for (imp, comment_set) in import_from_star {
+        blocks[find_block_index(forced_separate, &imp)]
+            .import_from_star
+            .insert(imp, comment_set);
+    }
+    blocks
+}


### PR DESCRIPTION
Support for [`forced_separate`](https://pycqa.github.io/isort/docs/configuration/options.html#forced-separate):

> Force certain sub modules to show separately
