### PR TITLE
Improve rule config resolution

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,37 @@
 # Breaking Changes
 
+## Unreleased
+
+### `select`, `extend-select`, `ignore`, and `extend-ignore` have new semantics ([#2312](https://github.com/charliermarsh/ruff/pull/2312))
+
+Previously, the interplay between `select` and its related options could lead to unexpected
+behavior. For example, `ruff --select E501 --ignore ALL` and `ruff --select E501 --extend-ignore
+ALL` behaved differently. (See [#2312](https://github.com/charliermarsh/ruff/pull/2312) for more
+examples.)
+
+When Ruff determines the enabled rule set, it has to reconcile `select` and `ignore` from a variety
+of sources, including the current `pyproject.toml`, any inherited `pyproject.toml` files, and the
+CLI.
+
+The new semantics are such that Ruff uses the "highest-priority" `select` as the basis for the rule
+set, and then applies any `extend-select`, `ignore`, and `extend-ignore` adjustments. CLI options
+are given higher priority than `pyproject.toml` options, and the current `pyproject.toml` file is
+given higher priority than any inherited `pyproject.toml` files.
+
+`extend-select` and `extend-ignore` are no longer given "top priority"; instead, they merely append
+to the `select` and `ignore` lists, as in Flake8.
+
+This change is largely backwards compatible -- most users should experience no change in behavior.
+However, as an example of a breaking change, consider the following:
+
+```toml
+[tool.ruff]
+ignore = ["F401"]
+```
+
+Running `ruff --select F` would previously have enabled all `F` rules, apart from `F401`. Now, it
+will enable all `F` rules, including `F401`, as the command line's `--select` resets the resolution.
+
 ## 0.0.237
 
 ### `--explain`, `--clean`, and `--generate-shell-completion` are now subcommands ([#2190](https://github.com/charliermarsh/ruff/pull/2190))

--- a/README.md
+++ b/README.md
@@ -433,8 +433,6 @@ Rule selection:
           Comma-separated list of rule codes to disable
       --extend-select <RULE_CODE>
           Like --select, but adds additional rule codes on top of the selected ones
-      --extend-ignore <RULE_CODE>
-          Like --ignore, but adds additional rule codes on top of the ignored ones
       --per-file-ignores <PER_FILE_IGNORES>
           List of mappings from file pattern to code to exclude
       --fixable <RULE_CODE>
@@ -2212,11 +2210,8 @@ extend-exclude = ["tests", "src/bad.py"]
 A list of rule codes or prefixes to ignore, in addition to those
 specified by `ignore`.
 
-Note that `extend-ignore` is applied after resolving rules from
-`ignore`/`select` and a less specific rule in `extend-ignore`
-would overwrite a more specific rule in `select`. It is
-recommended to only use `extend-ignore` when extending a
-`pyproject.toml` file via `extend`.
+This option has been DEPRECATED in favor of `ignore`
+since its usage is now interchangeable with `ignore`.
 
 **Default value**: `[]`
 
@@ -2236,12 +2231,6 @@ extend-ignore = ["F841"]
 
 A list of rule codes or prefixes to enable, in addition to those
 specified by `select`.
-
-Note that `extend-select` is applied after resolving rules from
-`ignore`/`select` and a less specific rule in `extend-select`
-would overwrite a more specific rule in `ignore`. It is
-recommended to only use `extend-select` when extending a
-`pyproject.toml` file via `extend`.
 
 **Default value**: `[]`
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,33 @@ By default, Ruff will also skip any files that are omitted via `.ignore`, `.giti
 Files that are passed to `ruff` directly are always linted, regardless of the above criteria.
 For example, `ruff /path/to/excluded/file.py` will always lint `file.py`.
 
+### Rule resolution
+
+The set of enabled rules is controlled via the [`select`](#select) and [`ignore`](#ignore) settings,
+along with the [`extend-select`](#extend-select) and [`extend-ignore`](#extend-ignore) modifiers.
+
+To resolve the enabled rule set, Ruff may need to reconcile `select` and `ignore` from a variety
+of sources, including the current `pyproject.toml`, any inherited `pyproject.toml` files, and the
+CLI (e.g., `--select`).
+
+In those scenarios, Ruff uses the "highest-priority" `select` as the basis for the rule set, and
+then applies any `extend-select`, `ignore`, and `extend-ignore` adjustments. CLI options are given
+higher priority than `pyproject.toml` options, and the current `pyproject.toml` file is given higher
+priority than any inherited `pyproject.toml` files.
+
+For example, given the following `pyproject.toml` file:
+
+```toml
+[tool.ruff]
+select = ["E", "F"]
+ignore = ["F401"]
+```
+
+Running `ruff --select F401` would result in Ruff enforcing `F401`, and no other rules.
+
+Running `ruff --extend-select B` would result in Ruff enforcing the `E`, `F`, and `B` rules, with
+the exception of `F401`.
+
 ### Ignoring errors
 
 To omit a lint rule entirely, add it to the "ignore" list via [`ignore`](#ignore) or

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -67,7 +67,7 @@
       }
     },
     "extend-ignore": {
-      "description": "A list of rule codes or prefixes to ignore, in addition to those specified by `ignore`.\n\nNote that `extend-ignore` is applied after resolving rules from `ignore`/`select` and a less specific rule in `extend-ignore` would overwrite a more specific rule in `select`. It is recommended to only use `extend-ignore` when extending a `pyproject.toml` file via `extend`.",
+      "description": "A list of rule codes or prefixes to ignore, in addition to those specified by `ignore`.\n\nThis option has been DEPRECATED in favor of `ignore` since its usage is now interchangeable with `ignore`.",
       "type": [
         "array",
         "null"
@@ -77,7 +77,7 @@
       }
     },
     "extend-select": {
-      "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.\n\nNote that `extend-select` is applied after resolving rules from `ignore`/`select` and a less specific rule in `extend-select` would overwrite a more specific rule in `ignore`. It is recommended to only use `extend-select` when extending a `pyproject.toml` file via `extend`.",
+      "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
       "type": [
         "array",
         "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -66,16 +66,6 @@
         "type": "string"
       }
     },
-    "extend-ignore": {
-      "description": "A list of rule codes or prefixes to ignore, in addition to those specified by `ignore`.\n\nThis option has been DEPRECATED in favor of `ignore` since its usage is now interchangeable with `ignore`.",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/RuleSelector"
-      }
-    },
     "extend-select": {
       "description": "A list of rule codes or prefixes to enable, in addition to those specified by `select`.",
       "type": [

--- a/src/rule_selector.rs
+++ b/src/rule_selector.rs
@@ -6,6 +6,7 @@ use schemars::JsonSchema;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
 
 use crate::registry::{Rule, RuleCodePrefix, RuleIter};
 use crate::rule_redirects::get_redirect;
@@ -171,7 +172,7 @@ impl RuleSelector {
     }
 }
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(EnumIter, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Specificity {
     All,
     Linter,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -413,6 +413,14 @@ mod tests {
         assert_eq!(actual, expected);
 
         let actual = resolve_rules(Configuration {
+            select: Some(vec![RuleCodePrefix::W292.into()]),
+            ignore: Some(vec![RuleCodePrefix::W.into()]),
+            ..Configuration::default()
+        });
+        let expected = FxHashSet::from_iter([Rule::NoNewLineAtEndOfFile]);
+        assert_eq!(actual, expected);
+
+        let actual = resolve_rules(Configuration {
             select: Some(vec![RuleCodePrefix::W605.into()]),
             ignore: Some(vec![RuleCodePrefix::W605.into()]),
             ..Configuration::default()

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -147,6 +147,7 @@ pub struct Options {
     ///
     /// This option has been DEPRECATED in favor of `ignore`
     /// since its usage is now interchangeable with `ignore`.
+    #[schemars(skip)]
     pub extend_ignore: Option<Vec<RuleSelector>>,
     #[option(
         default = "[]",

--- a/src/settings/options.rs
+++ b/src/settings/options.rs
@@ -145,11 +145,8 @@ pub struct Options {
     /// A list of rule codes or prefixes to ignore, in addition to those
     /// specified by `ignore`.
     ///
-    /// Note that `extend-ignore` is applied after resolving rules from
-    /// `ignore`/`select` and a less specific rule in `extend-ignore`
-    /// would overwrite a more specific rule in `select`. It is
-    /// recommended to only use `extend-ignore` when extending a
-    /// `pyproject.toml` file via `extend`.
+    /// This option has been DEPRECATED in favor of `ignore`
+    /// since its usage is now interchangeable with `ignore`.
     pub extend_ignore: Option<Vec<RuleSelector>>,
     #[option(
         default = "[]",
@@ -161,12 +158,6 @@ pub struct Options {
     )]
     /// A list of rule codes or prefixes to enable, in addition to those
     /// specified by `select`.
-    ///
-    /// Note that `extend-select` is applied after resolving rules from
-    /// `ignore`/`select` and a less specific rule in `extend-select`
-    /// would overwrite a more specific rule in `ignore`. It is
-    /// recommended to only use `extend-select` when extending a
-    /// `pyproject.toml` file via `extend`.
     pub extend_select: Option<Vec<RuleSelector>>,
     #[option(
         default = "[]",


### PR DESCRIPTION
Ruff allows rules to be enabled with `select` and disabled with
`ignore`, where the more specific rule selector takes precedence,
for example:

    `--select ALL --ignore E501` selects all rules except E501
    `--ignore ALL --select E501` selects only E501

(If both selectors have the same specificity ignore selectors
take precedence.)

Ruff always had two quirks:

* If `pyproject.toml` specified `ignore = ["E501"]` then you could
  previously not override that with `--select E501` on the command-line
  (since the resolution didn't take into account that the select was
  specified after the ignore).

* If `pyproject.toml` specified `select = ["E501"]` then you could
  previously not override that with `--ignore E` on the command-line
  (since the resolution didn't take into account that the ignore was
  specified after the select).

Since d067efe2656dfa86c8ac2baa87f43f408e862a3a (#1245)
`extend-select` and `extend-ignore` always override
`select` and `ignore` and are applied iteratively in pairs,
which introduced another quirk:

* If some `pyproject.toml` file specified `extend-select`
  or `extend-ignore`, `select` and `ignore` became pretty much
  unreliable after that with no way of resetting that.

This commit fixes all of these quirks by making later configuration
sources take precedence over earlier configuration sources.

While this is a breaking change, it fixes the broken status quo.

Fixes #2300.