### PR TITLE
Mark sometimes-fixable rules as `Availability::Sometimes`

### DIFF
--- a/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -51,7 +51,7 @@ define_violation!(
     }
 );
 impl Violation for UnusedLoopControlVariable {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -19,7 +19,7 @@ define_violation!(
     }
 );
 impl Violation for YodaConditions {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -18,7 +18,7 @@ fn fmt_blank_line_after_summary_autofix_msg(_: &BlankLineAfterSummary) -> String
     "Insert single blank line".to_string()
 }
 impl Violation for BlankLineAfterSummary {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pyflakes/rules/imports.rs
+++ b/src/rules/pyflakes/rules/imports.rs
@@ -24,7 +24,7 @@ fn fmt_unused_import_autofix_msg(unused_import: &UnusedImport) -> String {
     }
 }
 impl Violation for UnusedImport {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/src/rules/pyflakes/rules/repeated_keys.rs
@@ -21,7 +21,7 @@ define_violation!(
     }
 );
 impl Violation for MultiValueRepeatedKeyLiteral {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -47,7 +47,7 @@ define_violation!(
     }
 );
 impl Violation for MultiValueRepeatedKeyVariable {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pylint/rules/use_from_import.rs
+++ b/src/rules/pylint/rules/use_from_import.rs
@@ -18,7 +18,7 @@ define_violation!(
     }
 );
 impl Violation for ConsiderUsingFromImport {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -15,7 +15,7 @@ define_violation!(
     }
 );
 impl Violation for DatetimeTimezoneUTC {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/src/rules/pyupgrade/rules/import_replacements.rs
+++ b/src/rules/pyupgrade/rules/import_replacements.rs
@@ -21,7 +21,7 @@ define_violation!(
     }
 );
 impl Violation for ImportReplacements {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
 
     #[derive_message_formats]
     fn message(&self) -> String {


### PR DESCRIPTION
Probably just an oversight that was then cargo-culted to new definitions.