### PR TITLE
Portably find ruff binary path from Python

### DIFF
--- a/python/ruff/__main__.py
+++ b/python/ruff/__main__.py
@@ -3,23 +3,32 @@ import sys
 import sysconfig
 from pathlib import Path
 
-RUFF_PATHS = [
-    Path(sysconfig.get_config_var("userbase")) / "bin" / "ruff",
-    Path(sysconfig.get_path("scripts")) / "ruff",
-]
-
 
 def find_ruff_bin() -> Path:
     """Return the ruff binary path."""
-    for ruff_path in RUFF_PATHS:
-        if ruff_path.is_file():
-            return ruff_path
-    raise FileNotFoundError(ruff_path)
+
+    ruff_exe = "ruff" + sysconfig.get_config_var("EXE")
+
+    path = Path(sysconfig.get_path("scripts")) / ruff_exe
+    if path.is_file():
+        return path
+
+    if sys.version_info >= (3, 10):
+        user_scheme = sysconfig.get_preferred_scheme("user")
+    elif os.name == "nt":
+        user_scheme = "nt_user"
+    elif sys.platform == "darwin" and sys._framework:
+        user_scheme = "osx_framework_user"
+    else:
+        user_scheme = "posix_user"
+
+    path = Path(sysconfig.get_path("scripts", scheme=user_scheme)) / ruff_exe
+    if path.is_file():
+        return path
+
+    raise FileNotFoundError(path)
 
 
 if __name__ == "__main__":
-    try:
-        ruff = find_ruff_bin()
-    except FileNotFoundError as e:
-        raise FileNotFoundError(e) from e
-    sys.exit(os.spawnv(os.P_WAIT, ruff, [ruff, *sys.argv[1:]]))
+    ruff = find_ruff_bin()
+    sys.exit(os.spawnv(os.P_WAIT, ruff, ["ruff", *sys.argv[1:]]))


### PR DESCRIPTION
Prefer the version from a currently active virtualenv over a version from `pip install --user`.  Add the .exe extension on Windows, and find the path for `pip install --user` correctly on Windows.