### PR TITLE
Extend conventional imports defaults to include TensorFlow et al

### DIFF
--- a/README.md
+++ b/README.md
@@ -2929,7 +2929,7 @@ allow-multiline = false
 The conventional aliases for imports. These aliases can be extended by
 the `extend_aliases` option.
 
-**Default value**: `{"altair": "alt", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns"}`
+**Default value**: `{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}`
 
 **Type**: `FxHashMap<String, String>`
 
@@ -2944,6 +2944,7 @@ altair = "alt"
 numpy = "np"
 pandas = "pd"
 seaborn = "sns"
+scripy = "sp"
 ```
 
 ---

--- a/resources/test/fixtures/flake8_import_conventions/custom.py
+++ b/resources/test/fixtures/flake8_import_conventions/custom.py
@@ -7,6 +7,13 @@ import matplotlib.pyplot  # unconventional
 import numpy  # unconventional
 import pandas  # unconventional
 import seaborn  # unconventional
+import tensorflow  # unconventional
+import holoviews  # unconventional
+import panel  # unconventional
+import plotly.express  # unconventional
+import matplotlib  # unconventional
+import polars  # unconventional
+import pyarrow  # unconventional
 
 import altair as altr  # unconventional
 import matplotlib.pyplot as plot  # unconventional
@@ -15,6 +22,13 @@ import dask.dataframe as ddf  # unconventional
 import numpy as nmp  # unconventional
 import pandas as pdas  # unconventional
 import seaborn as sbrn  # unconventional
+import tensorflow as tfz  # unconventional
+import holoviews as hsv  # unconventional
+import panel as pns  # unconventional
+import plotly.express as pltx  # unconventional
+import matplotlib as ml  # unconventional
+import polars as ps # unconventional
+import pyarrow as arr  # unconventional
 
 import altair as alt  # conventional
 import dask.array as da  # conventional
@@ -23,3 +37,12 @@ import matplotlib.pyplot as plt  # conventional
 import numpy as np  # conventional
 import pandas as pd  # conventional
 import seaborn as sns  # conventional
+import tensorflow as tf # conventional
+import holoviews as hv  # conventional
+import panel as pn  # conventional
+import plotly.express as px  # conventional
+import matplotlib as mpl  # conventional
+import polars as pl # conventional
+import pyarrow as pa  # conventional
+
+from tensorflow.keras import Model  # conventional

--- a/src/rules/flake8_import_conventions/settings.rs
+++ b/src/rules/flake8_import_conventions/settings.rs
@@ -11,10 +11,17 @@ use crate::settings::hashable::HashableHashMap;
 
 const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("altair", "alt"),
+    ("matplotlib", "mpl"),
     ("matplotlib.pyplot", "plt"),
     ("numpy", "np"),
     ("pandas", "pd"),
     ("seaborn", "sns"),
+    ("tensorflow", "tf"),
+    ("holoviews", "hv"),
+    ("panel", "pn"),
+    ("plotly.express", "px"),
+    ("polars", "pl"),
+    ("pyarrow", "pa"),
 ];
 
 #[derive(
@@ -27,7 +34,7 @@ const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
 )]
 pub struct Options {
     #[option(
-        default = r#"{"altair": "alt", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns"}"#,
+        default = r#"{"altair": "alt", "matplotlib": "mpl", "matplotlib.pyplot": "plt", "numpy": "np", "pandas": "pd", "seaborn": "sns", "tensorflow": "tf", "holoviews": "hv", "panel": "pn", "plotly.express": "px", "polars": "pl", "pyarrow": "pa"}"#,
         value_type = "FxHashMap<String, String>",
         example = r#"
             [tool.ruff.flake8-import-conventions.aliases]
@@ -37,6 +44,7 @@ pub struct Options {
             numpy = "np"
             pandas = "pd"
             seaborn = "sns"
+            scripy = "sp"
         "#
     )]
     /// The conventional aliases for imports. These aliases can be extended by

--- a/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
+++ b/src/rules/flake8_import_conventions/snapshots/ruff__rules__flake8_import_conventions__tests__custom.snap
@@ -88,13 +88,97 @@ expression: diagnostics
   parent: ~
 - kind:
     ImportAliasIsNotConventional:
-      - altair
-      - alt
+      - tensorflow
+      - tf
+  location:
+    row: 10
+    column: 0
+  end_location:
+    row: 10
+    column: 17
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - holoviews
+      - hv
   location:
     row: 11
     column: 0
   end_location:
     row: 11
+    column: 16
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - panel
+      - pn
+  location:
+    row: 12
+    column: 0
+  end_location:
+    row: 12
+    column: 12
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - plotly.express
+      - px
+  location:
+    row: 13
+    column: 0
+  end_location:
+    row: 13
+    column: 21
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - matplotlib
+      - mpl
+  location:
+    row: 14
+    column: 0
+  end_location:
+    row: 14
+    column: 17
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - polars
+      - pl
+  location:
+    row: 15
+    column: 0
+  end_location:
+    row: 15
+    column: 13
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - pyarrow
+      - pa
+  location:
+    row: 16
+    column: 0
+  end_location:
+    row: 16
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - altair
+      - alt
+  location:
+    row: 18
+    column: 0
+  end_location:
+    row: 18
     column: 21
   fix: ~
   parent: ~
@@ -103,10 +187,10 @@ expression: diagnostics
       - matplotlib.pyplot
       - plt
   location:
-    row: 12
+    row: 19
     column: 0
   end_location:
-    row: 12
+    row: 19
     column: 32
   fix: ~
   parent: ~
@@ -115,10 +199,10 @@ expression: diagnostics
       - dask.array
       - da
   location:
-    row: 13
+    row: 20
     column: 0
   end_location:
-    row: 13
+    row: 20
     column: 27
   fix: ~
   parent: ~
@@ -127,10 +211,10 @@ expression: diagnostics
       - dask.dataframe
       - dd
   location:
-    row: 14
+    row: 21
     column: 0
   end_location:
-    row: 14
+    row: 21
     column: 28
   fix: ~
   parent: ~
@@ -139,10 +223,10 @@ expression: diagnostics
       - numpy
       - np
   location:
-    row: 15
+    row: 22
     column: 0
   end_location:
-    row: 15
+    row: 22
     column: 19
   fix: ~
   parent: ~
@@ -151,10 +235,10 @@ expression: diagnostics
       - pandas
       - pd
   location:
-    row: 16
+    row: 23
     column: 0
   end_location:
-    row: 16
+    row: 23
     column: 21
   fix: ~
   parent: ~
@@ -163,11 +247,95 @@ expression: diagnostics
       - seaborn
       - sns
   location:
-    row: 17
+    row: 24
     column: 0
   end_location:
-    row: 17
+    row: 24
     column: 22
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - tensorflow
+      - tf
+  location:
+    row: 25
+    column: 0
+  end_location:
+    row: 25
+    column: 24
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - holoviews
+      - hv
+  location:
+    row: 26
+    column: 0
+  end_location:
+    row: 26
+    column: 23
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - panel
+      - pn
+  location:
+    row: 27
+    column: 0
+  end_location:
+    row: 27
+    column: 19
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - plotly.express
+      - px
+  location:
+    row: 28
+    column: 0
+  end_location:
+    row: 28
+    column: 29
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - matplotlib
+      - mpl
+  location:
+    row: 29
+    column: 0
+  end_location:
+    row: 29
+    column: 23
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - polars
+      - pl
+  location:
+    row: 30
+    column: 0
+  end_location:
+    row: 30
+    column: 19
+  fix: ~
+  parent: ~
+- kind:
+    ImportAliasIsNotConventional:
+      - pyarrow
+      - pa
+  location:
+    row: 31
+    column: 0
+  end_location:
+    row: 31
+    column: 21
   fix: ~
   parent: ~
 


### PR DESCRIPTION
Based on configuration from Visual Studio for Python (https://code.visualstudio.com/docs/python/editing#_quick-fixes) and suggestion by @edgarrmondragon.

Semi-common conventions (e.g. `scipy.io` as `spio` or `sio`) are not included.

### Alternatives considered
In principle these can be user configured, but we should have sensible defaults where possible. Criteria to include `tensorflow`, `matplotlib`, `holoviews`, `panel`, `plotly.express`, `polars` and `pyarrow` (measured a part of dash) are (1) the abbreviations are used the official documentation and (2) the packages are reasonably popular by a rule of thumb (e.g. > 1k stars on github). 

- tensorflow: https://www.tensorflow.org/overview
- holoview: https://holoviews.org/getting_started/Introduction.html
- panel: https://panel.holoviz.org/getting_started/build_app.html
- plotly.express: https://dash.plotly.com/duplicate-callback-outputs
- matplotlib: https://github.com/matplotlib/matplotlib/search?q=mpl
- polars: https://www.pola.rs/
- pyarrow: https://arrow.apache.org/docs/python/getstarted.html

(as a santity check one can [search](https://github.com/search?l=Python&q=import+pyspark+as&type=Code) all of github)