### PR TITLE
Move Clippy configuration to config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,26 @@
 [alias]
 dev = "run --package ruff_dev --bin ruff_dev"
+
+[target.'cfg(all())']
+rustflags = [
+  # CLIPPY LINT SETTINGS
+  # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
+  # See: `https://github.com/rust-lang/cargo/issues/5034`
+  #      `https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395`
+  "-Dunsafe_code",
+  "-Wclippy::pedantic",
+  # "-Wclippy::print_stdout",
+  # "-Wclippy::print_stderr",
+  # "-Wclippy::dbg_macro",
+  "-Wclippy::char_lit_as_u8",
+  "-Aclippy::collapsible_else_if",
+  "-Aclippy::collapsible_if",
+  "-Aclippy::implicit_hasher",
+  "-Aclippy::match_same_arms",
+  "-Aclippy::missing_errors_doc",
+  "-Aclippy::missing_panics_doc",
+  "-Aclippy::module_name_repetitions",
+  "-Aclippy::must_use_candidate",
+  "-Aclippy::similar_names",
+  "-Aclippy::too_many_lines"
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,8 @@ jobs:
           rustup component add clippy
           rustup target add wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v1
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
-      - run: cargo clippy -p ruff --target wasm32-unknown-unknown --all-features -- -D warnings -W clippy::pedantic
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy -p ruff --target wasm32-unknown-unknown --all-features -- -D warnings
 
   cargo-test:
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         types: [rust]
       - id: clippy
         name: clippy
-        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic
+        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
         language: rust
         pass_filenames: false
       - id: ruff

--- a/flake8_to_ruff/src/main.rs
+++ b/flake8_to_ruff/src/main.rs
@@ -1,18 +1,4 @@
 //! Utility to generate Ruff's `pyproject.toml` section from a Flake8 INI file.
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::implicit_hasher,
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::similar_names,
-    clippy::too_many_lines
-)]
 
 use std::path::PathBuf;
 

--- a/ruff_cli/src/args.rs
+++ b/ruff_cli/src/args.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::path::PathBuf;
 
 use clap::{command, Parser};

--- a/ruff_cli/src/lib.rs
+++ b/ruff_cli/src/lib.rs
@@ -2,9 +2,6 @@
 //! to automatically update the `ruff help` output in the `README.md`.
 //!
 //! For the actual Ruff library, see [`ruff`].
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::must_use_candidate, dead_code)]
 
 mod args;
 

--- a/ruff_cli/src/main.rs
+++ b/ruff_cli/src/main.rs
@@ -1,12 +1,3 @@
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::module_name_repetitions,
-    clippy::too_many_lines
-)]
-
 use std::io::{self};
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/ruff_dev/src/main.rs
+++ b/ruff_dev/src/main.rs
@@ -1,20 +1,6 @@
 //! This crate implements an internal CLI for developers of Ruff.
 //!
 //! Within the ruff repository you can run it with `cargo dev`.
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::implicit_hasher,
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::similar_names,
-    clippy::too_many_lines
-)]
 
 mod generate_all;
 mod generate_cli_help;

--- a/ruff_macros/src/lib.rs
+++ b/ruff_macros/src/lib.rs
@@ -1,18 +1,4 @@
 //! This crate implements internal macros for the `ruff` library.
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::implicit_hasher,
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::similar_names,
-    clippy::too_many_lines
-)]
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput, ItemFn};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,20 +4,6 @@
 //! and subject to change drastically.
 //!
 //! [Ruff]: https://github.com/charliermarsh/ruff
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(
-    clippy::collapsible_else_if,
-    clippy::collapsible_if,
-    clippy::implicit_hasher,
-    clippy::match_same_arms,
-    clippy::missing_errors_doc,
-    clippy::missing_panics_doc,
-    clippy::module_name_repetitions,
-    clippy::must_use_candidate,
-    clippy::similar_names,
-    clippy::too_many_lines
-)]
 
 mod assert_yaml_snapshot;
 mod ast;


### PR DESCRIPTION
This enables us to use a centralized configuration for the entire project, without having to add macros to each module or repeat precise commands everywhere. The main downside I've found is that modifying the configuration triggers a complete rebuild -- but that's a rare operation.