### PR TITLE
Fix version shorthand detection to use -V instead of -v

### DIFF
--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -44,7 +44,7 @@ fn inner_main() -> Result<ExitCode> {
         if !Command::has_subcommand(rewrite_legacy_subcommand(arg))
             && arg != "-h"
             && arg != "--help"
-            && arg != "-v"
+            && arg != "-V"
             && arg != "--version"
             && arg != "help"
         {


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/charliermarsh/ruff/commit/eda2be635062c37dfaaccb630d2510cf458f8dd6 (but not yet released to users). (`-v` is a real flag, but it's an alias for `--verbose`, not `--version`.)

Closes #2299.