### PR TITLE
define_simple_violation

### DIFF
--- a/src/rules/eradicate/rules.rs
+++ b/src/rules/eradicate/rules.rs
@@ -3,26 +3,18 @@ use rustpython_ast::Location;
 
 use super::detection::comment_contains_code;
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct CommentedOutCode;
+define_simple_autofix_violation!(
+    CommentedOutCode,
+    "Found commented-out code",
+    "Remove commented-out code"
 );
-impl AlwaysAutofixableViolation for CommentedOutCode {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Found commented-out code")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove commented-out code".to_string()
-    }
-}
 
 fn is_standalone_comment(line: &str) -> bool {
     for char in line.chars() {

--- a/src/rules/flake8_2020/rules.rs
+++ b/src/rules/flake8_2020/rules.rs
@@ -6,114 +6,60 @@ use crate::checkers::ast::Checker;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct SysVersionSlice3Referenced;
+define_simple_violation!(
+    SysVersionSlice3Referenced,
+    "`sys.version[:3]` referenced (python3.10), use `sys.version_info`"
 );
-impl Violation for SysVersionSlice3Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version[:3]` referenced (python3.10), use `sys.version_info`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersion2Referenced;
+define_simple_violation!(
+    SysVersion2Referenced,
+    "`sys.version[2]` referenced (python3.10), use `sys.version_info`"
 );
-impl Violation for SysVersion2Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version[2]` referenced (python3.10), use `sys.version_info`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersionCmpStr3;
+define_simple_violation!(
+    SysVersionCmpStr3,
+    "`sys.version` compared to string (python3.10), use `sys.version_info`"
 );
-impl Violation for SysVersionCmpStr3 {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version` compared to string (python3.10), use `sys.version_info`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersionInfo0Eq3Referenced;
+define_simple_violation!(
+    SysVersionInfo0Eq3Referenced,
+    "`sys.version_info[0] == 3` referenced (python4), use `>=`"
 );
-impl Violation for SysVersionInfo0Eq3Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version_info[0] == 3` referenced (python4), use `>=`")
-    }
-}
 
-define_violation!(
-    pub struct SixPY3Referenced;
+define_simple_violation!(
+    SixPY3Referenced,
+    "`six.PY3` referenced (python4), use `not six.PY2`"
 );
-impl Violation for SixPY3Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`six.PY3` referenced (python4), use `not six.PY2`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersionInfo1CmpInt;
-);
-impl Violation for SysVersionInfo1CmpInt {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "`sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to \
+define_simple_violation!(
+    SysVersionInfo1CmpInt,
+    "`sys.version_info[1]` compared to integer (python4), compare `sys.version_info` to \
              tuple"
-        )
-    }
-}
-
-define_violation!(
-    pub struct SysVersionInfoMinorCmpInt;
 );
-impl Violation for SysVersionInfoMinorCmpInt {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "`sys.version_info.minor` compared to integer (python4), compare `sys.version_info` \
+
+define_simple_violation!(
+    SysVersionInfoMinorCmpInt,
+    "`sys.version_info.minor` compared to integer (python4), compare `sys.version_info` \
              to tuple"
-        )
-    }
-}
-
-define_violation!(
-    pub struct SysVersion0Referenced;
 );
-impl Violation for SysVersion0Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version[0]` referenced (python10), use `sys.version_info`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersionCmpStr10;
+define_simple_violation!(
+    SysVersion0Referenced,
+    "`sys.version[0]` referenced (python10), use `sys.version_info`"
 );
-impl Violation for SysVersionCmpStr10 {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version` compared to string (python10), use `sys.version_info`")
-    }
-}
 
-define_violation!(
-    pub struct SysVersionSlice1Referenced;
+define_simple_violation!(
+    SysVersionCmpStr10,
+    "`sys.version` compared to string (python10), use `sys.version_info`"
 );
-impl Violation for SysVersionSlice1Referenced {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`sys.version[:1]` referenced (python10), use `sys.version_info`")
-    }
-}
+
+define_simple_violation!(
+    SysVersionSlice1Referenced,
+    "`sys.version[:1]` referenced (python10), use `sys.version_info`"
+);
 
 fn is_sys(checker: &Checker, expr: &Expr, target: &str) -> bool {
     checker

--- a/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/src/rules/flake8_bandit/rules/assert_used.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Located, StmtKind};
@@ -6,15 +6,7 @@ use rustpython_ast::{Located, StmtKind};
 use crate::ast::types::Range;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct AssertUsed;
