### PR TITLE
Avoid non-recursion in nested typing function calls

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_unused_arguments/ARG.py
+++ b/crates/ruff/resources/test/fixtures/flake8_unused_arguments/ARG.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import overload
+from typing import overload, cast
 from typing_extensions import override
 
 
@@ -195,3 +195,10 @@ class C:
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         print("Hello, world!")
+
+
+###
+# Used arguments on chained cast.
+###
+def f(x: None) -> None:
+    _ = cast(Any, _identity)(x=x)

--- a/crates/ruff/src/ast/helpers.rs
+++ b/crates/ruff/src/ast/helpers.rs
@@ -46,7 +46,6 @@ pub fn unparse_stmt(stmt: &Stmt, stylist: &Stylist) -> String {
 
 fn collect_call_path_inner<'a>(expr: &'a Expr, parts: &mut CallPath<'a>) -> bool {
     match &expr.node {
-        ExprKind::Call { func, .. } => collect_call_path_inner(func, parts),
         ExprKind::Attribute { value, attr, .. } => {
             if collect_call_path_inner(value, parts) {
                 parts.push(attr);
@@ -66,7 +65,14 @@ fn collect_call_path_inner<'a>(expr: &'a Expr, parts: &mut CallPath<'a>) -> bool
 /// Convert an `Expr` to its [`CallPath`] segments (like `["typing", "List"]`).
 pub fn collect_call_path(expr: &Expr) -> CallPath {
     let mut segments = smallvec![];
-    collect_call_path_inner(expr, &mut segments);
+    collect_call_path_inner(
+        if let ExprKind::Call { func, .. } = &expr.node {
+            func
+        } else {
+            expr
+        },
+        &mut segments,
+    );
     segments
 }
 

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -3226,7 +3226,7 @@ where
                 args,
                 keywords,
             } => {
-                let callable = self.resolve_call_path(func).and_then(|call_path| {
+                let callable = self.resolve_call_path(expr).and_then(|call_path| {
                     if self.match_typing_call_path(&call_path, "ForwardRef") {
                         Some(Callable::ForwardRef)
                     } else if self.match_typing_call_path(&call_path, "cast") {


### PR DESCRIPTION
Previously, we treated the outer `Call` in `cast(...)(x=x)` as `cast`, whereas in reality only the _inner_ call is `cast`.

Closes #2620.