### PR TITLE
Move pycodestyle violations to rule modules

### DIFF
--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -98,7 +98,7 @@ pub struct Checker<'a> {
     in_literal: bool,
     in_subscript: bool,
     in_type_checking_block: bool,
-    seen_import_boundary: bool,
+    pub(crate) seen_import_boundary: bool,
     futures_allowed: bool,
     annotations_future_enabled: bool,
     except_handlers: Vec<Vec<Vec<&'a str>>>,
@@ -815,25 +815,14 @@ where
             }
             StmtKind::Import { names } => {
                 if self.settings.rules.enabled(&Rule::MultipleImportsOnOneLine) {
-                    if names.len() > 1 {
-                        self.diagnostics.push(Diagnostic::new(
-                            violations::MultipleImportsOnOneLine,
-                            Range::from_located(stmt),
-                        ));
-                    }
+                    pycodestyle::rules::multiple_imports_on_one_line(self, stmt, names);
                 }
-
                 if self
                     .settings
                     .rules
                     .enabled(&Rule::ModuleImportNotAtTopOfFile)
                 {
-                    if self.seen_import_boundary && stmt.location.column() == 0 {
-                        self.diagnostics.push(Diagnostic::new(
-                            violations::ModuleImportNotAtTopOfFile,
-                            Range::from_located(stmt),
-                        ));
-                    }
+                    pycodestyle::rules::module_import_not_at_top_of_file(self, stmt);
                 }
                 if self.settings.rules.enabled(&Rule::RewriteCElementTree) {
                     pyupgrade::rules::replace_c_element_tree(self, stmt);
@@ -1058,12 +1047,7 @@ where
                     .rules
                     .enabled(&Rule::ModuleImportNotAtTopOfFile)
                 {
-                    if self.seen_import_boundary && stmt.location.column() == 0 {
-                        self.diagnostics.push(Diagnostic::new(
-                            violations::ModuleImportNotAtTopOfFile,
-                            Range::from_located(stmt),
-                        ));
-                    }
+                    pycodestyle::rules::module_import_not_at_top_of_file(self, stmt);
                 }
 
                 if self.settings.rules.enabled(&Rule::UnnecessaryFutureImport)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ mod visibility;
 
 use cfg_if::cfg_if;
 pub use rule_selector::RuleSelector;
+pub use rules::pycodestyle::rules::IOError;
 pub use violation::{AutofixKind, Availability as AutofixAvailability};
-pub use violations::IOError;
 
 cfg_if! {
     if #[cfg(not(target_family = "wasm"))] {

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use colored::Colorize;
 use rustpython_parser::lexer::LexResult;
 
-use crate::ast::types::Range;
 use crate::autofix::fix_file;
 use crate::checkers::ast::check_ast;
 use crate::checkers::filesystem::check_file_path;
@@ -17,9 +16,10 @@ use crate::doc_lines::{doc_lines_from_ast, doc_lines_from_tokens};
 use crate::message::{Message, Source};
 use crate::noqa::add_noqa;
 use crate::registry::{Diagnostic, LintSource, Rule};
+use crate::rules::pycodestyle;
 use crate::settings::{flags, Settings};
 use crate::source_code::{Indexer, Locator, Stylist};
-use crate::{directives, fs, rustpython_helpers, violations};
+use crate::{directives, fs, rustpython_helpers};
 
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
@@ -115,12 +115,7 @@ pub fn check_path(
             }
             Err(parse_error) => {
                 if settings.rules.enabled(&Rule::SyntaxError) {
-                    diagnostics.push(Diagnostic::new(
-                        violations::SyntaxError {
-                            message: parse_error.error.to_string(),
-                        },
-                        Range::new(parse_error.location, parse_error.location),
-                    ));
+                    pycodestyle::rules::syntax_error(&mut diagnostics, &parse_error);
                 }
             }
         }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -13,8 +13,8 @@ use crate::{rules, violations};
 ruff_macros::define_rule_mapping!(
     // pycodestyle errors
     E101 => rules::pycodestyle::rules::MixedSpacesAndTabs,
-    E401 => violations::MultipleImportsOnOneLine,
-    E402 => violations::ModuleImportNotAtTopOfFile,
+    E401 => rules::pycodestyle::rules::MultipleImportsOnOneLine,
+    E402 => rules::pycodestyle::rules::ModuleImportNotAtTopOfFile,
     E501 => rules::pycodestyle::rules::LineTooLong,
     E711 => rules::pycodestyle::rules::NoneComparison,
     E712 => rules::pycodestyle::rules::TrueFalseComparison,
@@ -26,8 +26,8 @@ ruff_macros::define_rule_mapping!(
     E741 => rules::pycodestyle::rules::AmbiguousVariableName,
     E742 => rules::pycodestyle::rules::AmbiguousClassName,
     E743 => rules::pycodestyle::rules::AmbiguousFunctionName,
-    E902 => violations::IOError,
-    E999 => violations::SyntaxError,
+    E902 => rules::pycodestyle::rules::IOError,
+    E999 => rules::pycodestyle::rules::SyntaxError,
     // pycodestyle warnings
     W292 => rules::pycodestyle::rules::NoNewLineAtEndOfFile,
     W505 => rules::pycodestyle::rules::DocLineTooLong,

--- a/src/rules/pycodestyle/rules/errors.rs
+++ b/src/rules/pycodestyle/rules/errors.rs
@@ -1,0 +1,41 @@
+use crate::ast::types::Range;
+use crate::define_violation;
+use crate::registry::Diagnostic;
+use crate::violation::Violation;
+use ruff_macros::derive_message_formats;
+use rustpython_parser::error::ParseError;
+
+define_violation!(
+    pub struct IOError {
+        pub message: String,
+    }
+);
+impl Violation for IOError {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let IOError { message } = self;
+        format!("{message}")
+    }
+}
+
+define_violation!(
+    pub struct SyntaxError {
+        pub message: String,
+    }
+);
+impl Violation for SyntaxError {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let SyntaxError { message } = self;
+        format!("SyntaxError: {message}")
+    }
+}
+
+pub fn syntax_error(diagnostics: &mut Vec<Diagnostic>, parse_error: &ParseError) {
+    diagnostics.push(Diagnostic::new(
+        SyntaxError {
+            message: parse_error.error.to_string(),
+        },
+        Range::new(parse_error.location, parse_error.location),
+    ));
+}

--- a/src/rules/pycodestyle/rules/imports.rs
+++ b/src/rules/pycodestyle/rules/imports.rs
@@ -1,0 +1,46 @@
+use crate::ast::types::Range;
+use crate::checkers::ast::Checker;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Alias, Stmt};
+
+use crate::define_violation;
+use crate::registry::Diagnostic;
+use crate::violation::Violation;
+
+define_violation!(
+    pub struct MultipleImportsOnOneLine;
+);
+impl Violation for MultipleImportsOnOneLine {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Multiple imports on one line")
+    }
+}
+
+define_violation!(
+    pub struct ModuleImportNotAtTopOfFile;
+);
+impl Violation for ModuleImportNotAtTopOfFile {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        format!("Module level import not at top of file")
+    }
+}
+
+pub fn multiple_imports_on_one_line(checker: &mut Checker, stmt: &Stmt, names: &[Alias]) {
+    if names.len() > 1 {
+        checker.diagnostics.push(Diagnostic::new(
+            MultipleImportsOnOneLine,
+            Range::from_located(stmt),
+        ));
+    }
+}
+
+pub fn module_import_not_at_top_of_file(checker: &mut Checker, stmt: &Stmt) {
+    if checker.seen_import_boundary && stmt.location.column() == 0 {
+        checker.diagnostics.push(Diagnostic::new(
+            ModuleImportNotAtTopOfFile,
+            Range::from_located(stmt),
+        ));
+    }
+}