-);
-impl Violation for AssertUsed {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use of `assert` detected")
-    }
-}
+define_simple_violation!(AssertUsed, "Use of `assert` detected");
 
 /// S101
 pub fn assert_used(stmt: &Located<StmtKind>) -> Diagnostic {

--- a/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/src/rules/flake8_bandit/rules/exec_used.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
@@ -6,15 +6,7 @@ use rustpython_ast::{Expr, ExprKind};
 use crate::ast::types::Range;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct ExecUsed;
-);
-impl Violation for ExecUsed {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use of `exec` detected")
-    }
-}
+define_simple_violation!(ExecUsed, "Use of `exec` detected");
 
 /// S102
 pub fn exec_used(expr: &Expr, func: &Expr) -> Option<Diagnostic> {

--- a/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -2,18 +2,13 @@ use crate::ast::types::Range;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct HardcodedBindAllInterfaces;
+define_simple_violation!(
+    HardcodedBindAllInterfaces,
+    "Possible binding to all interfaces"
 );
-impl Violation for HardcodedBindAllInterfaces {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Possible binding to all interfaces")
-    }
-}
 
 /// S104
 pub fn hardcoded_bind_all_interfaces(value: &str, range: &Range) -> Option<Diagnostic> {

--- a/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -5,19 +5,14 @@ use ruff_macros::derive_message_formats;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct LoggingConfigInsecureListen;
+define_simple_violation!(
+    LoggingConfigInsecureListen,
+    "Use of insecure `logging.config.listen` detected"
 );
-impl Violation for LoggingConfigInsecureListen {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use of insecure `logging.config.listen` detected")
-    }
-}
 
 /// S612
 pub fn logging_config_insecure_listen(

--- a/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use num_traits::{One, Zero};
 use ruff_macros::derive_message_formats;
@@ -10,15 +10,10 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct SnmpInsecureVersion;
+define_simple_violation!(
+    SnmpInsecureVersion,
+    "The use of SNMPv1 and SNMPv2 is insecure. Use SNMPv3 if able."
 );
-impl Violation for SnmpInsecureVersion {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("The use of SNMPv1 and SNMPv2 is insecure. Use SNMPv3 if able.")
-    }
-}
 
 /// S508
 pub fn snmp_insecure_version(

--- a/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword};
@@ -8,18 +8,11 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct SnmpWeakCryptography;
-);
-impl Violation for SnmpWeakCryptography {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is \
+define_simple_violation!(
+    SnmpWeakCryptography,
+    "You should not use SNMPv3 without encryption. `noAuthNoPriv` & `authNoPriv` is \
              insecure."
-        )
-    }
-}
+);
 
 /// S509
 pub fn snmp_weak_cryptography(

--- a/src/rules/flake8_bandit/rules/try_except_pass.rs
+++ b/src/rules/flake8_bandit/rules/try_except_pass.rs
@@ -3,19 +3,14 @@ use rustpython_ast::{Expr, Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct TryExceptPass;
+define_simple_violation!(
+    TryExceptPass,
+    "`try`-`except`-`pass` detected, consider logging the exception"
 );
-impl Violation for TryExceptPass {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`try`-`except`-`pass` detected, consider logging the exception")
-    }
-}
 
 /// S110
 pub fn try_except_pass(

--- a/src/rules/flake8_boolean_trap/rules.rs
+++ b/src/rules/flake8_boolean_trap/rules.rs
@@ -4,39 +4,24 @@ use rustpython_parser::ast::{Constant, Expr};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::{Diagnostic, DiagnosticKind};
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct BooleanPositionalArgInFunctionDefinition;
+define_simple_violation!(
+    BooleanPositionalArgInFunctionDefinition,
+    "Boolean positional arg in function definition"
 );
-impl Violation for BooleanPositionalArgInFunctionDefinition {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Boolean positional arg in function definition")
-    }
-}
 
-define_violation!(
-    pub struct BooleanDefaultValueInFunctionDefinition;
+define_simple_violation!(
+    BooleanDefaultValueInFunctionDefinition,
+    "Boolean default value in function definition"
 );
-impl Violation for BooleanDefaultValueInFunctionDefinition {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Boolean default value in function definition")
-    }
-}
 
-define_violation!(
-    pub struct BooleanPositionalValueInFunctionCall;
+define_simple_violation!(
+    BooleanPositionalValueInFunctionCall,
+    "Boolean positional value in function call"
 );
-impl Violation for BooleanPositionalValueInFunctionCall {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Boolean positional value in function call")
-    }
-}
 
 const FUNC_NAME_ALLOWLIST: &[&str] = &[
     "assertEqual",

--- a/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,26 +1,18 @@
 use crate::ast::helpers::unparse_stmt;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
-define_violation!(
-    pub struct DoNotAssertFalse;
+define_simple_autofix_violation!(
+    DoNotAssertFalse,
+    "Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`",
+    "Replace `assert False`"
 );
-impl AlwaysAutofixableViolation for DoNotAssertFalse {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace `assert False`".to_string()
-    }
-}
 
 fn assertion_error(msg: Option<&Expr>) -> Stmt {
     Stmt::new(

--- a/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -9,21 +9,16 @@
 //! `assertRaises`.
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{ExprKind, Stmt, Withitem};
 
-define_violation!(
-    pub struct NoAssertRaisesException;
+define_simple_violation!(
+    NoAssertRaisesException,
+    "`assertRaises(Exception)` should be considered evil"
 );
-impl Violation for NoAssertRaisesException {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`assertRaises(Exception)` should be considered evil")
-    }
-}
 
 /// B017
 pub fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items: &[Withitem]) {

--- a/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -1,20 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct AssignmentToOsEnviron;
+define_simple_violation!(
+    AssignmentToOsEnviron,
+    "Assigning to `os.environ` doesn't clear the environment"
 );
-impl Violation for AssignmentToOsEnviron {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Assigning to `os.environ` doesn't clear the environment")
-    }
-}
+
 /// B003
 pub fn assignment_to_os_environ(checker: &mut Checker, targets: &[Expr]) {
     if targets.len() != 1 {

--- a/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -1,22 +1,15 @@
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct CachedInstanceMethod;
+define_simple_violation!(
+    CachedInstanceMethod,
+    "Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks"
 );
-impl Violation for CachedInstanceMethod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks"
-        )
-    }
-}
 
 fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
     checker.resolve_call_path(expr).map_or(false, |call_path| {

--- a/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
+++ b/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
@@ -1,20 +1,15 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct CannotRaiseLiteral;
+define_simple_violation!(
+    CannotRaiseLiteral,
+    "Cannot raise a literal. Did you intend to return it or raise an Exception?"
 );
-impl Violation for CannotRaiseLiteral {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Cannot raise a literal. Did you intend to return it or raise an Exception?")
-    }
-}
 
 /// B016
 pub fn cannot_raise_literal(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -1,23 +1,16 @@
 use crate::ast::helpers;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{ExprKind, Stmt, StmtKind};
 
-define_violation!(
-    pub struct FStringDocstring;
-);
-impl Violation for FStringDocstring {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "f-string used as docstring. This will be interpreted by python as a joined string \
+define_simple_violation!(
+    FStringDocstring,
+    "f-string used as docstring. This will be interpreted by python as a joined string \
              rather than a docstring."
-        )
-    }
-}
+);
 
 /// B021
 pub fn f_string_docstring(checker: &mut Checker, body: &[Stmt]) {

--- a/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -1,7 +1,7 @@
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::python::identifiers::{is_identifier, is_mangled_private};
 use crate::python::keyword::KWLIST;
@@ -10,22 +10,13 @@ use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location};
 
-define_violation!(
-    pub struct GetAttrWithConstant;
+define_simple_autofix_violation!(
+    GetAttrWithConstant,
+    "Do not call `getattr` with a constant attribute value. It is not any safer than \
+             normal property access.",
+    "Replace `getattr` with attribute access"
 );
-impl AlwaysAutofixableViolation for GetAttrWithConstant {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Do not call `getattr` with a constant attribute value. It is not any safer than \
-             normal property access."
-        )
-    }
 
-    fn autofix_title(&self) -> String {
-        "Replace `getattr` with attribute access".to_string()
-    }
-}
 fn attribute(value: &Expr, attr: &str) -> Expr {
     Expr::new(
         Location::default(),

--- a/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,20 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Arguments, Constant, Expr, ExprKind, Operator};
 
-define_violation!(
-    pub struct MutableArgumentDefault;
+define_simple_violation!(
+    MutableArgumentDefault,
+    "Do not use mutable data structures for argument defaults"
 );
-impl Violation for MutableArgumentDefault {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Do not use mutable data structures for argument defaults")
-    }
-}
+
 const MUTABLE_FUNCS: &[&[&str]] = &[
     &["", "dict"],
     &["", "list"],

--- a/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -1,25 +1,18 @@
 use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::python::string::is_lower;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{ExprKind, Stmt, StmtKind};
 
-define_violation!(
-    pub struct RaiseWithoutFromInsideExcept;
-);
-impl Violation for RaiseWithoutFromInsideExcept {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Within an except clause, raise exceptions with `raise ... from err` or `raise ... \
+define_simple_violation!(
+    RaiseWithoutFromInsideExcept,
+    "Within an except clause, raise exceptions with `raise ... from err` or `raise ... \
              from None` to distinguish them from errors in exception handling"
-        )
-    }
-}
+);
 
 struct RaiseVisitor {
     diagnostics: Vec<Diagnostic>,

--- a/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,7 +1,7 @@
 use crate::ast::helpers::unparse_stmt;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::python::identifiers::{is_identifier, is_mangled_private};
 use crate::python::keyword::KWLIST;
@@ -11,22 +11,12 @@ use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
-define_violation!(
-    pub struct SetAttrWithConstant;
+define_simple_autofix_violation!(
+    SetAttrWithConstant,
+    "Do not call `setattr` with a constant attribute value. It is not any safer than \
+             normal property access.",
+    "Replace `setattr` with assignment"
 );
-impl AlwaysAutofixableViolation for SetAttrWithConstant {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Do not call `setattr` with a constant attribute value. It is not any safer than \
-             normal property access."
-        )
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace `setattr` with assignment".to_string()
-    }
-}
 
 fn assignment(obj: &Expr, name: &str, value: &Expr, stylist: &Stylist) -> String {
     let stmt = Stmt::new(

--- a/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
+++ b/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
@@ -9,21 +9,16 @@
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct StarArgUnpackingAfterKeywordArg;
+define_simple_violation!(
+    StarArgUnpackingAfterKeywordArg,
+    "Star-arg unpacking after a keyword argument is strongly discouraged"
 );
-impl Violation for StarArgUnpackingAfterKeywordArg {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Star-arg unpacking after a keyword argument is strongly discouraged")
-    }
-}
 
 /// B026
 pub fn star_arg_unpacking_after_keyword_arg(

--- a/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -1,21 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
-define_violation!(
-    pub struct StripWithMultiCharacters;
+define_simple_violation!(
+    StripWithMultiCharacters,
+    "Using `.strip()` with multi-character strings is misleading the reader"
 );
-impl Violation for StripWithMultiCharacters {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Using `.strip()` with multi-character strings is misleading the reader")
-    }
-}
 
 /// B005
 pub fn strip_with_multi_characters(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {

--- a/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
+++ b/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
@@ -19,21 +19,16 @@
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Unaryop};
 
-define_violation!(
-    pub struct UnaryPrefixIncrement;
+define_simple_violation!(
+    UnaryPrefixIncrement,
+    "Python does not support the unary prefix increment"
 );
-impl Violation for UnaryPrefixIncrement {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Python does not support the unary prefix increment")
-    }
-}
 
 /// B002
 pub fn unary_prefix_increment(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand: &Expr) {

--- a/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -1,23 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
-define_violation!(
-    pub struct UnreliableCallableCheck;
-);
-impl Violation for UnreliableCallableCheck {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            " Using `hasattr(x, '__call__')` to test if x is callable is unreliable. Use \
+define_simple_violation!(
+    UnreliableCallableCheck,
+    " Using `hasattr(x, '__call__')` to test if x is callable is unreliable. Use \
              `callable(x)` for consistent results."
-        )
-    }
-}
+);
 
 /// B004
 pub fn unreliable_callable_check(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {

--- a/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -1,23 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct UselessComparison;
-);
-impl Violation for UselessComparison {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Pointless comparison. This comparison does nothing but waste CPU instructions. \
+define_simple_violation!(
+    UselessComparison,
+    "Pointless comparison. This comparison does nothing but waste CPU instructions. \
              Either prepend `assert` or remove it."
-        )
-    }
-}
+);
 
 pub fn useless_comparison(checker: &mut Checker, expr: &Expr) {
     if matches!(expr.node, ExprKind::Compare { .. }) {

--- a/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -1,23 +1,16 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
-define_violation!(
-    pub struct UselessContextlibSuppress;
-);
-impl Violation for UselessContextlibSuppress {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and \
+define_simple_violation!(
+    UselessContextlibSuppress,
+    "No arguments passed to `contextlib.suppress`. No exceptions will be suppressed and \
              therefore this context manager is redundant"
-        )
-    }
-}
+);
 
 /// B005
 pub fn useless_contextlib_suppress(checker: &mut Checker, expr: &Expr, args: &[Expr]) {

--- a/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -1,20 +1,15 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, ExprKind, Stmt, StmtKind};
 
-define_violation!(
-    pub struct UselessExpression;
+define_simple_violation!(
+    UselessExpression,
+    "Found useless expression. Either assign it to a variable or remove it."
 );
-impl Violation for UselessExpression {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Found useless expression. Either assign it to a variable or remove it.")
-    }
-}
 
 // B018
 pub fn useless_expression(checker: &mut Checker, body: &[Stmt]) {

--- a/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -1,20 +1,15 @@
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct ZipWithoutExplicitStrict;
+define_simple_violation!(
+    ZipWithoutExplicitStrict,
+    "`zip()` without an explicit `strict=` parameter"
 );
-impl Violation for ZipWithoutExplicitStrict {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`zip()` without an explicit `strict=` parameter")
-    }
-}
 
 /// B905
 pub fn zip_without_explicit_strict(

--- a/src/rules/flake8_commas/rules.rs
+++ b/src/rules/flake8_commas/rules.rs
@@ -8,7 +8,7 @@ use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation};
 
 /// Simplified token type.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -109,38 +109,22 @@ impl Context {
     }
 }
 
-define_violation!(
-    pub struct TrailingCommaMissing;
+define_simple_autofix_violation!(
+    TrailingCommaMissing,
+    "Trailing comma missing",
+    "Add trailing comma"
 );
-impl AlwaysAutofixableViolation for TrailingCommaMissing {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Trailing comma missing")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Add trailing comma".to_string()
-    }
-}
 
 define_simple_violation!(
     TrailingCommaOnBareTupleProhibited,
     "Trailing comma on bare tuple prohibited"
 );
 
-define_violation!(
-    pub struct TrailingCommaProhibited;
+define_simple_autofix_violation!(
+    TrailingCommaProhibited,
+    "Trailing comma prohibited",
+    "Remove trailing comma"
 );
-impl AlwaysAutofixableViolation for TrailingCommaProhibited {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Trailing comma prohibited")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove trailing comma".to_string()
-    }
-}
 
 /// COM812, COM818, COM819
 pub fn trailing_commas(

--- a/src/rules/flake8_commas/rules.rs
+++ b/src/rules/flake8_commas/rules.rs
@@ -4,11 +4,11 @@ use rustpython_parser::lexer::{LexResult, Spanned};
 use rustpython_parser::token::Tok;
 
 use crate::ast::types::Range;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 
 /// Simplified token type.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -123,15 +123,10 @@ impl AlwaysAutofixableViolation for TrailingCommaMissing {
     }
 }
 
-define_violation!(
-    pub struct TrailingCommaOnBareTupleProhibited;
+define_simple_violation!(
+    TrailingCommaOnBareTupleProhibited,
+    "Trailing comma on bare tuple prohibited"
 );
-impl Violation for TrailingCommaOnBareTupleProhibited {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Trailing comma on bare tuple prohibited")
-    }
-}
 
 define_violation!(
     pub struct TrailingCommaProhibited;

--- a/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct UnnecessaryGeneratorDict;
+define_simple_autofix_violation!(
+    UnnecessaryGeneratorDict,
+    "Unnecessary generator (rewrite as a `dict` comprehension)",
+    "Rewrite as a `dict` comprehension"
 );
-impl AlwaysAutofixableViolation for UnnecessaryGeneratorDict {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary generator (rewrite as a `dict` comprehension)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite as a `dict` comprehension".to_string()
-    }
-}
 
 /// C402 (`dict((x, y) for x, y in iterable)`)
 pub fn unnecessary_generator_dict(

--- a/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct UnnecessaryGeneratorList;
+define_simple_autofix_violation!(
+    UnnecessaryGeneratorList,
+    "Unnecessary generator (rewrite as a `list` comprehension)",
+    "Rewrite as a `list` comprehension"
 );
-impl AlwaysAutofixableViolation for UnnecessaryGeneratorList {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary generator (rewrite as a `list` comprehension)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite as a `list` comprehension".to_string()
-    }
-}
 
 /// C400 (`list(generator)`)
 pub fn unnecessary_generator_list(

--- a/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct UnnecessaryGeneratorSet;
+define_simple_autofix_violation!(
+    UnnecessaryGeneratorSet,
+    "Unnecessary generator (rewrite as a `set` comprehension)",
+    "Rewrite as a `set` comprehension"
 );
-impl AlwaysAutofixableViolation for UnnecessaryGeneratorSet {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary generator (rewrite as a `set` comprehension)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite as a `set` comprehension".to_string()
-    }
-}
 
 /// C401 (`set(generator)`)
 pub fn unnecessary_generator_set(

--- a/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct UnnecessaryListCall;
+define_simple_autofix_violation!(
+    UnnecessaryListCall,
+    "Unnecessary `list` call (remove the outer call to `list()`)",
+    "Remove outer `list` call"
 );
-impl AlwaysAutofixableViolation for UnnecessaryListCall {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary `list` call (remove the outer call to `list()`)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove outer `list` call".to_string()
-    }
-}
 
 /// C411
 pub fn unnecessary_list_call(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {

--- a/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct UnnecessaryListComprehensionDict;
+define_simple_autofix_violation!(
+    UnnecessaryListComprehensionDict,
+    "Unnecessary `list` comprehension (rewrite as a `dict` comprehension)",
+    "Rewrite as a `dict` comprehension"
 );
-impl AlwaysAutofixableViolation for UnnecessaryListComprehensionDict {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary `list` comprehension (rewrite as a `dict` comprehension)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite as a `dict` comprehension".to_string()
-    }
-}
 
 /// C404 (`dict([...])`)
 pub fn unnecessary_list_comprehension_dict(

--- a/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -1,7 +1,7 @@
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
-define_violation!(
-    pub struct UnnecessaryListComprehensionSet;
+define_simple_autofix_violation!(
+    UnnecessaryListComprehensionSet,
+    "Unnecessary `list` comprehension (rewrite as a `set` comprehension)",
+    "Rewrite as a `set` comprehension"
 );
-impl AlwaysAutofixableViolation for UnnecessaryListComprehensionSet {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary `list` comprehension (rewrite as a `set` comprehension)")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite as a `set` comprehension".to_string()
-    }
-}
 
 /// C403 (`set([...])`)
 pub fn unnecessary_list_comprehension_set(

--- a/src/rules/flake8_datetimez/rules.rs
+++ b/src/rules/flake8_datetimez/rules.rs
@@ -5,119 +5,60 @@ use ruff_macros::derive_message_formats;
 use crate::ast::helpers::{has_non_none_keyword, is_const_none};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct CallDatetimeWithoutTzinfo;
+define_simple_violation!(
+    CallDatetimeWithoutTzinfo,
+    "The use of `datetime.datetime()` without `tzinfo` argument is not allowed"
 );
-impl Violation for CallDatetimeWithoutTzinfo {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("The use of `datetime.datetime()` without `tzinfo` argument is not allowed")
-    }
-}
 
-define_violation!(
-    pub struct CallDatetimeToday;
-);
-impl Violation for CallDatetimeToday {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.today()` is not allowed, use \
+define_simple_violation!(
+    CallDatetimeToday,
+    "The use of `datetime.datetime.today()` is not allowed, use \
              `datetime.datetime.now(tz=)` instead"
-        )
-    }
-}
-
-define_violation!(
-    pub struct CallDatetimeUtcnow;
 );
-impl Violation for CallDatetimeUtcnow {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.utcnow()` is not allowed, use \
+
+define_simple_violation!(
+    CallDatetimeUtcnow,
+    "The use of `datetime.datetime.utcnow()` is not allowed, use \
              `datetime.datetime.now(tz=)` instead"
-        )
-    }
-}
-
-define_violation!(
-    pub struct CallDatetimeUtcfromtimestamp;
 );
-impl Violation for CallDatetimeUtcfromtimestamp {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.utcfromtimestamp()` is not allowed, use \
+
+define_simple_violation!(
+    CallDatetimeUtcfromtimestamp,
+    "The use of `datetime.datetime.utcfromtimestamp()` is not allowed, use \
              `datetime.datetime.fromtimestamp(ts, tz=)` instead"
-        )
-    }
-}
-
-define_violation!(
-    pub struct CallDatetimeNowWithoutTzinfo;
 );
-impl Violation for CallDatetimeNowWithoutTzinfo {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("The use of `datetime.datetime.now()` without `tz` argument is not allowed")
-    }
-}
 
-define_violation!(
-    pub struct CallDatetimeFromtimestamp;
+define_simple_violation!(
+    CallDatetimeNowWithoutTzinfo,
+    "The use of `datetime.datetime.now()` without `tz` argument is not allowed"
 );
-impl Violation for CallDatetimeFromtimestamp {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed"
-        )
-    }
-}
 
-define_violation!(
-    pub struct CallDatetimeStrptimeWithoutZone;
+define_simple_violation!(
+    CallDatetimeFromtimestamp,
+    "The use of `datetime.datetime.fromtimestamp()` without `tz` argument is not allowed"
 );
-impl Violation for CallDatetimeStrptimeWithoutZone {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.datetime.strptime()` without %z must be followed by \
+
+define_simple_violation!(
+    CallDatetimeStrptimeWithoutZone,
+    "The use of `datetime.datetime.strptime()` without %z must be followed by \
              `.replace(tzinfo=)` or `.astimezone()`"
-        )
-    }
-}
-
-define_violation!(
-    pub struct CallDateToday;
 );
-impl Violation for CallDateToday {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.date.today()` is not allowed, use \
+
+define_simple_violation!(
+    CallDateToday,
+    "The use of `datetime.date.today()` is not allowed, use \
              `datetime.datetime.now(tz=).date()` instead"
-        )
-    }
-}
-
-define_violation!(
-    pub struct CallDateFromtimestamp;
 );
-impl Violation for CallDateFromtimestamp {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "The use of `datetime.date.fromtimestamp()` is not allowed, use \
+
+define_simple_violation!(
+    CallDateFromtimestamp,
+    "The use of `datetime.date.fromtimestamp()` is not allowed, use \
              `datetime.datetime.fromtimestamp(ts, tz=).date()` instead"
-        )
-    }
-}
+);
 
 pub fn call_datetime_without_tzinfo(
     checker: &mut Checker,

--- a/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -6,19 +6,14 @@ use ruff_macros::derive_message_formats;
 
 #[cfg(not(target_family = "wasm"))]
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ShebangMissingExecutableFile;
+define_simple_violation!(
+    ShebangMissingExecutableFile,
+    "The file is executable but no shebang is present"
 );
-impl Violation for ShebangMissingExecutableFile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("The file is executable but no shebang is present")
-    }
-}
 
 /// EXE002
 #[cfg(not(target_family = "wasm"))]

