### PR TITLE
Fix typo in typing_extensions

### DIFF
--- a/src/python/typing.rs
+++ b/src/python/typing.rs
@@ -49,7 +49,7 @@ pub static TYPING_EXTENSIONS: Lazy<FxHashSet<&'static str>> = Lazy::new(|| {
         "assert_type",
         "clear_overloads",
         "final",
-        "get_Type_hints",
+        "get_type_hints",
         "get_args",
         "get_origin",
         "get_overloads",


### PR DESCRIPTION
This PR fixes incorrect capitalization for the `typing.get_type_hints` function for `typing_extensions`.

Love the project, thanks for building it!
