### PR TITLE
Track overridden bindings within each scope

### DIFF
--- a/resources/test/fixtures/flake8_bugbear/B007.py
+++ b/resources/test/fixtures/flake8_bugbear/B007.py
@@ -64,9 +64,19 @@ def f():
 
 
 def f():
-    # Fixable, but not fixed in practice, since we can't tell if `bar` is used.
+    # Fixable.
     for foo, bar, baz in (["1", "2", "3"],):
         if foo or baz:
             break
 
     bar = 1
+
+
+def f():
+    # Fixable.
+    for foo, bar, baz in (["1", "2", "3"],):
+        if foo or baz:
+            break
+
+    bar = 1
+    print(bar)

--- a/src/ast/operations.rs
+++ b/src/ast/operations.rs
@@ -97,7 +97,7 @@ pub fn extract_all_names(
 
     // Grab the existing bound __all__ values.
     if let StmtKind::AugAssign { .. } = &stmt.node {
-        if let Some(index) = scope.values.get("__all__") {
+        if let Some(index) = scope.bindings.get("__all__") {
             if let BindingKind::Export(existing) = &checker.bindings[*index].kind {
                 names.extend_from_slice(existing);
             }

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -87,8 +87,11 @@ pub struct Scope<'a> {
     pub kind: ScopeKind<'a>,
     pub import_starred: bool,
     pub uses_locals: bool,
-    /// A map from bound name to binding index.
-    pub values: FxHashMap<&'a str, usize>,
+    /// A map from bound name to binding index, for live bindings.
+    pub bindings: FxHashMap<&'a str, usize>,
+    /// A map from bound name to binding index, for bindings that were created in the scope but
+    /// rebound (and thus overridden) later on in the same scope.
+    pub rebounds: FxHashMap<&'a str, Vec<usize>>,
 }
 
 impl<'a> Scope<'a> {
@@ -98,7 +101,8 @@ impl<'a> Scope<'a> {
             kind,
             import_starred: false,
             uses_locals: false,
-            values: FxHashMap::default(),
+            bindings: FxHashMap::default(),
+            rebounds: FxHashMap::default(),
         }
     }
 }

--- a/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
+++ b/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
@@ -24,7 +24,15 @@ expression: diagnostics
   end_location:
     row: 18
     column: 13
-  fix: ~
+  fix:
+    content:
+      - _k
+    location:
+      row: 18
+      column: 12
+    end_location:
+      row: 18
+      column: 13
   parent: ~
 - kind:
     UnusedLoopControlVariable:
@@ -148,6 +156,34 @@ expression: diagnostics
   end_location:
     row: 68
     column: 16
-  fix: ~
+  fix:
+    content:
+      - _bar
+    location:
+      row: 68
+      column: 13
+    end_location:
+      row: 68
+      column: 16
+  parent: ~
+- kind:
+    UnusedLoopControlVariable:
+      name: bar
+      certainty: Certain
+  location:
+    row: 77
+    column: 13
+  end_location:
+    row: 77
+    column: 16
+  fix:
+    content:
+      - _bar
+    location:
+      row: 77
+      column: 13
+    end_location:
+      row: 77
+      column: 16
   parent: ~
 

--- a/src/rules/flake8_unused_arguments/rules.rs
+++ b/src/rules/flake8_unused_arguments/rules.rs
@@ -135,7 +135,7 @@ pub fn unused_arguments(
                         function(
                             &Argumentable::Function,
                             args,
-                            &scope.values,
+                            &scope.bindings,
                             bindings,
                             &checker.settings.dummy_variable_rgx,
                             checker
@@ -164,7 +164,7 @@ pub fn unused_arguments(
                         method(
                             &Argumentable::Method,
                             args,
-                            &scope.values,
+                            &scope.bindings,
                             bindings,
                             &checker.settings.dummy_variable_rgx,
                             checker
@@ -193,7 +193,7 @@ pub fn unused_arguments(
                         method(
                             &Argumentable::ClassMethod,
                             args,
-                            &scope.values,
+                            &scope.bindings,
                             bindings,
                             &checker.settings.dummy_variable_rgx,
                             checker
@@ -222,7 +222,7 @@ pub fn unused_arguments(
                         function(
                             &Argumentable::StaticMethod,
                             args,
-                            &scope.values,
+                            &scope.bindings,
                             bindings,
                             &checker.settings.dummy_variable_rgx,
                             checker
@@ -245,7 +245,7 @@ pub fn unused_arguments(
                 function(
                     &Argumentable::Lambda,
                     args,
-                    &scope.values,
+                    &scope.bindings,
                     bindings,
                     &checker.settings.dummy_variable_rgx,
                     checker

--- a/src/rules/pyflakes/rules/undefined_local.rs
+++ b/src/rules/pyflakes/rules/undefined_local.rs
@@ -24,10 +24,10 @@ impl Violation for UndefinedLocal {
 /// F821
 pub fn undefined_local(name: &str, scopes: &[&Scope], bindings: &[Binding]) -> Option<Diagnostic> {
     let current = &scopes.last().expect("No current scope found");
-    if matches!(current.kind, ScopeKind::Function(_)) && !current.values.contains_key(name) {
+    if matches!(current.kind, ScopeKind::Function(_)) && !current.bindings.contains_key(name) {
         for scope in scopes.iter().rev().skip(1) {
             if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Module) {
-                if let Some(binding) = scope.values.get(name).map(|index| &bindings[*index]) {
+                if let Some(binding) = scope.bindings.get(name).map(|index| &bindings[*index]) {
                     if let Some((scope_id, location)) = binding.runtime_usage {
                         if scope_id == current.id {
                             return Some(Diagnostic::new(

--- a/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/src/rules/pyflakes/rules/unused_annotation.rs
@@ -23,7 +23,7 @@ impl Violation for UnusedAnnotation {
 pub fn unused_annotation(checker: &mut Checker, scope: usize) {
     let scope = &checker.scopes[scope];
     for (name, binding) in scope
-        .values
+        .bindings
         .iter()
         .map(|(name, index)| (name, &checker.bindings[*index]))
     {

--- a/src/rules/pyflakes/rules/unused_variable.rs
+++ b/src/rules/pyflakes/rules/unused_variable.rs
@@ -182,7 +182,7 @@ pub fn unused_variable(checker: &mut Checker, scope: usize) {
     }
 
     for (name, binding) in scope
-        .values
+        .bindings
         .iter()
         .map(|(name, index)| (name, &checker.bindings[*index]))
     {

--- a/src/rules/pylint/rules/use_sys_exit.rs
+++ b/src/rules/pylint/rules/use_sys_exit.rs
@@ -30,7 +30,7 @@ impl Violation for UseSysExit {
 /// sys import *`).
 fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
     checker.current_scopes().any(|scope| {
-        scope.values.values().any(|index| {
+        scope.bindings.values().any(|index| {
             if let BindingKind::StarImportation(_, name) = &checker.bindings[*index].kind {
                 name.as_ref().map(|name| name == module).unwrap_or_default()
             } else {
@@ -45,7 +45,7 @@ fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
 fn get_member_import_name_alias(checker: &Checker, module: &str, member: &str) -> Option<String> {
     checker.current_scopes().find_map(|scope| {
         scope
-            .values
+            .bindings
             .values()
             .find_map(|index| match &checker.bindings[*index].kind {
                 // e.g. module=sys object=exit

--- a/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -35,7 +35,7 @@ fn rule(name: &str, bases: &[Expr], scope: &Scope, bindings: &[Binding]) -> Opti
         }
         if !matches!(
             scope
-                .values
+                .bindings
                 .get(&id.as_str())
                 .map(|index| &bindings[*index]),
             None | Some(Binding {


### PR DESCRIPTION
A follow-up to #2509 that lets us track a few more cases while still avoiding the errors raised in #2207.