### PR TITLE
fix: ignore UP006 for Python < 3.9

### DIFF
--- a/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -4,6 +4,7 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::settings::types::PythonVersion;
 use crate::violations;
 
 /// UP006
@@ -12,6 +13,9 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
         .resolve_call_path(expr)
         .and_then(|call_path| call_path.last().copied())
     {
+        if checker.settings.target_version <= PythonVersion::Py39 {
+            return;
+        }
         let mut diagnostic = Diagnostic::new(
             violations::UsePEP585Annotation {
                 name: binding.to_string(),

--- a/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
+++ b/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
@@ -2,23 +2,4 @@
 source: src/rules/pyupgrade/mod.rs
 expression: diagnostics
 ---
-- kind:
-    UsePEP585Annotation:
-      name: List
-  location:
-    row: 34
-    column: 17
-  end_location:
-    row: 34
-    column: 21
-  fix:
-    content:
-      - list
-    location:
-      row: 34
-      column: 17
-    end_location:
-      row: 34
-      column: 21
-  parent: ~
-
+[]


### PR DESCRIPTION
UP006 transforms `typing.Dict[str, str]` into `dict[str, str]` which is a `TypeError: 'type' object is not subscriptable` in Python < 3.9: https://peps.python.org/pep-0585/

The test should ignore it if the target version doesn't match.