### PR TITLE
[`I001`] fix isort check for files with tabs and no indented blocks

### DIFF
--- a/resources/test/fixtures/isort/preserve_tabs_2.py
+++ b/resources/test/fixtures/isort/preserve_tabs_2.py
@@ -1,0 +1,13 @@
+from numpy import (
+	cos,
+	int8,
+	int16,
+	int32,
+	int64,
+	sin,
+	tan,
+	uint8,
+	uint16,
+	uint32,
+	uint64,
+)

--- a/src/rules/isort/mod.rs
+++ b/src/rules/isort/mod.rs
@@ -715,6 +715,7 @@ mod tests {
     #[test_case(Path::new("preserve_import_star.py"))]
     #[test_case(Path::new("preserve_indentation.py"))]
     #[test_case(Path::new("preserve_tabs.py"))]
+    #[test_case(Path::new("preserve_tabs_2.py"))]
     #[test_case(Path::new("relative_imports_order.py"))]
     #[test_case(Path::new("reorder_within_section.py"))]
     #[test_case(Path::new("separate_first_party_imports.py"))]

--- a/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_tabs_2.py.snap
+++ b/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_tabs_2.py.snap
@@ -1,0 +1,6 @@
+---
+source: src/rules/isort/mod.rs
+expression: diagnostics
+---
+[]
+


### PR DESCRIPTION
This is a followup to #2361. The isort check still had an issue in a rather specific case: files with a multiline import, indented with tabs, and not containing any indented blocks.

The root cause is this: [`Stylist`'s indentation detection](https://github.com/charliermarsh/ruff/blob/ad8693e3deddbd8e178546dad7be5759ebf1a095/src/source_code/stylist.rs#L163-L172) works by finding `Indent` tokens to determine the type of indentation used by a file. This works for indented code blocks (loops/classes/functions/etc) but does not work for multiline values, so falls back to 4 spaces if the file doesn't contain code blocks.

I considered a few possible solutions:

1. Fix `detect_indentation` to avoid tokenizing and instead use some other heuristic to determine indentation. This would have the benefit of working in other places where this is potentially an issue, but would still fail if the file doesn't contain any indentation at all, and would need to fall back to option 2 anyways.
2. Add an option for specifying the default indentation in Ruff's config. I think this would confusing, since it wouldn't affect the detection behavior and only operate as a fallback, has no other current application and would probably end up being overloaded for other things.
3. Relax the isort check by comparing the expected and actual code's lexed tokens. This would require an additional lexing step.
4. Relax the isort check by comparing the expected and actual code modulo whitespace at the start of lines.

This PR does approach 4, which in addition to being the simplest option, has the (expected, although I didn't benchmark) added benefit of improved performance, since the check no longer needs to do two allocations for the two `dedent` calls. I also believe that the check is still correct enough for all practical purposes.