### PR TITLE
Allow non-ruff.toml-named files for --config

### DIFF
--- a/src/settings/configuration.rs
+++ b/src/settings/configuration.rs
@@ -21,7 +21,6 @@ use crate::rules::{
     pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 use crate::settings::options::Options;
-use crate::settings::pyproject::load_options;
 use crate::settings::types::{
     FilePattern, PerFileIgnore, PythonVersion, SerializationFormat, Version,
 };
@@ -86,10 +85,6 @@ pub struct Configuration {
 }
 
 impl Configuration {
-    pub fn from_toml(path: &Path, project_root: &Path) -> Result<Self> {
-        Self::from_options(load_options(path)?, project_root)
-    }
-
     pub fn from_options(options: Options, project_root: &Path) -> Result<Self> {
         Ok(Configuration {
             rule_selections: vec![RuleSelection {

--- a/src/settings/pyproject.rs
+++ b/src/settings/pyproject.rs
@@ -99,9 +99,7 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
 
 /// Load `Options` from a `pyproject.toml` or `ruff.toml` file.
 pub fn load_options<P: AsRef<Path>>(path: P) -> Result<Options> {
-    if path.as_ref().ends_with("ruff.toml") {
-        parse_ruff_toml(path)
-    } else if path.as_ref().ends_with("pyproject.toml") {
+    if path.as_ref().ends_with("pyproject.toml") {
         let pyproject = parse_pyproject_toml(&path).map_err(|err| {
             anyhow!(
                 "Failed to parse `{}`: {}",
@@ -114,10 +112,7 @@ pub fn load_options<P: AsRef<Path>>(path: P) -> Result<Options> {
             .and_then(|tool| tool.ruff)
             .unwrap_or_default())
     } else {
-        Err(anyhow!(
-            "Unrecognized settings file: `{}`",
-            path.as_ref().to_string_lossy()
-        ))
+        parse_ruff_toml(path)
     }
 }
 


### PR DESCRIPTION
Previously, if you passed in a file on the command-line via `--config`, it had to be named either `pyproject.toml` or `ruff.toml` -- otherwise, we errored. I think this is too strict. `pyproject.toml` is a special name in the ecosystem, so we should require _that_; but otherwise, let's just assume it's in `ruff.toml` format.

As an alternative, we could add a `--pyproject` argument for `pyproject.toml`, and assume anything passed to `--config` is in `ruff.toml` format. But that _would_ be a breaking change and is arguably more confusing. (This isn't a breaking change, since it only loosens the CLI.)

Closes #2462.