--- a/src/rules/flake8_executable/rules/shebang_newline.rs
+++ b/src/rules/flake8_executable/rules/shebang_newline.rs
@@ -2,20 +2,15 @@ use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ShebangNewline;
+define_simple_violation!(
+    ShebangNewline,
+    "Shebang should be at the beginning of the file"
 );
-impl Violation for ShebangNewline {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Shebang should be at the beginning of the file")
-    }
-}
 
 /// EXE005
 pub fn shebang_newline(lineno: usize, shebang: &ShebangDirective) -> Option<Diagnostic> {

--- a/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -8,20 +8,15 @@ use rustpython_ast::Location;
 
 #[cfg(not(target_family = "wasm"))]
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ShebangNotExecutable;
+define_simple_violation!(
+    ShebangNotExecutable,
+    "Shebang is present but file is not executable"
 );
-impl Violation for ShebangNotExecutable {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Shebang is present but file is not executable")
-    }
-}
 
 /// EXE001
 #[cfg(not(target_family = "wasm"))]

--- a/src/rules/flake8_executable/rules/shebang_python.rs
+++ b/src/rules/flake8_executable/rules/shebang_python.rs
@@ -2,20 +2,12 @@ use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ShebangPython;
-);
-impl Violation for ShebangPython {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Shebang should contain \"python\"")
-    }
-}
+define_simple_violation!(ShebangPython, "Shebang should contain \"python\"");
 
 /// EXE003
 pub fn shebang_python(lineno: usize, shebang: &ShebangDirective) -> Option<Diagnostic> {

--- a/src/rules/flake8_implicit_str_concat/rules.rs
+++ b/src/rules/flake8_implicit_str_concat/rules.rs
@@ -5,40 +5,25 @@ use rustpython_parser::lexer::{LexResult, Tok};
 use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_implicit_str_concat::settings::Settings;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct SingleLineImplicitStringConcatenation;
+define_simple_violation!(
+    SingleLineImplicitStringConcatenation,
+    "Implicitly concatenated string literals on one line"
 );
-impl Violation for SingleLineImplicitStringConcatenation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Implicitly concatenated string literals on one line")
-    }
-}
 
-define_violation!(
-    pub struct MultiLineImplicitStringConcatenation;
+define_simple_violation!(
+    MultiLineImplicitStringConcatenation,
+    "Implicitly concatenated string literals over multiple lines"
 );
-impl Violation for MultiLineImplicitStringConcatenation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Implicitly concatenated string literals over multiple lines")
-    }
-}
 
-define_violation!(
-    pub struct ExplicitStringConcatenation;
+define_simple_violation!(
+    ExplicitStringConcatenation,
+    "Explicitly concatenated string should be implicitly concatenated"
 );
-impl Violation for ExplicitStringConcatenation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Explicitly concatenated string should be implicitly concatenated")
-    }
-}
 
 /// ISC001, ISC002
 pub fn implicit(tokens: &[LexResult], settings: &Settings) -> Vec<Diagnostic> {

--- a/src/rules/flake8_logging_format/violations.rs
+++ b/src/rules/flake8_logging_format/violations.rs
@@ -1,47 +1,18 @@
 use ruff_macros::derive_message_formats;
 
-use crate::define_violation;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 
-define_violation!(
-    pub struct LoggingStringFormat;
+define_simple_violation!(
+    LoggingStringFormat,
+    "Logging statement uses `string.format()`"
 );
-impl Violation for LoggingStringFormat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement uses `string.format()`")
-    }
-}
 
-define_violation!(
-    pub struct LoggingPercentFormat;
-);
-impl Violation for LoggingPercentFormat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement uses `%`")
-    }
-}
+define_simple_violation!(LoggingPercentFormat, "Logging statement uses `%`");
 
-define_violation!(
-    pub struct LoggingStringConcat;
-);
-impl Violation for LoggingStringConcat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement uses `+`")
-    }
-}
+define_simple_violation!(LoggingStringConcat, "Logging statement uses `+`");
 
-define_violation!(
-    pub struct LoggingFString;
-);
-impl Violation for LoggingFString {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement uses f-string")
-    }
-}
+define_simple_violation!(LoggingFString, "Logging statement uses f-string");
 
 define_violation!(
     pub struct LoggingWarn;
@@ -70,22 +41,12 @@ impl Violation for LoggingExtraAttrClash {
     }
 }
 
-define_violation!(
-    pub struct LoggingExcInfo;
+define_simple_violation!(
+    LoggingExcInfo,
+    "Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`"
 );
-impl Violation for LoggingExcInfo {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging `.exception(...)` should be used instead of `.error(..., exc_info=True)`")
-    }
-}
 
-define_violation!(
-    pub struct LoggingRedundantExcInfo;
+define_simple_violation!(
+    LoggingRedundantExcInfo,
+    "Logging statement has redundant `exc_info`"
 );
-impl Violation for LoggingRedundantExcInfo {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement has redundant `exc_info`")
-    }
-}

--- a/src/rules/flake8_logging_format/violations.rs
+++ b/src/rules/flake8_logging_format/violations.rs
@@ -1,7 +1,7 @@
 use ruff_macros::derive_message_formats;
 
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation, define_violation};
 
 define_simple_violation!(
     LoggingStringFormat,
@@ -14,19 +14,11 @@ define_simple_violation!(LoggingStringConcat, "Logging statement uses `+`");
 
 define_simple_violation!(LoggingFString, "Logging statement uses f-string");
 
-define_violation!(
-    pub struct LoggingWarn;
+define_simple_autofix_violation!(
+    LoggingWarn,
+    "Logging statement uses `warn` instead of `warning`",
+    "Convert to `warn`"
 );
-impl AlwaysAutofixableViolation for LoggingWarn {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Logging statement uses `warn` instead of `warning`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Convert to `warn`".to_string()
-    }
-}
 
 define_violation!(
     pub struct LoggingExtraAttrClash(pub String);

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -8,12 +8,12 @@ use crate::ast::helpers::{match_trailing_comment, unparse_expr};
 use crate::ast::types::{Range, RefEquality};
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::python::identifiers::is_identifier;
 use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 
 define_violation!(
     pub struct NoUnnecessaryPass;
@@ -58,25 +58,9 @@ impl Violation for PreferUniqueEnums {
     }
 }
 
-define_violation!(
-    pub struct NoUnnecessarySpread;
-);
-impl Violation for NoUnnecessarySpread {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary spread `**`")
-    }
-}
+define_simple_violation!(NoUnnecessarySpread, "Unnecessary spread `**`");
 
-define_violation!(
-    pub struct NoUnnecessaryDictKwargs;
-);
-impl Violation for NoUnnecessaryDictKwargs {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary `dict` kwargs")
-    }
-}
+define_simple_violation!(NoUnnecessaryDictKwargs, "Unnecessary `dict` kwargs");
 
 define_violation!(
     pub struct PreferListBuiltin;

--- a/src/rules/flake8_pie/rules.rs
+++ b/src/rules/flake8_pie/rules.rs
@@ -13,21 +13,13 @@ use crate::message::Location;
 use crate::python::identifiers::is_identifier;
 use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation, define_violation};
 
