### PR TITLE
Verbose show number of files

### DIFF
--- a/ruff_cli/src/commands.rs
+++ b/ruff_cli/src/commands.rs
@@ -136,7 +136,7 @@ pub fn run(
 
     diagnostics.messages.sort_unstable();
     let duration = start.elapsed();
-    debug!("Checked files in: {:?}", duration);
+    debug!("Checked {:?} files in: {:?}", paths.len(), duration);
 
     Ok(diagnostics)
 }


### PR DESCRIPTION
Added the number of files scanned in "-v", as discussed here https://github.com/charliermarsh/ruff/issues/2188#issuecomment-1413236168