### PR TITLE
Refine criteria for `exc_info` logger rules

### DIFF
--- a/resources/test/fixtures/flake8_logging_format/G201.py
+++ b/resources/test/fixtures/flake8_logging_format/G201.py
@@ -1,3 +1,21 @@
 import logging
+import sys
 
-logging.error('Hello World', exc_info=True)
+# G201
+try:
+    pass
+except:
+    logging.error("Hello World", exc_info=True)
+
+try:
+    pass
+except:
+    logging.error("Hello World", exc_info=sys.exc_info())
+
+# OK
+try:
+    pass
+except:
+    logging.error("Hello World", exc_info=False)
+
+logging.error("Hello World", exc_info=sys.exc_info())

--- a/resources/test/fixtures/flake8_logging_format/G202.py
+++ b/resources/test/fixtures/flake8_logging_format/G202.py
@@ -1,3 +1,21 @@
 import logging
+import sys
 
-logging.exception('Hello World', exc_info=True)
+# G202
+try:
+    pass
+except:
+    logging.exception("Hello World", exc_info=True)
+
+try:
+    pass
+except:
+    logging.exception("Hello World", exc_info=sys.exc_info())
+
+# OK
+try:
+    pass
+except:
+    logging.exception("Hello World", exc_info=False)
+
+logging.exception("Hello World", exc_info=True)

--- a/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G201.py.snap
+++ b/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G201.py.snap
@@ -5,11 +5,21 @@ expression: diagnostics
 - kind:
     LoggingExcInfo: ~
   location:
-    row: 3
-    column: 8
+    row: 8
+    column: 12
   end_location:
-    row: 3
-    column: 13
+    row: 8
+    column: 17
+  fix: ~
+  parent: ~
+- kind:
+    LoggingExcInfo: ~
+  location:
+    row: 13
+    column: 12
+  end_location:
+    row: 13
+    column: 17
   fix: ~
   parent: ~
 

--- a/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G202.py.snap
+++ b/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G202.py.snap
@@ -5,11 +5,21 @@ expression: diagnostics
 - kind:
     LoggingRedundantExcInfo: ~
   location:
-    row: 3
-    column: 33
+    row: 8
+    column: 37
   end_location:
-    row: 3
-    column: 46
+    row: 8
+    column: 50
+  fix: ~
+  parent: ~
+- kind:
+    LoggingRedundantExcInfo: ~
+  location:
+    row: 13
+    column: 37
+  end_location:
+    row: 13
+    column: 60
   fix: ~
   parent: ~
 


### PR DESCRIPTION
We now only trigger `logging-exc-info` and `logging-redundant-exc-info` when in an exception handler, with an `exc_info` that isn't `true` or `sys.exc_info()`.

Closes #2356.