### PR TITLE
debug assert for fix usage

### DIFF
--- a/src/fix.rs
+++ b/src/fix.rs
@@ -36,6 +36,8 @@ impl Fix {
     }
 
     pub fn replacement(content: String, start: Location, end: Location) -> Self {
+        debug_assert!(!content.is_empty(), "Prefer `Fix::deletion`");
+
         Self {
             content,
             location: start,
@@ -44,6 +46,8 @@ impl Fix {
     }
 
     pub fn insertion(content: String, at: Location) -> Self {
+        debug_assert!(!content.is_empty(), "Insert content is empty");
+
         Self {
             content,
             location: at,

--- a/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -109,11 +109,8 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 && args.is_empty()
                 && keywords.is_empty()
             {
-                let fix = Fix::replacement(
-                    String::new(),
-                    func.end_location.unwrap(),
-                    decorator.end_location.unwrap(),
-                );
+                let fix =
+                    Fix::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
                 pytest_fixture_parentheses(checker, decorator, fix, "", "()");
             }
 

--- a/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/src/rules/flake8_pytest_style/rules/marks.rs
@@ -40,11 +40,8 @@ fn check_mark_parentheses(checker: &mut Checker, decorator: &Expr) {
                 && args.is_empty()
                 && keywords.is_empty()
             {
-                let fix = Fix::replacement(
-                    String::new(),
-                    func.end_location.unwrap(),
-                    decorator.end_location.unwrap(),
-                );
+                let fix =
+                    Fix::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
                 pytest_mark_parentheses(checker, decorator, fix, "", "()");
             }
         }

--- a/src/rules/pyupgrade/fixes.rs
+++ b/src/rules/pyupgrade/fixes.rs
@@ -79,7 +79,7 @@ pub fn remove_class_def_base(
         }
 
         match (fix_start, fix_end) {
-            (Some(start), Some(end)) => Some(Fix::replacement(String::new(), start, end)),
+            (Some(start), Some(end)) => Some(Fix::deletion(start, end)),
             _ => None,
         }
     } else {
@@ -98,7 +98,7 @@ pub fn remove_class_def_base(
         }
 
         match (fix_start, fix_end) {
-            (Some(start), Some(end)) => Some(Fix::replacement(String::new(), start, end)),
+            (Some(start), Some(end)) => Some(Fix::deletion(start, end)),
             _ => None,
         }
     }


### PR DESCRIPTION
Helps prevent developers from choosing `replacement` instead of `deletion`.
Is removed when optimized.
(Just a suggestion, If you don't like it, close it.)