### PR TITLE
Disable panic hook about reporting issues for debug builds

### DIFF
--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -58,20 +58,23 @@ fn inner_main() -> Result<ExitCode> {
         log_level_args,
     } = Args::parse_from(args);
 
-    let default_panic_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |info| {
-        eprintln!(
-            r#"
+    #[cfg(not(debug_assertions))]
+    {
+        let default_panic_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            eprintln!(
+                r#"
 {}: `ruff` crashed. This indicates a bug in `ruff`. If you could open an issue at:
 
 https://github.com/charliermarsh/ruff/issues/new?title=%5BPanic%5D
 
 quoting the executed command, along with the relevant file contents and `pyproject.toml` settings, we'd be very appreciative!
 "#,
-            "error".red().bold(),
-        );
-        default_panic_hook(info);
-    }));
+                "error".red().bold(),
+            );
+            default_panic_hook(info);
+        }));
+    }
 
     let log_level: LogLevel = (&log_level_args).into();
     set_up_logging(&log_level)?;


### PR DESCRIPTION
In order to avoid confusing new developers.  When a debug build panics chances are that the panic is caused by local changes and should in fact not be reported on GitHub.