### PR TITLE
mark some fixers as sometimes-fixable

### DIFF
--- a/src/violations.rs
+++ b/src/violations.rs
@@ -817,16 +817,18 @@ impl Violation for ConsiderMergingIsinstance {
 define_violation!(
     pub struct UseSysExit(pub String);
 );
-impl AlwaysAutofixableViolation for UseSysExit {
+impl Violation for UseSysExit {
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let UseSysExit(name) = self;
         format!("Use `sys.exit()` instead of `{name}`")
     }
 
-    fn autofix_title(&self) -> String {
-        let UseSysExit(name) = self;
-        format!("Replace `{name}` with `sys.exit()`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        let UseSysExit(_name) = self;
+        Some(|UseSysExit(name)| format!("Replace `{name}` with `sys.exit()`"))
     }
 }
 

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -827,7 +827,6 @@ impl Violation for UseSysExit {
     }
 
     fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
-        let UseSysExit(_name) = self;
         Some(|UseSysExit(name)| format!("Replace `{name}` with `sys.exit()`"))
     }
 }
@@ -2186,7 +2185,6 @@ impl Violation for UseTernaryOperator {
     }
 
     fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
-        let UseTernaryOperator(_contents) = self;
         Some(|UseTernaryOperator(contents)| format!("Replace if-else-block with `{contents}`"))
     }
 }

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -2176,16 +2176,18 @@ impl Violation for ReturnInTryExceptFinally {
 define_violation!(
     pub struct UseTernaryOperator(pub String);
 );
-impl AlwaysAutofixableViolation for UseTernaryOperator {
+impl Violation for UseTernaryOperator {
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let UseTernaryOperator(contents) = self;
         format!("Use ternary operator `{contents}` instead of if-else-block")
     }
 
-    fn autofix_title(&self) -> String {
-        let UseTernaryOperator(contents) = self;
-        format!("Replace if-else-block with `{contents}`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        let UseTernaryOperator(_contents) = self;
+        Some(|UseTernaryOperator(contents)| format!("Replace if-else-block with `{contents}`"))
     }
 }
 


### PR DESCRIPTION
A lot of fixers tell they are `always` fixable while they are only sometimes fixable.

```
$ ruff --explain PLR1722
use-sys-exit

Code: PLR1722 (Pylint)

Autofix is always available.
           ^^^^^^

Message formats:

* Use `sys.exit()` instead of `{name}`
```

My rust knowledge is not enough to introduce a `SometimesAutofixableViolation` so I downgrade it to regular `Violations`.