### PR TITLE
Recommend disabling `explicit-string-concatenation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,7 +1054,7 @@ For more, see [flake8-implicit-str-concat](https://pypi.org/project/flake8-impli
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
 | ISC001 | single-line-implicit-string-concatenation | Implicitly concatenated string literals on one line |  |
-| ISC002 | multi-line-implicit-string-concatenation | Implicitly concatenated string literals over continuation line |  |
+| ISC002 | multi-line-implicit-string-concatenation | Implicitly concatenated string literals over multiple lines |  |
 | ISC003 | explicit-string-concatenation | Explicitly concatenated string should be implicitly concatenated |  |
 
 ### flake8-import-conventions (ICN)
@@ -2932,6 +2932,11 @@ Whether to allow implicit string concatenations for multiline strings.
 By default, implicit concatenations of multiline strings are
 allowed (but continuation lines, delimited with a backslash, are
 prohibited).
+
+Note that setting `allow-multiline = false` should typically be coupled
+with disabling `explicit-string-concatenation` (`ISC003`). Otherwise,
+both explicit and implicit multiline string concatenations will be seen
+as violations.
 
 **Default value**: `true`
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -649,7 +649,7 @@
       "type": "object",
       "properties": {
         "allow-multiline": {
-          "description": "Whether to allow implicit string concatenations for multiline strings. By default, implicit concatenations of multiline strings are allowed (but continuation lines, delimited with a backslash, are prohibited).",
+          "description": "Whether to allow implicit string concatenations for multiline strings. By default, implicit concatenations of multiline strings are allowed (but continuation lines, delimited with a backslash, are prohibited).\n\nNote that setting `allow-multiline = false` should typically be coupled with disabling `explicit-string-concatenation` (`ISC003`). Otherwise, both explicit and implicit multiline string concatenations will be seen as violations.",
           "type": [
             "boolean",
             "null"

--- a/src/rules/flake8_implicit_str_concat/settings.rs
+++ b/src/rules/flake8_implicit_str_concat/settings.rs
@@ -24,6 +24,11 @@ pub struct Options {
     /// By default, implicit concatenations of multiline strings are
     /// allowed (but continuation lines, delimited with a backslash, are
     /// prohibited).
+    ///
+    /// Note that setting `allow-multiline = false` should typically be coupled
+    /// with disabling `explicit-string-concatenation` (`ISC003`). Otherwise,
+    /// both explicit and implicit multiline string concatenations will be seen
+    /// as violations.
     pub allow_multiline: Option<bool>,
 }
 

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -1855,7 +1855,7 @@ define_violation!(
 impl Violation for MultiLineImplicitStringConcatenation {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Implicitly concatenated string literals over continuation line")
+        format!("Implicitly concatenated string literals over multiple lines")
     }
 }
 


### PR DESCRIPTION
If `allow-multiline = false` is set, then if the user enables `explicit-string-concatenation` (`ISC003`), there's no way for them to create valid multiline strings. This PR notes that they should turn off `ISC003`.

Closes #2362.