### PR TITLE
Disable incompatible rules rather than merely warning

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -742,18 +742,18 @@ impl Diagnostic {
 }
 
 /// Pairs of checks that shouldn't be enabled together.
-pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str)] = &[
+pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 2] = &[
     (
-        Rule::OneBlankLineBeforeClass,
         Rule::NoBlankLineBeforeClass,
+        Rule::OneBlankLineBeforeClass,
         "`one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are \
-         incompatible. Consider ignoring `one-blank-line-before-class`.",
+         incompatible. Ignoring `one-blank-line-before-class`.",
     ),
     (
         Rule::MultiLineSummaryFirstLine,
         Rule::MultiLineSummarySecondLine,
         "`multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are \
-         incompatible. Consider ignoring one.",
+         incompatible. Ignoring `multi-line-summary-second-line`.",
     ),
 ];
 


### PR DESCRIPTION
This is another temporary fix for the problem described in #2289 and #2292. Rather than merely warning, we now disable the incompatible rules (in addition to the warning). I actually think this is quite a reasonable solution, but we can revisit later. I just can't bring myself to ship another release with autofix broken-by-default :joy:
