### PR TITLE
Fix an error in scripts/add_rule.py

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,11 +1,14 @@
 [tool.ruff]
 select = ["ALL"]
 ignore = [
-  "E501",    # line-too-long
-  "INP001",  # implicit-namespace-package
-  "PLR2004", # magic-value-comparison
-  "S101",    # assert-used
-  "EM"
+  "E501",   # line-too-long
+  "INP001", # implicit-namespace-package
+  "PL",     # pylint
+  "S101",   # assert-used
+  "EM",     # errmgs
+]
+unfixable = [
+  "RUF100", # unused-noqa
 ]
 
 [tool.ruff.pydocstyle]


### PR DESCRIPTION
Ignore `PLR0915` Too many statements in `add_rule.py`.
Add `RUF100` to unfixable to avoid removing on `Fix all` `# noqa: PLR0915` which is not recognized by old Ruff versions.