-define_violation!(
-    pub struct NoUnnecessaryPass;
+define_simple_autofix_violation!(
+    NoUnnecessaryPass,
+    "Unnecessary `pass` statement",
+    "Remove unnecessary `pass`"
 );
-impl AlwaysAutofixableViolation for NoUnnecessaryPass {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary `pass` statement")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove unnecessary `pass`".to_string()
-    }
-}
 
 define_violation!(
     pub struct DupeClassFieldDefinitions(pub String);
@@ -62,19 +54,11 @@ define_simple_violation!(NoUnnecessarySpread, "Unnecessary spread `**`");
 
 define_simple_violation!(NoUnnecessaryDictKwargs, "Unnecessary `dict` kwargs");
 
-define_violation!(
-    pub struct PreferListBuiltin;
+define_simple_autofix_violation!(
+    PreferListBuiltin,
+    "Prefer `list` over useless lambda",
+    "Replace with `list`"
 );
-impl AlwaysAutofixableViolation for PreferListBuiltin {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Prefer `list` over useless lambda")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `list`".to_string()
-    }
-}
 
 /// PIE790
 pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {

--- a/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -9,21 +9,16 @@ use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct CompositeAssertion;
+define_simple_violation!(
+    CompositeAssertion,
+    "Assertion should be broken down into multiple parts"
 );
-impl Violation for CompositeAssertion {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Assertion should be broken down into multiple parts")
-    }
-}
 
 define_violation!(
     pub struct AssertInExcept {
@@ -40,15 +35,10 @@ impl Violation for AssertInExcept {
     }
 }
 
-define_violation!(
-    pub struct AssertAlwaysFalse;
+define_simple_violation!(
+    AssertAlwaysFalse,
+    "Assertion always fails, replace with `pytest.fail()`"
 );
-impl Violation for AssertAlwaysFalse {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Assertion always fails, replace with `pytest.fail()`")
-    }
-}
 
 define_violation!(
     pub struct UnittestAssertion {

--- a/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/src/rules/flake8_pytest_style/rules/fail.rs
@@ -4,20 +4,12 @@ use super::helpers::{is_empty_or_null_string, is_pytest_fail};
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct FailWithoutMessage;
-);
-impl Violation for FailWithoutMessage {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("No message passed to `pytest.fail()`")
-    }
-}
+define_simple_violation!(FailWithoutMessage, "No message passed to `pytest.fail()`");
 
 pub fn fail_call(checker: &mut Checker, call: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_fail(call, checker) {

--- a/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -13,11 +13,11 @@ use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::autofix::helpers::remove_argument;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 
 define_violation!(
     pub struct IncorrectFixtureParenthesesStyle {
@@ -109,25 +109,15 @@ impl Violation for FixtureParamWithoutValue {
     }
 }
 
-define_violation!(
-    pub struct DeprecatedYieldFixture;
+define_simple_violation!(
+    DeprecatedYieldFixture,
+    "`@pytest.yield_fixture` is deprecated, use `@pytest.fixture`"
 );
-impl Violation for DeprecatedYieldFixture {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`@pytest.yield_fixture` is deprecated, use `@pytest.fixture`")
-    }
-}
 
-define_violation!(
-    pub struct FixtureFinalizerCallback;
+define_simple_violation!(
+    FixtureFinalizerCallback,
+    "Use `yield` instead of `request.addfinalizer`"
 );
-impl Violation for FixtureFinalizerCallback {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `yield` instead of `request.addfinalizer`")
-    }
-}
 
 define_violation!(
     pub struct UselessYieldFixture {

--- a/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -17,7 +17,7 @@ use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation, define_violation};
 
 define_violation!(
     pub struct IncorrectFixtureParenthesesStyle {
@@ -53,19 +53,11 @@ impl Violation for FixturePositionalArgs {
     }
 }
 
-define_violation!(
-    pub struct ExtraneousScopeFunction;
+define_simple_autofix_violation!(
+    ExtraneousScopeFunction,
+    "`scope='function'` is implied in `@pytest.fixture()`",
+    "Remove implied `scope` argument"
 );
-impl AlwaysAutofixableViolation for ExtraneousScopeFunction {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`scope='function'` is implied in `@pytest.fixture()`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove implied `scope` argument".to_string()
-    }
-}
 
 define_violation!(
     pub struct MissingFixtureNameUnderscore {
@@ -136,33 +128,17 @@ impl AlwaysAutofixableViolation for UselessYieldFixture {
     }
 }
 
-define_violation!(
-    pub struct ErroneousUseFixturesOnFixture;
+define_simple_autofix_violation!(
+    ErroneousUseFixturesOnFixture,
+    "`pytest.mark.usefixtures` has no effect on fixtures",
+    "Remove `pytest.mark.usefixtures`"
 );
-impl AlwaysAutofixableViolation for ErroneousUseFixturesOnFixture {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`pytest.mark.usefixtures` has no effect on fixtures")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Remove `pytest.mark.usefixtures`".to_string()
-    }
-}
-
-define_violation!(
-    pub struct UnnecessaryAsyncioMarkOnFixture;
+define_simple_autofix_violation!(
+    UnnecessaryAsyncioMarkOnFixture,
+    "`pytest.mark.asyncio` is unnecessary for fixtures",
+    "Remove `pytest.mark.asyncio`"
 );
-impl AlwaysAutofixableViolation for UnnecessaryAsyncioMarkOnFixture {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`pytest.mark.asyncio` is unnecessary for fixtures")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `pytest.mark.asyncio`".to_string()
-    }
-}
 
 #[derive(Default)]
 /// Visitor that skips functions

--- a/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/src/rules/flake8_pytest_style/rules/imports.rs
@@ -1,20 +1,15 @@
 use rustpython_ast::Stmt;
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct IncorrectPytestImport;
+define_simple_violation!(
+    IncorrectPytestImport,
+    "Found incorrect import of pytest, use simple `import pytest` instead"
 );
-impl Violation for IncorrectPytestImport {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Found incorrect import of pytest, use simple `import pytest` instead")
-    }
-}
 
 fn is_pytest_or_subpackage(imported_name: &str) -> bool {
     imported_name == "pytest" || imported_name.starts_with("pytest.")

--- a/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/src/rules/flake8_pytest_style/rules/marks.rs
@@ -1,10 +1,10 @@
 use super::helpers::{get_mark_decorators, get_mark_name};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::AlwaysAutofixableViolation;
+use crate::{define_simple_autofix_violation, define_violation};
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Location};
 
@@ -34,19 +34,11 @@ impl AlwaysAutofixableViolation for IncorrectMarkParenthesesStyle {
     }
 }
 
-define_violation!(
-    pub struct UseFixturesWithoutParameters;
+define_simple_autofix_violation!(
+    UseFixturesWithoutParameters,
+    "Useless `pytest.mark.usefixtures` without parameters",
+    "Remove `usefixtures` decorator or pass parameters"
 );
-impl AlwaysAutofixableViolation for UseFixturesWithoutParameters {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Useless `pytest.mark.usefixtures` without parameters")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `usefixtures` decorator or pass parameters".to_string()
-    }
-}
 
 fn pytest_mark_parentheses(
     checker: &mut Checker,

--- a/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/src/rules/flake8_pytest_style/rules/patch.rs
@@ -5,20 +5,15 @@ use crate::ast::helpers::{collect_arg_names, compose_call_path, SimpleCallArgs};
 use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct PatchWithLambda;
+define_simple_violation!(
+    PatchWithLambda,
+    "Use `return_value=` instead of patching with `lambda`"
 );
-impl Violation for PatchWithLambda {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `return_value=` instead of patching with `lambda`")
-    }
-}
 
 const PATCH_NAMES: &[&str] = &[
     "mocker.patch",

--- a/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/src/rules/flake8_pytest_style/rules/raises.rs
@@ -4,20 +4,15 @@ use super::helpers::is_empty_or_null_string;
 use crate::ast::helpers::{format_call_path, to_call_path};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct RaisesWithMultipleStatements;
+define_simple_violation!(
+    RaisesWithMultipleStatements,
+    "`pytest.raises()` block should contain a single simple statement"
 );
-impl Violation for RaisesWithMultipleStatements {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`pytest.raises()` block should contain a single simple statement")
-    }
-}
 
 define_violation!(
     pub struct RaisesTooBroad {
@@ -35,15 +30,10 @@ impl Violation for RaisesTooBroad {
     }
 }
 
-define_violation!(
-    pub struct RaisesWithoutException;
+define_simple_violation!(
+    RaisesWithoutException,
+    "set the expected exception in `pytest.raises()`"
 );
-impl Violation for RaisesWithoutException {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("set the expected exception in `pytest.raises()`")
-    }
-}
 
 fn is_pytest_raises(checker: &Checker, func: &Expr) -> bool {
     checker.resolve_call_path(func).map_or(false, |call_path| {

--- a/src/rules/flake8_quotes/rules.rs
+++ b/src/rules/flake8_quotes/rules.rs
@@ -1,12 +1,12 @@
 use super::settings::Quote;
 use crate::ast::types::Range;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::lex::docstring_detection::StateMachine;
 use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violation::AlwaysAutofixableViolation;
+use crate::{define_simple_autofix_violation, define_violation};
 
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
@@ -84,19 +84,11 @@ impl AlwaysAutofixableViolation for BadQuotesDocstring {
     }
 }
 
-define_violation!(
-    pub struct AvoidQuoteEscape;
+define_simple_autofix_violation!(
+    AvoidQuoteEscape,
+    "Change outer quotes to avoid escaping inner quotes",
+    "Change outer quotes to avoid escaping inner quotes"
 );
-impl AlwaysAutofixableViolation for AvoidQuoteEscape {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Change outer quotes to avoid escaping inner quotes")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Change outer quotes to avoid escaping inner quotes".to_string()
-    }
-}
 
 fn good_single(quote: &Quote) -> char {
     match quote {

--- a/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -2,20 +2,15 @@ use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use rustpython_ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct UnnecessaryParenOnRaiseException;
+define_simple_violation!(
+    UnnecessaryParenOnRaiseException,
+    "Unnecessary parentheses on raised exception"
 );
-impl Violation for UnnecessaryParenOnRaiseException {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary parentheses on raised exception")
-    }
-}
 
 /// RSE102
 pub fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -12,52 +12,26 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct UnnecessaryReturnNone;
+define_simple_autofix_violation!(
+    UnnecessaryReturnNone,
+    "Do not explicitly `return None` in function if it is the only possible return value",
+    "Remove explicit `return None`"
 );
-impl AlwaysAutofixableViolation for UnnecessaryReturnNone {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Do not explicitly `return None` in function if it is the only possible return value"
-        )
-    }
 
-    fn autofix_title(&self) -> String {
-        "Remove explicit `return None`".to_string()
-    }
-}
-
-define_violation!(
-    pub struct ImplicitReturnValue;
+define_simple_autofix_violation!(
+    ImplicitReturnValue,
+    "Do not implicitly `return None` in function able to return non-`None` value",
+    "Add explicit `None` return value"
 );
-impl AlwaysAutofixableViolation for ImplicitReturnValue {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Do not implicitly `return None` in function able to return non-`None` value")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Add explicit `None` return value".to_string()
-    }
-}
-
-define_violation!(
-    pub struct ImplicitReturn;
+define_simple_autofix_violation!(
+    ImplicitReturn,
+    "Missing explicit `return` at the end of function able to return non-`None` value",
+    "Add explicit `return` statement"
 );
-impl AlwaysAutofixableViolation for ImplicitReturn {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing explicit `return` at the end of function able to return non-`None` value")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Add explicit `return` statement".to_string()
-    }
-}
 
 define_simple_violation!(
     UnnecessaryAssign,

--- a/src/rules/flake8_return/rules.rs
+++ b/src/rules/flake8_return/rules.rs
@@ -9,10 +9,10 @@ use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
 use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
 define_violation!(
@@ -59,15 +59,10 @@ impl AlwaysAutofixableViolation for ImplicitReturn {
     }
 }
 
-define_violation!(
-    pub struct UnnecessaryAssign;
+define_simple_violation!(
+    UnnecessaryAssign,
+    "Unnecessary variable assignment before `return` statement"
 );
-impl Violation for UnnecessaryAssign {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary variable assignment before `return` statement")
-    }
-}
 
 define_violation!(
     pub struct SuperfluousElseReturn {

--- a/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -1,5 +1,5 @@
-use crate::define_violation;
 use crate::violation::AlwaysAutofixableViolation;
+use crate::{define_simple_autofix_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
 use std::collections::BTreeMap;
@@ -84,33 +84,17 @@ impl AlwaysAutofixableViolation for AOrNotA {
     }
 }
 
-define_violation!(
-    pub struct OrTrue;
+define_simple_autofix_violation!(
+    OrTrue,
+    "Use `True` instead of `... or True`",
+    "Replace with `True`"
 );
-impl AlwaysAutofixableViolation for OrTrue {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `True` instead of `... or True`")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Replace with `True`".to_string()
-    }
-}
-
-define_violation!(
-    pub struct AndFalse;
+define_simple_autofix_violation!(
+    AndFalse,
+    "Use `False` instead of `... and False`",
+    "Replace with `False`"
 );
-impl AlwaysAutofixableViolation for AndFalse {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `False` instead of `... and False`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `False`".to_string()
-    }
-}
 
 /// Return `true` if two `Expr` instances are equivalent names.
 fn is_same_expr<'a>(a: &'a Expr, b: &'a Expr) -> Option<&'a str> {

--- a/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/src/rules/flake8_simplify/rules/ast_if.rs
@@ -1,5 +1,5 @@
 use crate::violation::{AlwaysAutofixableViolation, Availability, Violation};
-use crate::{define_violation, AutofixKind};
+use crate::{define_simple_autofix_violation, define_violation, AutofixKind};
 use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
@@ -15,19 +15,11 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_simplify::rules::fix_if;
 
-define_violation!(
-    pub struct NestedIfStatements;
+define_simple_autofix_violation!(
+    NestedIfStatements,
+    "Use a single `if` statement instead of nested `if` statements",
+    "Combine `if` statements using `and`"
 );
-impl AlwaysAutofixableViolation for NestedIfStatements {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use a single `if` statement instead of nested `if` statements")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Combine `if` statements using `and`".to_string()
-    }
-}
 
 define_violation!(
     pub struct ReturnBoolConditionDirectly {

--- a/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/src/rules/flake8_simplify/rules/ast_with.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use log::error;
 use ruff_macros::derive_message_formats;
@@ -10,22 +10,12 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct MultipleWithStatements;
+define_simple_autofix_violation!(
+    MultipleWithStatements,
+    "Use a single `with` statement with multiple contexts instead of nested `with` \
+             statements",
+    "Combine `with` statements"
 );
-impl AlwaysAutofixableViolation for MultipleWithStatements {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Use a single `with` statement with multiple contexts instead of nested `with` \
-             statements"
-        )
-    }
-
-    fn autofix_title(&self) -> String {
-        "Combine `with` statements".to_string()
-    }
-}
 
 fn find_last_with(body: &[Stmt]) -> Option<(&Vec<Withitem>, &Vec<Stmt>)> {
     let [Located { node: StmtKind::With { items, body, .. }, ..}] = body else { return None };

--- a/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
@@ -8,15 +8,10 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct OpenFileWithContextHandler;
+define_simple_violation!(
+    OpenFileWithContextHandler,
+    "Use context handler for opening files"
 );
-impl Violation for OpenFileWithContextHandler {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use context handler for opening files")
-    }
-}
 
 /// Return `true` if the current expression is nested in an `await
 /// exit_stack.enter_async_context` call.

--- a/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Excepthandler, ExcepthandlerKind, Stmt, StmtKind};
@@ -7,15 +7,10 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct ReturnInTryExceptFinally;
+define_simple_violation!(
+    ReturnInTryExceptFinally,
+    "Don't use `return` in `try`/`except` and `finally`"
 );
-impl Violation for ReturnInTryExceptFinally {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Don't use `return` in `try`/`except` and `finally`")
-    }
-}
 
 fn find_return(stmts: &[Stmt]) -> Option<&Stmt> {
     stmts

--- a/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -4,19 +4,11 @@ use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct EmptyTypeCheckingBlock;
-);
-impl Violation for EmptyTypeCheckingBlock {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Found empty type-checking block")
-    }
-}
+define_simple_violation!(EmptyTypeCheckingBlock, "Found empty type-checking block");
 
 /// TCH005
 pub fn empty_type_checking_block(checker: &mut Checker, body: &[Stmt]) {

--- a/src/rules/flake8_use_pathlib/violations.rs
+++ b/src/rules/flake8_use_pathlib/violations.rs
@@ -1,279 +1,145 @@
 use ruff_macros::derive_message_formats;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 
 // PTH100
-define_violation!(
-    pub struct PathlibAbspath;
+define_simple_violation!(
+    PathlibAbspath,
+    "`os.path.abspath` should be replaced by `.resolve()`"
 );
-impl Violation for PathlibAbspath {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.abspath` should be replaced by `.resolve()`")
-    }
-}
 
 // PTH101
-define_violation!(
-    pub struct PathlibChmod;
-);
-impl Violation for PathlibChmod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.chmod` should be replaced by `.chmod()`")
-    }
-}
+define_simple_violation!(PathlibChmod, "`os.chmod` should be replaced by `.chmod()`");
 
 // PTH102
-define_violation!(
-    pub struct PathlibMakedirs;
+define_simple_violation!(
+    PathlibMakedirs,
+    "`os.makedirs` should be replaced by `.mkdir(parents=True)`"
 );
-impl Violation for PathlibMakedirs {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.makedirs` should be replaced by `.mkdir(parents=True)`")
-    }
-}
 
 // PTH103
-define_violation!(
-    pub struct PathlibMkdir;
-);
-impl Violation for PathlibMkdir {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.mkdir` should be replaced by `.mkdir()`")
-    }
-}
+define_simple_violation!(PathlibMkdir, "`os.mkdir` should be replaced by `.mkdir()`");
 
 // PTH104
-define_violation!(
-    pub struct PathlibRename;
+define_simple_violation!(
+    PathlibRename,
+    "`os.rename` should be replaced by `.rename()`"
 );
-impl Violation for PathlibRename {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.rename` should be replaced by `.rename()`")
-    }
-}
 
 // PTH105
-define_violation!(
-    pub struct PathlibReplace;
+define_simple_violation!(
+    PathlibReplace,
+    "`os.replace`should be replaced by `.replace()`"
 );
-impl Violation for PathlibReplace {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.replace`should be replaced by `.replace()`")
-    }
-}
 
 // PTH106
-define_violation!(
-    pub struct PathlibRmdir;
-);
-impl Violation for PathlibRmdir {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.rmdir` should be replaced by `.rmdir()`")
-    }
-}
+define_simple_violation!(PathlibRmdir, "`os.rmdir` should be replaced by `.rmdir()`");
 
 // PTH107
-define_violation!(
-    pub struct PathlibRemove;
+define_simple_violation!(
+    PathlibRemove,
+    "`os.remove` should be replaced by `.unlink()`"
 );
-impl Violation for PathlibRemove {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.remove` should be replaced by `.unlink()`")
-    }
-}
 
 // PTH108
-define_violation!(
-    pub struct PathlibUnlink;
+define_simple_violation!(
+    PathlibUnlink,
+    "`os.unlink` should be replaced by `.unlink()`"
 );
-impl Violation for PathlibUnlink {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.unlink` should be replaced by `.unlink()`")
-    }
-}
 
 // PTH109
-define_violation!(
-    pub struct PathlibGetcwd;
+define_simple_violation!(
+    PathlibGetcwd,
+    "`os.getcwd` should be replaced by `Path.cwd()`"
 );
-impl Violation for PathlibGetcwd {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.getcwd` should be replaced by `Path.cwd()`")
-    }
-}
 
 // PTH110
-define_violation!(
-    pub struct PathlibExists;
+define_simple_violation!(
+    PathlibExists,
+    "`os.path.exists` should be replaced by `.exists()`"
 );
-impl Violation for PathlibExists {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.exists` should be replaced by `.exists()`")
-    }
-}
 
 // PTH111
-define_violation!(
-    pub struct PathlibExpanduser;
+define_simple_violation!(
+    PathlibExpanduser,
+    "`os.path.expanduser` should be replaced by `.expanduser()`"
 );
-impl Violation for PathlibExpanduser {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.expanduser` should be replaced by `.expanduser()`")
-    }
-}
 
 // PTH112
-define_violation!(
-    pub struct PathlibIsDir;
+define_simple_violation!(
+    PathlibIsDir,
+    "`os.path.isdir` should be replaced by `.is_dir()`"
 );
-impl Violation for PathlibIsDir {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.isdir` should be replaced by `.is_dir()`")
-    }
-}
 
 // PTH113
-define_violation!(
-    pub struct PathlibIsFile;
+define_simple_violation!(
+    PathlibIsFile,
+    "`os.path.isfile` should be replaced by `.is_file()`"
 );
-impl Violation for PathlibIsFile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.isfile` should be replaced by `.is_file()`")
-    }
-}
 
 // PTH114
-define_violation!(
-    pub struct PathlibIsLink;
+define_simple_violation!(
+    PathlibIsLink,
+    "`os.path.islink` should be replaced by `.is_symlink()`"
 );
-impl Violation for PathlibIsLink {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.islink` should be replaced by `.is_symlink()`")
-    }
-}
 
 // PTH115
-define_violation!(
-    pub struct PathlibReadlink;
+define_simple_violation!(
+    PathlibReadlink,
+    "`os.readlink` should be replaced by `.readlink()`"
 );
-impl Violation for PathlibReadlink {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.readlink` should be replaced by `.readlink()`")
-    }
-}
 
 // PTH116
-define_violation!(
-    pub struct PathlibStat;
+define_simple_violation!(
+    PathlibStat,
+    "`os.stat` should be replaced by `.stat()` or `.owner()` or `.group()`"
 );
-impl Violation for PathlibStat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.stat` should be replaced by `.stat()` or `.owner()` or `.group()`")
-    }
-}
 
 // PTH117
-define_violation!(
-    pub struct PathlibIsAbs;
+define_simple_violation!(
+    PathlibIsAbs,
+    "`os.path.isabs` should be replaced by `.is_absolute()`"
 );
-impl Violation for PathlibIsAbs {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.isabs` should be replaced by `.is_absolute()`")
-    }
-}
 
 // PTH118
-define_violation!(
-    pub struct PathlibJoin;
+define_simple_violation!(
+    PathlibJoin,
+    "`os.path.join` should be replaced by foo_path / \"bar\""
 );
-impl Violation for PathlibJoin {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.join` should be replaced by foo_path / \"bar\"")
-    }
-}
 
 // PTH119
-define_violation!(
-    pub struct PathlibBasename;
+define_simple_violation!(
+    PathlibBasename,
+    "`os.path.basename` should be replaced by `.name`"
 );
-impl Violation for PathlibBasename {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.basename` should be replaced by `.name`")
-    }
-}
 
 // PTH120
-define_violation!(
-    pub struct PathlibDirname;
+define_simple_violation!(
+    PathlibDirname,
+    "`os.path.dirname` should be replaced by `.parent`"
 );
-impl Violation for PathlibDirname {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.dirname` should be replaced by `.parent`")
-    }
-}
 
 // PTH121
-define_violation!(
-    pub struct PathlibSamefile;
+define_simple_violation!(
+    PathlibSamefile,
+    "`os.path.samefile` should be replaced by `.samefile()`"
 );
-impl Violation for PathlibSamefile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.samefile` should be replaced by `.samefile()`")
-    }
-}
 
 // PTH122
-define_violation!(
-    pub struct PathlibSplitext;
+define_simple_violation!(
+    PathlibSplitext,
+    "`os.path.splitext` should be replaced by `.suffix`"
 );
-impl Violation for PathlibSplitext {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`os.path.splitext` should be replaced by `.suffix`")
-    }
-}
 
 // PTH123
-define_violation!(
-    pub struct PathlibOpen;
+define_simple_violation!(
+    PathlibOpen,
+    "`open(\"foo\")` should be replaced by `Path(\"foo\").open()`"
 );
-impl Violation for PathlibOpen {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`open(\"foo\")` should be replaced by `Path(\"foo\").open()`")
-    }
-}
 
 // PTH124
-define_violation!(
-    pub struct PathlibPyPath;
+define_simple_violation!(
+    PathlibPyPath,
+    "`py.path` is in maintenance mode, use `pathlib` instead"
 );
-impl Violation for PathlibPyPath {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`py.path` is in maintenance mode, use `pathlib` instead")
-    }
-}

--- a/src/rules/isort/rules/organize_imports.rs
+++ b/src/rules/isort/rules/organize_imports.rs
@@ -12,26 +12,18 @@ use crate::ast::helpers::{
 };
 use crate::ast::types::Range;
 use crate::ast::whitespace::leading_space;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::settings::{flags, Settings};
 use crate::source_code::{Indexer, Locator, Stylist};
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct UnsortedImports;
+define_simple_autofix_violation!(
+    UnsortedImports,
+    "Import block is un-sorted or un-formatted",
+    "Organize imports"
 );
-impl AlwaysAutofixableViolation for UnsortedImports {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Import block is un-sorted or un-formatted")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Organize imports".to_string()
-    }
-}
 
 fn extract_range(body: &[&Stmt]) -> Range {
     let location = body.first().unwrap().location;

--- a/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -2,19 +2,14 @@ use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct DfIsABadVariableName;
+define_simple_violation!(
+    DfIsABadVariableName,
+    "`df` is a bad variable name. Be kinder to your future self."
 );
-impl Violation for DfIsABadVariableName {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`df` is a bad variable name. Be kinder to your future self.")
-    }
-}
 
 /// PD901
 pub fn assignment_to_df(targets: &[Expr]) -> Option<Diagnostic> {

--- a/src/rules/pandas_vet/rules/check_attr.rs
+++ b/src/rules/pandas_vet/rules/check_attr.rs
@@ -3,50 +3,27 @@ use rustpython_ast::{ExprKind, Located};
 
 use crate::ast::types::{BindingKind, Range};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::{Diagnostic, DiagnosticKind, Rule};
 use crate::rules::pandas_vet::helpers::is_dataframe_candidate;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct UseOfDotIx;
+define_simple_violation!(
+    UseOfDotIx,
+    "`.ix` is deprecated; use more explicit `.loc` or `.iloc`"
 );
-impl Violation for UseOfDotIx {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.ix` is deprecated; use more explicit `.loc` or `.iloc`")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotAt;
+define_simple_violation!(
+    UseOfDotAt,
+    "Use `.loc` instead of `.at`.  If speed is important, use numpy."
 );
-impl Violation for UseOfDotAt {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `.loc` instead of `.at`.  If speed is important, use numpy.")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotIat;
+define_simple_violation!(
+    UseOfDotIat,
+    "Use `.iloc` instead of `.iat`.  If speed is important, use numpy."
 );
-impl Violation for UseOfDotIat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `.iloc` instead of `.iat`.  If speed is important, use numpy.")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotValues;
-);
-impl Violation for UseOfDotValues {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `.to_numpy()` instead of `.values`")
-    }
-}
+define_simple_violation!(UseOfDotValues, "Use `.to_numpy()` instead of `.values`");
 
 pub fn check_attr(
     checker: &mut Checker,

--- a/src/rules/pandas_vet/rules/check_call.rs
+++ b/src/rules/pandas_vet/rules/check_call.rs
@@ -3,62 +3,35 @@ use rustpython_ast::{ExprKind, Located};
 
 use crate::ast::types::{BindingKind, Range};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::{Diagnostic, DiagnosticKind, Rule};
 use crate::rules::pandas_vet::helpers::is_dataframe_candidate;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct UseOfDotIsNull;
+define_simple_violation!(
+    UseOfDotIsNull,
+    "`.isna` is preferred to `.isnull`; functionality is equivalent"
 );
-impl Violation for UseOfDotIsNull {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.isna` is preferred to `.isnull`; functionality is equivalent")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotNotNull;
+define_simple_violation!(
+    UseOfDotNotNull,
+    "`.notna` is preferred to `.notnull`; functionality is equivalent"
 );
-impl Violation for UseOfDotNotNull {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.notna` is preferred to `.notnull`; functionality is equivalent")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotPivotOrUnstack;
+define_simple_violation!(
+    UseOfDotPivotOrUnstack,
+    "`.pivot_table` is preferred to `.pivot` or `.unstack`; provides same functionality"
 );
-impl Violation for UseOfDotPivotOrUnstack {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "`.pivot_table` is preferred to `.pivot` or `.unstack`; provides same functionality"
-        )
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotReadTable;
+define_simple_violation!(
+    UseOfDotReadTable,
+    "`.read_csv` is preferred to `.read_table`; provides same functionality"
 );
-impl Violation for UseOfDotReadTable {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.read_csv` is preferred to `.read_table`; provides same functionality")
-    }
-}
 
-define_violation!(
-    pub struct UseOfDotStack;
+define_simple_violation!(
+    UseOfDotStack,
+    "`.melt` is preferred to `.stack`; provides same functionality"
 );
-impl Violation for UseOfDotStack {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.melt` is preferred to `.stack`; provides same functionality")
-    }
-}
 
 pub fn check_call(checker: &mut Checker, func: &Located<ExprKind>) {
     let rules = &checker.settings.rules;

--- a/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/src/rules/pandas_vet/rules/pd_merge.rs
@@ -2,22 +2,15 @@ use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct UseOfPdMerge;
-);
-impl Violation for UseOfPdMerge {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Use `.merge` method instead of `pd.merge` function. They have equivalent \
+define_simple_violation!(
+    UseOfPdMerge,
+    "Use `.merge` method instead of `pd.merge` function. They have equivalent \
              functionality."
-        )
-    }
-}
+);
 
 /// PD015
 pub fn use_of_pd_merge(func: &Expr) -> Option<Diagnostic> {

--- a/src/rules/pep8_naming/rules.rs
+++ b/src/rules/pep8_naming/rules.rs
@@ -5,11 +5,11 @@ use crate::ast::function_type;
 use crate::ast::helpers::identifier_range;
 use crate::ast::types::{Range, Scope, ScopeKind};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::python::string::{self};
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
 define_violation!(
@@ -51,25 +51,15 @@ impl Violation for InvalidArgumentName {
     }
 }
 
-define_violation!(
-    pub struct InvalidFirstArgumentNameForClassMethod;
+define_simple_violation!(
+    InvalidFirstArgumentNameForClassMethod,
+    "First argument of a class method should be named `cls`"
 );
-impl Violation for InvalidFirstArgumentNameForClassMethod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First argument of a class method should be named `cls`")
-    }
-}
 
-define_violation!(
-    pub struct InvalidFirstArgumentNameForMethod;
+define_simple_violation!(
+    InvalidFirstArgumentNameForMethod,
+    "First argument of a method should be named `self`"
 );
-impl Violation for InvalidFirstArgumentNameForMethod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First argument of a method should be named `self`")
-    }
-}
 
 define_violation!(
     pub struct NonLowercaseVariableInFunction {
@@ -84,15 +74,10 @@ impl Violation for NonLowercaseVariableInFunction {
     }
 }
 
-define_violation!(
-    pub struct DunderFunctionName;
+define_simple_violation!(
+    DunderFunctionName,
+    "Function name should not start and end with `__`"
 );
-impl Violation for DunderFunctionName {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Function name should not start and end with `__`")
-    }
-}
 
 define_violation!(
     pub struct ConstantImportedAsNonConstant {

--- a/src/rules/pycodestyle/rules/do_not_use_bare_except.rs
+++ b/src/rules/pycodestyle/rules/do_not_use_bare_except.rs
@@ -3,20 +3,12 @@ use rustpython_ast::{Excepthandler, Stmt, StmtKind};
 use rustpython_parser::ast::Expr;
 
 use crate::ast::helpers::except_range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct DoNotUseBareExcept;
-);
-impl Violation for DoNotUseBareExcept {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Do not use bare `except`")
-    }
-}
+define_simple_violation!(DoNotUseBareExcept, "Do not use bare `except`");
 
 /// E722
 pub fn do_not_use_bare_except(

--- a/src/rules/pycodestyle/rules/imports.rs
+++ b/src/rules/pycodestyle/rules/imports.rs
@@ -3,29 +3,16 @@ use crate::checkers::ast::Checker;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Alias, Stmt};
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct MultipleImportsOnOneLine;
-);
-impl Violation for MultipleImportsOnOneLine {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Multiple imports on one line")
-    }
-}
+define_simple_violation!(MultipleImportsOnOneLine, "Multiple imports on one line");
 
-define_violation!(
-    pub struct ModuleImportNotAtTopOfFile;
+define_simple_violation!(
+    ModuleImportNotAtTopOfFile,
+    "Module level import not at top of file"
 );
-impl Violation for ModuleImportNotAtTopOfFile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Module level import not at top of file")
-    }
-}
 
 pub fn multiple_imports_on_one_line(checker: &mut Checker, stmt: &Stmt, names: &[Alias]) {
     if names.len() > 1 {

--- a/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -3,19 +3,14 @@ use rustpython_ast::Location;
 
 use crate::ast::types::Range;
 use crate::ast::whitespace::leading_space;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct MixedSpacesAndTabs;
+define_simple_violation!(
+    MixedSpacesAndTabs,
+    "Indentation contains mixed spaces and tabs"
 );
-impl Violation for MixedSpacesAndTabs {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Indentation contains mixed spaces and tabs")
-    }
-}
 
 /// E101
 pub fn mixed_spaces_and_tabs(lineno: usize, line: &str) -> Option<Diagnostic> {

--- a/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
+++ b/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
@@ -2,25 +2,17 @@ use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::Stylist;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct NoNewLineAtEndOfFile;
+define_simple_autofix_violation!(
+    NoNewLineAtEndOfFile,
+    "No newline at end of file",
+    "Add trailing newline"
 );
-impl AlwaysAutofixableViolation for NoNewLineAtEndOfFile {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("No newline at end of file")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Add trailing newline".to_string()
-    }
-}
 
 /// W292
 pub fn no_newline_at_end_of_file(

--- a/src/rules/pycodestyle/rules/not_tests.rs
+++ b/src/rules/pycodestyle/rules/not_tests.rs
@@ -4,39 +4,23 @@ use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::compare;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct NotInTest;
+define_simple_autofix_violation!(
+    NotInTest,
+    "Test for membership should be `not in`",
+    "Convert to `not in`"
 );
-impl AlwaysAutofixableViolation for NotInTest {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Test for membership should be `not in`")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Convert to `not in`".to_string()
-    }
-}
-
-define_violation!(
-    pub struct NotIsTest;
+define_simple_autofix_violation!(
+    NotIsTest,
+    "Test for object identity should be `is not`",
+    "Convert to `is not`"
 );
-impl AlwaysAutofixableViolation for NotIsTest {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Test for object identity should be `is not`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Convert to `is not`".to_string()
-    }
-}
 
 /// E713, E714
 pub fn not_tests(

--- a/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/src/rules/pycodestyle/rules/type_comparison.rs
@@ -4,19 +4,11 @@ use rustpython_ast::Constant;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct TypeComparison;
-);
-impl Violation for TypeComparison {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Do not compare types, use `isinstance()`")
-    }
-}
+define_simple_violation!(TypeComparison, "Do not compare types, use `isinstance()`");
 
 /// E721
 pub fn type_comparison(ops: &[Cmpop], comparators: &[Expr], location: Range) -> Vec<Diagnostic> {

--- a/src/rules/pydocstyle/rules/capitalized.rs
+++ b/src/rules/pydocstyle/rules/capitalized.rs
@@ -4,18 +4,13 @@ use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct FirstLineCapitalized;
+define_simple_violation!(
+    FirstLineCapitalized,
+    "First word of the first line should be properly capitalized"
 );
-impl Violation for FirstLineCapitalized {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First word of the first line should be properly capitalized")
-    }
-}
 
 /// D403
 pub fn capitalized(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -8,22 +8,14 @@ use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct EndsInPeriod;
+define_simple_autofix_violation!(
+    EndsInPeriod,
+    "First line should end with a period",
+    "Add period"
 );
-impl AlwaysAutofixableViolation for EndsInPeriod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First line should end with a period")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Add period".to_string()
-    }
-}
 
 /// D400
 pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -8,22 +8,14 @@ use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct EndsInPunctuation;
+define_simple_autofix_violation!(
+    EndsInPunctuation,
+    "First line should end with a period, question mark, or exclamation point",
+    "Add closing punctuation"
 );
-impl AlwaysAutofixableViolation for EndsInPunctuation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First line should end with a period, question mark, or exclamation point")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Add closing punctuation".to_string()
-    }
-}
 
 /// D415
 pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/if_needed.rs
+++ b/src/rules/pydocstyle/rules/if_needed.rs
@@ -5,19 +5,14 @@ use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::visibility::is_overload;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct SkipDocstring;
+define_simple_violation!(
+    SkipDocstring,
+    "Function decorated with `@overload` shouldn't contain a docstring"
 );
-impl Violation for SkipDocstring {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Function decorated with `@overload` shouldn't contain a docstring")
-    }
-}
 
 /// D418
 pub fn if_needed(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/indent.rs
+++ b/src/rules/pydocstyle/rules/indent.rs
@@ -8,18 +8,13 @@ use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
 
-use crate::define_violation;
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct IndentWithSpaces;
+define_simple_violation!(
+    IndentWithSpaces,
+    "Docstring should be indented with spaces, not tabs"
 );
-impl Violation for IndentWithSpaces {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Docstring should be indented with spaces, not tabs")
-    }
-}
 
 define_violation!(
     pub struct NoUnderIndentation;

--- a/src/rules/pydocstyle/rules/indent.rs
+++ b/src/rules/pydocstyle/rules/indent.rs
@@ -8,7 +8,7 @@ use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
 
-use crate::{define_simple_violation, define_violation};
+use crate::{define_simple_autofix_violation, define_simple_violation};
 use ruff_macros::derive_message_formats;
 
 define_simple_violation!(
@@ -16,33 +16,17 @@ define_simple_violation!(
     "Docstring should be indented with spaces, not tabs"
 );
 
-define_violation!(
-    pub struct NoUnderIndentation;
+define_simple_autofix_violation!(
+    NoUnderIndentation,
+    "Docstring is under-indented",
+    "Increase indentation"
 );
-impl AlwaysAutofixableViolation for NoUnderIndentation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Docstring is under-indented")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Increase indentation".to_string()
-    }
-}
-
-define_violation!(
-    pub struct NoOverIndentation;
+define_simple_autofix_violation!(
+    NoOverIndentation,
+    "Docstring is over-indented",
+    "Remove over-indentation"
 );
-impl AlwaysAutofixableViolation for NoOverIndentation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Docstring is over-indented")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove over-indentation".to_string()
-    }
-}
 
 /// D206, D207, D208
 pub fn indent(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -9,36 +9,20 @@ use crate::registry::{Diagnostic, Rule};
 use crate::rules::pydocstyle::helpers::leading_quote;
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct MultiLineSummaryFirstLine;
+define_simple_autofix_violation!(
+    MultiLineSummaryFirstLine,
+    "Multi-line docstring summary should start at the first line",
+    "Remove whitespace after opening quotes"
 );
-impl AlwaysAutofixableViolation for MultiLineSummaryFirstLine {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Multi-line docstring summary should start at the first line")
-    }
 
-    fn autofix_title(&self) -> String {
-        "Remove whitespace after opening quotes".to_string()
-    }
-}
-
-define_violation!(
-    pub struct MultiLineSummarySecondLine;
+define_simple_autofix_violation!(
+    MultiLineSummarySecondLine,
+    "Multi-line docstring summary should start at the second line",
+    "Insert line break and indentation after opening quotes"
 );
-impl AlwaysAutofixableViolation for MultiLineSummarySecondLine {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Multi-line docstring summary should start at the second line")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Insert line break and indentation after opening quotes".to_string()
-    }
-}
 
 /// D212, D213
 pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -8,22 +8,14 @@ use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct NewLineAfterLastParagraph;
+define_simple_autofix_violation!(
+    NewLineAfterLastParagraph,
+    "Multi-line docstring closing quotes should be on a separate line",
+    "Move closing quotes to new line"
 );
-impl AlwaysAutofixableViolation for NewLineAfterLastParagraph {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Multi-line docstring closing quotes should be on a separate line")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Move closing quotes to new line".to_string()
-    }
-}
 
 /// D209
 pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/no_signature.rs
+++ b/src/rules/pydocstyle/rules/no_signature.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::StmtKind;
@@ -8,15 +8,10 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct NoSignature;
+define_simple_violation!(
+    NoSignature,
+    "First line should not be the function's signature"
 );
-impl Violation for NoSignature {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("First line should not be the function's signature")
-    }
-}
 
 /// D402
 pub fn no_signature(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -8,22 +8,14 @@ use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::leading_quote;
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct NoSurroundingWhitespace;
+define_simple_autofix_violation!(
+    NoSurroundingWhitespace,
+    "No whitespaces allowed surrounding docstring text",
+    "Trim surrounding whitespace"
 );
-impl AlwaysAutofixableViolation for NoSurroundingWhitespace {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("No whitespaces allowed surrounding docstring text")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Trim surrounding whitespace".to_string()
-    }
-}
 
 /// D210
 pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pydocstyle/rules/not_empty.rs
+++ b/src/rules/pydocstyle/rules/not_empty.rs
@@ -4,18 +4,10 @@ use crate::docstrings::definition::Docstring;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct NonEmpty;
-);
-impl Violation for NonEmpty {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Docstring is empty")
-    }
-}
+define_simple_violation!(NonEmpty, "Docstring is empty");
 
 /// D419
 pub fn not_empty(checker: &mut Checker, docstring: &Docstring) -> bool {

--- a/src/rules/pydocstyle/rules/not_missing.rs
+++ b/src/rules/pydocstyle/rules/not_missing.rs
@@ -7,89 +7,28 @@ use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
 
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::visibility::{is_call, is_init, is_magic, is_new, is_overload, is_override, Visibility};
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct PublicModule;
-);
-impl Violation for PublicModule {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public module")
-    }
-}
+define_simple_violation!(PublicModule, "Missing docstring in public module");
 
-define_violation!(
-    pub struct PublicClass;
-);
-impl Violation for PublicClass {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public class")
-    }
-}
+define_simple_violation!(PublicClass, "Missing docstring in public class");
 
-define_violation!(
-    pub struct PublicMethod;
-);
-impl Violation for PublicMethod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public method")
-    }
-}
+define_simple_violation!(PublicMethod, "Missing docstring in public method");
 
-define_violation!(
-    pub struct PublicFunction;
-);
-impl Violation for PublicFunction {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public function")
-    }
-}
+define_simple_violation!(PublicFunction, "Missing docstring in public function");
 
-define_violation!(
-    pub struct PublicPackage;
-);
-impl Violation for PublicPackage {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public package")
-    }
-}
+define_simple_violation!(PublicPackage, "Missing docstring in public package");
 
-define_violation!(
-    pub struct MagicMethod;
-);
-impl Violation for MagicMethod {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in magic method")
-    }
-}
+define_simple_violation!(MagicMethod, "Missing docstring in magic method");
 
-define_violation!(
-    pub struct PublicNestedClass;
+define_simple_violation!(
+    PublicNestedClass,
+    "Missing docstring in public nested class"
 );
-impl Violation for PublicNestedClass {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in public nested class")
-    }
-}
 
-define_violation!(
-    pub struct PublicInit;
-);
-impl Violation for PublicInit {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Missing docstring in `__init__`")
-    }
-}
+define_simple_violation!(PublicInit, "Missing docstring in `__init__`");
 
 /// D100, D101, D102, D103, D104, D105, D106, D107
 pub fn not_missing(

--- a/src/rules/pydocstyle/rules/one_liner.rs
+++ b/src/rules/pydocstyle/rules/one_liner.rs
@@ -7,22 +7,14 @@ use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers;
 use crate::violation::AlwaysAutofixableViolation;
 
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct FitsOnOneLine;
+define_simple_autofix_violation!(
+    FitsOnOneLine,
+    "One-line docstring should fit on one line",
+    "Reformat to one line"
 );
-impl AlwaysAutofixableViolation for FitsOnOneLine {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("One-line docstring should fit on one line")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Reformat to one line".to_string()
-    }
-}
 
 /// D200
 pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {

--- a/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/src/rules/pyflakes/rules/assert_tuple.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Stmt};
 
@@ -7,15 +7,10 @@ use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct AssertTuple;
+define_simple_violation!(
+    AssertTuple,
+    "Assert test is a non-empty tuple, which is always `True`"
 );
-impl Violation for AssertTuple {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Assert test is a non-empty tuple, which is always `True`")
-    }
-}
 
 /// F631
 pub fn assert_tuple(checker: &mut Checker, stmt: &Stmt, test: &Expr) {

--- a/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -1,20 +1,12 @@
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Stmt, StmtKind};
 
-define_violation!(
-    pub struct BreakOutsideLoop;
-);
-impl Violation for BreakOutsideLoop {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`break` outside loop")
-    }
-}
+define_simple_violation!(BreakOutsideLoop, "`break` outside loop");
 
 /// F701
 pub fn break_outside_loop<'a>(

--- a/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -1,20 +1,12 @@
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Stmt, StmtKind};
 
-define_violation!(
-    pub struct ContinueOutsideLoop;
-);
-impl Violation for ContinueOutsideLoop {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`continue` not properly in loop")
-    }
-}
+define_simple_violation!(ContinueOutsideLoop, "`continue` not properly in loop");
 
 /// F702
 pub fn continue_outside_loop<'a>(

--- a/src/rules/pyflakes/rules/default_except_not_last.rs
+++ b/src/rules/pyflakes/rules/default_except_not_last.rs
@@ -1,5 +1,5 @@
 use crate::ast::helpers::except_range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 
@@ -7,15 +7,10 @@ use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Excepthandler, ExcepthandlerKind};
 
-define_violation!(
-    pub struct DefaultExceptNotLast;
+define_simple_violation!(
+    DefaultExceptNotLast,
+    "An `except` block as not the last exception handler"
 );
-impl Violation for DefaultExceptNotLast {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("An `except` block as not the last exception handler")
-    }
-}
 
 /// F707
 pub fn default_except_not_last(

--- a/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
@@ -8,19 +8,11 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct FStringMissingPlaceholders;
+define_simple_autofix_violation!(
+    FStringMissingPlaceholders,
+    "f-string without any placeholders",
+    "Remove extraneous `f` prefix"
 );
-impl AlwaysAutofixableViolation for FStringMissingPlaceholders {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("f-string without any placeholders")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove extraneous `f` prefix".to_string()
-    }
-}
 
 /// F541
 pub fn f_string_missing_placeholders(expr: &Expr, values: &[Expr], checker: &mut Checker) {

--- a/src/rules/pyflakes/rules/if_tuple.rs
+++ b/src/rules/pyflakes/rules/if_tuple.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Stmt};
 
@@ -7,15 +7,7 @@ use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct IfTuple;
-);
-impl Violation for IfTuple {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("If test is a tuple, which is always `True`")
-    }
-}
+define_simple_violation!(IfTuple, "If test is a tuple, which is always `True`");
 
 /// F634
 pub fn if_tuple(checker: &mut Checker, stmt: &Stmt, test: &Expr) {

--- a/src/rules/pyflakes/rules/imports.rs
+++ b/src/rules/pyflakes/rules/imports.rs
@@ -3,7 +3,7 @@ use crate::checkers::ast::Checker;
 use crate::python::future::ALL_FEATURE_NAMES;
 use crate::registry::Diagnostic;
 use crate::violation::{Availability, Violation};
-use crate::{define_violation, AutofixKind};
+use crate::{define_simple_violation, define_violation, AutofixKind};
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Alias;
@@ -77,15 +77,10 @@ impl Violation for ImportStarUsed {
     }
 }
 
-define_violation!(
-    pub struct LateFutureImport;
+define_simple_violation!(
+    LateFutureImport,
+    "`from __future__` imports must occur at the beginning of the file"
 );
-impl Violation for LateFutureImport {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`from __future__` imports must occur at the beginning of the file")
-    }
-}
 
 define_violation!(
     pub struct ImportStarUsage {

--- a/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
@@ -7,15 +7,10 @@ use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct InvalidPrintSyntax;
+define_simple_violation!(
+    InvalidPrintSyntax,
+    "Use of `>>` is invalid with `print` function"
 );
-impl Violation for InvalidPrintSyntax {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use of `>>` is invalid with `print` function")
-    }
-}
 
 /// F633
 pub fn invalid_print_syntax(checker: &mut Checker, left: &Expr) {

--- a/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
@@ -8,19 +8,11 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct RaiseNotImplemented;
+define_simple_autofix_violation!(
+    RaiseNotImplemented,
+    "`raise NotImplemented` should be `raise NotImplementedError`",
+    "Use `raise NotImplementedError`"
 );
-impl AlwaysAutofixableViolation for RaiseNotImplemented {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`raise NotImplemented` should be `raise NotImplementedError`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Use `raise NotImplementedError`".to_string()
-    }
-}
 
 fn match_not_implemented(expr: &Expr) -> Option<&Expr> {
     match &expr.node {

--- a/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/src/rules/pyflakes/rules/return_outside_function.rs
@@ -1,20 +1,15 @@
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Stmt;
 
-define_violation!(
-    pub struct ReturnOutsideFunction;
+define_simple_violation!(
+    ReturnOutsideFunction,
+    "`return` statement outside of a function/method"
 );
-impl Violation for ReturnOutsideFunction {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`return` statement outside of a function/method")
-    }
-}
 
 pub fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
     if let Some(&index) = checker.scope_stack.last() {

--- a/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/src/rules/pyflakes/rules/starred_expressions.rs
@@ -1,29 +1,19 @@
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_parser::ast::{Expr, ExprKind};
 
-define_violation!(
-    pub struct ExpressionsInStarAssignment;
+define_simple_violation!(
+    ExpressionsInStarAssignment,
+    "Too many expressions in star-unpacking assignment"
 );
-impl Violation for ExpressionsInStarAssignment {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Too many expressions in star-unpacking assignment")
-    }
-}
 
-define_violation!(
-    pub struct TwoStarredExpressions;
+define_simple_violation!(
+    TwoStarredExpressions,
+    "Two starred expressions in assignment"
 );
-impl Violation for TwoStarredExpressions {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Two starred expressions in assignment")
-    }
-}
 
 /// F621, F622
 pub fn starred_expressions(

--- a/src/rules/pyflakes/rules/strings.rs
+++ b/src/rules/pyflakes/rules/strings.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::{define_simple_violation, define_violation};
 use ruff_macros::derive_message_formats;
 use std::string::ToString;
 
@@ -30,25 +30,15 @@ impl Violation for PercentFormatInvalidFormat {
     }
 }
 
-define_violation!(
-    pub struct PercentFormatExpectedMapping;
+define_simple_violation!(
+    PercentFormatExpectedMapping,
+    "`%`-format string expected mapping but got sequence"
 );
-impl Violation for PercentFormatExpectedMapping {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`%`-format string expected mapping but got sequence")
-    }
-}
 
-define_violation!(
-    pub struct PercentFormatExpectedSequence;
+define_simple_violation!(
+    PercentFormatExpectedSequence,
+    "`%`-format string expected sequence but got mapping"
 );
-impl Violation for PercentFormatExpectedSequence {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`%`-format string expected sequence but got mapping")
-    }
-}
 
 define_violation!(
     pub struct PercentFormatExtraNamedArguments {
@@ -84,15 +74,10 @@ impl Violation for PercentFormatMissingArgument {
     }
 }
 
-define_violation!(
-    pub struct PercentFormatMixedPositionalAndNamed;
+define_simple_violation!(
+    PercentFormatMixedPositionalAndNamed,
+    "`%`-format string has mixed positional and named placeholders"
 );
-impl Violation for PercentFormatMixedPositionalAndNamed {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`%`-format string has mixed positional and named placeholders")
-    }
-}
 
 define_violation!(
     pub struct PercentFormatPositionalCountMismatch {
@@ -108,15 +93,10 @@ impl Violation for PercentFormatPositionalCountMismatch {
     }
 }
 
-define_violation!(
-    pub struct PercentFormatStarRequiresSequence;
+define_simple_violation!(
+    PercentFormatStarRequiresSequence,
+    "`%`-format string `*` specifier requires sequence"
 );
-impl Violation for PercentFormatStarRequiresSequence {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`%`-format string `*` specifier requires sequence")
-    }
-}
 
 define_violation!(
     pub struct PercentFormatUnsupportedFormatCharacter {
@@ -192,15 +172,10 @@ impl Violation for StringDotFormatMissingArguments {
     }
 }
 
-define_violation!(
-    pub struct StringDotFormatMixingAutomatic;
+define_simple_violation!(
+    StringDotFormatMixingAutomatic,
+    "`.format` string mixes automatic and manual numbering"
 );
-impl Violation for StringDotFormatMixingAutomatic {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`.format` string mixes automatic and manual numbering")
-    }
-}
 
 fn has_star_star_kwargs(keywords: &[Keyword]) -> bool {
     keywords.iter().any(|k| {

--- a/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -8,15 +8,7 @@ use rustpython_ast::Location;
 use crate::ast::types::Range;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct BlanketNOQA;
-);
-impl Violation for BlanketNOQA {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use specific rule codes when using `noqa`")
-    }
-}
+define_simple_violation!(BlanketNOQA, "Use specific rule codes when using `noqa`");
 
 static BLANKET_NOQA_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)# noqa($|\s|:[^ ])").unwrap());

--- a/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -8,15 +8,10 @@ use rustpython_ast::Location;
 use crate::ast::types::Range;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct BlanketTypeIgnore;
+define_simple_violation!(
+    BlanketTypeIgnore,
+    "Use specific rule codes when ignoring type issues"
 );
-impl Violation for BlanketTypeIgnore {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use specific rule codes when ignoring type issues")
-    }
-}
 
 static BLANKET_TYPE_IGNORE_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"# type:? *ignore($|\s)").unwrap());

--- a/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
@@ -7,15 +7,10 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct DeprecatedLogWarn;
+define_simple_violation!(
+    DeprecatedLogWarn,
+    "`warn` is deprecated in favor of `warning`"
 );
-impl Violation for DeprecatedLogWarn {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`warn` is deprecated in favor of `warning`")
-    }
-}
 
 /// PGH002 - deprecated use of logging.warn
 pub fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {

--- a/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
@@ -7,15 +7,8 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct NoEval;
-);
-impl Violation for NoEval {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("No builtin `eval()` allowed")
-    }
-}
+define_simple_violation!(NoEval, "No builtin `eval()` allowed");
+
 /// PGH001 - no eval
 pub fn no_eval(checker: &mut Checker, func: &Expr) {
     let ExprKind::Name { id, .. } = &func.node else {

--- a/src/rules/pylint/rules/await_outside_async.rs
+++ b/src/rules/pylint/rules/await_outside_async.rs
@@ -1,21 +1,16 @@
 use crate::ast::types::{FunctionDef, Range, ScopeKind};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
-define_violation!(
-    pub struct AwaitOutsideAsync;
+define_simple_violation!(
+    AwaitOutsideAsync,
+    "`await` should be used within an async function"
 );
-impl Violation for AwaitOutsideAsync {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`await` should be used within an async function")
-    }
-}
 
 /// PLE1142
 pub fn await_outside_async(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/pylint/rules/invalid_all_format.rs
+++ b/src/rules/pylint/rules/invalid_all_format.rs
@@ -3,19 +3,14 @@ use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct InvalidAllFormat;
+define_simple_violation!(
+    InvalidAllFormat,
+    "Invalid format for `__all__`, must be `tuple` or `list`"
 );
-impl Violation for InvalidAllFormat {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Invalid format for `__all__`, must be `tuple` or `list`")
-    }
-}
 
 /// PLE0605
 pub fn invalid_all_format(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/pylint/rules/invalid_all_object.rs
+++ b/src/rules/pylint/rules/invalid_all_object.rs
@@ -3,19 +3,14 @@ use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct InvalidAllObject;
+define_simple_violation!(
+    InvalidAllObject,
+    "Invalid object in `__all__`, must contain only strings"
 );
-impl Violation for InvalidAllObject {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Invalid object in `__all__`, must contain only strings")
-    }
-}
 
 /// PLE0604
 pub fn invalid_all_object(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/pylint/rules/property_with_parameters.rs
+++ b/src/rules/pylint/rules/property_with_parameters.rs
@@ -2,20 +2,16 @@ use rustpython_ast::{Arguments, Expr, ExprKind, Stmt};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct PropertyWithParameters;
+define_simple_violation!(
+    PropertyWithParameters,
+    "Cannot have defined parameters for properties"
 );
-impl Violation for PropertyWithParameters {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Cannot have defined parameters for properties")
-    }
-}
+
 /// PLR0206
 pub fn property_with_parameters(
     checker: &mut Checker,

--- a/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -2,20 +2,15 @@ use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct UnnecessaryDirectLambdaCall;
+define_simple_violation!(
+    UnnecessaryDirectLambdaCall,
+    "Lambda expression called directly. Execute the expression inline instead."
 );
-impl Violation for UnnecessaryDirectLambdaCall {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Lambda expression called directly. Execute the expression inline instead.")
-    }
-}
 
 /// PLC3002
 pub fn unnecessary_direct_lambda_call(checker: &mut Checker, expr: &Expr, func: &Expr) {

--- a/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -2,23 +2,16 @@ use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
 
 use crate::ast::helpers;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct UselessElseOnLoop;
-);
-impl Violation for UselessElseOnLoop {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!(
-            "Else clause on loop without a break statement, remove the else and de-indent all the \
+define_simple_violation!(
+    UselessElseOnLoop,
+    "Else clause on loop without a break statement, remove the else and de-indent all the \
              code inside it"
-        )
-    }
-}
+);
 
 fn loop_exits_early(body: &[Stmt]) -> bool {
     body.iter().any(|stmt| match &stmt.node {

--- a/src/rules/pylint/rules/useless_import_alias.rs
+++ b/src/rules/pylint/rules/useless_import_alias.rs
@@ -2,25 +2,17 @@ use rustpython_ast::Alias;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 
-define_violation!(
-    pub struct UselessImportAlias;
+define_simple_autofix_violation!(
+    UselessImportAlias,
+    "Import alias does not rename original package",
+    "Remove import alias"
 );
-impl AlwaysAutofixableViolation for UselessImportAlias {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Import alias does not rename original package")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove import alias".to_string()
-    }
-}
 
 /// PLC0414
 pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {

--- a/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_parser::lexer::{LexResult, Tok};
@@ -9,19 +9,11 @@ use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 
-define_violation!(
-    pub struct ExtraneousParentheses;
+define_simple_autofix_violation!(
+    ExtraneousParentheses,
+    "Avoid extraneous parentheses",
+    "Remove extraneous parentheses"
 );
-impl AlwaysAutofixableViolation for ExtraneousParentheses {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Avoid extraneous parentheses")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove extraneous parentheses".to_string()
-    }
-}
 
 // See: https://github.com/asottile/pyupgrade/blob/97ed6fb3cf2e650d4f762ba231c3f04c41797710/pyupgrade/_main.py#L148
 fn match_extraneous_parentheses(tokens: &[LexResult], mut i: usize) -> Option<(usize, usize)> {

--- a/src/rules/pyupgrade/rules/f_strings.rs
+++ b/src/rules/pyupgrade/rules/f_strings.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
@@ -17,19 +17,11 @@ use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
 
-define_violation!(
-    pub struct FString;
+define_simple_autofix_violation!(
+    FString,
+    "Use f-string instead of `format` call",
+    "Convert to f-string"
 );
-impl AlwaysAutofixableViolation for FString {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use f-string instead of `format` call")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Convert to f-string".to_string()
-    }
-}
 
 /// Like [`FormatSummary`], but maps positional and keyword arguments to their
 /// values. For example, given `{a} {b}".format(a=1, b=2)`, `FormatFunction`

--- a/src/rules/pyupgrade/rules/format_literals.rs
+++ b/src/rules/pyupgrade/rules/format_literals.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use anyhow::{anyhow, bail, Result};
 use libcst_native::{Arg, Codegen, CodegenState, Expression};
@@ -15,19 +15,11 @@ use crate::registry::Diagnostic;
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::source_code::{Locator, Stylist};
 
-define_violation!(
-    pub struct FormatLiterals;
+define_simple_autofix_violation!(
+    FormatLiterals,
+    "Use implicit references for positional format fields",
+    "Remove explicit positional indexes"
 );
-impl AlwaysAutofixableViolation for FormatLiterals {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use implicit references for positional format fields")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove explicit positional indexes".to_string()
-    }
-}
 
 // An opening curly brace, followed by any integer, followed by any text,
 // followed by a closing brace.

--- a/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/src/rules/pyupgrade/rules/functools_cache.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, ExprKind, KeywordData};
@@ -10,19 +10,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct FunctoolsCache;
+define_simple_autofix_violation!(
+    FunctoolsCache,
+    "Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`",
+    "Rewrite with `@functools.cache"
 );
-impl AlwaysAutofixableViolation for FunctoolsCache {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `@functools.cache` instead of `@functools.lru_cache(maxsize=None)`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Rewrite with `@functools.cache".to_string()
-    }
-}
 
 /// UP033
 pub fn functools_cache(checker: &mut Checker, decorator_list: &[Expr]) {

--- a/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::ExprKind;
@@ -10,19 +10,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct LRUCacheWithoutParameters;
+define_simple_autofix_violation!(
+    LRUCacheWithoutParameters,
+    "Unnecessary parameters to `functools.lru_cache`",
+    "Remove unnecessary parameters"
 );
-impl AlwaysAutofixableViolation for LRUCacheWithoutParameters {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary parameters to `functools.lru_cache`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove unnecessary parameters".to_string()
-    }
-}
 
 /// UP011
 pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Expr]) {

--- a/src/rules/pyupgrade/rules/open_alias.rs
+++ b/src/rules/pyupgrade/rules/open_alias.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
@@ -8,19 +8,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct OpenAlias;
+define_simple_autofix_violation!(
+    OpenAlias,
+    "Use builtin `open`",
+    "Replace with builtin `open`"
 );
-impl AlwaysAutofixableViolation for OpenAlias {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use builtin `open`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with builtin `open`".to_string()
-    }
-}
 
 /// UP020
 pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {

--- a/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -13,7 +13,7 @@ use crate::ast::types::{Range, RefEquality};
 use crate::ast::whitespace::indentation;
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::pyupgrade::fixes::adjust_indentation;
@@ -21,19 +21,11 @@ use crate::settings::types::PythonVersion;
 use crate::source_code::Locator;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct OutdatedVersionBlock;
+define_simple_autofix_violation!(
+    OutdatedVersionBlock,
+    "Version block is outdated for minimum Python version",
+    "Remove outdated version block"
 );
-impl AlwaysAutofixableViolation for OutdatedVersionBlock {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Version block is outdated for minimum Python version")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove outdated version block".to_string()
-    }
-}
 
 #[derive(Debug)]
 struct BlockMetadata {

--- a/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 
@@ -22,19 +22,11 @@ use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyupgrade::helpers::curly_escape;
 
-define_violation!(
-    pub struct PrintfStringFormatting;
+define_simple_autofix_violation!(
+    PrintfStringFormatting,
+    "Use format specifiers instead of percent format",
+    "Replace with format specifiers"
 );
-impl AlwaysAutofixableViolation for PrintfStringFormatting {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use format specifiers instead of percent format")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with format specifiers".to_string()
-    }
-}
 
 fn simplify_conversion_flag(flags: CConversionFlags) -> String {
     let mut flag_string = String::new();

--- a/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword};
@@ -11,19 +11,11 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::{Locator, Stylist};
 
-define_violation!(
-    pub struct ReplaceStdoutStderr;
+define_simple_autofix_violation!(
+    ReplaceStdoutStderr,
+    "Sending stdout and stderr to pipe is deprecated, use `capture_output`",
+    "Replace with `capture_output` keyword argument"
 );
-impl AlwaysAutofixableViolation for ReplaceStdoutStderr {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Sending stdout and stderr to pipe is deprecated, use `capture_output`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `capture_output` keyword argument".to_string()
-    }
-}
 
 #[derive(Debug)]
 struct MiddleContent<'a> {

--- a/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword, Location};
@@ -9,19 +9,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct ReplaceUniversalNewlines;
+define_simple_autofix_violation!(
+    ReplaceUniversalNewlines,
+    "`universal_newlines` is deprecated, use `text`",
+    "Replace with `text` keyword argument"
 );
-impl AlwaysAutofixableViolation for ReplaceUniversalNewlines {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`universal_newlines` is deprecated, use `text`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `text` keyword argument".to_string()
-    }
-}
 
 /// UP021
 pub fn replace_universal_newlines(checker: &mut Checker, expr: &Expr, kwargs: &[Keyword]) {

--- a/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Located, Stmt, StmtKind};
@@ -8,19 +8,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct RewriteCElementTree;
+define_simple_autofix_violation!(
+    RewriteCElementTree,
+    "`cElementTree` is deprecated, use `ElementTree`",
+    "Replace with `ElementTree`"
 );
-impl AlwaysAutofixableViolation for RewriteCElementTree {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`cElementTree` is deprecated, use `ElementTree`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `ElementTree`".to_string()
-    }
-}
 
 fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic = Diagnostic::new(RewriteCElementTree, Range::from_located(node));

--- a/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
+++ b/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Location};
@@ -8,19 +8,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct RewriteUnicodeLiteral;
+define_simple_autofix_violation!(
+    RewriteUnicodeLiteral,
+    "Remove unicode literals from strings",
+    "Remove unicode prefix"
 );
-impl AlwaysAutofixableViolation for RewriteUnicodeLiteral {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Remove unicode literals from strings")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove unicode prefix".to_string()
-    }
-}
 
 /// UP025
 pub fn rewrite_unicode_literal(checker: &mut Checker, expr: &Expr, kind: Option<&str>) {

--- a/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
@@ -11,19 +11,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct RewriteYieldFrom;
+define_simple_autofix_violation!(
+    RewriteYieldFrom,
+    "Replace `yield` over `for` loop with `yield from`",
+    "Replace with `yield from`"
 );
-impl AlwaysAutofixableViolation for RewriteYieldFrom {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Replace `yield` over `for` loop with `yield from`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `yield from`".to_string()
-    }
-}
 
 /// Return `true` if the two expressions are equivalent, and consistent solely
 /// of tuples and names.

--- a/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Stmt};
@@ -7,19 +7,11 @@ use super::super::fixes;
 use crate::ast::helpers;
 use crate::checkers::ast::Checker;
 
-define_violation!(
-    pub struct SuperCallWithParameters;
+define_simple_autofix_violation!(
+    SuperCallWithParameters,
+    "Use `super()` instead of `super(__class__, self)`",
+    "Remove `__super__` parameters"
 );
-impl AlwaysAutofixableViolation for SuperCallWithParameters {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `super()` instead of `super(__class__, self)`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `__super__` parameters".to_string()
-    }
-}
 
 /// UP008
 pub fn super_call_with_parameters(checker: &mut Checker, expr: &Expr, func: &Expr, args: &[Expr]) {

--- a/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
@@ -8,19 +8,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct TypingTextStrAlias;
+define_simple_autofix_violation!(
+    TypingTextStrAlias,
+    "`typing.Text` is deprecated, use `str`",
+    "Replace with `str`"
 );
-impl AlwaysAutofixableViolation for TypingTextStrAlias {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`typing.Text` is deprecated, use `str`")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with `str`".to_string()
-    }
-}
 
 /// UP019
 pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -1,5 +1,5 @@
 use crate::ast::types::Range;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
@@ -9,19 +9,11 @@ use regex::Regex;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
-define_violation!(
-    pub struct PEP3120UnnecessaryCodingComment;
+define_simple_autofix_violation!(
+    PEP3120UnnecessaryCodingComment,
+    "UTF-8 encoding declaration is unnecessary",
+    "Remove unnecessary coding comment"
 );
-impl AlwaysAutofixableViolation for PEP3120UnnecessaryCodingComment {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("UTF-8 encoding declaration is unnecessary")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove unnecessary coding comment".to_string()
-    }
-}
 
 // Regex from PEP263.
 static CODING_COMMENT_REGEX: Lazy<Regex> =

--- a/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
@@ -9,19 +9,11 @@ use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
 
-define_violation!(
-    pub struct UnnecessaryEncodeUTF8;
+define_simple_autofix_violation!(
+    UnnecessaryEncodeUTF8,
+    "Unnecessary call to `encode` as UTF-8",
+    "Remove unnecessary `encode`"
 );
-impl AlwaysAutofixableViolation for UnnecessaryEncodeUTF8 {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Unnecessary call to `encode` as UTF-8")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove unnecessary `encode`".to_string()
-    }
-}
 
 const UTF8_LITERALS: &[&str] = &["utf-8", "utf8", "utf_8", "u8", "utf", "cp65001"];
 

--- a/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
@@ -8,19 +8,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct RewriteListComprehension;
+define_simple_autofix_violation!(
+    RewriteListComprehension,
+    "Replace unpacked list comprehension with a generator expression",
+    "Replace with generator expression"
 );
-impl AlwaysAutofixableViolation for RewriteListComprehension {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Replace unpacked list comprehension with a generator expression")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Replace with generator expression".to_string()
-    }
-}
 
 /// Returns `true` if `expr` contains an `ExprKind::Await`.
 fn contains_await(expr: &Expr) -> bool {

--- a/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Location, Operator};
@@ -9,19 +9,11 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct UsePEP604Annotation;
+define_simple_autofix_violation!(
+    UsePEP604Annotation,
+    "Use `X | Y` for type annotations",
+    "Convert to `X | Y`"
 );
-impl AlwaysAutofixableViolation for UsePEP604Annotation {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `X | Y` for type annotations")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Convert to `X | Y`".to_string()
-    }
-}
 
 fn optional(expr: &Expr) -> Expr {
     Expr::new(

--- a/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -1,4 +1,4 @@
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::violation::AlwaysAutofixableViolation;
 use log::error;
 use ruff_macros::derive_message_formats;
@@ -9,19 +9,11 @@ use crate::autofix::helpers;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 
-define_violation!(
-    pub struct UselessMetaclassType;
+define_simple_autofix_violation!(
+    UselessMetaclassType,
+    "`__metaclass__ = type` is implied",
+    "Remove `__metaclass__ = type`"
 );
-impl AlwaysAutofixableViolation for UselessMetaclassType {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("`__metaclass__ = type` is implied")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `__metaclass__ = type`".to_string()
-    }
-}
 
 fn rule(targets: &[Expr], value: &Expr, location: Range) -> Option<Diagnostic> {
     if targets.len() != 1 {

--- a/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -6,19 +6,14 @@ use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ErrorInsteadOfException;
+define_simple_violation!(
+    ErrorInsteadOfException,
+    "Use `logging.exception` instead of `logging.error`"
 );
-impl Violation for ErrorInsteadOfException {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `logging.exception` instead of `logging.error`")
-    }
-}
 
 #[derive(Default)]
 /// Collect `logging`-like calls from an AST.

--- a/src/rules/tryceratops/rules/prefer_type_error.rs
+++ b/src/rules/tryceratops/rules/prefer_type_error.rs
@@ -5,24 +5,16 @@ use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_autofix_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
 
-define_violation!(
-    pub struct PreferTypeError;
+define_simple_autofix_violation!(
+    PreferTypeError,
+    "Prefer `TypeError` exception for invalid type",
+    "Use `TypeError` exception type"
 );
-impl AlwaysAutofixableViolation for PreferTypeError {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Prefer `TypeError` exception for invalid type")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Use `TypeError` exception type".to_string()
-    }
-}
 
 #[derive(Default)]
 struct ControlFlowVisitor<'a> {

--- a/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -3,19 +3,14 @@ use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct RaiseVanillaArgs;
+define_simple_violation!(
+    RaiseVanillaArgs,
+    "Avoid specifying long messages outside the exception class"
 );
-impl Violation for RaiseVanillaArgs {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Avoid specifying long messages outside the exception class")
-    }
-}
 
 fn collect_strings_impl<'a>(expr: &'a Expr, parts: &mut Vec<&'a str>) {
     match &expr.node {

--- a/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -3,19 +3,11 @@ use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct RaiseVanillaClass;
-);
-impl Violation for RaiseVanillaClass {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Create your own exception")
-    }
-}
+define_simple_violation!(RaiseVanillaClass, "Create your own exception");
 
 /// TRY002
 pub fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {

--- a/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/src/rules/tryceratops/rules/raise_within_try.rs
@@ -4,19 +4,11 @@ use rustpython_ast::{Stmt, StmtKind};
 use crate::ast::types::Range;
 use crate::ast::visitor::{self, Visitor};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct RaiseWithinTry;
-);
-impl Violation for RaiseWithinTry {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Abstract `raise` to an inner function")
-    }
-}
+define_simple_violation!(RaiseWithinTry, "Abstract `raise` to an inner function");
 
 #[derive(Default)]
 struct RaiseStatementVisitor<'a> {

--- a/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -4,19 +4,14 @@ use rustpython_ast::{ExprKind, Stmt, StmtKind};
 use crate::ast::types::Range;
 use crate::ast::visitor::{self, Visitor};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct ReraiseNoCause;
+define_simple_violation!(
+    ReraiseNoCause,
+    "Use `raise from` to specify exception cause"
 );
-impl Violation for ReraiseNoCause {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `raise from` to specify exception cause")
-    }
-}
 
 #[derive(Default)]
 struct RaiseStatementVisitor<'a> {

--- a/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/src/rules/tryceratops/rules/try_consider_else.rs
@@ -3,19 +3,14 @@ use rustpython_ast::{Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct TryConsiderElse;
+define_simple_violation!(
+    TryConsiderElse,
+    "Consider moving this statement to an `else` block"
 );
-impl Violation for TryConsiderElse {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Consider moving this statement to an `else` block")
-    }
-}
 
 /// TRY300
 pub fn try_consider_else(checker: &mut Checker, body: &[Stmt], orelse: &[Stmt]) {

--- a/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/src/rules/tryceratops/rules/verbose_raise.rs
@@ -5,19 +5,14 @@ use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
-use crate::define_violation;
+use crate::define_simple_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
-define_violation!(
-    pub struct VerboseRaise;
+define_simple_violation!(
+    VerboseRaise,
+    "Use `raise` without specifying exception name"
 );
-impl Violation for VerboseRaise {
-    #[derive_message_formats]
-    fn message(&self) -> String {
-        format!("Use `raise` without specifying exception name")
-    }
-}
 
 #[derive(Default)]
 struct RaiseStatementVisitor<'a> {

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -80,3 +80,20 @@ macro_rules! define_violation {
         $($struct)*
     };
 }
+
+#[macro_export]
+/// This macro exists to make it simpler to define violations that only have a
+/// simple message, and no parametrization.
+macro_rules! define_simple_violation {
+    ($name:ident, $message:expr) => {
+        $crate::define_violation!(
+            pub struct $name;
+        );
+        impl Violation for $name {
+            #[derive_message_formats]
+            fn message(&self) -> String {
+                format!($message)
+            }
+        }
+    };
+}

--- a/src/violation.rs
+++ b/src/violation.rs
@@ -97,3 +97,23 @@ macro_rules! define_simple_violation {
         }
     };
 }
+
+#[macro_export]
+/// This macro exists to make it simpler to define violations that only have a
+/// simple message, and no parametrization.
+macro_rules! define_simple_autofix_violation {
+    ($name:ident, $message:expr, $autofix_title:expr) => {
+        $crate::define_violation!(
+            pub struct $name;
+        );
+        impl AlwaysAutofixableViolation for $name {
+            #[derive_message_formats]
+            fn message(&self) -> String {
+                format!($message)
+            }
+            fn autofix_title(&self) -> String {
+                $autofix_title.to_string()
+            }
+        }
+    };
+}


### PR DESCRIPTION
This PR defines a pair of new macros, `define_simple_violation!`, `define_simple_autofix_validation!` that define an unit struct and derive the `Violation`/`AlwaysAutofixableViolation` traits.

Since this hasn't been really discussed or anything, just a pattern that repeated throughout the Great Violation Migration, I'm totally fine with this being nixed, e.g. on the grounds of avoiding [Tim Toady](https://en.wikipedia.org/wiki/There%27s_more_than_one_way_to_do_it). (Even if the PR looks like it could've been a lot of work, it honestly wasn't – the majority of the half-hour here was spent tweaking the regexp I used to find the current simple-enough violations 😁 )
