### PR TITLE
For neovim:null_ls use ruff builtin for formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,30 +1541,10 @@ tools:
 
 ```lua
 local null_ls = require("null-ls")
-local methods = require("null-ls.methods")
-local helpers = require("null-ls.helpers")
-
-local function ruff_fix()
-    return helpers.make_builtin({
-        name = "ruff",
-        meta = {
-            url = "https://github.com/charliermarsh/ruff/",
-            description = "An extremely fast Python linter, written in Rust.",
-        },
-        method = methods.internal.FORMATTING,
-        filetypes = { "python" },
-        generator_opts = {
-            command = "ruff",
-            args = { "--fix", "-e", "-n", "--stdin-filename", "$FILENAME", "-" },
-            to_stdin = true
-        },
-        factory = helpers.formatter_factory
-    })
-end
 
 null_ls.setup({
     sources = {
-        ruff_fix(),
+        null_ls.builtins.formatting.ruff,
         null_ls.builtins.diagnostics.ruff,
     }
 })


### PR DESCRIPTION
[null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) picked up the recommended snippet in README.md and ruff formatting now a builtin.

Ref:
1. https://github.com/jose-elias-alvarez/null-ls.nvim/pull/1290/commits/482990e39171e3d69b8ead67fa5bc8339d4f9d43

2. https://github.com/jose-elias-alvarez/null-ls.nvim/blob/7b2b28e207a1df4ebb13c7dc0bd83f69b5403d71/doc/BUILTINS.md#ruff-1