### PR TITLE
Treat `if 0:` and `if False:` as type-checking blocks

### DIFF
--- a/resources/test/fixtures/flake8_type_checking/TCH005.py
+++ b/resources/test/fixtures/flake8_type_checking/TCH005.py
@@ -4,15 +4,22 @@ if TYPE_CHECKING:
     pass  # TCH005
 
 
+if False:
+    pass  # TCH005
+
+if 0:
+    pass  # TCH005
+
+
 def example():
     if TYPE_CHECKING:
-        pass  # TYP005
+        pass  # TCH005
     return
 
 
 class Test:
     if TYPE_CHECKING:
-        pass  # TYP005
+        pass  # TCH005
     x = 2
 
 
@@ -22,4 +29,11 @@ if TYPE_CHECKING:
 
 
 if TYPE_CHECKING:
+    x: List
+
+
+if False:
+    x: List
+
+if 0:
     x: List

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -1944,7 +1944,7 @@ where
 
                 if flake8_type_checking::helpers::is_type_checking_block(self, test) {
                     if self.settings.rules.enabled(&Rule::EmptyTypeCheckingBlock) {
-                        flake8_type_checking::rules::empty_type_checking_block(self, test, body);
+                        flake8_type_checking::rules::empty_type_checking_block(self, body);
                     }
 
                     let prev_in_type_checking_block = self.in_type_checking_block;

--- a/src/rules/flake8_type_checking/helpers.rs
+++ b/src/rules/flake8_type_checking/helpers.rs
@@ -1,12 +1,41 @@
-use rustpython_ast::Expr;
+use num_traits::Zero;
+use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::types::{Binding, BindingKind, ExecutionContext};
 use crate::checkers::ast::Checker;
 
+/// Return `true` if [`Expr`] is a guard for a type-checking block.
 pub fn is_type_checking_block(checker: &Checker, test: &Expr) -> bool {
-    checker.resolve_call_path(test).map_or(false, |call_path| {
+    // Ex) `if False:`
+    if matches!(
+        test.node,
+        ExprKind::Constant {
+            value: Constant::Bool(false),
+            ..
+        }
+    ) {
+        return true;
+    }
+
+    // Ex) `if 0:`
+    if let ExprKind::Constant {
+        value: Constant::Int(value),
+        ..
+    } = &test.node
+    {
+        if value.is_zero() {
+            return true;
+        }
+    }
+
+    // Ex) `if typing.TYPE_CHECKING:`
+    if checker.resolve_call_path(test).map_or(false, |call_path| {
         call_path.as_slice() == ["typing", "TYPE_CHECKING"]
-    })
+    }) {
+        return true;
+    }
+
+    false
 }
 
 pub fn is_valid_runtime_import(binding: &Binding) -> bool {

--- a/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -1,5 +1,6 @@
+use rustpython_ast::{Stmt, StmtKind};
+
 use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -18,15 +19,11 @@ impl Violation for EmptyTypeCheckingBlock {
 }
 
 /// TCH005
-pub fn empty_type_checking_block(checker: &mut Checker, test: &Expr, body: &[Stmt]) {
-    if checker.resolve_call_path(test).map_or(false, |call_path| {
-        call_path.as_slice() == ["typing", "TYPE_CHECKING"]
-    }) {
-        if body.len() == 1 && matches!(body[0].node, StmtKind::Pass) {
-            checker.diagnostics.push(Diagnostic::new(
-                EmptyTypeCheckingBlock,
-                Range::from_located(&body[0]),
-            ));
-        }
+pub fn empty_type_checking_block(checker: &mut Checker, body: &[Stmt]) {
+    if body.len() == 1 && matches!(body[0].node, StmtKind::Pass) {
+        checker.diagnostics.push(Diagnostic::new(
+            EmptyTypeCheckingBlock,
+            Range::from_located(&body[0]),
+        ));
     }
 }

--- a/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
+++ b/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
@@ -15,20 +15,40 @@ expression: diagnostics
 - kind:
     EmptyTypeCheckingBlock: ~
   location:
-    row: 9
+    row: 8
+    column: 4
+  end_location:
+    row: 8
+    column: 8
+  fix: ~
+  parent: ~
+- kind:
+    EmptyTypeCheckingBlock: ~
+  location:
+    row: 11
+    column: 4
+  end_location:
+    row: 11
+    column: 8
+  fix: ~
+  parent: ~
+- kind:
+    EmptyTypeCheckingBlock: ~
+  location:
+    row: 16
     column: 8
   end_location:
-    row: 9
+    row: 16
     column: 12
   fix: ~
   parent: ~
 - kind:
     EmptyTypeCheckingBlock: ~
   location:
-    row: 15
+    row: 22
     column: 8
   end_location:
-    row: 15
+    row: 22
     column: 12
   fix: ~
   parent: ~


### PR DESCRIPTION
Closes #2408.