### PR TITLE
[`I001`] fix isort for files with tab-based indentation

### DIFF
--- a/resources/test/fixtures/isort/preserve_tabs.py
+++ b/resources/test/fixtures/isort/preserve_tabs.py
@@ -1,0 +1,29 @@
+from numpy import (
+	cos,
+	int8,
+	int16,
+	int32,
+	int64,
+	sin,
+	tan,
+	uint8,
+	uint16,
+	uint32,
+	uint64,
+)
+
+if True:
+	# inside nested block
+	from numpy import (
+		cos,
+		int8,
+		int16,
+		int32,
+		int64,
+		sin,
+		tan,
+		uint8,
+		uint16,
+		uint32,
+		uint64,
+	)

--- a/src/rules/isort/format.rs
+++ b/src/rules/isort/format.rs
@@ -1,9 +1,6 @@
 use super::types::{AliasData, CommentSet, ImportFromData, Importable};
 use crate::source_code::Stylist;
 
-// Hard-code four-space indentation for the imports themselves, to match Black.
-const INDENT: &str = "    ";
-
 // Guess a capacity to use for string allocation.
 const CAPACITY: usize = 200;
 
@@ -174,11 +171,11 @@ fn format_multi_line(
 
     for (AliasData { name, asname }, comments) in aliases {
         for comment in &comments.atop {
-            output.push_str(INDENT);
+            output.push_str(stylist.indentation());
             output.push_str(comment);
             output.push_str(stylist.line_ending());
         }
-        output.push_str(INDENT);
+        output.push_str(stylist.indentation());
         if let Some(asname) = asname {
             output.push_str(name);
             output.push_str(" as ");

--- a/src/rules/isort/mod.rs
+++ b/src/rules/isort/mod.rs
@@ -714,6 +714,7 @@ mod tests {
     #[test_case(Path::new("preserve_comment_order.py"))]
     #[test_case(Path::new("preserve_import_star.py"))]
     #[test_case(Path::new("preserve_indentation.py"))]
+    #[test_case(Path::new("preserve_tabs.py"))]
     #[test_case(Path::new("relative_imports_order.py"))]
     #[test_case(Path::new("reorder_within_section.py"))]
     #[test_case(Path::new("separate_first_party_imports.py"))]

--- a/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_tabs.py.snap
+++ b/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_tabs.py.snap
@@ -1,0 +1,6 @@
+---
+source: src/rules/isort/mod.rs
+expression: diagnostics
+---
+[]
+


### PR DESCRIPTION
This PR fixes two related issues with using isort on files using tabs for indentation:

- Multiline imports are never considered correctly formatted, since the comparison with the generated code will always fail.
- Using autofix generates code that can have mixed indentation in the same line, for imports that are within nested blocks.