### PR TITLE
Minor fixes to PLR0915 logic

### DIFF
--- a/resources/test/fixtures/pylint/too_many_statements_params.py
+++ b/resources/test/fixtures/pylint/too_many_statements_params.py
@@ -1,3 +1,8 @@
 # Too may statements (2/1) for max_statements=1
 def f(x):
     pass
+
+
+def f(x):
+    def g(x):
+        pass

--- a/src/rules/pylint/rules/too_many_statements.rs
+++ b/src/rules/pylint/rules/too_many_statements.rs
@@ -185,7 +185,7 @@ def f():
         print()
 "#;
         let stmts = parser::parse_program(source, "<filename>")?;
-        assert_eq!(num_statements(&stmts), 9); // counter-intuitive, but elif counts as 2 statements according to pylint itself
+        assert_eq!(num_statements(&stmts), 9);
         Ok(())
     }
 

--- a/src/rules/pylint/rules/too_many_statements.rs
+++ b/src/rules/pylint/rules/too_many_statements.rs
@@ -25,7 +25,7 @@ impl Violation for TooManyStatements {
 }
 
 fn num_statements(stmts: &[Stmt]) -> usize {
-    let mut count: usize = 0;
+    let mut count = 0;
     for stmt in stmts {
         // TODO(charlie): Account for pattern match statement.
         match &stmt.node {

--- a/src/rules/pylint/rules/too_many_statements.rs
+++ b/src/rules/pylint/rules/too_many_statements.rs
@@ -389,7 +389,7 @@ def f():  # 11
     #[test]
     fn yield_() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 2
     for i in range(10):
         yield i
 "#;

--- a/src/rules/pylint/rules/too_many_statements.rs
+++ b/src/rules/pylint/rules/too_many_statements.rs
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn pass() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 2
     pass
 "#;
         let stmts = parser::parse_program(source, "<filename>")?;
@@ -160,7 +160,7 @@ def f():
     #[test]
     fn if_elif() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 5
     if a:
         print()
     elif a:
@@ -174,7 +174,7 @@ def f():
     #[test]
     fn if_elif_else() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 9
     if a:
         print()
     elif a == 2:
@@ -192,7 +192,7 @@ def f():
     #[test]
     fn many_statements() -> Result<()> {
         let source: &str = r#"
-async def f():
+async def f():  # 19
     a = 1
     b = 2
     c = 3
@@ -247,7 +247,7 @@ def f():  # 3
     #[test]
     fn nested_def() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 5
     def g():
         print()
         print()
@@ -262,7 +262,7 @@ def f():
     #[test]
     fn nested_class() -> Result<()> {
         let source: &str = r#"
-def f():
+def f():  # 3
     class A:
         def __init__(self):
             pass

--- a/src/rules/pylint/snapshots/ruff__rules__pylint__tests__max_statements.snap
+++ b/src/rules/pylint/snapshots/ruff__rules__pylint__tests__max_statements.snap
@@ -14,4 +14,28 @@ expression: diagnostics
     column: 5
   fix: ~
   parent: ~
+- kind:
+    TooManyStatements:
+      statements: 3
+      max_statements: 1
+  location:
+    row: 6
+    column: 4
+  end_location:
+    row: 6
+    column: 5
+  fix: ~
+  parent: ~
+- kind:
+    TooManyStatements:
+      statements: 2
+      max_statements: 1
+  location:
+    row: 7
+    column: 8
+  end_location:
+    row: 7
+    column: 9
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
Some very small fixes, namely to get rid of the comment on a unittest which was inaccurate, and also to make sure that a nested def and its parent can both have the too-many-statements message.