### PR TITLE
Implement pylint's `too-many-return-statements` rule (`PLR0911`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3742,6 +3742,23 @@ allow-magic-value-types = ["int"]
 
 ---
 
+#### [`max-args`](#max-args)
+
+Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).
+
+**Default value**: `5`
+
+**Type**: `int`
+
+**Example usage**:
+
+```toml
+[tool.ruff.pylint]
+max-args = 5
+```
+
+---
+
 #### [`max-branches`](#max-branches)
 
 Maximum number of branches allowed for a function or method body (see: `PLR0912`).
@@ -3763,7 +3780,7 @@ max-branches = 12
 
 Maximum number of return statements allowed for a function or method body (see `PLR0911`)
 
-**Default value**: `5`
+**Default value**: `6`
 
 **Type**: `int`
 
@@ -3771,7 +3788,7 @@ Maximum number of return statements allowed for a function or method body (see `
 
 ```toml
 [tool.ruff.pylint]
-max-args = 5
+max-returns = 6
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,7 @@ For more, see [Pylint](https://pypi.org/project/pylint/) on PyPI.
 | PLR0133 | comparison-of-constant | Two constants compared in a comparison, consider replacing `{left_constant} {op} {right_constant}` |  |
 | PLR0206 | property-with-parameters | Cannot have defined parameters for properties |  |
 | PLR0402 | consider-using-from-import | Use `from {module} import {name}` in lieu of alias | 🛠 |
+| PLR0911 | too-many-return-statements | Too many return statements ({returns}/{max_returns}) |  |
 | PLR0913 | too-many-arguments | Too many arguments to function call ({c_args}/{max_args}) |  |
 | PLR0915 | too-many-statements | Too many statements ({statements}/{max_statements}) |  |
 | PLR1701 | consider-merging-isinstance | Merge these isinstance calls: `isinstance({obj}, ({types}))` |  |
@@ -3740,9 +3741,9 @@ allow-magic-value-types = ["int"]
 
 ---
 
-#### [`max-args`](#max-args)
+#### [`max-returns`](#max-returns)
 
-Maximum number of arguments allowed for a function definition (see: `PLR0913`).
+Maximum number of return statements allowed for a function or method (see `PLR0911`)
 
 **Default value**: `5`
 

--- a/resources/test/fixtures/pylint/too_many_return_statements.py
+++ b/resources/test/fixtures/pylint/too_many_return_statements.py
@@ -1,0 +1,41 @@
+"""
+taken from the pylint source code 2023-02-04
+"""
+def stupid_function(arg): # [too-many-return-statements]
+    if arg == 1:
+        return 1
+    if arg == 2:
+        return 2
+    if arg == 3:
+        return 3
+    if arg == 4:
+        return 4
+    if arg == 5:
+        return 5
+    if arg == 6:
+        return 6
+    if arg == 7:
+        return 7
+    if arg == 8:
+        return 8
+    if arg == 9:
+        return 9
+    if arg == 10:
+        return 10
+    return None
+
+
+def many_yield(text):
+    """Not a problem"""
+    if text:
+        yield f"    line 1: {text}\n"
+        yield "    line 2\n"
+        yield "    line 3\n"
+        yield "    line 4\n"
+        yield "    line 5\n"
+    else:
+        yield "    line 6\n"
+        yield "    line 7\n"
+        yield "    line 8\n"
+        yield "    line 9\n"
+        yield "    line 10\n"

--- a/resources/test/fixtures/pylint/too_many_return_statements.py
+++ b/resources/test/fixtures/pylint/too_many_return_statements.py
@@ -1,5 +1,5 @@
 """
-taken from the pylint source code 2023-02-04
+https://github.com/PyCQA/pylint/blob/69eca9b3f9856c3033957b769358803ee48e8e47/tests/functional/t/too/too_many_return_statements.py
 """
 def stupid_function(arg): # [too-many-return-statements]
     if arg == 1:

--- a/resources/test/fixtures/pylint/too_many_return_statements_params.py
+++ b/resources/test/fixtures/pylint/too_many_return_statements_params.py
@@ -1,0 +1,5 @@
+def f(x):  # Too many return statements (2/1)
+    if x == 1:
+        return
+    if x == 2:
+        return

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1190,6 +1190,15 @@
           "format": "uint",
           "minimum": 0.0
         },
+        "max-returns": {
+          "description": "Maximum number of return statements allowed for a function or method (see `PLR0911`)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "max-statements": {
           "description": "Maximum number of statements allowed for a method or a statement (see: `PLR0915`).",
           "type": [
@@ -1669,6 +1678,7 @@
         "PLR0402",
         "PLR09",
         "PLR091",
+        "PLR0911",
         "PLR0913",
         "PLR0915",
         "PLR1",

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -596,7 +596,8 @@ where
                     if let Some(diagnostic) = pylint::rules::too_many_return_statements(
                         stmt,
                         body,
-                        self.settings.pylint.max_returns, self.locator,
+                        self.settings.pylint.max_returns,
+                        self.locator,
                     ) {
                         self.diagnostics.push(diagnostic);
                     }

--- a/src/checkers/ast.rs
+++ b/src/checkers/ast.rs
@@ -592,6 +592,17 @@ where
                     pylint::rules::too_many_arguments(self, args, stmt);
                 }
 
+                if self.settings.rules.enabled(&Rule::TooManyReturnStatements) {
+                    if let Some(diagnostic) = pylint::rules::too_many_return_statements(
+                        stmt,
+                        body,
+                        self.settings.pylint.max_returns,
+                        self.locator,
+                    ) {
+                        self.diagnostics.push(diagnostic);
+                    }
+                }
+
                 if self.settings.rules.enabled(&Rule::TooManyStatements) {
                     if let Some(diagnostic) = pylint::rules::too_many_statements(
                         stmt,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -92,6 +92,7 @@ ruff_macros::define_rule_mapping!(
     PLR2004 => rules::pylint::rules::MagicValueComparison,
     PLW0120 => rules::pylint::rules::UselessElseOnLoop,
     PLW0602 => rules::pylint::rules::GlobalVariableNotAssigned,
+    PLR0911 => rules::pylint::rules::TooManyReturnStatements,
     PLR0913 => rules::pylint::rules::TooManyArguments,
     PLR0915 => rules::pylint::rules::TooManyStatements,
     // flake8-builtins

--- a/src/rules/flake8_annotations/rules.rs
+++ b/src/rules/flake8_annotations/rules.rs
@@ -163,8 +163,14 @@ impl Violation for DynamicallyTypedExpression {
 }
 
 #[derive(Default)]
-struct ReturnStatementVisitor<'a> {
+pub struct ReturnStatementVisitor<'a> {
     returns: Vec<Option<&'a Expr>>,
+}
+
+impl<'a> ReturnStatementVisitor<'a> {
+    pub fn num_returns(&self) -> usize {
+        self.returns.len()
+    }
 }
 
 impl<'a, 'b> Visitor<'b> for ReturnStatementVisitor<'a>

--- a/src/rules/flake8_annotations/rules.rs
+++ b/src/rules/flake8_annotations/rules.rs
@@ -1,11 +1,12 @@
 use log::error;
-use rustpython_ast::{Constant, Expr, ExprKind, Stmt, StmtKind};
+use rustpython_ast::{Constant, Expr, ExprKind, Stmt};
 
-use super::fixes;
-use super::helpers::match_function_def;
+use ruff_macros::derive_message_formats;
+
+use crate::ast::helpers::ReturnStatementVisitor;
 use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
-use crate::ast::{cast, helpers, visitor};
+use crate::ast::{cast, helpers};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::docstrings::definition::{Definition, DefinitionKind};
@@ -13,7 +14,9 @@ use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
 use crate::visibility;
 use crate::visibility::Visibility;
-use ruff_macros::derive_message_formats;
+
+use super::fixes;
+use super::helpers::match_function_def;
 
 define_violation!(
     pub struct MissingTypeFunctionArgument {
@@ -159,32 +162,6 @@ impl Violation for DynamicallyTypedExpression {
     fn message(&self) -> String {
         let DynamicallyTypedExpression { name } = self;
         format!("Dynamically typed expressions (typing.Any) are disallowed in `{name}`")
-    }
-}
-
-#[derive(Default)]
-pub struct ReturnStatementVisitor<'a> {
-    returns: Vec<Option<&'a Expr>>,
-}
-
-impl<'a> ReturnStatementVisitor<'a> {
-    pub fn num_returns(&self) -> usize {
-        self.returns.len()
-    }
-}
-
-impl<'a, 'b> Visitor<'b> for ReturnStatementVisitor<'a>
-where
-    'b: 'a,
-{
-    fn visit_stmt(&mut self, stmt: &'b Stmt) {
-        match &stmt.node {
-            StmtKind::FunctionDef { .. } | StmtKind::AsyncFunctionDef { .. } => {
-                // Don't recurse.
-            }
-            StmtKind::Return { value } => self.returns.push(value.as_ref().map(|expr| &**expr)),
-            _ => visitor::walk_stmt(self, stmt),
-        }
     }
 }
 

--- a/src/rules/pylint/mod.rs
+++ b/src/rules/pylint/mod.rs
@@ -36,6 +36,7 @@ mod tests {
     #[test_case(Rule::GlobalVariableNotAssigned, Path::new("global_variable_not_assigned.py"); "PLW0602")]
     #[test_case(Rule::InvalidAllFormat, Path::new("invalid_all_format.py"); "PLE0605")]
     #[test_case(Rule::InvalidAllObject, Path::new("invalid_all_object.py"); "PLE0604")]
+    #[test_case(Rule::TooManyReturnStatements, Path::new("too_many_return_statements.py"); "PLR0911")]
     #[test_case(Rule::TooManyArguments, Path::new("too_many_arguments.py"); "PLR0913")]
     #[test_case(Rule::TooManyStatements, Path::new("too_many_statements.py"); "PLR0915")]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
@@ -103,6 +104,22 @@ mod tests {
                     ..pylint::settings::Settings::default()
                 },
                 ..Settings::for_rules(vec![Rule::TooManyStatements])
+            },
+        )?;
+        assert_yaml_snapshot!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn max_return_statements() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pylint/too_many_return_statements_params.py"),
+            &Settings {
+                pylint: pylint::settings::Settings {
+                    max_returns: 1,
+                    ..pylint::settings::Settings::default()
+                },
+                ..Settings::for_rules(vec![Rule::TooManyReturnStatements])
             },
         )?;
         assert_yaml_snapshot!(diagnostics);

--- a/src/rules/pylint/rules/mod.rs
+++ b/src/rules/pylint/rules/mod.rs
@@ -9,6 +9,7 @@ pub use merge_isinstance::{merge_isinstance, ConsiderMergingIsinstance};
 pub use nonlocal_without_binding::NonlocalWithoutBinding;
 pub use property_with_parameters::{property_with_parameters, PropertyWithParameters};
 pub use too_many_arguments::{too_many_arguments, TooManyArguments};
+pub use too_many_return_statements::{too_many_return_statements, TooManyReturnStatements};
 pub use too_many_statements::{too_many_statements, TooManyStatements};
 pub use unnecessary_direct_lambda_call::{
     unnecessary_direct_lambda_call, UnnecessaryDirectLambdaCall,
@@ -31,6 +32,7 @@ mod merge_isinstance;
 mod nonlocal_without_binding;
 mod property_with_parameters;
 mod too_many_arguments;
+mod too_many_return_statements;
 mod too_many_statements;
 mod unnecessary_direct_lambda_call;
 mod use_from_import;

--- a/src/rules/pylint/rules/mod.rs
+++ b/src/rules/pylint/rules/mod.rs
@@ -9,8 +9,8 @@ pub use merge_isinstance::{merge_isinstance, ConsiderMergingIsinstance};
 pub use nonlocal_without_binding::NonlocalWithoutBinding;
 pub use property_with_parameters::{property_with_parameters, PropertyWithParameters};
 pub use too_many_arguments::{too_many_arguments, TooManyArguments};
-pub use too_many_return_statements::{too_many_return_statements, TooManyReturnStatements};
 pub use too_many_branches::{too_many_branches, TooManyBranches};
+pub use too_many_return_statements::{too_many_return_statements, TooManyReturnStatements};
 pub use too_many_statements::{too_many_statements, TooManyStatements};
 pub use unnecessary_direct_lambda_call::{
     unnecessary_direct_lambda_call, UnnecessaryDirectLambdaCall,
@@ -33,8 +33,8 @@ mod merge_isinstance;
 mod nonlocal_without_binding;
 mod property_with_parameters;
 mod too_many_arguments;
-mod too_many_return_statements;
 mod too_many_branches;
+mod too_many_return_statements;
 mod too_many_statements;
 mod unnecessary_direct_lambda_call;
 mod use_from_import;

--- a/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/src/rules/pylint/rules/too_many_return_statements.rs
@@ -1,8 +1,7 @@
-use crate::ast::helpers::identifier_range;
+use crate::ast::helpers::{identifier_range, ReturnStatementVisitor};
 use crate::ast::visitor::Visitor;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-use crate::rules::flake8_annotations::rules::ReturnStatementVisitor;
 use crate::source_code::Locator;
 use crate::violation::Violation;
 
@@ -26,12 +25,11 @@ impl Violation for TooManyReturnStatements {
     }
 }
 
-fn num_returns(stmts: &[Stmt]) -> usize {
+/// Count the number of return statements in a function or method body.
+fn num_returns(body: &[Stmt]) -> usize {
     let mut visitor = ReturnStatementVisitor::default();
-    for stmt in stmts {
-        visitor.visit_stmt(stmt);
-    }
-    visitor.num_returns()
+    visitor.visit_body(body);
+    visitor.returns.len()
 }
 
 /// PLR0911

--- a/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/src/rules/pylint/rules/too_many_return_statements.rs
@@ -1,0 +1,266 @@
+use crate::ast::helpers::identifier_range;
+use crate::define_violation;
+use crate::registry::Diagnostic;
+use crate::source_code::Locator;
+use crate::violation::Violation;
+
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
+
+define_violation!(
+    pub struct TooManyReturnStatements {
+        pub returns: usize,
+        pub max_returns: usize,
+    }
+);
+impl Violation for TooManyReturnStatements {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let TooManyReturnStatements {
+            returns,
+            max_returns,
+        } = self;
+        format!("Too many return statements ({returns}/{max_returns})")
+    }
+}
+
+fn num_returns(stmts: &[Stmt]) -> usize {
+    stmts
+        .iter()
+        .map(|stmt| match &stmt.node {
+            StmtKind::If { body, orelse, .. }
+            | StmtKind::For { body, orelse, .. }
+            | StmtKind::AsyncFor { body, orelse, .. }
+            | StmtKind::While { body, orelse, .. } => num_returns(body) + num_returns(orelse),
+            StmtKind::With { body, .. } | StmtKind::AsyncWith { body, .. } => num_returns(body),
+            StmtKind::Try {
+                body,
+                handlers,
+                orelse,
+                finalbody,
+            } => {
+                num_returns(body)
+                    + num_returns(orelse)
+                    + num_returns(finalbody)
+                    + handlers
+                        .iter()
+                        .map(|handler| {
+                            let ExcepthandlerKind::ExceptHandler { body, .. } = &handler.node;
+                            num_returns(body)
+                        })
+                        .sum::<usize>()
+            }
+            StmtKind::Match { .. } => {
+                // TODO: Uncomment when pattern matching is available, is in rustpython so have to match
+                // Add the 'cases' field when it is
+                /*
+                cases.iter().map(|case|
+                    num_returns(&case.body)
+                ).sum::<usize>()
+                */
+                unimplemented!("Match case is unimplemented")
+            }
+            StmtKind::Return { .. } => 1,
+            StmtKind::ImportFrom { .. }
+            | StmtKind::Import { .. }
+            | StmtKind::Global { .. }
+            | StmtKind::Nonlocal { .. }
+            | StmtKind::FunctionDef { .. }
+            | StmtKind::AsyncFunctionDef { .. }
+            | StmtKind::ClassDef { .. }
+            | StmtKind::Assert { .. }
+            | StmtKind::Raise { .. }
+            | StmtKind::Assign { .. }
+            | StmtKind::AugAssign { .. }
+            | StmtKind::AnnAssign { .. }
+            | StmtKind::Delete { .. }
+            | StmtKind::Expr { .. }
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Pass => 0,
+        })
+        .sum()
+}
+
+/// PLR0911
+pub fn too_many_return_statements(
+    stmt: &Stmt,
+    body: &[Stmt],
+    max_returns: usize,
+    locator: &Locator,
+) -> Option<Diagnostic> {
+    let returns = num_returns(body);
+    if returns > max_returns {
+        Some(Diagnostic::new(
+            TooManyReturnStatements {
+                returns,
+                max_returns,
+            },
+            identifier_range(stmt, locator),
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use rustpython_parser::parser;
+
+    use super::num_returns;
+
+    fn test_helper(source: &str, expected: usize) -> Result<()> {
+        let stmts = parser::parse_program(source, "<filename>")?;
+        assert_eq!(num_returns(&stmts), expected);
+        Ok(())
+    }
+
+    #[test]
+    fn if_() -> Result<()> {
+        let source = r#"
+x = 1
+if x == 1:  # 9
+    return
+if x == 2:
+    return
+if x == 3:
+    return
+if x == 4:
+    return
+if x == 5:
+    return
+if x == 6:
+    return
+if x == 7:
+    return
+if x == 8:
+    return
+if x == 9:
+    return            
+"#;
+
+        test_helper(source, 9)?;
+        Ok(())
+    }
+
+    #[test]
+    fn for_else() -> Result<()> {
+        let source = r#"
+for _i in range(10):
+    return
+else:
+    return
+"#;
+
+        test_helper(source, 2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn async_for_else() -> Result<()> {
+        let source = r#"
+async for _i in range(10):
+    return
+else:
+    return
+"#;
+
+        test_helper(source, 2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn nested_def_ignored() -> Result<()> {
+        let source = r#"
+def f():
+    return
+
+x = 1
+if x == 1:
+    print()
+else:
+    print()
+"#;
+
+        test_helper(source, 0)?;
+        Ok(())
+    }
+
+    #[test]
+    fn while_nested_if() -> Result<()> {
+        let source = r#"
+x = 1
+while x < 10:
+    print()
+    if x == 3:
+        return
+    x += 1
+return
+"#;
+
+        test_helper(source, 2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn with_if() -> Result<()> {
+        let source = r#"
+with a as f:
+    return
+    if f == 1:
+        return
+"#;
+
+        test_helper(source, 2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn async_with_if() -> Result<()> {
+        let source = r#"
+async with a as f:
+    return
+    if f == 1:
+        return
+"#;
+
+        test_helper(source, 2)?;
+        Ok(())
+    }
+
+    #[test]
+    fn try_except_except_else_finally() -> Result<()> {
+        let source = r#"
+try:
+    print()
+    return
+except ValueError:
+    return
+except Exception:
+    return
+else:
+    return
+finally:
+    return
+"#;
+
+        test_helper(source, 5)?;
+        Ok(())
+    }
+
+    #[test]
+    fn class_def_ignored() -> Result<()> {
+        let source = r#"
+class A:
+    def f(self):
+        return
+
+    def g(self):
+        return
+"#;
+
+        test_helper(source, 0)?;
+        Ok(())
+    }
+}

--- a/src/rules/pylint/settings.rs
+++ b/src/rules/pylint/settings.rs
@@ -56,10 +56,10 @@ pub struct Options {
     #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
     /// Maximum number of branches allowed for a function or method body (see: `PLR0912`).
     pub max_branches: Option<usize>,
-    #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
-    /// Maximum number of return statements allowed for a function or method body (see `PLR0911`)
     #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
+    /// Maximum number of return statements allowed for a function or method body (see `PLR0911`)
     pub max_returns: Option<usize>,
+    #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
     /// Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).
     pub max_args: Option<usize>,
     #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]

--- a/src/rules/pylint/settings.rs
+++ b/src/rules/pylint/settings.rs
@@ -54,6 +54,9 @@ pub struct Options {
     /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
     #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
+    /// Maximum number of return statements allowed for a function or method (see `PLR0911`)
+    #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
+    pub max_returns: Option<usize>,
     /// Maximum number of arguments allowed for a function definition (see: `PLR0913`).
     pub max_args: Option<usize>,
     #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]
@@ -65,6 +68,7 @@ pub struct Options {
 pub struct Settings {
     pub allow_magic_value_types: Vec<ConstantType>,
     pub max_args: usize,
+    pub max_returns: usize,
     pub max_statements: usize,
 }
 
@@ -73,6 +77,7 @@ impl Default for Settings {
         Self {
             allow_magic_value_types: vec![ConstantType::Str, ConstantType::Bytes],
             max_args: 5,
+            max_returns: 6,
             max_statements: 50,
         }
     }
@@ -86,6 +91,7 @@ impl From<Options> for Settings {
                 .allow_magic_value_types
                 .unwrap_or(defaults.allow_magic_value_types),
             max_args: options.max_args.unwrap_or(defaults.max_args),
+            max_returns: options.max_returns.unwrap_or(defaults.max_returns),
             max_statements: options.max_statements.unwrap_or(defaults.max_statements),
         }
     }
@@ -96,6 +102,7 @@ impl From<Settings> for Options {
         Self {
             allow_magic_value_types: Some(settings.allow_magic_value_types),
             max_args: Some(settings.max_args),
+            max_returns: Some(settings.max_returns),
             max_statements: Some(settings.max_statements),
         }
     }

--- a/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0911_too_many_return_statements.py.snap
+++ b/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0911_too_many_return_statements.py.snap
@@ -7,10 +7,10 @@ expression: diagnostics
       returns: 11
       max_returns: 6
   location:
-    row: 1
+    row: 4
     column: 4
   end_location:
-    row: 1
+    row: 4
     column: 19
   fix: ~
   parent: ~

--- a/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0911_too_many_return_statements.py.snap
+++ b/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0911_too_many_return_statements.py.snap
@@ -1,0 +1,17 @@
+---
+source: src/rules/pylint/mod.rs
+expression: diagnostics
+---
+- kind:
+    TooManyReturnStatements:
+      returns: 11
+      max_returns: 6
+  location:
+    row: 1
+    column: 4
+  end_location:
+    row: 1
+    column: 19
+  fix: ~
+  parent: ~
+

--- a/src/rules/pylint/snapshots/ruff__rules__pylint__tests__max_return_statements.snap
+++ b/src/rules/pylint/snapshots/ruff__rules__pylint__tests__max_return_statements.snap
@@ -1,0 +1,17 @@
+---
+source: src/rules/pylint/mod.rs
+expression: diagnostics
+---
+- kind:
+    TooManyReturnStatements:
+      returns: 2
+      max_returns: 1
+  location:
+    row: 1
+    column: 4
+  end_location:
+    row: 1
+    column: 5
+  fix: ~
+  parent: ~
+


### PR DESCRIPTION
https://pylint.pycqa.org/en/latest/user_guide/messages/refactor/too-many-return-statements.html

Issue #970 
Required by #2414