--- a/src/rules/pycodestyle/rules/mod.rs
+++ b/src/rules/pycodestyle/rules/mod.rs
@@ -4,6 +4,11 @@ pub use ambiguous_variable_name::{ambiguous_variable_name, AmbiguousVariableName
 pub use do_not_assign_lambda::{do_not_assign_lambda, DoNotAssignLambda};
 pub use do_not_use_bare_except::{do_not_use_bare_except, DoNotUseBareExcept};
 pub use doc_line_too_long::{doc_line_too_long, DocLineTooLong};
+pub use errors::{syntax_error, IOError, SyntaxError};
+pub use imports::{
+    module_import_not_at_top_of_file, multiple_imports_on_one_line, ModuleImportNotAtTopOfFile,
+    MultipleImportsOnOneLine,
+};
 pub use invalid_escape_sequence::{invalid_escape_sequence, InvalidEscapeSequence};
 pub use line_too_long::{line_too_long, LineTooLong};
 pub use literal_comparisons::{literal_comparisons, NoneComparison, TrueFalseComparison};
@@ -18,6 +23,8 @@ mod ambiguous_variable_name;
 mod do_not_assign_lambda;
 mod do_not_use_bare_except;
 mod doc_line_too_long;
+mod errors;
+mod imports;
 mod invalid_escape_sequence;
 mod line_too_long;
 mod literal_comparisons;

--- a/src/violations.rs
+++ b/src/violations.rs
@@ -11,54 +11,6 @@ use crate::rules::flake8_debugger::types::DebuggerUsingType;
 use crate::rules::pyupgrade::types::Primitive;
 use crate::violation::{AlwaysAutofixableViolation, AutofixKind, Availability, Violation};
 
-// pycodestyle errors
-
-define_violation!(
-    pub struct MultipleImportsOnOneLine;
-);
-impl Violation for MultipleImportsOnOneLine {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Multiple imports on one line")
-    }
-}
-
-define_violation!(
-    pub struct ModuleImportNotAtTopOfFile;
-);
-impl Violation for ModuleImportNotAtTopOfFile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Module level import not at top of file")
-    }
-}
-
-define_violation!(
-    pub struct IOError {
-        pub message: String,
-    }
-);
-impl Violation for IOError {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        let IOError { message } = self;
-        format!("{message}")
-    }
-}
-
-define_violation!(
-    pub struct SyntaxError {
-        pub message: String,
-    }
-);
-impl Violation for SyntaxError {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        let SyntaxError { message } = self;
-        format!("SyntaxError: {message}")
-    }
-}
-
 // pylint
 
 define_violation!(


### PR DESCRIPTION
This doesn't change where `IOError`s come from though, that felt unintuitive.