### PR TITLE
Support `ignore-names` for all relevant pep8-naming rules

### DIFF
--- a/crates/ruff/resources/test/fixtures/pep8_naming/N803.py
+++ b/crates/ruff/resources/test/fixtures/pep8_naming/N803.py
@@ -5,3 +5,7 @@ def func(_, a, A):
 class Class:
     def method(self, _, a, A):
         return _, a, A
+
+
+def func(_, setUp):
+    return _, setUp

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -3702,8 +3702,11 @@ where
         }
 
         if self.settings.rules.enabled(&Rule::InvalidArgumentName) {
-            if let Some(diagnostic) = pep8_naming::rules::invalid_argument_name(&arg.node.arg, arg)
-            {
+            if let Some(diagnostic) = pep8_naming::rules::invalid_argument_name(
+                &arg.node.arg,
+                arg,
+                &self.settings.pep8_naming.ignore_names,
+            ) {
                 self.diagnostics.push(diagnostic);
             }
         }


### PR DESCRIPTION
Closes #2612.