### PR TITLE
feat: include os.getcwdb (bytes) into flake8-use-pathlib

### DIFF
--- a/resources/test/fixtures/flake8_use_pathlib/full_name.py
+++ b/resources/test/fixtures/flake8_use_pathlib/full_name.py
@@ -29,3 +29,4 @@ os.path.splitext(p)
 with open(p) as fp:
     fp.read()
 open(p).close()
+os.getcwdb(p)

--- a/src/rules/flake8_use_pathlib/helpers.rs
+++ b/src/rules/flake8_use_pathlib/helpers.rs
@@ -26,6 +26,7 @@ pub fn replaceable_by_pathlib(checker: &mut Checker, expr: &Expr) {
                 ["os", "remove"] => Some(PathlibRemove.into()),
                 ["os", "unlink"] => Some(PathlibUnlink.into()),
                 ["os", "getcwd"] => Some(PathlibGetcwd.into()),
+                ["os", "getcwdb"] => Some(PathlibGetcwd.into()),
                 ["os", "path", "exists"] => Some(PathlibExists.into()),
                 ["os", "path", "expanduser"] => Some(PathlibExpanduser.into()),
                 ["os", "path", "isdir"] => Some(PathlibIsDir.into()),

--- a/src/rules/flake8_use_pathlib/snapshots/ruff__rules__flake8_use_pathlib__tests__full_name.py.snap
+++ b/src/rules/flake8_use_pathlib/snapshots/ruff__rules__flake8_use_pathlib__tests__full_name.py.snap
@@ -252,4 +252,14 @@ expression: diagnostics
     column: 4
   fix: ~
   parent: ~
+- kind:
+    PathlibGetcwd: ~
+  location:
+    row: 32
+    column: 0
+  end_location:
+    row: 32
+    column: 10
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
Grouping those together as they should be both replaced with `Path(...).cwd()`

