### PR TITLE
fix: assertTrue()/assertFalse() fixer should not test for identity

### DIFF
--- a/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -265,15 +265,15 @@ impl UnittestAssert {
                     .get("expr")
                     .ok_or_else(|| anyhow!("Missing argument `expr`"))?;
                 let msg = args.get("msg").copied();
-                if matches!(self, UnittestAssert::False) {
+                Ok(if matches!(self, UnittestAssert::False) {
                     let unary_expr = create_expr(ExprKind::UnaryOp {
                         op: Unaryop::Not,
                         operand: Box::new(create_expr(expr.node.clone())),
                     });
-                    Ok(assert(&unary_expr, msg))
+                    assert(&unary_expr, msg)
                 } else {
-                    Ok(assert(expr, msg))
-                }
+                    assert(expr, msg)
+                })
             }
             UnittestAssert::Equal
             | UnittestAssert::Equals

--- a/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -265,12 +265,15 @@ impl UnittestAssert {
                     .get("expr")
                     .ok_or_else(|| anyhow!("Missing argument `expr`"))?;
                 let msg = args.get("msg").copied();
-                let bool = create_expr(ExprKind::Constant {
-                    value: Constant::Bool(matches!(self, UnittestAssert::True)),
-                    kind: None,
-                });
-                let expr = compare(expr, Cmpop::Is, &bool);
-                Ok(assert(&expr, msg))
+                if matches!(self, UnittestAssert::False) {
+                    let unary_expr = create_expr(ExprKind::UnaryOp {
+                        op: Unaryop::Not,
+                        operand: Box::new(create_expr(expr.node.clone())),
+                    });
+                    Ok(assert(&unary_expr, msg))
+                } else {
+                    Ok(assert(expr, msg))
+                }
             }
             UnittestAssert::Equal
             | UnittestAssert::Equals

--- a/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
+++ b/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
@@ -13,7 +13,7 @@ expression: diagnostics
     column: 23
   fix:
     content:
-      - assert expr is True
+      - assert expr
     location:
       row: 11
       column: 8
@@ -32,7 +32,7 @@ expression: diagnostics
     column: 23
   fix:
     content:
-      - assert expr is True
+      - assert expr
     location:
       row: 12
       column: 8
@@ -51,7 +51,7 @@ expression: diagnostics
     column: 23
   fix:
     content:
-      - assert expr is True
+      - assert expr
     location:
       row: 13
       column: 8
@@ -70,7 +70,7 @@ expression: diagnostics
     column: 23
   fix:
     content:
-      - "assert expr is True, msg"
+      - "assert expr, msg"
     location:
       row: 14
       column: 8
@@ -89,7 +89,7 @@ expression: diagnostics
     column: 23
   fix:
     content:
-      - "assert expr is True, msg"
+      - "assert expr, msg"
     location:
       row: 15
       column: 8
@@ -152,7 +152,7 @@ expression: diagnostics
     column: 24
   fix:
     content:
-      - assert True is False
+      - assert not True
     location:
       row: 22
       column: 8


### PR DESCRIPTION
Issue #2456

`cargo clippy` wants this but then `_expr` is unused:
```diff
diff --git src/rules/flake8_pytest_style/rules/unittest_assert.rs src/rules/flake8_pytest_style/rules/unittest_assert.rs
index 29f7ab44..35beaeca 100644
--- src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -266,12 +266,12 @@ impl UnittestAssert {
                     .ok_or_else(|| anyhow!("Missing argument `expr`"))?;
                 let msg = args.get("msg").copied();
                 if matches!(self, UnittestAssert::True) {
-                    let expr = create_expr(ExprKind::UnaryOp {
+                    let _expr = create_expr(ExprKind::UnaryOp {
                         op: Unaryop::Not,
                         operand: Box::new(create_expr(expr.node.clone())),
                     });
                 }
-                Ok(assert(&expr, msg))
+                Ok(assert(expr, msg))
             }
             UnittestAssert::Equal
             | UnittestAssert::Equals
```

strange...