### PR TITLE
Only avoid PEP604 rewrites for pre-Python 3.10 code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3814,7 +3814,9 @@ Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604
 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from
 __future__ import annotations`. Note that this setting is only
 applicable when the target Python version is below 3.9 and 3.10
-respectively.
+respectively, and enabling it is equivalent to disabling
+`use-pep585-annotation` (`UP006`) and `use-pep604-annotation`
+(`UP007`) entirely.
 
 **Default value**: `false`
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1102,7 +1102,7 @@
       "type": "object",
       "properties": {
         "keep-runtime-typing": {
-          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively.",
+          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and enabling it is equivalent to disabling `use-pep585-annotation` (`UP006`) and `use-pep604-annotation` (`UP007`) entirely.",
           "type": [
             "boolean",
             "null"

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -2018,12 +2018,12 @@ where
             ExprKind::Subscript { value, slice, .. } => {
                 // Ex) Optional[...]
                 if !self.in_deferred_string_type_definition
-                    && self.in_annotation
+                    && !self.settings.pyupgrade.keep_runtime_typing
                     && self.settings.rules.enabled(&Rule::UsePEP604Annotation)
                     && (self.settings.target_version >= PythonVersion::Py310
                         || (self.settings.target_version >= PythonVersion::Py37
-                            && !self.settings.pyupgrade.keep_runtime_typing
-                            && self.annotations_future_enabled))
+                            && self.annotations_future_enabled
+                            && self.in_annotation))
                 {
                     pyupgrade::rules::use_pep604_annotation(self, expr, value, slice);
                 }
@@ -2073,10 +2073,10 @@ where
 
                         // Ex) List[...]
                         if !self.in_deferred_string_type_definition
+                            && !self.settings.pyupgrade.keep_runtime_typing
                             && self.settings.rules.enabled(&Rule::UsePEP585Annotation)
                             && (self.settings.target_version >= PythonVersion::Py39
                                 || (self.settings.target_version >= PythonVersion::Py37
-                                    && !self.settings.pyupgrade.keep_runtime_typing
                                     && self.annotations_future_enabled
                                     && self.in_annotation))
                             && typing::is_pep585_builtin(self, expr)
@@ -2118,6 +2118,7 @@ where
             ExprKind::Attribute { attr, value, .. } => {
                 // Ex) typing.List[...]
                 if !self.in_deferred_string_type_definition
+                    && !self.settings.pyupgrade.keep_runtime_typing
                     && self.settings.rules.enabled(&Rule::UsePEP585Annotation)
                     && (self.settings.target_version >= PythonVersion::Py39
                         || (self.settings.target_version >= PythonVersion::Py37

--- a/src/rules/pyupgrade/settings.rs
+++ b/src/rules/pyupgrade/settings.rs
@@ -25,7 +25,9 @@ pub struct Options {
     /// (`Optional[str]` -> `str | None`) rewrites even if a file imports `from
     /// __future__ import annotations`. Note that this setting is only
     /// applicable when the target Python version is below 3.9 and 3.10
-    /// respectively.
+    /// respectively, and enabling it is equivalent to disabling
+    /// `use-pep585-annotation` (`UP006`) and `use-pep604-annotation`
+    /// (`UP007`) entirely.
     pub keep_runtime_typing: Option<bool>,
 }
 

--- a/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
+++ b/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
@@ -20,4 +20,22 @@ expression: diagnostics
       row: 40
       column: 16
   parent: ~
+- kind:
+    UsePEP604Annotation: ~
+  location:
+    row: 42
+    column: 20
+  end_location:
+    row: 42
+    column: 47
+  fix:
+    content:
+      - "List[int] | List[str]"
+    location:
+      row: 42
+      column: 20
+    end_location:
+      row: 42
+      column: 47
+  parent: ~
 


### PR DESCRIPTION
I moved the `self.in_annotation` guard out of the version check in #1563. But, I think that was a mistake. It was done to resolve #1560, but the fix in that case _should've_ been to set a different Python version.

Closes #2447.