### PR TITLE
Handle multi-byte lines in RUF100

### DIFF
--- a/resources/test/fixtures/ruff/RUF100_0.py
+++ b/resources/test/fixtures/ruff/RUF100_0.py
@@ -86,3 +86,5 @@ import shelve  # noqa: RUF100
 import sys  # noqa: F401, RUF100
 
 print(sys.path)
+
+"shape:  (6,)\nSeries: '' [duration[μs]]\n[\n\t0µs\n\t1µs\n\t2µs\n\t3µs\n\t4µs\n\t5µs\n]"  # noqa: F401

--- a/src/checkers/noqa.rs
+++ b/src/checkers/noqa.rs
@@ -100,8 +100,11 @@ pub fn check_noqa(
     if enforce_noqa {
         for (row, (directive, matches)) in noqa_directives {
             match directive {
-                Directive::All(spaces, start, end) => {
+                Directive::All(spaces, start_byte, end_byte) => {
                     if matches.is_empty() {
+                        let start = lines[row][..start_byte].chars().count();
+                        let end = start + lines[row][start_byte..end_byte].chars().count();
+
                         let mut diagnostic = Diagnostic::new(
                             violations::UnusedNOQA { codes: None },
                             Range::new(Location::new(row + 1, start), Location::new(row + 1, end)),
@@ -117,7 +120,7 @@ pub fn check_noqa(
                         diagnostics.push(diagnostic);
                     }
                 }
-                Directive::Codes(spaces, start, end, codes) => {
+                Directive::Codes(spaces, start_byte, end_byte, codes) => {
                     let mut disabled_codes = vec![];
                     let mut unknown_codes = vec![];
                     let mut unmatched_codes = vec![];
@@ -153,6 +156,9 @@ pub fn check_noqa(
                         && unknown_codes.is_empty()
                         && unmatched_codes.is_empty())
                     {
+                        let start = lines[row][..start_byte].chars().count();
+                        let end = start + lines[row][start_byte..end_byte].chars().count();
+
                         let mut diagnostic = Diagnostic::new(
                             violations::UnusedNOQA {
                                 codes: Some(UnusedCodes {

--- a/src/noqa.rs
+++ b/src/noqa.rs
@@ -166,13 +166,13 @@ fn add_noqa_inner(
                         output.push_str(line_ending);
                         count += 1;
                     }
-                    Directive::Codes(_, start, _, existing) => {
+                    Directive::Codes(_, start_byte, _, existing) => {
                         // Reconstruct the line based on the preserved rule codes.
                         // This enables us to tally the number of edits.
-                        let mut formatted = String::new();
+                        let mut formatted = String::with_capacity(line.len());
 
                         // Add existing content.
-                        formatted.push_str(line[..start].trim_end());
+                        formatted.push_str(line[..start_byte].trim_end());
 
                         // Add `noqa` directive.
                         formatted.push_str("  # noqa: ");

--- a/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
+++ b/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
@@ -268,4 +268,39 @@ expression: diagnostics
       row: 86
       column: 0
   parent: ~
+- kind:
+    LineTooLong:
+      - 103
+      - 88
+  location:
+    row: 90
+    column: 88
+  end_location:
+    row: 90
+    column: 103
+  fix: ~
+  parent: ~
+- kind:
+    UnusedNOQA:
+      codes:
+        unknown: []
+        disabled: []
+        unmatched:
+          - F401
+  location:
+    row: 90
+    column: 91
+  end_location:
+    row: 90
+    column: 103
+  fix:
+    content:
+      - ""
+    location:
+      row: 90
+      column: 89
+    end_location:
+      row: 90
+      column: 103
+  parent: ~
 


### PR DESCRIPTION
The regex locations are byte locations, not character locations. Need to convert!

Closes #2379.