### PR TITLE
Mark fixable issues in printer output

### DIFF
--- a/ruff_cli/src/printer.rs
+++ b/ruff_cli/src/printer.rs
@@ -122,7 +122,7 @@ impl<'a> Printer<'a> {
                         if num_fixable > 0 {
                             writeln!(
                                 stdout,
-                                "{num_fixable} potentially fixable with the --fix option."
+                                "[*] {num_fixable} potentially fixable with the --fix option."
                             )?;
                         }
                     }
@@ -475,17 +475,31 @@ fn num_digits(n: usize) -> usize {
 
 /// Print a single `Message` with full details.
 fn print_message<T: Write>(stdout: &mut T, message: &Message) -> Result<()> {
-    let label = format!(
-        "{}{}{}{}{}{} {} {}",
-        relativize_path(Path::new(&message.filename)).bold(),
-        ":".cyan(),
-        message.location.row(),
-        ":".cyan(),
-        message.location.column(),
-        ":".cyan(),
-        message.kind.rule().code().red().bold(),
-        message.kind.body(),
-    );
+    let label = if message.kind.fixable() {
+        format!(
+            "{}{}{}{}{}{} {} [*] {}",
+            relativize_path(Path::new(&message.filename)).bold(),
+            ":".cyan(),
+            message.location.row(),
+            ":".cyan(),
+            message.location.column(),
+            ":".cyan(),
+            message.kind.rule().code().red().bold(),
+            message.kind.body(),
+        )
+    } else {
+        format!(
+            "{}{}{}{}{}{} {} {}",
+            relativize_path(Path::new(&message.filename)).bold(),
+            ":".cyan(),
+            message.location.row(),
+            ":".cyan(),
+            message.location.column(),
+            ":".cyan(),
+            message.kind.rule().code().red().bold(),
+            message.kind.body(),
+        )
+    };
     writeln!(stdout, "{label}")?;
     if let Some(source) = &message.source {
         let commit = message.kind.commit();
@@ -540,16 +554,29 @@ fn print_grouped_message<T: Write>(
     row_length: usize,
     column_length: usize,
 ) -> Result<()> {
-    let label = format!(
-        "  {}{}{}{}{}  {}  {}",
-        " ".repeat(row_length - num_digits(message.location.row())),
-        message.location.row(),
-        ":".cyan(),
-        message.location.column(),
-        " ".repeat(column_length - num_digits(message.location.column())),
-        message.kind.rule().code().red().bold(),
-        message.kind.body(),
-    );
+    let label = if message.kind.fixable() {
+        format!(
+            "  {}{}{}{}{}  {}  [*] {}",
+            " ".repeat(row_length - num_digits(message.location.row())),
+            message.location.row(),
+            ":".cyan(),
+            message.location.column(),
+            " ".repeat(column_length - num_digits(message.location.column())),
+            message.kind.rule().code().red().bold(),
+            message.kind.body(),
+        )
+    } else {
+        format!(
+            "  {}{}{}{}{}  {}  {}",
+            " ".repeat(row_length - num_digits(message.location.row())),
+            message.location.row(),
+            ":".cyan(),
+            message.location.column(),
+            " ".repeat(column_length - num_digits(message.location.column())),
+            message.kind.rule().code().red().bold(),
+            message.kind.body(),
+        )
+    };
     writeln!(stdout, "{label}")?;
     if let Some(source) = &message.source {
         let commit = message.kind.commit();

--- a/ruff_cli/tests/integration_test.rs
+++ b/ruff_cli/tests/integration_test.rs
@@ -31,8 +31,10 @@ fn test_stdin_error() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        "-:1:8: F401 `os` imported but unused\nFound 1 error.\n1 potentially fixable with the \
-         --fix option.\n"
+        r#"-:1:8: F401 [*] `os` imported but unused
+Found 1 error.
+[*] 1 potentially fixable with the --fix option.
+"#
     );
     Ok(())
 }
@@ -54,8 +56,10 @@ fn test_stdin_filename() -> Result<()> {
         .failure();
     assert_eq!(
         str::from_utf8(&output.get_output().stdout)?,
-        "F401.py:1:8: F401 `os` imported but unused\nFound 1 error.\n1 potentially fixable with \
-         the --fix option.\n"
+        r#"F401.py:1:8: F401 [*] `os` imported but unused
+Found 1 error.
+[*] 1 potentially fixable with the --fix option.
+"#
     );
     Ok(())
 }


### PR DESCRIPTION
Here's an example:

<img width="1624" alt="Screen Shot 2023-02-02 at 3 51 49 PM" src="https://user-images.githubusercontent.com/1309177/216446831-bfcd8340-7a42-4e80-ab22-66a7006f4358.png">

Closes #2452.