### PR TITLE
refactor: use `patch(diagnostic.kind.rule())`

### DIFF
--- a/src/rules/flake8_comprehensions/rules.rs
+++ b/src/rules/flake8_comprehensions/rules.rs
@@ -5,7 +5,7 @@ use rustpython_ast::{Comprehension, Constant, Expr, ExprKind, Keyword, Unaryop};
 use super::fixes;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 fn function_name(func: &Expr) -> Option<&str> {
@@ -65,7 +65,7 @@ pub fn unnecessary_generator_list(
             violations::UnnecessaryGeneratorList,
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::UnnecessaryGeneratorList) {
+        if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_generator_list(checker.locator, checker.stylist, expr) {
                 Ok(fix) => {
                     diagnostic.amend(fix);
@@ -96,7 +96,7 @@ pub fn unnecessary_generator_set(
             violations::UnnecessaryGeneratorSet,
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::UnnecessaryGeneratorSet) {
+        if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_generator_set(checker.locator, checker.stylist, expr) {
                 Ok(fix) => {
                     diagnostic.amend(fix);
@@ -126,7 +126,7 @@ pub fn unnecessary_generator_dict(
                     violations::UnnecessaryGeneratorDict,
                     Range::from_located(expr),
                 );
-                if checker.patch(&Rule::UnnecessaryGeneratorDict) {
+                if checker.patch(diagnostic.kind.rule()) {
                     match fixes::fix_unnecessary_generator_dict(
                         checker.locator,
                         checker.stylist,
@@ -164,7 +164,7 @@ pub fn unnecessary_list_comprehension_set(
             violations::UnnecessaryListComprehensionSet,
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::UnnecessaryListComprehensionSet) {
+        if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_list_comprehension_set(
                 checker.locator,
                 checker.stylist,
@@ -207,7 +207,7 @@ pub fn unnecessary_list_comprehension_dict(
         violations::UnnecessaryListComprehensionDict,
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryListComprehensionDict) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_list_comprehension_dict(checker.locator, checker.stylist, expr)
         {
             Ok(fix) => {
@@ -244,7 +244,7 @@ pub fn unnecessary_literal_set(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryLiteralSet) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_set(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -287,7 +287,7 @@ pub fn unnecessary_literal_dict(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryLiteralDict) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_dict(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -330,7 +330,7 @@ pub fn unnecessary_collection_call(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryCollectionCall) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_collection_call(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -365,7 +365,7 @@ pub fn unnecessary_literal_within_tuple_call(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryLiteralWithinTupleCall) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_within_tuple_call(
             checker.locator,
             checker.stylist,
@@ -404,7 +404,7 @@ pub fn unnecessary_literal_within_list_call(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryLiteralWithinListCall) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_within_list_call(
             checker.locator,
             checker.stylist,
@@ -432,7 +432,7 @@ pub fn unnecessary_list_call(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     }
     let mut diagnostic =
         Diagnostic::new(violations::UnnecessaryListCall, Range::from_located(expr));
-    if checker.patch(&Rule::UnnecessaryListCall) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_list_call(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -477,7 +477,7 @@ pub fn unnecessary_call_around_sorted(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryCallAroundSorted) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_call_around_sorted(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);
@@ -647,7 +647,7 @@ pub fn unnecessary_comprehension(
         },
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::UnnecessaryComprehension) {
+    if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_comprehension(checker.locator, checker.stylist, expr) {
             Ok(fix) => {
                 diagnostic.amend(fix);

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -12,7 +12,7 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::python::identifiers::is_identifier;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
 
 define_violation!(
@@ -112,7 +112,7 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
             if matches!(pass_stmt.node, StmtKind::Pass) {
                 let mut diagnostic =
                     Diagnostic::new(NoUnnecessaryPass, Range::from_located(pass_stmt));
-                if checker.patch(&Rule::NoUnnecessaryPass) {
+                if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = match_trailing_comment(pass_stmt, checker.locator) {
                         diagnostic.amend(Fix::deletion(
                             pass_stmt.location,
@@ -182,7 +182,7 @@ pub fn dupe_class_field_definitions<'a, 'b>(
                 DupeClassFieldDefinitions(target.to_string()),
                 Range::from_located(stmt),
             );
-            if checker.patch(&Rule::DupeClassFieldDefinitions) {
+            if checker.patch(diagnostic.kind.rule()) {
                 let deleted: Vec<&Stmt> = checker
                     .deletions
                     .iter()
@@ -311,7 +311,7 @@ pub fn prefer_list_builtin(checker: &mut Checker, expr: &Expr) {
         if let ExprKind::List { elts, .. } = &body.node {
             if elts.is_empty() {
                 let mut diagnostic = Diagnostic::new(PreferListBuiltin, Range::from_located(expr));
-                if checker.patch(&Rule::PreferListBuiltin) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         "list".to_string(),
                         expr.location,

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -30,7 +30,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic =
             Diagnostic::new(violations::UnnecessaryReturnNone, Range::from_located(stmt));
-        if checker.patch(&Rule::UnnecessaryReturnNone) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "return".to_string(),
                 stmt.location,
@@ -49,7 +49,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic =
             Diagnostic::new(violations::ImplicitReturnValue, Range::from_located(stmt));
-        if checker.patch(&Rule::ImplicitReturnValue) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "return None".to_string(),
                 stmt.location,
@@ -106,7 +106,7 @@ fn implicit_return(checker: &mut Checker, last_stmt: &Stmt) {
         _ => {
             let mut diagnostic =
                 Diagnostic::new(violations::ImplicitReturn, Range::from_located(last_stmt));
-            if checker.patch(&Rule::ImplicitReturn) {
+            if checker.patch(diagnostic.kind.rule()) {
                 if let Some(indent) = indentation(checker.locator, last_stmt) {
                     let mut content = String::new();
                     content.push_str(indent);
@@ -228,46 +228,42 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
     };
     for child in body {
         if matches!(child.node, StmtKind::Return { .. }) {
-            if checker.settings.rules.enabled(&Rule::SuperfluousElseReturn) {
-                checker.diagnostics.push(Diagnostic::new(
-                    violations::SuperfluousElseReturn { branch },
-                    elif_else_range(stmt, checker.locator)
-                        .unwrap_or_else(|| Range::from_located(stmt)),
-                ));
+            let diagnostic = Diagnostic::new(
+                violations::SuperfluousElseReturn { branch },
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+            );
+            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+                checker.diagnostics.push(diagnostic);
             }
             return true;
         }
         if matches!(child.node, StmtKind::Break) {
-            if checker.settings.rules.enabled(&Rule::SuperfluousElseBreak) {
-                checker.diagnostics.push(Diagnostic::new(
-                    violations::SuperfluousElseBreak { branch },
-                    elif_else_range(stmt, checker.locator)
-                        .unwrap_or_else(|| Range::from_located(stmt)),
-                ));
+            let diagnostic = Diagnostic::new(
+                violations::SuperfluousElseBreak { branch },
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+            );
+            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+                checker.diagnostics.push(diagnostic);
             }
             return true;
         }
         if matches!(child.node, StmtKind::Raise { .. }) {
-            if checker.settings.rules.enabled(&Rule::SuperfluousElseRaise) {
-                checker.diagnostics.push(Diagnostic::new(
-                    violations::SuperfluousElseRaise { branch },
-                    elif_else_range(stmt, checker.locator)
-                        .unwrap_or_else(|| Range::from_located(stmt)),
-                ));
+            let diagnostic = Diagnostic::new(
+                violations::SuperfluousElseRaise { branch },
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+            );
+            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+                checker.diagnostics.push(diagnostic);
             }
             return true;
         }
         if matches!(child.node, StmtKind::Continue) {
-            if checker
-                .settings
-                .rules
-                .enabled(&Rule::SuperfluousElseContinue)
-            {
-                checker.diagnostics.push(Diagnostic::new(
-                    violations::SuperfluousElseContinue { branch },
-                    elif_else_range(stmt, checker.locator)
-                        .unwrap_or_else(|| Range::from_located(stmt)),
-                ));
+            let diagnostic = Diagnostic::new(
+                violations::SuperfluousElseContinue { branch },
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+            );
+            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+                checker.diagnostics.push(diagnostic);
             }
             return true;
         }

--- a/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -8,7 +8,7 @@ use crate::ast::helpers::{contains_effect, create_expr, has_comments_in, unparse
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// Return `true` if two `Expr` instances are equivalent names.
@@ -67,7 +67,7 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 },
                 Range::from_located(expr),
             );
-            if checker.patch(&Rule::DuplicateIsinstanceCall) {
+            if checker.patch(diagnostic.kind.rule()) {
                 // Grab the types used in each duplicate `isinstance` call.
                 let types: Vec<&Expr> = indices
                     .iter()
@@ -213,7 +213,7 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
             },
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::CompareWithTuple) {
+        if checker.patch(diagnostic.kind.rule()) {
             let unmatched: Vec<Expr> = values
                 .iter()
                 .enumerate()
@@ -280,7 +280,7 @@ pub fn a_and_not_a(checker: &mut Checker, expr: &Expr) {
                     },
                     Range::from_located(expr),
                 );
-                if checker.patch(&Rule::AAndNotA) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         "False".to_string(),
                         expr.location,
@@ -334,7 +334,7 @@ pub fn a_or_not_a(checker: &mut Checker, expr: &Expr) {
                     },
                     Range::from_located(expr),
                 );
-                if checker.patch(&Rule::AAndNotA) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         "True".to_string(),
                         expr.location,
@@ -362,7 +362,7 @@ pub fn or_true(checker: &mut Checker, expr: &Expr) {
         } = &value.node
         {
             let mut diagnostic = Diagnostic::new(violations::OrTrue, Range::from_located(value));
-            if checker.patch(&Rule::AndFalse) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     "True".to_string(),
                     expr.location,
@@ -389,7 +389,7 @@ pub fn and_false(checker: &mut Checker, expr: &Expr) {
         } = &value.node
         {
             let mut diagnostic = Diagnostic::new(violations::AndFalse, Range::from_located(value));
-            if checker.patch(&Rule::AndFalse) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     "False".to_string(),
                     expr.location,

--- a/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -4,7 +4,7 @@ use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// SIM112
@@ -43,7 +43,7 @@ pub fn use_capital_environment_variables(checker: &mut Checker, expr: &Expr) {
         },
         Range::from_located(arg),
     );
-    if checker.patch(&Rule::UseCapitalEnvironmentVariables) {
+    if checker.patch(diagnostic.kind.rule()) {
         let new_env_var = create_expr(ExprKind::Constant {
             value: capital_env_var.into(),
             kind: kind.clone(),
@@ -85,7 +85,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
         },
         Range::from_located(slice),
     );
-    if checker.patch(&Rule::UseCapitalEnvironmentVariables) {
+    if checker.patch(diagnostic.kind.rule()) {
         let new_env_var = create_expr(ExprKind::Constant {
             value: capital_env_var.into(),
             kind: kind.clone(),

--- a/src/rules/flake8_simplify/rules/ast_for.rs
+++ b/src/rules/flake8_simplify/rules/ast_for.rs
@@ -199,7 +199,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     },
                     Range::from_located(stmt),
                 );
-                if checker.patch(&Rule::ConvertLoopToAny) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         contents,
                         stmt.location,
@@ -249,7 +249,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     },
                     Range::from_located(stmt),
                 );
-                if checker.patch(&Rule::ConvertLoopToAll) {
+                if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         contents,
                         stmt.location,

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -9,7 +9,7 @@ use crate::ast::helpers::{
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::flake8_simplify::rules::fix_if;
 use crate::violations;
 
@@ -103,7 +103,7 @@ pub fn nested_if_statements(
             |colon| Range::new(stmt.location, colon.end_location),
         ),
     );
-    if checker.patch(&Rule::NestedIfStatements) {
+    if checker.patch(diagnostic.kind.rule()) {
         // The fixer preserves comments in the nested body, but removes comments between
         // the outer and inner if statements.
         let nested_if = &body[0];
@@ -172,7 +172,7 @@ pub fn return_bool_condition_directly(checker: &mut Checker, stmt: &Stmt) {
         violations::ReturnBoolConditionDirectly { cond: condition },
         Range::from_located(stmt),
     );
-    if checker.patch(&Rule::ReturnBoolConditionDirectly)
+    if checker.patch(diagnostic.kind.rule())
         && matches!(if_return, Bool::True)
         && matches!(else_return, Bool::False)
         && !has_comments_in(Range::from_located(stmt), checker.locator)
@@ -296,7 +296,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
         },
         Range::from_located(stmt),
     );
-    if checker.patch(&Rule::UseTernaryOperator) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,
             stmt.location,
@@ -432,7 +432,7 @@ pub fn use_dict_get_with_default(
         },
         Range::from_located(stmt),
     );
-    if checker.patch(&Rule::DictGetWithDefault) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,
             stmt.location,

--- a/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/src/rules/flake8_simplify/rules/ast_with.rs
@@ -5,7 +5,7 @@ use super::fix_with;
 use crate::ast::helpers::{first_colon_range, has_comments_in};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
@@ -49,7 +49,7 @@ pub fn multiple_with_statements(
                 |colon| Range::new(with_stmt.location, colon.end_location),
             ),
         );
-        if checker.patch(&Rule::MultipleWithStatements) {
+        if checker.patch(diagnostic.kind.rule()) {
             let nested_with = &with_body[0];
             if !has_comments_in(
                 Range::new(with_stmt.location, nested_with.location),

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
@@ -11,7 +11,15 @@ expression: diagnostics
   end_location:
     row: 1
     column: 13
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 1
+      column: 3
+    end_location:
+      row: 1
+      column: 13
   parent: ~
 - kind:
     AOrNotA:
@@ -22,7 +30,15 @@ expression: diagnostics
   end_location:
     row: 4
     column: 14
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 4
+      column: 4
+    end_location:
+      row: 4
+      column: 14
   parent: ~
 - kind:
     AOrNotA:
@@ -33,6 +49,14 @@ expression: diagnostics
   end_location:
     row: 7
     column: 14
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 7
+      column: 4
+    end_location:
+      row: 7
+      column: 14
   parent: ~
 

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -10,7 +10,15 @@ expression: diagnostics
   end_location:
     row: 1
     column: 12
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 1
+      column: 3
+    end_location:
+      row: 1
+      column: 12
   parent: ~
 - kind:
     OrTrue: ~
@@ -20,7 +28,15 @@ expression: diagnostics
   end_location:
     row: 4
     column: 19
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 4
+      column: 3
+    end_location:
+      row: 4
+      column: 19
   parent: ~
 - kind:
     OrTrue: ~
@@ -30,6 +46,14 @@ expression: diagnostics
   end_location:
     row: 7
     column: 18
-  fix: ~
+  fix:
+    content:
+      - "True"
+    location:
+      row: 7
+      column: 9
+    end_location:
+      row: 7
+      column: 18
   parent: ~
 

--- a/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -4,7 +4,7 @@ use crate::docstrings::definition::Docstring;
 use crate::docstrings::styles::SectionStyle;
 use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violations;
 
@@ -48,7 +48,7 @@ pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
                 Range::from_located(docstring.expr),
             );
             // Best-effort autofix: avoid adding a period after other punctuation marks.
-            if checker.patch(&Rule::EndsInPeriod)
+            if checker.patch(diagnostic.kind.rule())
                 && !trimmed.ends_with(':')
                 && !trimmed.ends_with(';')
             {

--- a/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -4,7 +4,7 @@ use crate::docstrings::definition::Docstring;
 use crate::docstrings::styles::SectionStyle;
 use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violations;
 
@@ -47,7 +47,7 @@ pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {
                 Range::from_located(docstring.expr),
             );
             // Best-effort autofix: avoid adding a period after other punctuation marks.
-            if checker.patch(&Rule::EndsInPunctuation)
+            if checker.patch(diagnostic.kind.rule())
                 && !trimmed.ends_with(':')
                 && !trimmed.ends_with(';')
             {

--- a/src/rules/pydocstyle/rules/one_liner.rs
+++ b/src/rules/pydocstyle/rules/one_liner.rs
@@ -3,7 +3,7 @@ use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers;
 use crate::violations;
 
@@ -26,7 +26,7 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
             violations::FitsOnOneLine,
             Range::from_located(docstring.expr),
         );
-        if checker.patch(&Rule::FitsOnOneLine) {
+        if checker.patch(diagnostic.kind.rule()) {
             if let (Some(leading), Some(trailing)) = (
                 helpers::leading_quote(docstring.contents),
                 helpers::trailing_quote(docstring.contents),

--- a/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::helpers::find_useless_f_strings;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// F541
@@ -14,7 +14,7 @@ pub fn f_string_missing_placeholders(expr: &Expr, values: &[Expr], checker: &mut
     {
         for (prefix_range, tok_range) in find_useless_f_strings(expr, checker.locator) {
             let mut diagnostic = Diagnostic::new(violations::FStringMissingPlaceholders, tok_range);
-            if checker.patch(&Rule::FStringMissingPlaceholders) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::deletion(
                     prefix_range.location,
                     prefix_range.end_location,

--- a/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/src/rules/pyflakes/rules/repeated_keys.rs
@@ -55,7 +55,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                                 Range::from_located(key),
                             );
                             if is_duplicate_value {
-                                if checker.patch(&Rule::MultiValueRepeatedKeyLiteral) {
+                                if checker.patch(diagnostic.kind.rule()) {
                                     diagnostic.amend(Fix::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),
@@ -83,7 +83,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                                 Range::from_located(key),
                             );
                             if is_duplicate_value {
-                                if checker.patch(&Rule::MultiValueRepeatedKeyVariable) {
+                                if checker.patch(diagnostic.kind.rule()) {
                                     diagnostic.amend(Fix::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),

--- a/src/rules/pyflakes/rules/unused_variable.rs
+++ b/src/rules/pyflakes/rules/unused_variable.rs
@@ -9,7 +9,7 @@ use crate::ast::types::{BindingKind, Range, RefEquality, ScopeKind};
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violations;
 
@@ -179,7 +179,7 @@ pub fn unused_variable(checker: &mut Checker, scope: usize) {
                 },
                 binding.range,
             );
-            if checker.patch(&Rule::UnusedVariable) {
+            if checker.patch(diagnostic.kind.rule()) {
                 if let Some(stmt) = binding.source.as_ref().map(std::convert::Into::into) {
                     if let Some((kind, fix)) = remove_unused_variable(stmt, &binding.range, checker)
                     {

--- a/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -4,7 +4,7 @@ use crate::ast::helpers::collect_call_path;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// UP017
@@ -17,7 +17,7 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
             violations::DatetimeTimezoneUTC { straight_import },
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::DatetimeTimezoneUTC) {
+        if checker.patch(diagnostic.kind.rule()) {
             if straight_import {
                 diagnostic.amend(Fix::replacement(
                     "datetime.UTC".to_string(),

--- a/src/rules/pyupgrade/rules/f_strings.rs
+++ b/src/rules/pyupgrade/rules/f_strings.rs
@@ -9,7 +9,7 @@ use rustpython_parser::lexer::Tok;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
@@ -258,7 +258,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
     }
 
     let mut diagnostic = Diagnostic::new(violations::FString, Range::from_located(expr));
-    if checker.patch(&Rule::FString) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,
             expr.location,

--- a/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/src/rules/pyupgrade/rules/functools_cache.rs
@@ -5,7 +5,7 @@ use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// UP033
@@ -40,7 +40,7 @@ pub fn functools_cache(checker: &mut Checker, decorator_list: &[Expr]) {
                     violations::FunctoolsCache,
                     Range::new(func.end_location.unwrap(), expr.end_location.unwrap()),
                 );
-                if checker.patch(&Rule::FunctoolsCache) {
+                if checker.patch(diagnostic.kind.rule()) {
                     if let ExprKind::Attribute { value, ctx, .. } = &func.node {
                         diagnostic.amend(Fix::replacement(
                             unparse_expr(

--- a/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -5,7 +5,7 @@ use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// UP011
@@ -30,7 +30,7 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
                 violations::LRUCacheWithoutParameters,
                 Range::new(func.end_location.unwrap(), expr.end_location.unwrap()),
             );
-            if checker.patch(&Rule::LRUCacheWithoutParameters) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     unparse_expr(func, checker.stylist),
                     expr.location,

--- a/src/rules/pyupgrade/rules/native_literals.rs
+++ b/src/rules/pyupgrade/rules/native_literals.rs
@@ -5,7 +5,7 @@ use rustpython_parser::lexer::Tok;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 use crate::violations::LiteralType;
 
@@ -30,7 +30,7 @@ pub fn native_literals(
             } else {
                 LiteralType::Bytes
             }}, Range::from_located(expr));
-            if checker.patch(&Rule::NativeLiterals) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
@@ -103,7 +103,7 @@ pub fn native_literals(
             },
             Range::from_located(expr),
         );
-        if checker.patch(&Rule::NativeLiterals) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 arg_code.to_string(),
                 expr.location,

--- a/src/rules/pyupgrade/rules/open_alias.rs
+++ b/src/rules/pyupgrade/rules/open_alias.rs
@@ -3,7 +3,7 @@ use rustpython_ast::Expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// UP020
@@ -13,7 +13,7 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
     {
         let mut diagnostic = Diagnostic::new(violations::OpenAlias, Range::from_located(expr));
-        if checker.patch(&Rule::OpenAlias) {
+        if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "open".to_string(),
                 func.location,

--- a/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -14,7 +14,7 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::python::identifiers::is_identifier;
 use crate::python::keyword::KWLIST;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyupgrade::helpers::curly_escape;
 use crate::violations;
@@ -410,7 +410,7 @@ pub(crate) fn printf_string_formatting(
         violations::PrintfStringFormatting,
         Range::from_located(expr),
     );
-    if checker.patch(&Rule::PrintfStringFormatting) {
+    if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,
             expr.location,

--- a/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -214,7 +214,7 @@ pub fn rewrite_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 },
                 Range::from_located(value),
             );
-            if checker.patch(&Rule::RewriteMockImport) {
+            if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     "mock".to_string(),
                     value.location,
@@ -289,7 +289,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     },
                     Range::from_located(stmt),
                 );
-                if checker.patch(&Rule::RewriteMockImport) {
+                if checker.patch(diagnostic.kind.rule()) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         match format_import_from(stmt, indent, checker.locator, checker.stylist) {
                             Ok(content) => {

--- a/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -3,7 +3,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Diagnostic;
 use crate::violations;
 
 /// Returns `true` if `expr` contains an `ExprKind::Await`.
@@ -83,7 +83,7 @@ pub fn unpack_list_comprehension(checker: &mut Checker, targets: &[Expr], value:
                 violations::RewriteListComprehension,
                 Range::from_located(value),
             );
-            if checker.patch(&Rule::RewriteListComprehension) {
+            if checker.patch(diagnostic.kind.rule()) {
                 let existing = checker
                     .locator
                     .slice_source_code_range(&Range::from_located(value));


### PR DESCRIPTION
Use the `checker.patch(diagnostic.kind.rule())` to prevent mismatch with the diagnostic.

Caught one case where the name was mistaken.