### PR TITLE
fix(commented-out-code): `mypy` and `SPDX-License-Identifier` false positives

### DIFF
--- a/src/rules/eradicate/detection.rs
+++ b/src/rules/eradicate/detection.rs
@@ -4,7 +4,7 @@ use regex::Regex;
 
 static ALLOWLIST_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
-        r"^(?i)(?:pylint|pyright|noqa|nosec|type:\s*ignore|fmt:\s*(on|off)|isort:\s*(on|off|skip|skip_file|split|dont-add-imports(:\s*\[.*?])?))"
+        r"^(?i)(?:pylint|pyright|noqa|nosec|type:\s*ignore|fmt:\s*(on|off)|isort:\s*(on|off|skip|skip_file|split|dont-add-imports(:\s*\[.*?])?)|mypy:|SPDX-License-Identifier:)"
     ).unwrap()
 });
 static BRACKET_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[()\[\]{}\s]+$").unwrap());
@@ -126,6 +126,11 @@ mod tests {
         ),);
         assert!(!comment_contains_code(
             "# Issue #999: This is not code",
+            &[]
+        ));
+        assert!(!comment_contains_code("# mypy: allow-untyped-calls", &[]));
+        assert!(!comment_contains_code(
+            "# SPDX-License-Identifier: MIT",
             &[]
         ));
 


### PR DESCRIPTION
https://mypy.readthedocs.io/en/stable/inline_config.html#configuration-comment-format
https://spdx.github.io/spdx-spec/v2.3/using-SPDX-short-identifiers-in-source-files/#e2-format-for-spdx-license-identifier