### PR TITLE
Implement `ruff linter` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,11 @@ Ruff: An extremely fast Python linter.
 Usage: ruff [OPTIONS] <COMMAND>
 
 Commands:
-  check  Run Ruff on the given files or directories (default)
-  rule   Explain a rule
-  clean  Clear any caches in the current directory and any subdirectories
-  help   Print this message or the help of the given subcommand(s)
+  check   Run Ruff on the given files or directories (default)
+  rule    Explain a rule
+  linter  List all supported upstream linters
+  clean   Clear any caches in the current directory and any subdirectories
+  help    Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help

--- a/ruff_cli/Cargo.toml
+++ b/ruff_cli/Cargo.toml
@@ -53,6 +53,7 @@ similar = { version = "2.2.1" }
 textwrap = { version = "0.16.0" }
 update-informer = { version = "0.6.0", default-features = false, features = ["pypi"], optional = true }
 walkdir = { version = "2.3.2" }
+strum = "0.24.1"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.4" }

--- a/ruff_cli/src/args.rs
+++ b/ruff_cli/src/args.rs
@@ -41,6 +41,12 @@ pub enum Command {
         #[arg(long, value_enum, default_value = "text")]
         format: HelpFormat,
     },
+    /// List all supported upstream linters
+    Linter {
+        /// Output format
+        #[arg(long, value_enum, default_value = "text")]
+        format: HelpFormat,
+    },
     /// Clear any caches in the current directory and any subdirectories.
     #[clap(alias = "--clean")]
     Clean,

--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -27,6 +27,8 @@ use crate::cache;
 use crate::diagnostics::{lint_path, lint_stdin, Diagnostics};
 use crate::iterators::par_iter;
 
+pub mod linter;
+
 /// Run the linter over a collection of files.
 pub fn run(
     files: &[PathBuf],

--- a/ruff_cli/src/commands/linter.rs
+++ b/ruff_cli/src/commands/linter.rs
@@ -1,0 +1,59 @@
+use itertools::Itertools;
+use serde::Serialize;
+use strum::IntoEnumIterator;
+
+use ruff::registry::{Linter, LinterCategory, RuleNamespace};
+
+use crate::args::HelpFormat;
+
+pub fn linter(format: HelpFormat) {
+    match format {
+        HelpFormat::Text => {
+            for linter in Linter::iter() {
+                let prefix = match linter.common_prefix() {
+                    "" => linter
+                        .categories()
+                        .unwrap()
+                        .iter()
+                        .map(|LinterCategory(prefix, ..)| prefix)
+                        .join("/"),
+                    prefix => prefix.to_string(),
+                };
+                println!("{:>4} {}", prefix, linter.name());
+            }
+        }
+
+        HelpFormat::Json => {
+            let linters: Vec<_> = Linter::iter()
+                .map(|linter_info| LinterInfo {
+                    prefix: linter_info.common_prefix(),
+                    name: linter_info.name(),
+                    categories: linter_info.categories().map(|cats| {
+                        cats.iter()
+                            .map(|LinterCategory(prefix, name, ..)| LinterCategoryInfo {
+                                prefix,
+                                name,
+                            })
+                            .collect()
+                    }),
+                })
+                .collect();
+
+            println!("{}", serde_json::to_string_pretty(&linters).unwrap());
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct LinterInfo {
+    prefix: &'static str,
+    name: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    categories: Option<Vec<LinterCategoryInfo>>,
+}
+
+#[derive(Serialize)]
+struct LinterCategoryInfo {
+    prefix: &'static str,
+    name: &'static str,
+}

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -78,6 +78,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
 
     match command {
         Command::Rule { rule, format } => commands::rule(rule, format)?,
+        Command::Linter { format } => commands::linter::linter(format),
         Command::Clean => commands::clean(log_level)?,
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut io::stdout());

--- a/ruff_dev/src/generate_rules_table.rs
+++ b/ruff_dev/src/generate_rules_table.rs
@@ -1,6 +1,7 @@
 //! Generate a Markdown-compatible table of supported lint rules.
 
 use anyhow::Result;
+use itertools::Itertools;
 use ruff::registry::{Linter, LinterCategory, Rule, RuleNamespace};
 use strum::IntoEnumIterator;
 
@@ -47,7 +48,15 @@ pub fn main(args: &Args) -> Result<()> {
     let mut table_out = String::new();
     let mut toc_out = String::new();
     for linter in Linter::iter() {
-        let codes_csv: String = linter.prefixes().join(", ");
+        let codes_csv: String = match linter.common_prefix() {
+            "" => linter
+                .categories()
+                .unwrap()
+                .iter()
+                .map(|LinterCategory(prefix, ..)| prefix)
+                .join(", "),
+            prefix => prefix.to_string(),
+        };
         table_out.push_str(&format!("### {} ({codes_csv})", linter.name()));
         table_out.push('\n');
         table_out.push('\n');

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -616,9 +616,16 @@ pub enum Linter {
 }
 
 pub trait RuleNamespace: Sized {
-    fn parse_code(code: &str) -> Option<(Self, &str)>;
+    /// Returns the prefix that every single code that ruff uses to identify
+    /// rules from this linter starts with.  In the case that multiple
+    /// `#[prefix]`es are configured for the variant in the `Linter` enum
+    /// definition this is the empty string.
+    fn common_prefix(&self) -> &'static str;
 
-    fn prefixes(&self) -> &'static [&'static str];
+    /// Attempts to parse the given rule code. If the prefix is recognized
+    /// returns the respective variant along with the code with the common
+    /// prefix stripped.
+    fn parse_code(code: &str) -> Option<(Self, &str)>;
 
     fn name(&self) -> &'static str;
 
@@ -767,10 +774,12 @@ mod tests {
     }
 
     #[test]
-    fn test_linter_prefixes() {
+    fn test_linter_parse_code() {
         for rule in Rule::iter() {
-            Linter::parse_code(rule.code())
-                .unwrap_or_else(|| panic!("couldn't parse {:?}", rule.code()));
+            let code = rule.code();
+            let (linter, rest) =
+                Linter::parse_code(code).unwrap_or_else(|| panic!("couldn't parse {:?}", code));
+            assert_eq!(code, format!("{}{rest}", linter.common_prefix()));
         }
     }
 }


### PR DESCRIPTION
Followup PR for #2288.

The subcommand lists all supported upstream linters and their prefixes:

    $ ruff linter
       F Pyflakes
     E/W pycodestyle
     C90 mccabe
       I isort
       N pep8-naming
       D pydocstyle
      UP pyupgrade
     YTT flake8-2020
    # etc...

Just like with the `rule` subcommand `--format json` is supported:

    $ ruff linter --format json
    [
      {
        "prefix": "F",
        "name": "Pyflakes"
      },
      {
        "prefix": "",
        "name": "pycodestyle",
        "categories": [
          {
            "prefix": "E",
            "name": "Error"
          },
          {
            "prefix": "W",
            "name": "Warning"
          }
        ]
      },
      # etc...
