### PR TITLE
Respect per-file-ignores when checking noqa

### DIFF
--- a/resources/test/fixtures/ruff/RUF100_2.py
+++ b/resources/test/fixtures/ruff/RUF100_2.py
@@ -1,0 +1,1 @@
+import itertools  # noqa: F401

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -132,6 +132,15 @@ pub fn check_path(
         doc_lines.dedup();
     }
 
+    // Ignore diagnostics based on per-file-ignores.
+    if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
+        let ignores = fs::ignores_from_path(path, &settings.per_file_ignores)?;
+
+        if !ignores.is_empty() {
+            diagnostics.retain(|diagnostic| !ignores.contains(&diagnostic.kind.rule()));
+        }
+    };
+
     // Run the lines-based rules.
     if settings
         .rules
@@ -164,17 +173,6 @@ pub fn check_path(
             settings,
             autofix,
         );
-    }
-
-    // Create path ignores.
-    if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
-        let ignores = fs::ignores_from_path(path, &settings.per_file_ignores)?;
-        if !ignores.is_empty() {
-            return Ok(diagnostics
-                .into_iter()
-                .filter(|diagnostic| !ignores.contains(&diagnostic.kind.rule()))
-                .collect());
-        }
     }
 
     Ok(diagnostics)

--- a/src/rules/ruff/mod.rs
+++ b/src/rules/ruff/mod.rs
@@ -12,6 +12,8 @@ mod tests {
 
     use crate::linter::test_path;
     use crate::registry::Rule;
+    use crate::settings::resolve_per_file_ignores;
+    use crate::settings::types::PerFileIgnore;
     use crate::{assert_yaml_snapshot, settings};
 
     #[test_case(Rule::KeywordArgumentBeforeStarArgument, Path::new("RUF004.py"); "RUF004")]
@@ -65,6 +67,26 @@ mod tests {
         let diagnostics = test_path(
             Path::new("./resources/test/fixtures/ruff/RUF100_1.py"),
             &settings::Settings::for_rules(vec![Rule::UnusedNOQA, Rule::UnusedImport]),
+        )?;
+        assert_yaml_snapshot!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn ruf100_2() -> Result<()> {
+        let mut settings =
+            settings::Settings::for_rules(vec![Rule::UnusedNOQA, Rule::UnusedImport]);
+
+        settings.per_file_ignores = resolve_per_file_ignores(vec![PerFileIgnore::new(
+            "RUF100_2.py".to_string(),
+            &["F401".parse().unwrap()],
+            None,
+        )])
+        .unwrap();
+
+        let diagnostics = test_path(
+            Path::new("./resources/test/fixtures/ruff/RUF100_2.py"),
+            &settings,
         )?;
         assert_yaml_snapshot!(diagnostics);
         Ok(())

--- a/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
+++ b/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
@@ -1,0 +1,27 @@
+---
+source: src/rules/ruff/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnusedNOQA:
+      unknown: []
+      disabled: []
+      unmatched:
+        - F401
+  location:
+    row: 1
+    column: 18
+  end_location:
+    row: 1
+    column: 30
+  fix:
+    content:
+      - ""
+    location:
+      row: 1
+      column: 16
+    end_location:
+      row: 1
+      column: 30
+  parent: ~
+


### PR DESCRIPTION
`RUF100` does not take into account a rule ignored for a file via a `per-file-ignores` configuration. To see this, try the following pyproject.toml:

```toml
[tool.ruff.per-file-ignores]
"test.py" = ["F401"]
```

and this test.py file:

```python
import itertools  # noqa: F401
```

Running `ruff --extend-select RUF100 test.py`, we should expect to get this error:

```
test.py:1:19: RUF100 Unused `noqa` directive (unused: `F401`)
```

The issue is that the per-file-ignores diagnostics are filtered out after the noqa checks, rather than before.