### PR TITLE
Always report parse errors back to the user

### DIFF
--- a/ruff_cli/src/cache.rs
+++ b/ruff_cli/src/cache.rs
@@ -85,6 +85,10 @@ fn read_sync(cache_dir: &Path, key: u64) -> Result<Vec<u8>, std::io::Error> {
     fs::read(cache_dir.join(content_dir()).join(format!("{key:x}")))
 }
 
+fn del_sync(cache_dir: &Path, key: u64) -> Result<(), std::io::Error> {
+    fs::remove_file(cache_dir.join(content_dir()).join(format!("{key:x}")))
+}
+
 /// Get a value from the cache.
 pub fn get<P: AsRef<Path>>(
     path: P,
@@ -136,4 +140,17 @@ pub fn set<P: AsRef<Path>>(
     ) {
         error!("Failed to write to cache: {e:?}");
     }
+}
+
+/// Delete a value from the cache.
+pub fn del<P: AsRef<Path>>(
+    path: P,
+    package: Option<&P>,
+    settings: &AllSettings,
+    autofix: flags::Autofix,
+) {
+    drop(del_sync(
+        &settings.cli.cache_dir,
+        cache_key(path, package, &settings.lib, autofix),
+    ));
 }

--- a/src/lib_native.rs
+++ b/src/lib_native.rs
@@ -49,7 +49,7 @@ pub fn check(path: &Path, contents: &str, autofix: bool) -> Result<Vec<Diagnosti
         directives::extract_directives(&tokens, directives::Flags::from_settings(&settings));
 
     // Generate diagnostics.
-    let diagnostics = check_path(
+    let result = check_path(
         path,
         packaging::detect_package_root(path, &settings.namespace_packages),
         contents,
@@ -63,5 +63,5 @@ pub fn check(path: &Path, contents: &str, autofix: bool) -> Result<Vec<Diagnosti
         flags::Noqa::Enabled,
     );
 
-    Ok(diagnostics)
+    Ok(result.data)
 }

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
 use crate::directives;
-use crate::linter::check_path;
+use crate::linter::{check_path, LinterResult};
 use crate::registry::Rule;
 use crate::rules::{
     flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
@@ -187,7 +187,9 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
     let directives = directives::extract_directives(&tokens, directives::Flags::empty());
 
     // Generate checks.
-    let diagnostics = check_path(
+    let LinterResult {
+        data: diagnostics, ..
+    } = check_path(
         Path::new("<filename>"),
         None,
         contents,

--- a/src/rules/pandas_vet/mod.rs
+++ b/src/rules/pandas_vet/mod.rs
@@ -12,7 +12,7 @@ mod tests {
     use test_case::test_case;
     use textwrap::dedent;
 
-    use crate::linter::check_path;
+    use crate::linter::{check_path, LinterResult};
     use crate::registry::{Rule, RuleCodePrefix};
     use crate::settings::flags;
     use crate::source_code::{Indexer, Locator, Stylist};
@@ -28,7 +28,9 @@ mod tests {
         let indexer: Indexer = tokens.as_slice().into();
         let directives =
             directives::extract_directives(&tokens, directives::Flags::from_settings(&settings));
-        let diagnostics = check_path(
+        let LinterResult {
+            data: diagnostics, ..
+        } = check_path(
             Path::new("<filename>"),
             None,
             &contents,

--- a/src/rules/pyflakes/mod.rs
+++ b/src/rules/pyflakes/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use test_case::test_case;
     use textwrap::dedent;
 
-    use crate::linter::check_path;
+    use crate::linter::{check_path, LinterResult};
     use crate::registry::{Rule, RuleCodePrefix};
     use crate::settings::flags;
     use crate::source_code::{Indexer, Locator, Stylist};
@@ -217,7 +217,10 @@ mod tests {
         let indexer: Indexer = tokens.as_slice().into();
         let directives =
             directives::extract_directives(&tokens, directives::Flags::from_settings(&settings));
-        let mut diagnostics = check_path(
+        let LinterResult {
+            data: mut diagnostics,
+            ..
+        } = check_path(
             Path::new("<filename>"),
             None,
             &contents,

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::Result;
 use rustpython_parser::lexer::LexResult;
 
+use crate::linter::LinterResult;
 use crate::{
     autofix::fix_file,
     directives, fs,
@@ -15,8 +16,8 @@ use crate::{
     source_code::{Indexer, Locator, Stylist},
 };
 
-pub fn test_resource_path(path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
-    std::path::Path::new("./resources/test/").join(path)
+pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
+    Path::new("./resources/test/").join(path)
 }
 
 /// A convenient wrapper around [`check_path`], that additionally
@@ -30,7 +31,10 @@ pub fn test_path(path: &Path, settings: &Settings) -> Result<Vec<Diagnostic>> {
     let indexer: Indexer = tokens.as_slice().into();
     let directives =
         directives::extract_directives(&tokens, directives::Flags::from_settings(settings));
-    let mut diagnostics = check_path(
+    let LinterResult {
+        data: mut diagnostics,
+        ..
+    } = check_path(
         &path,
         path.parent()
             .and_then(|parent| detect_package_root(parent, &settings.namespace_packages)),
@@ -62,7 +66,9 @@ pub fn test_path(path: &Path, settings: &Settings) -> Result<Vec<Diagnostic>> {
             let indexer: Indexer = tokens.as_slice().into();
             let directives =
                 directives::extract_directives(&tokens, directives::Flags::from_settings(settings));
-            let diagnostics = check_path(
+            let LinterResult {
+                data: diagnostics, ..
+            } = check_path(
                 &path,
                 None,
                 &contents,


### PR DESCRIPTION
# Summary

We treat parse errors as lint errors -- they have their own code (`E999`). If we fail to parse a file, we add an `E999` diagnostic, and move on. Parse errors _are_ recoverable, as many checks don't rely on the AST (like `E501`, line-length enforcement) -- so even if the parse fails, we can still report some other diagnostics.

However, here's a common and confusing workflow: say a user introduces (e.g.) a `match` statement into their code, then runs `ruff --select I /path/to/file.py`.  They'll then wonder why their imports aren't being sorted. We can't parse `match` statements, so under the hood, we're adding an `E999` to the diagnostic list, but it's being suppressed (since `E999` isn't in the `select`), so the user doesn't get any feedback.

This PR modifies the linter to propagate parse errors. They're still included as `E999`, and we still try to find other violations; however, we _also_ log a warning to the console _and_ avoid doing any caching to the file (so the warning appears on every invocation).

Here's an example.

Given these code changes:

![Screen Shot 2023-02-02 at 7 01 54 PM](https://user-images.githubusercontent.com/1309177/216478374-07e43c4e-500e-4d46-acd0-32ddc29284fd.png)

We now yield:

![Screen Shot 2023-02-02 at 7 02 19 PM](https://user-images.githubusercontent.com/1309177/216478400-a01a1f98-e09f-42ca-b84b-b5b4871d6db5.png)

So it's a little redundant, between the warning and the `E999`, but I think it's much clearer.

Closes #2473.
