### PR TITLE
Use LibCST to reverse Yoda conditions

### DIFF
--- a/resources/test/fixtures/flake8_simplify/SIM300.py
+++ b/resources/test/fixtures/flake8_simplify/SIM300.py
@@ -10,6 +10,7 @@ YODA == age  # SIM300
 YODA > age  # SIM300
 YODA >= age  # SIM300
 JediOrder.YODA == age  # SIM300
+0 < (number - 100)  # SIM300
 
 # OK
 compare == "yoda"
@@ -24,3 +25,4 @@ age < YODA
 age <= YODA
 YODA == YODA
 age == JediOrder.YODA
+(number - 100) > 0

--- a/src/cst/matchers.rs
+++ b/src/cst/matchers.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use libcst_native::{
-    Call, Expr, Expression, Import, ImportFrom, Module, SmallStatement, Statement,
+    Call, Comparison, Expr, Expression, Import, ImportFrom, Module, SmallStatement, Statement,
 };
 
 pub fn match_module(module_text: &str) -> Result<Module> {
@@ -34,7 +34,7 @@ pub fn match_import<'a, 'b>(module: &'a mut Module<'b>) -> Result<&'a mut Import
         if let Some(SmallStatement::Import(expr)) = expr.body.first_mut() {
             Ok(expr)
         } else {
-            bail!("Expected SmallStatement::Expr")
+            bail!("Expected SmallStatement::Import")
         }
     } else {
         bail!("Expected Statement::Simple")
@@ -46,7 +46,7 @@ pub fn match_import_from<'a, 'b>(module: &'a mut Module<'b>) -> Result<&'a mut I
         if let Some(SmallStatement::ImportFrom(expr)) = expr.body.first_mut() {
             Ok(expr)
         } else {
-            bail!("Expected SmallStatement::Expr")
+            bail!("Expected SmallStatement::ImportFrom")
         }
     } else {
         bail!("Expected Statement::Simple")
@@ -57,6 +57,16 @@ pub fn match_call<'a, 'b>(expression: &'a mut Expression<'b>) -> Result<&'a mut 
     if let Expression::Call(call) = expression {
         Ok(call)
     } else {
-        bail!("Expected SmallStatement::Expr")
+        bail!("Expected Expression::Call")
+    }
+}
+
+pub fn match_comparison<'a, 'b>(
+    expression: &'a mut Expression<'b>,
+) -> Result<&'a mut Comparison<'b>> {
+    if let Expression::Comparison(comparison) = expression {
+        Ok(comparison)
+    } else {
+        bail!("Expected Expression::Comparison")
     }
 }

--- a/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
+++ b/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
@@ -211,4 +211,23 @@ expression: diagnostics
       row: 12
       column: 21
   parent: ~
+- kind:
+    YodaConditions:
+      suggestion: (number - 100) > 0
+  location:
+    row: 13
+    column: 0
+  end_location:
+    row: 13
+    column: 18
+  fix:
+    content:
+      - (number - 100) > 0
+    location:
+      row: 13
+      column: 0
+    end_location:
+      row: 13
+      column: 17
+  parent: ~
 

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -2575,19 +2575,32 @@ impl AlwaysAutofixableViolation for AndFalse {
 
 define_violation!(
     pub struct YodaConditions {
-        pub suggestion: String,
+        pub suggestion: Option<String>,
     }
 );
-impl AlwaysAutofixableViolation for YodaConditions {
+impl Violation for YodaConditions {
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let YodaConditions { suggestion } = self;
-        format!("Yoda conditions are discouraged, use `{suggestion}` instead")
+        if let Some(suggestion) = suggestion {
+            format!("Yoda conditions are discouraged, use `{suggestion}` instead")
+        } else {
+            format!("Yoda conditions are discouraged")
+        }
     }
 
-    fn autofix_title(&self) -> String {
-        let YodaConditions { suggestion } = self;
-        format!("Replace Yoda condition with `{suggestion}`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        let YodaConditions { suggestion, .. } = self;
+        if suggestion.is_some() {
+            Some(|YodaConditions { suggestion }| {
+                let suggestion = suggestion.as_ref().unwrap();
+                format!("Replace Yoda condition with `{suggestion}`")
+            })
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Our existing solution was having trouble with parenthesized expressions. This actually may affect more than `SIM300`, but let's address them as they come up.

Closes #2466.
