### PR TITLE
Reorder imports

### DIFF
--- a/crates/ruff/src/ast/helpers.rs
+++ b/crates/ruff/src/ast/helpers.rs
@@ -667,8 +667,8 @@ pub fn to_call_path(target: &str) -> CallPath {
 
 /// Create a module path from a (package, path) pair.
 ///
-/// For example, if the package is `foo/bar` and the path is `foo/bar/baz.py`, the call path is
-/// `["baz"]`.
+/// For example, if the package is `foo/bar` and the path is `foo/bar/baz.py`,
+/// the call path is `["baz"]`.
 pub fn to_module_path(package: &Path, path: &Path) -> Option<Vec<String>> {
     path.strip_prefix(package.parent()?)
         .ok()?

--- a/crates/ruff/src/ast/types.rs
+++ b/crates/ruff/src/ast/types.rs
@@ -89,8 +89,9 @@ pub struct Scope<'a> {
     pub uses_locals: bool,
     /// A map from bound name to binding index, for live bindings.
     pub bindings: FxHashMap<&'a str, usize>,
-    /// A map from bound name to binding index, for bindings that were created in the scope but
-    /// rebound (and thus overridden) later on in the same scope.
+    /// A map from bound name to binding index, for bindings that were created
+    /// in the scope but rebound (and thus overridden) later on in the same
+    /// scope.
     pub rebounds: FxHashMap<&'a str, Vec<usize>>,
 }
 

--- a/crates/ruff/src/ast/typing.rs
+++ b/crates/ruff/src/ast/typing.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{Expr, ExprKind};
-
 use ruff_python::typing::{PEP_585_BUILTINS_ELIGIBLE, PEP_593_SUBSCRIPTS, SUBSCRIPTS};
+use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::CallPath;
 

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use itertools::Itertools;
 use log::error;
 use nohash_hasher::IntMap;
+use ruff_python::builtins::{BUILTINS, MAGIC_GLOBALS};
+use ruff_python::typing::TYPING_EXTENSIONS;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_ast::{Comprehension, Located, Location};
 use rustpython_common::cformat::{CFormatError, CFormatErrorType};
@@ -15,9 +17,6 @@ use rustpython_parser::ast::{
 };
 use rustpython_parser::parser;
 use smallvec::smallvec;
-
-use ruff_python::builtins::{BUILTINS, MAGIC_GLOBALS};
-use ruff_python::typing::TYPING_EXTENSIONS;
 
 use crate::ast::helpers::{
     binding_range, collect_call_path, extract_handler_names, from_relative_import, to_module_path,
@@ -3955,8 +3954,8 @@ impl<'a> Checker<'a> {
                 // Avoid overriding builtins.
                 binding
             } else if matches!(self.bindings[*index].kind, BindingKind::Global) {
-                // If the original binding was a global, and the new binding conflicts within the
-                // current scope, then the new binding is also a global.
+                // If the original binding was a global, and the new binding conflicts within
+                // the current scope, then the new binding is also a global.
                 Binding {
                     runtime_usage: self.bindings[*index].runtime_usage,
                     synthetic_usage: self.bindings[*index].synthetic_usage,
@@ -3965,8 +3964,8 @@ impl<'a> Checker<'a> {
                     ..binding
                 }
             } else if matches!(self.bindings[*index].kind, BindingKind::Nonlocal) {
-                // If the original binding was a nonlocal, and the new binding conflicts within the
-                // current scope, then the new binding is also a nonlocal.
+                // If the original binding was a nonlocal, and the new binding conflicts within
+                // the current scope, then the new binding is also a nonlocal.
                 Binding {
                     runtime_usage: self.bindings[*index].runtime_usage,
                     synthetic_usage: self.bindings[*index].synthetic_usage,

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -27,8 +27,9 @@ use crate::{directives, fs, rustpython_helpers};
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
 
-/// A [`Result`]-like type that returns both data and an error. Used to return diagnostics even in
-/// the face of parse errors, since many diagnostics can be generated without a full AST.
+/// A [`Result`]-like type that returns both data and an error. Used to return
+/// diagnostics even in the face of parse errors, since many diagnostics can be
+/// generated without a full AST.
 pub struct LinterResult<T> {
     pub data: T,
     pub error: Option<ParseError>,
@@ -270,7 +271,8 @@ pub fn add_noqa_to_path(path: &Path, settings: &Settings) -> Result<usize> {
     )
 }
 
-/// Generate a [`Message`] for each [`Diagnostic`] triggered by the given source code.
+/// Generate a [`Message`] for each [`Diagnostic`] triggered by the given source
+/// code.
 pub fn lint_only(
     contents: &str,
     path: &Path,

--- a/crates/ruff/src/logging.rs
+++ b/crates/ruff/src/logging.rs
@@ -50,7 +50,8 @@ macro_rules! notify_user {
 pub enum LogLevel {
     /// No output ([`log::LevelFilter::Off`]).
     Silent,
-    /// Only show lint violations, with no decorative output ([`log::LevelFilter::Off`]).
+    /// Only show lint violations, with no decorative output
+    /// ([`log::LevelFilter::Off`]).
     Quiet,
     /// All user-facing output ([`log::LevelFilter::Info`]).
     #[default]

--- a/crates/ruff/src/packaging.rs
+++ b/crates/ruff/src/packaging.rs
@@ -119,7 +119,8 @@ pub fn detect_package_roots<'a>(
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{packaging::detect_package_root, test::test_resource_path};
+    use crate::packaging::detect_package_root;
+    use crate::test::test_resource_path;
 
     #[test]
     fn package_detection() {

--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -587,15 +587,16 @@ mod tests {
             &Relativity::Parent,
             &NoOpProcessor,
         )?);
-        // src/app.py should not be excluded even if it lives in a hierarchy that should be
-        // excluded by virtue of the pyproject.toml having `resources/*` in it.
+        // src/app.py should not be excluded even if it lives in a hierarchy that should
+        // be excluded by virtue of the pyproject.toml having `resources/*` in
+        // it.
         assert!(!is_file_excluded(
             &package_root.join("src/app.py"),
             &resolver,
             &ppd,
         ));
-        // However, resources/ignored.py should be ignored, since that `resources` is beneath
-        // the package root.
+        // However, resources/ignored.py should be ignored, since that `resources` is
+        // beneath the package root.
         assert!(is_file_excluded(
             &package_root.join("resources/ignored.py"),
             &resolver,

--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -1,13 +1,12 @@
 use num_bigint::BigInt;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Constant, Expr, ExprKind, Located};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct SysVersionSlice3Referenced;

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -1,22 +1,19 @@
 use log::error;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Stmt};
 
-use ruff_macros::derive_message_formats;
-
+use super::fixes;
+use super::helpers::match_function_def;
 use crate::ast::helpers::ReturnStatementVisitor;
 use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
 use crate::ast::{cast, helpers};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::docstrings::definition::{Definition, DefinitionKind};
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use crate::visibility;
 use crate::visibility::Visibility;
-
-use super::fixes;
-use super::helpers::match_function_def;
+use crate::{define_violation, visibility};
 
 define_violation!(
     pub struct MissingTypeFunctionArgument {

--- a/crates/ruff/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/assert_used.rs
@@ -1,10 +1,10 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Located, StmtKind};
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct AssertUsed;

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use num_traits::ToPrimitive;
 use once_cell::sync::Lazy;
 use ruff_macros::derive_message_formats;
@@ -9,7 +7,9 @@ use rustpython_ast::{Constant, Expr, ExprKind, Keyword, Operator};
 use crate::ast::helpers::{compose_call_path, SimpleCallArgs};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct BadFilePermissions {

--- a/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
@@ -1,10 +1,10 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct ExecUsed;

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -1,9 +1,9 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct HardcodedBindAllInterfaces;

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{ArgData, Arguments, Expr, Located};
 
 use super::super::helpers::{matches_password_name, string_literal};
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct HardcodedPasswordDefault {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Keyword;
 
 use super::super::helpers::{matches_password_name, string_literal};
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct HardcodedPasswordFuncArg {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
 use super::super::helpers::{matches_password_name, string_literal};
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct HardcodedPasswordString {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -1,10 +1,10 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct HardcodedTempFile {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
 
@@ -7,7 +5,9 @@ use super::super::helpers::string_literal;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct HashlibInsecureHashFunction {

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 use rustpython_parser::ast::Constant;
@@ -7,7 +5,9 @@ use rustpython_parser::ast::Constant;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct Jinja2AutoescapeFalse {

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{Expr, Keyword};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, Keyword};
 
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 use rustpython_parser::ast::Constant;
@@ -7,7 +5,9 @@ use rustpython_parser::ast::Constant;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct RequestWithNoCertValidation {

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 use rustpython_parser::ast::Constant;
@@ -7,7 +5,9 @@ use rustpython_parser::ast::Constant;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct RequestWithoutTimeout {

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use num_traits::{One, Zero};
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword};
@@ -8,7 +6,9 @@ use rustpython_parser::ast::Constant;
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct SnmpInsecureVersion;

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword};
 
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct SnmpWeakCryptography;

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{Expr, ExprKind, Keyword};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
 
 use crate::ast::helpers::SimpleCallArgs;
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/flake8_bandit/settings.rs
+++ b/crates/ruff/src/rules/flake8_bandit/settings.rs
@@ -39,8 +39,9 @@ pub struct Options {
         value_type = "bool",
         example = "check-typed-exception = true"
     )]
-    /// Whether to disallow `try`-`except`-`pass` (`S110`) for specific exception types. By default,
-    /// `try`-`except`-`pass` is only disallowed for `Exception` and `BaseException`.
+    /// Whether to disallow `try`-`except`-`pass` (`S110`) for specific
+    /// exception types. By default, `try`-`except`-`pass` is only
+    /// disallowed for `Exception` and `BaseException`.
     pub check_typed_exception: Option<bool>,
 }
 

--- a/crates/ruff/src/rules/flake8_blind_except/rules.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Stmt, StmtKind};
+
 use crate::ast::helpers;
 use crate::ast::helpers::{find_keyword, is_const_true};
 use crate::ast::types::Range;
@@ -5,8 +8,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct BlindExcept {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -1,11 +1,12 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
 use crate::visibility::{is_abstract, is_overload};
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
 define_violation!(
     pub struct AbstractBaseClassWithoutAbstractMethod {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
+
 use crate::ast::helpers::unparse_stmt;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,8 +8,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
 define_violation!(
     pub struct DoNotAssertFalse;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -7,13 +7,14 @@
 //! typo. Either assert for a more specific exception (builtin or
 //! custom), use `assertRaisesRegex`, or use the context manager form of
 //! `assertRaises`.
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{ExprKind, Stmt, Withitem};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{ExprKind, Stmt, Withitem};
 
 define_violation!(
     pub struct NoAssertRaisesException;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct AssignmentToOsEnviron;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct CachedInstanceMethod;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct CannotRaiseLiteral;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -1,3 +1,8 @@
+use itertools::Itertools;
+use ruff_macros::derive_message_formats;
+use rustc_hash::{FxHashMap, FxHashSet};
+use rustpython_ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind, Location};
+
 use crate::ast::helpers;
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::{CallPath, Range};
@@ -6,10 +11,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use itertools::Itertools;
-use ruff_macros::derive_message_formats;
-use rustc_hash::{FxHashMap, FxHashSet};
-use rustpython_ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind, Location};
 
 define_violation!(
     pub struct DuplicateTryBlockException {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{ExprKind, Stmt, StmtKind};
+
 use crate::ast::helpers;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{ExprKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct FStringDocstring;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Arguments, Constant, Expr, ExprKind};
+
 use super::mutable_argument_default::is_mutable_func;
 use crate::ast::helpers::{compose_call_path, to_call_path};
 use crate::ast::types::{CallPath, Range};
@@ -7,8 +10,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::{Diagnostic, DiagnosticKind};
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Arguments, Constant, Expr, ExprKind};
 
 define_violation!(
     pub struct FunctionCallArgumentDefault {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -1,3 +1,7 @@
+use ruff_macros::derive_message_formats;
+use rustc_hash::FxHashSet;
+use rustpython_ast::{Comprehension, Expr, ExprContext, ExprKind, Stmt, StmtKind};
+
 use crate::ast::helpers::collect_arg_names;
 use crate::ast::types::{Node, Range};
 use crate::ast::visitor;
@@ -6,9 +10,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustc_hash::FxHashSet;
-use rustpython_ast::{Comprehension, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct FunctionUsesLoopVariable {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -1,3 +1,8 @@
+use ruff_macros::derive_message_formats;
+use ruff_python::identifiers::{is_identifier, is_mangled_private};
+use ruff_python::keyword::KWLIST;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location};
+
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,10 +10,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-use ruff_python::identifiers::{is_identifier, is_mangled_private};
-use ruff_python::keyword::KWLIST;
-use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location};
 
 define_violation!(
     pub struct GetAttrWithConstant;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Stmt, StmtKind};
 
 define_violation!(
     pub struct JumpStatementInFinally {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -1,3 +1,7 @@
+use ruff_macros::derive_message_formats;
+use rustc_hash::FxHashMap;
+use rustpython_ast::{Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
@@ -5,9 +9,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustc_hash::FxHashMap;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct LoopVariableOverridesIterator {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mod.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mod.rs
@@ -27,7 +27,6 @@ pub use raise_without_from_inside_except::{
 pub use redundant_tuple_in_exception_handler::{
     redundant_tuple_in_exception_handler, RedundantTupleInExceptionHandler,
 };
-
 pub use setattr_with_constant::{setattr_with_constant, SetAttrWithConstant};
 pub use star_arg_unpacking_after_keyword_arg::{
     star_arg_unpacking_after_keyword_arg, StarArgUnpackingAfterKeywordArg,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Arguments, Constant, Expr, ExprKind, Operator};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Arguments, Constant, Expr, ExprKind, Operator};
 
 define_violation!(
     pub struct MutableArgumentDefault;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -1,12 +1,13 @@
+use ruff_macros::derive_message_formats;
+use ruff_python::string::is_lower;
+use rustpython_ast::{ExprKind, Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use ruff_python::string::is_lower;
-use rustpython_ast::{ExprKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct RaiseWithoutFromInsideExcept;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Excepthandler, ExcepthandlerKind, ExprKind};
+
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,8 +8,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
 define_violation!(
     pub struct RedundantTupleInExceptionHandler {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,3 +1,8 @@
+use ruff_macros::derive_message_formats;
+use ruff_python::identifiers::{is_identifier, is_mangled_private};
+use ruff_python::keyword::KWLIST;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
+
 use crate::ast::helpers::unparse_stmt;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -6,10 +11,6 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::Stylist;
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-use ruff_python::identifiers::{is_identifier, is_mangled_private};
-use ruff_python::keyword::KWLIST;
-use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
 define_violation!(
     pub struct SetAttrWithConstant;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
@@ -7,13 +7,14 @@
 //! by the unpacked sequence, and this change of ordering can surprise and
 //! mislead readers.
 
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct StarArgUnpackingAfterKeywordArg;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -1,11 +1,12 @@
+use itertools::Itertools;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use itertools::Itertools;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprKind};
 
 define_violation!(
     pub struct StripWithMultiCharacters;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
@@ -17,13 +17,14 @@
 //! n += 1
 //! ```
 
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Unaryop};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Unaryop};
 
 define_violation!(
     pub struct UnaryPrefixIncrement;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprKind};
 
 define_violation!(
     pub struct UnreliableCallableCheck;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -18,12 +18,12 @@
 //!     method()
 //! ```
 
-use rustc_hash::FxHashMap;
-use rustpython_ast::{Expr, ExprKind, Stmt};
-use serde::{Deserialize, Serialize};
 use std::iter;
 
 use ruff_macros::derive_message_formats;
+use rustc_hash::FxHashMap;
+use rustpython_ast::{Expr, ExprKind, Stmt};
+use serde::{Deserialize, Serialize};
 
 use crate::ast::types::{BindingKind, Range, RefEquality};
 use crate::ast::visitor::Visitor;
@@ -44,11 +44,13 @@ define_violation!(
     pub struct UnusedLoopControlVariable {
         /// The name of the loop control variable.
         pub name: String,
-        /// The name to which the variable should be renamed, if it can be safely renamed.
+        /// The name to which the variable should be renamed, if it can be
+        /// safely renamed.
         pub rename: Option<String>,
-        /// Whether the variable is certain to be unused in the loop body, or merely suspect.
-        /// A variable _may_ be used, but undetectably so, if the loop incorporates
-        /// by magic control flow (e.g., `locals()`).
+        /// Whether the variable is certain to be unused in the loop body, or
+        /// merely suspect. A variable _may_ be used, but undetectably
+        /// so, if the loop incorporates by magic control flow (e.g.,
+        /// `locals()`).
         pub certainty: Certainty,
     }
 );
@@ -147,8 +149,9 @@ pub fn unused_loop_control_variable(
             Certainty::Certain
         };
 
-        // Attempt to rename the variable by prepending an underscore, but avoid applying the fix
-        // if doing so wouldn't actually cause us to ignore the violation in the next pass.
+        // Attempt to rename the variable by prepending an underscore, but avoid
+        // applying the fix if doing so wouldn't actually cause us to ignore the
+        // violation in the next pass.
         let rename = format!("_{name}");
         let rename = if checker
             .settings

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UselessComparison;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Expr;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Expr;
 
 define_violation!(
     pub struct UselessContextlibSuppress;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, ExprKind, Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, ExprKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct UselessExpression;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct ZipWithoutExplicitStrict;

--- a/crates/ruff/src/rules/flake8_builtins/rules.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules.rs
@@ -1,11 +1,12 @@
+use ruff_macros::derive_message_formats;
+use ruff_python::builtins::BUILTINS;
+use rustpython_ast::Located;
+
 use super::types::ShadowingType;
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::{Diagnostic, DiagnosticKind};
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use ruff_python::builtins::BUILTINS;
-use rustpython_ast::Located;
 
 define_violation!(
     pub struct BuiltinVariableShadowing {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryCallAroundSorted {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, Keyword};
 
 define_violation!(
     pub struct UnnecessaryCollectionCall {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Comprehension, Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Comprehension, Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryComprehension {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -1,12 +1,12 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryDoubleCastOrProcess {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryGeneratorDict;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryGeneratorList;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryGeneratorSet;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryListCall;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryListComprehensionDict;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryListComprehensionSet;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryLiteralDict {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword};
 
 define_violation!(
     pub struct UnnecessaryLiteralSet {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryLiteralWithinListCall {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -1,3 +1,7 @@
+use log::error;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,9 +9,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::violation::AlwaysAutofixableViolation;
-use log::error;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryLiteralWithinTupleCall {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -1,12 +1,12 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct UnnecessaryMap {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -1,13 +1,13 @@
+use num_bigint::BigInt;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprKind, Unaryop};
+
 use super::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use num_bigint::BigInt;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprKind, Unaryop};
 
 define_violation!(
     pub struct UnnecessarySubscriptReversal {

--- a/crates/ruff/src/rules/flake8_datetimez/rules.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
 
 use crate::ast::helpers::{has_non_none_keyword, is_const_none};
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Stmt};
 
 use super::types::DebuggerUsingType;
@@ -7,8 +8,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
 
 // flake8-debugger
 

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -1,12 +1,11 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct RawStringInException;

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
@@ -1,8 +1,7 @@
 use itertools::Itertools;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Operator};
 use rustpython_parser::lexer::{LexResult, Tok};
-
-use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
 use crate::define_violation;

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -1,10 +1,9 @@
 use log::error;
-use rustc_hash::FxHashSet;
-use rustpython_ast::{Boolop, Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
-
 use ruff_macros::derive_message_formats;
 use ruff_python::identifiers::is_identifier;
 use ruff_python::keyword::KWLIST;
+use rustc_hash::FxHashSet;
+use rustpython_ast::{Boolop, Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
 use crate::ast::comparable::ComparableExpr;
 use crate::ast::helpers::{match_trailing_comment, unparse_expr};

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -1,7 +1,6 @@
 use log::error;
-use rustpython_ast::{Expr, Keyword, Stmt, StmtKind};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, Keyword, Stmt, StmtKind};
 
 use crate::ast::helpers::is_const_none;
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{
     Boolop, Excepthandler, ExcepthandlerKind, Expr, ExprKind, Keyword, Stmt, StmtKind, Unaryop,
 };
@@ -13,7 +14,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct CompositeAssertion;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword};
 
 use super::helpers::{is_empty_or_null_string, is_pytest_fail};
@@ -7,7 +8,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct FailWithoutMessage;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
@@ -1,10 +1,10 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::Stmt;
 
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct IncorrectPytestImport;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Location};
+
 use super::helpers::{get_mark_decorators, get_mark_name};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -5,8 +8,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Location};
 
 define_violation!(
     pub struct IncorrectMarkParenthesesStyle {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -1,3 +1,6 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Constant, Expr, ExprContext, ExprKind};
+
 use super::super::types;
 use super::helpers::{is_pytest_parametrize, split_names};
 use crate::ast::helpers::{create_expr, unparse_expr};
@@ -8,8 +11,6 @@ use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Generator;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Constant, Expr, ExprContext, ExprKind};
 
 define_violation!(
     pub struct ParametrizeNamesWrongType {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashSet;
 use rustpython_ast::{Expr, ExprKind, Keyword};
 
@@ -8,7 +9,6 @@ use crate::ast::visitor::Visitor;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct PatchWithLambda;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword, Stmt, StmtKind, Withitem};
 
 use super::helpers::is_empty_or_null_string;
@@ -7,7 +8,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct RaisesWithMultipleStatements;

--- a/crates/ruff/src/rules/flake8_pytest_style/settings.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/settings.rs
@@ -50,8 +50,8 @@ pub struct Options {
     ///
     /// * `csv` — a comma-separated list, e.g.
     ///   `@pytest.mark.parametrize('name1,name2', ...)`
-    /// * `tuple` (default) — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), ...)`
+    /// * `tuple` (default) — e.g. `@pytest.mark.parametrize(('name1', 'name2'),
+    ///   ...)`
     /// * `list` — e.g. `@pytest.mark.parametrize(['name1', 'name2'], ...)`
     pub parametrize_names_type: Option<types::ParametrizeNameType>,
     #[option(
@@ -73,10 +73,10 @@ pub struct Options {
     /// Expected type for each row of values in `@pytest.mark.parametrize` in
     /// case of multiple parameters. The following values are supported:
     ///
-    /// * `tuple` (default) — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), [(1, 2), (3, 4)])`
-    /// * `list` — e.g.
-    ///   `@pytest.mark.parametrize(('name1', 'name2'), [[1, 2], [3, 4]])`
+    /// * `tuple` (default) — e.g. `@pytest.mark.parametrize(('name1', 'name2'),
+    ///   [(1, 2), (3, 4)])`
+    /// * `list` — e.g. `@pytest.mark.parametrize(('name1', 'name2'), [[1, 2],
+    ///   [3, 4]])`
     pub parametrize_values_row_type: Option<types::ParametrizeValuesRowType>,
     #[option(
         default = r#"["BaseException", "Exception", "ValueError", "OSError", "IOError", "EnvironmentError", "socket.error"]"#,

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -1,3 +1,7 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Location;
+use rustpython_parser::lexer::{LexResult, Tok};
+
 use super::settings::Quote;
 use crate::ast::types::Range;
 use crate::define_violation;
@@ -7,10 +11,6 @@ use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
 use crate::violation::AlwaysAutofixableViolation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Location;
-use rustpython_parser::lexer::{LexResult, Tok};
 
 define_violation!(
     pub struct BadQuotesInlineString {
@@ -231,8 +231,8 @@ fn strings(
         })
         .collect::<Vec<_>>();
 
-    // Return `true` if any of the strings are inline strings that contain the quote character in
-    // the body.
+    // Return `true` if any of the strings are inline strings that contain the quote
+    // character in the body.
     let relax_quote = trivia.iter().any(|trivia| {
         if trivia.is_multiline {
             return false;
@@ -393,15 +393,15 @@ pub fn from_tokens(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
-    // Keep track of sequences of strings, which represent implicit string concatenation, and
-    // should thus be handled as a single unit.
+    // Keep track of sequences of strings, which represent implicit string
+    // concatenation, and should thus be handled as a single unit.
     let mut sequence = vec![];
     let mut state_machine = StateMachine::default();
     for &(start, ref tok, end) in lxr.iter().flatten() {
         let is_docstring = state_machine.consume(tok);
 
-        // If this is a docstring, consume the existing sequence, then consume the docstring, then
-        // move on.
+        // If this is a docstring, consume the existing sequence, then consume the
+        // docstring, then move on.
         if is_docstring {
             if !sequence.is_empty() {
                 diagnostics.extend(strings(locator, &sequence, settings, autofix));

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{Expr, ExprKind};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::helpers::match_parens;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Location, Stmt, StmtKind};
 
 use super::branch::Branch;
@@ -13,7 +14,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UnnecessaryReturnNone;

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -1,11 +1,11 @@
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use rustpython_ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct PrivateMemberAccess {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -1,18 +1,17 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-
 use std::collections::BTreeMap;
 use std::iter;
 
 use itertools::Either::{Left, Right};
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Boolop, Cmpop, Constant, Expr, ExprContext, ExprKind, Unaryop};
 
 use crate::ast::helpers::{contains_effect, create_expr, has_comments, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct DuplicateIsinstanceCall {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UseCapitalEnvironmentVariables {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_for.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_for.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{
     Comprehension, Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind, Unaryop,
@@ -8,9 +6,11 @@ use rustpython_ast::{
 use crate::ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Stylist;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ConvertLoopToAny {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -1,5 +1,3 @@
-use crate::violation::{AlwaysAutofixableViolation, Availability, Violation};
-use crate::{define_violation, AutofixKind};
 use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
@@ -14,6 +12,8 @@ use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_simplify::rules::fix_if;
+use crate::violation::{AlwaysAutofixableViolation, Availability, Violation};
+use crate::{define_violation, AutofixKind};
 
 define_violation!(
     pub struct NestedIfStatements;
@@ -240,7 +240,8 @@ pub fn return_bool_condition_directly(checker: &mut Checker, stmt: &Stmt) {
         return;
     };
 
-    // If the branches have the same condition, abort (although the code could be simplified).
+    // If the branches have the same condition, abort (although the code could be
+    // simplified).
     if if_return == else_return {
         return;
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Unaryop};
 
 use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct IfExprWithTrueFalse {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Expr, ExprKind, Stmt, StmtKind, Unaryop};
 
 use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct NegateEqualOp {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Located, Stmt, StmtKind, Withitem};
@@ -8,7 +6,9 @@ use super::fix_with;
 use crate::ast::helpers::{first_colon_range, has_comments_in};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct MultipleWithStatements;

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct KeyInDict {

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 use rustpython_parser::ast::StmtKind;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct OpenFileWithContextHandler;

--- a/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Excepthandler, ExcepthandlerKind, Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct ReturnInTryExceptFinally;

--- a/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Excepthandler, ExcepthandlerKind, Located, Stmt, StmtKind};
 
 use crate::ast::helpers;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct UseContextlibSuppress {

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -1,3 +1,9 @@
+use anyhow::Result;
+use libcst_native::{Codegen, CodegenState, CompOp};
+use ruff_macros::derive_message_formats;
+use ruff_python::string::{self};
+use rustpython_ast::{Cmpop, Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_comparison, match_expression};
@@ -6,12 +12,6 @@ use crate::registry::Diagnostic;
 use crate::source_code::{Locator, Stylist};
 use crate::violation::{Availability, Violation};
 use crate::{define_violation, AutofixKind};
-use ruff_python::string::{self};
-
-use anyhow::Result;
-use libcst_native::{Codegen, CodegenState, CompOp};
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Cmpop, Expr, ExprKind};
 
 define_violation!(
     pub struct YodaConditions {

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -1,7 +1,6 @@
 use log::error;
-use rustpython_ast::{Stmt, StmtKind};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{Stmt, StmtKind};
 
 use crate::ast::types::{Range, RefEquality};
 use crate::autofix::helpers::delete_stmt;

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
@@ -1,22 +1,19 @@
 use std::iter;
 
 use regex::Regex;
+use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
 use rustpython_ast::{Arg, Arguments};
 
-use ruff_macros::derive_message_formats;
-
+use super::helpers;
+use super::types::Argumentable;
 use crate::ast::function_type;
 use crate::ast::function_type::FunctionType;
 use crate::ast::types::{Binding, BindingKind, FunctionDef, Lambda, Scope, ScopeKind};
 use crate::checkers::ast::Checker;
-use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use crate::visibility;
-
-use super::helpers;
-use super::types::Argumentable;
+use crate::{define_violation, visibility};
 
 define_violation!(
     pub struct UnusedFunctionArgument {

--- a/crates/ruff/src/rules/isort/categorize.rs
+++ b/crates/ruff/src/rules/isort/categorize.rs
@@ -3,14 +3,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use log::debug;
+use ruff_python::sys::KNOWN_STANDARD_LIBRARY;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use ruff_python::sys::KNOWN_STANDARD_LIBRARY;
-
-use crate::settings::types::PythonVersion;
-
 use super::types::{ImportBlock, Importable};
+use crate::settings::types::PythonVersion;
 
 #[derive(
     Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema, Hash,

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -3,12 +3,11 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-use itertools::Either::{Left, Right};
-
 use annotate::annotate_imports;
 use categorize::categorize_imports;
 pub use categorize::{categorize, ImportType};
 use comments::Comment;
+use itertools::Either::{Left, Right};
 use normalize::normalize_imports;
 use order::order_imports;
 use settings::RelativeImportsOrder;
@@ -312,13 +311,12 @@ mod tests {
     use anyhow::Result;
     use test_case::test_case;
 
+    use super::categorize::ImportType;
+    use super::settings::RelativeImportsOrder;
     use crate::assert_yaml_snapshot;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::{test_path, test_resource_path};
-
-    use super::categorize::ImportType;
-    use super::settings::RelativeImportsOrder;
 
     #[test_case(Path::new("add_newline_before_comments.py"))]
     #[test_case(Path::new("combine_as_imports.py"))]

--- a/crates/ruff/src/rules/isort/sorting.rs
+++ b/crates/ruff/src/rules/isort/sorting.rs
@@ -2,10 +2,11 @@
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
 
+use ruff_python::string;
+
 use super::settings::RelativeImportsOrder;
 use super::types::EitherImport::{Import, ImportFrom};
 use super::types::{AliasData, EitherImport, ImportFromData};
-use ruff_python::string;
 
 #[derive(PartialOrd, Ord, PartialEq, Eq)]
 pub enum Prefix {

--- a/crates/ruff/src/rules/isort/split.rs
+++ b/crates/ruff/src/rules/isort/split.rs
@@ -2,7 +2,8 @@ use crate::rules::isort::types::{ImportBlock, Importable};
 
 /// Find the index of the block that the import should be placed in.
 /// The index is the position of the pattern in `forced_separate` plus one.
-/// If the import is not matched by any of the patterns, return 0 (the first block).
+/// If the import is not matched by any of the patterns, return 0 (the first
+/// block).
 fn find_block_index(forced_separate: &[String], imp: &dyn Importable) -> usize {
     forced_separate
         .iter()
@@ -10,10 +11,12 @@ fn find_block_index(forced_separate: &[String], imp: &dyn Importable) -> usize {
         .map_or(0, |position| position + 1)
 }
 
-/// Split the import block into multiple blocks, where the first block is the imports that are not
-/// matched by any of the patterns in `forced_separate`, and the rest of the blocks are the imports
-/// that _are_ matched by the patterns in `forced_separate`, in the order they appear in the
-/// `forced_separate` set. Empty blocks are retained for patterns that do not match any imports.
+/// Split the import block into multiple blocks, where the first block is the
+/// imports that are not matched by any of the patterns in `forced_separate`,
+/// and the rest of the blocks are the imports that _are_ matched by the
+/// patterns in `forced_separate`, in the order they appear in the
+/// `forced_separate` set. Empty blocks are retained for patterns that do not
+/// match any imports.
 pub fn split_by_forced_separate<'a>(
     block: ImportBlock<'a>,
     forced_separate: &[String],

--- a/crates/ruff/src/rules/mccabe/rules.rs
+++ b/crates/ruff/src/rules/mccabe/rules.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{ExcepthandlerKind, ExprKind, Stmt, StmtKind};
 
 use crate::ast::helpers::identifier_range;
@@ -5,7 +6,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct FunctionIsTooComplex {

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -1,6 +1,6 @@
-use crate::ast::helpers;
 use rustpython_ast::{Expr, ExprKind, Keyword, Location};
 
+use crate::ast::helpers;
 use crate::ast::types::Range;
 use crate::autofix::apply_fix;
 use crate::autofix::helpers::remove_argument;

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
+use ruff_python::string::{is_lower, is_upper};
 use rustpython_ast::{Stmt, StmtKind};
 
 use crate::checkers::ast::Checker;
-use ruff_python::string::{is_lower, is_upper};
 
 pub fn is_camelcase(name: &str) -> bool {
     !is_lower(name) && !is_upper(name) && !name.contains('_')

--- a/crates/ruff/src/rules/pep8_naming/rules.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules.rs
@@ -1,3 +1,5 @@
+use ruff_macros::derive_message_formats;
+use ruff_python::string::{self};
 use rustpython_ast::{Arg, Arguments, Expr, ExprKind, Stmt};
 
 use super::helpers;
@@ -9,8 +11,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use ruff_python::string::{self};
 
 define_violation!(
     pub struct InvalidClassName {

--- a/crates/ruff/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/errors.rs
@@ -1,9 +1,10 @@
+use ruff_macros::derive_message_formats;
+use rustpython_parser::error::ParseError;
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_parser::error::ParseError;
 
 define_violation!(
     pub struct IOError {

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -2,7 +2,6 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use ruff_macros::derive_message_formats;
 
 use crate::define_violation;

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -1,8 +1,8 @@
-use crate::ast::types::Range;
-use crate::checkers::ast::Checker;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Alias, Stmt};
 
+use crate::ast::types::Range;
+use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
+use ruff_macros::derive_message_formats;
+
 use crate::define_violation;
 use crate::registry::DiagnosticKind;
 use crate::rules::pycodestyle::logical_lines::LogicalLine;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct IndentationWithInvalidMultiple {

--- a/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
@@ -2,7 +2,6 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use ruff_macros::derive_message_formats;
 
 use crate::define_violation;

--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -1,6 +1,5 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -1,3 +1,5 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
@@ -5,9 +7,7 @@ use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::violation::{Availability, Violation};
-
 use crate::{define_violation, AutofixKind};
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct BlankLineAfterSummary {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -1,6 +1,5 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
-
 use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct FirstLineCapitalized;

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -1,5 +1,8 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::docstrings::styles::SectionStyle;
 use crate::fix::Fix;
@@ -7,9 +10,6 @@ use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct EndsInPeriod;

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -1,5 +1,8 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::docstrings::styles::SectionStyle;
 use crate::fix::Fix;
@@ -7,9 +10,6 @@ use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, logical_line};
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct EndsInPunctuation;

--- a/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
@@ -1,13 +1,13 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::cast;
 use crate::ast::helpers::identifier_range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use crate::define_violation;
 use crate::visibility::is_overload;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct SkipDocstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -1,15 +1,15 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::ast::whitespace;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::{AlwaysAutofixableViolation, Violation};
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct IndentWithSpaces;

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -1,6 +1,9 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::constants;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::fix::Fix;
@@ -8,9 +11,6 @@ use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::rules::pydocstyle::helpers::leading_quote;
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct MultiLineSummaryFirstLine;

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -1,15 +1,15 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::ast::whitespace;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct NewLineAfterLastParagraph;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::StmtKind;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct NoSignature;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,15 +1,15 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::leading_quote;
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct NoSurroundingWhitespace;

--- a/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct NonEmpty;

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -1,15 +1,15 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::cast;
 use crate::ast::helpers::identifier_range;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::{Definition, DefinitionKind};
 use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::violation::Violation;
-
-use crate::define_violation;
 use crate::visibility::{is_call, is_init, is_magic, is_new, is_overload, is_override, Visibility};
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct PublicModule;

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,14 +1,14 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers;
 use crate::violation::AlwaysAutofixableViolation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct FitsOnOneLine;

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::{AlwaysAutofixableViolation, Violation};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -11,6 +9,7 @@ use crate::ast::types::Range;
 use crate::ast::whitespace::LinesWithTrailingNewline;
 use crate::ast::{cast, whitespace};
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::docstrings::sections::{section_contexts, SectionContext};
 use crate::docstrings::styles::SectionStyle;
@@ -18,7 +17,7 @@ use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::{Diagnostic, Rule};
 use crate::rules::pydocstyle::settings::Convention;
-
+use crate::violation::{AlwaysAutofixableViolation, Violation};
 use crate::visibility::is_staticmethod;
 
 define_violation!(

--- a/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -1,12 +1,12 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::normalize_word;
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct NoThisPrefix;

--- a/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::docstrings::definition::Docstring;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UsesTripleQuotes;

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use libcst_native::{Call, Codegen, CodegenState, Dict, DictElement, Expression};
+use ruff_python::string::strip_quotes_and_prefixes;
 use rustpython_ast::{Excepthandler, Expr};
 use rustpython_parser::lexer;
 use rustpython_parser::lexer::Tok;
@@ -8,7 +9,6 @@ use crate::ast::types::Range;
 use crate::cst::matchers::{match_expr, match_module};
 use crate::fix::Fix;
 use crate::source_code::{Locator, Stylist};
-use ruff_python::string::strip_quotes_and_prefixes;
 
 /// Generate a [`Fix`] to remove unused keys from format dict.
 pub fn remove_unused_format_arguments_from_dict(

--- a/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
@@ -1,9 +1,9 @@
-use crate::define_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Stmt};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 

--- a/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -1,10 +1,10 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Stmt, StmtKind};
 
 define_violation!(
     pub struct BreakOutsideLoop;

--- a/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -1,10 +1,10 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Stmt, StmtKind};
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Stmt, StmtKind};
 
 define_violation!(
     pub struct ContinueOutsideLoop;

--- a/crates/ruff/src/rules/pyflakes/rules/default_except_not_last.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/default_except_not_last.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Excepthandler, ExcepthandlerKind};
+
 use crate::ast::helpers::except_range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Excepthandler, ExcepthandlerKind};
 
 define_violation!(
     pub struct DefaultExceptNotLast;

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -1,9 +1,9 @@
-use crate::define_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::helpers::find_useless_f_strings;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;

--- a/crates/ruff/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
@@ -1,6 +1,7 @@
+use ruff_macros::derive_message_formats;
+
 use crate::define_violation;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct ForwardAnnotationSyntaxError {

--- a/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
@@ -1,9 +1,9 @@
-use crate::define_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Stmt};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 

--- a/crates/ruff/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/imports.rs
@@ -1,12 +1,13 @@
+use itertools::Itertools;
+use ruff_macros::derive_message_formats;
+use ruff_python::future::ALL_FEATURE_NAMES;
+use rustpython_ast::Alias;
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::{Availability, Violation};
 use crate::{define_violation, AutofixKind};
-use itertools::Itertools;
-use ruff_macros::derive_message_formats;
-use ruff_python::future::ALL_FEATURE_NAMES;
-use rustpython_ast::Alias;
 
 define_violation!(
     pub struct UnusedImport {

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -1,10 +1,9 @@
 use itertools::izip;
 use log::error;
 use once_cell::unsync::Lazy;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Expr};
 use serde::{Deserialize, Serialize};
-
-use ruff_macros::derive_message_formats;
 
 use crate::ast::helpers;
 use crate::ast::operations::locate_cmpops;

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -1,9 +1,9 @@
-use crate::define_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -1,9 +1,9 @@
-use crate::define_violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;

--- a/crates/ruff/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -1,7 +1,7 @@
-use crate::define_violation;
-
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
+
+use crate::define_violation;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct RedefinedWhileUnused {

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -1,5 +1,6 @@
 use std::hash::{BuildHasherDefault, Hash};
 
+use ruff_macros::derive_message_formats;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_ast::{Expr, ExprKind};
 
@@ -9,10 +10,8 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
-use crate::{define_violation, AutofixKind};
-
 use crate::violation::{Availability, Violation};
-use ruff_macros::derive_message_formats;
+use crate::{define_violation, AutofixKind};
 
 define_violation!(
     pub struct MultiValueRepeatedKeyLiteral {

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -1,10 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Stmt;
+
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Stmt;
 
 define_violation!(
     pub struct ReturnOutsideFunction;

--- a/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
@@ -1,9 +1,10 @@
+use ruff_macros::derive_message_formats;
+use rustpython_parser::ast::{Expr, ExprKind};
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_parser::ast::{Expr, ExprKind};
 
 define_violation!(
     pub struct ExpressionsInStarAssignment;

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -1,8 +1,7 @@
-use crate::define_violation;
-use ruff_macros::derive_message_formats;
 use std::string::ToString;
 
 use log::error;
+use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashSet;
 use rustpython_ast::{Keyword, KeywordData};
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
@@ -14,6 +13,7 @@ use super::super::fixes::{
 use super::super::format::FormatSummary;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::{AlwaysAutofixableViolation, Violation};
 

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -1,7 +1,7 @@
-use crate::define_violation;
-
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
+
+use crate::define_violation;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct UndefinedExport {

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -1,12 +1,11 @@
-use crate::ast::types::{Binding, Scope, ScopeKind};
-use crate::registry::Diagnostic;
-
-use crate::define_violation;
+use std::string::ToString;
 
 use ruff_macros::derive_message_formats;
 
+use crate::ast::types::{Binding, Scope, ScopeKind};
+use crate::define_violation;
+use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use std::string::ToString;
 
 define_violation!(
     pub struct UndefinedLocal {

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_name.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_name.rs
@@ -1,6 +1,7 @@
+use ruff_macros::derive_message_formats;
+
 use crate::define_violation;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UndefinedName {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -1,10 +1,10 @@
+use ruff_macros::derive_message_formats;
+
 use crate::ast::types::BindingKind;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
-
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UnusedAnnotation {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -1,4 +1,3 @@
-use crate::define_violation;
 use itertools::Itertools;
 use log::error;
 use ruff_macros::derive_message_formats;
@@ -10,6 +9,7 @@ use crate::ast::helpers::contains_effect;
 use crate::ast::types::{BindingKind, Range, RefEquality, ScopeKind};
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -1,12 +1,14 @@
+use std::fmt;
+
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind};
+use serde::{Deserialize, Serialize};
+
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind};
-use serde::{Deserialize, Serialize};
-use std::fmt;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeferralKeyword {

--- a/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct BlanketNOQA;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct BlanketTypeIgnore;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct DeprecatedLogWarn;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -1,11 +1,11 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct NoEval;

--- a/crates/ruff/src/rules/pylint/mod.rs
+++ b/crates/ruff/src/rules/pylint/mod.rs
@@ -4,9 +4,10 @@ pub mod settings;
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use anyhow::Result;
     use regex::Regex;
-    use std::path::Path;
     use test_case::test_case;
 
     use crate::assert_yaml_snapshot;

--- a/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Expr;
+
 use crate::ast::types::{FunctionDef, Range, ScopeKind};
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Expr;
 
 define_violation!(
     pub struct AwaitOutsideAsync;

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 
+use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashSet;
 use rustpython_ast::{Constant, Expr, ExprKind};
 use serde::{Deserialize, Serialize};
-
-use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
@@ -88,7 +87,8 @@ impl fmt::Display for RemovalKind {
     }
 }
 
-/// Return `true` if a string contains duplicate characters, taking into account escapes.
+/// Return `true` if a string contains duplicate characters, taking into account
+/// escapes.
 fn has_duplicates(s: &str) -> bool {
     let mut escaped = false;
     let mut seen = FxHashSet::default();

--- a/crates/ruff/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::Expr;
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
@@ -1,14 +1,15 @@
+use std::fmt;
+
 use itertools::Itertools;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Cmpop, Expr, ExprKind, Located};
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViolationsCmpop {

--- a/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
+++ b/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::{BindingKind, Range};
@@ -6,7 +7,6 @@ use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::{Availability, Violation};
 use crate::{define_violation, AutofixKind};
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct ConsiderUsingSysExit {

--- a/crates/ruff/src/rules/pylint/rules/global_variable_not_assigned.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_variable_not_assigned.rs
@@ -1,6 +1,7 @@
+use ruff_macros::derive_message_formats;
+
 use crate::define_violation;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct GlobalVariableNotAssigned {

--- a/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind};
 
 use crate::ast::types::Range;
@@ -7,7 +8,6 @@ use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::rules::pylint::settings::ConstantType;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct MagicValueComparison {

--- a/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
+++ b/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use ruff_macros::derive_message_formats;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_ast::{Boolop, Expr, ExprKind};
 
@@ -9,7 +10,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct ConsiderMergingIsinstance {

--- a/crates/ruff/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -1,6 +1,7 @@
+use ruff_macros::derive_message_formats;
+
 use crate::define_violation;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct NonlocalWithoutBinding {

--- a/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Arguments, Expr, ExprKind, Stmt};
 
 use crate::ast::types::Range;
@@ -5,7 +6,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct PropertyWithParameters;

--- a/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Arguments, Stmt};
+
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Arguments, Stmt};
 
 define_violation!(
     pub struct TooManyArguments {

--- a/crates/ruff/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_branches.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
+
 use crate::ast::helpers::identifier_range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct TooManyBranches {

--- a/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
@@ -1,12 +1,12 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Stmt;
+
 use crate::ast::helpers::{identifier_range, ReturnStatementVisitor};
 use crate::ast::visitor::Visitor;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Stmt;
 
 define_violation!(
     pub struct TooManyReturnStatements {

--- a/crates/ruff/src/rules/pylint/rules/too_many_statements.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_statements.rs
@@ -1,11 +1,11 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
+
 use crate::ast::helpers::identifier_range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::source_code::Locator;
 use crate::violation::Violation;
-
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
 
 define_violation!(
     pub struct TooManyStatements {

--- a/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
@@ -5,7 +6,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UnnecessaryDirectLambdaCall;

--- a/crates/ruff/src/rules/pylint/rules/use_from_import.rs
+++ b/crates/ruff/src/rules/pylint/rules/use_from_import.rs
@@ -1,7 +1,6 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::Alias;
 use rustpython_parser::ast::Stmt;
-
-use ruff_macros::derive_message_formats;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::{Range, ScopeKind};
@@ -5,7 +6,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UsedPriorGlobalDeclaration {

--- a/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{ExcepthandlerKind, Stmt, StmtKind};
 
 use crate::ast::helpers;
@@ -5,7 +6,6 @@ use crate::checkers::ast::Checker;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UselessElseOnLoop;

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -1,3 +1,4 @@
+use ruff_macros::derive_message_formats;
 use rustpython_ast::Alias;
 
 use crate::ast::types::Range;
@@ -6,7 +7,6 @@ use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
 
 define_violation!(
     pub struct UselessImportAlias;

--- a/crates/ruff/src/rules/pylint/settings.rs
+++ b/crates/ruff/src/rules/pylint/settings.rs
@@ -1,11 +1,12 @@
 //! Settings for the `pylint` plugin.
 
+use std::hash::Hash;
+
 use anyhow::anyhow;
 use ruff_macros::ConfigurationOptions;
 use rustpython_ast::Constant;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::hash::Hash;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum ConstantType {
@@ -54,16 +55,20 @@ pub struct Options {
     /// Constant types to ignore when used as "magic values" (see: `PLR2004`).
     pub allow_magic_value_types: Option<Vec<ConstantType>>,
     #[option(default = r"12", value_type = "int", example = r"max-branches = 12")]
-    /// Maximum number of branches allowed for a function or method body (see: `PLR0912`).
+    /// Maximum number of branches allowed for a function or method body (see:
+    /// `PLR0912`).
     pub max_branches: Option<usize>,
     #[option(default = r"6", value_type = "int", example = r"max-returns = 6")]
-    /// Maximum number of return statements allowed for a function or method body (see `PLR0911`)
+    /// Maximum number of return statements allowed for a function or method
+    /// body (see `PLR0911`)
     pub max_returns: Option<usize>,
     #[option(default = r"5", value_type = "int", example = r"max-args = 5")]
-    /// Maximum number of arguments allowed for a function or method definition (see: `PLR0913`).
+    /// Maximum number of arguments allowed for a function or method definition
+    /// (see: `PLR0913`).
     pub max_args: Option<usize>,
     #[option(default = r"50", value_type = "int", example = r"max-statements = 50")]
-    /// Maximum number of statements allowed for a function or method body (see: `PLR0915`).
+    /// Maximum number of statements allowed for a function or method body (see:
+    /// `PLR0915`).
     pub max_statements: Option<usize>,
 }
 

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -107,7 +107,8 @@ pub fn remove_import_members(contents: &str, members: &[&str]) -> String {
     let mut commas: Vec<Range> = vec![];
     let mut removal_indices: Vec<usize> = vec![];
 
-    // Find all Tok::Name tokens that are not preceded by Tok::As, and all Tok::Comma tokens.
+    // Find all Tok::Name tokens that are not preceded by Tok::As, and all
+    // Tok::Comma tokens.
     let mut prev_tok = None;
     for (start, tok, end) in lexer::make_tokenizer(contents)
         .flatten()
@@ -147,8 +148,8 @@ pub fn remove_import_members(contents: &str, members: &[&str]) -> String {
         };
 
         // Add all contents from `last_pos` to `fix.location`.
-        // It's possible that `last_pos` is after `fix.location`, if we're removing the first _two_
-        // members.
+        // It's possible that `last_pos` is after `fix.location`, if we're removing the
+        // first _two_ members.
         if start_location > last_pos {
             let slice = locator.slice_source_code_range(&Range::new(last_pos, start_location));
             output.push_str(slice);

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -1,18 +1,18 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use anyhow::{bail, Result};
 use log::debug;
 use ruff_macros::derive_message_formats;
+use ruff_python::identifiers::is_identifier;
+use ruff_python::keyword::KWLIST;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
 use crate::ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::Stylist;
-use ruff_python::identifiers::is_identifier;
-use ruff_python::keyword::KWLIST;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ConvertNamedTupleFunctionalToClass {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -1,18 +1,18 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use anyhow::{bail, Result};
 use log::debug;
 use ruff_macros::derive_message_formats;
+use ruff_python::identifiers::is_identifier;
+use ruff_python::keyword::KWLIST;
 use rustpython_ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
 use crate::ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::Stylist;
-use ruff_python::identifiers::is_identifier;
-use ruff_python::keyword::KWLIST;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ConvertTypedDictFunctionalToClass {

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -1,5 +1,3 @@
-use crate::violation::{Availability, Violation};
-use crate::{define_violation, AutofixKind};
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
@@ -8,6 +6,8 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::{Availability, Violation};
+use crate::{define_violation, AutofixKind};
 
 define_violation!(
     pub struct DatetimeTimezoneUTC {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use once_cell::sync::Lazy;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
@@ -7,8 +5,10 @@ use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct DeprecatedUnittestAlias {

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_parser::lexer::{LexResult, Tok};
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ExtraneousParentheses;

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
 use rustpython_ast::{Constant, Expr, ExprKind, KeywordData};
@@ -11,11 +9,13 @@ use rustpython_parser::lexer::Tok;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct FString;

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -2,9 +2,8 @@ use anyhow::{anyhow, bail, Result};
 use libcst_native::{Arg, Codegen, CodegenState, Expression};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rustpython_ast::Expr;
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/functools_cache.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, ExprKind, KeywordData};
 use rustpython_parser::ast::Expr;
@@ -7,8 +5,10 @@ use rustpython_parser::ast::Expr;
 use crate::ast::helpers::{create_expr, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct FunctoolsCache;

--- a/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
@@ -342,9 +342,9 @@ impl<'a> ImportReplacer<'a> {
         } else {
             let indentation = indentation(self.locator, self.stmt);
 
-            // If we have matched _and_ unmatched names, but the import is not on its own line, we
-            // can't add a statement after it. For example, if we have `if True: import foo`, we can't
-            // add a statement to the next line.
+            // If we have matched _and_ unmatched names, but the import is not on its own
+            // line, we can't add a statement after it. For example, if we have
+            // `if True: import foo`, we can't add a statement to the next line.
             let Some(indentation) = indentation else {
                 return Some(Replacement {
                     module: target,
@@ -389,7 +389,8 @@ impl<'a> ImportReplacer<'a> {
         (matched_names, unmatched_names)
     }
 
-    /// Converts a list of names and a module into an `import from`-style import.
+    /// Converts a list of names and a module into an `import from`-style
+    /// import.
     fn format_import_from(names: &[&AliasData], module: &str) -> String {
         // Construct the whitespace strings.
         // Generate the formatted names.

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::ExprKind;
 use rustpython_parser::ast::Expr;
@@ -7,8 +5,10 @@ use rustpython_parser::ast::Expr;
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct LRUCacheWithoutParameters;

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -1,16 +1,17 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
+use std::fmt;
+
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::lexer;
 use rustpython_parser::lexer::Tok;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LiteralType {

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct OpenAlias;

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Excepthandler, ExcepthandlerKind, Expr, ExprKind, Located};
@@ -7,8 +5,10 @@ use rustpython_ast::{Excepthandler, ExcepthandlerKind, Expr, ExprKind, Located};
 use crate::ast::helpers::compose_call_path;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct OSErrorAlias {

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -1,9 +1,8 @@
-use ruff_macros::derive_message_formats;
-
 use std::cmp::Ordering;
 
 use log::error;
 use num_bigint::{BigInt, Sign};
+use ruff_macros::derive_message_formats;
 use rustpython_ast::Location;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Located, Stmt};
 use rustpython_parser::lexer;
@@ -58,8 +57,8 @@ impl BlockMetadata {
 fn metadata<T>(locator: &Locator, located: &Located<T>) -> Option<BlockMetadata> {
     indentation(locator, located)?;
 
-    // Start the selection at the start-of-line. This ensures consistent indentation in the
-    // token stream, in the event that the entire block is indented.
+    // Start the selection at the start-of-line. This ensures consistent indentation
+    // in the token stream, in the event that the entire block is indented.
     let text = locator.slice_source_code_range(&Range::new(
         Location::new(located.location.row(), 0),
         located.end_location.unwrap(),
@@ -163,9 +162,9 @@ fn fix_py2_block(
     block: &BlockMetadata,
 ) -> Option<Fix> {
     if orelse.is_empty() {
-        // Delete the entire statement. If this is an `elif`, know it's the only child of its
-        // parent, so avoid passing in the parent at all. Otherwise, `delete_stmt` will erroneously
-        // include a `pass`.
+        // Delete the entire statement. If this is an `elif`, know it's the only child
+        // of its parent, so avoid passing in the parent at all. Otherwise,
+        // `delete_stmt` will erroneously include a `pass`.
         let deleted: Vec<&Stmt> = checker
             .deletions
             .iter()
@@ -263,7 +262,8 @@ fn fix_py3_block(
 ) -> Option<Fix> {
     match block.starter {
         Tok::If => {
-            // If the first statement is an if, use the body of this statement, and ignore the rest.
+            // If the first statement is an if, use the body of this statement, and ignore
+            // the rest.
             let start = body.first().unwrap();
             let end = body.last().unwrap();
 
@@ -304,7 +304,8 @@ fn fix_py3_block(
             }
         }
         Tok::Elif => {
-            // Replace the `elif` with an `else, preserve the body of the elif, and remove the rest.
+            // Replace the `elif` with an `else, preserve the body of the elif, and remove
+            // the rest.
             let end = body.last().unwrap();
             let text = checker.locator.slice_source_code_range(&Range::new(
                 test.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -1,9 +1,8 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-
 use std::str::FromStr;
 
+use ruff_macros::derive_message_formats;
+use ruff_python::identifiers::is_identifier;
+use ruff_python::keyword::KWLIST;
 use rustpython_ast::Location;
 use rustpython_common::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,
@@ -15,12 +14,12 @@ use rustpython_parser::lexer::Tok;
 use crate::ast::types::Range;
 use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::{leading_quote, trailing_quote};
 use crate::rules::pyupgrade::helpers::curly_escape;
-use ruff_python::identifiers::is_identifier;
-use ruff_python::keyword::KWLIST;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct PrintfStringFormatting;

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -1,11 +1,8 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
-use ruff_macros::derive_message_formats;
-
 use std::str::FromStr;
 
 use anyhow::{anyhow, Result};
 use log::error;
+use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Keyword, Location};
 use rustpython_parser::lexer;
 use rustpython_parser::token::Tok;
@@ -13,9 +10,11 @@ use rustpython_parser::token::Tok;
 use crate::ast::helpers::find_keyword;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct RedundantOpenModes {

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword};
 
@@ -7,9 +5,11 @@ use crate::ast::helpers::find_keyword;
 use crate::ast::types::Range;
 use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::source_code::{Locator, Stylist};
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ReplaceStdoutStderr;

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Keyword, Location};
 
 use crate::ast::helpers::find_keyword;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct ReplaceUniversalNewlines;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Located, Stmt, StmtKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct RewriteCElementTree;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use anyhow::Result;
 use libcst_native::{
     AsName, AssignTargetExpression, Attribute, Codegen, CodegenState, Dot, Expression, Import,
@@ -15,9 +13,11 @@ use crate::ast::types::Range;
 use crate::ast::whitespace::indentation;
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_import, match_import_from, match_module};
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::{Locator, Stylist};
+use crate::violation::AlwaysAutofixableViolation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MockReference {

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, Location};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct RewriteUnicodeLiteral;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
 use rustpython_ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind};
@@ -8,8 +6,10 @@ use crate::ast::types::{Range, RefEquality};
 use crate::ast::visitor;
 use crate::ast::visitor::Visitor;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct RewriteYieldFrom;

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -1,6 +1,5 @@
-use rustpython_ast::{ArgData, Expr, ExprKind, Stmt, StmtKind};
-
 use ruff_macros::derive_message_formats;
+use rustpython_ast::{ArgData, Expr, ExprKind, Stmt, StmtKind};
 
 use crate::ast::types::{Range, ScopeKind};
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use super::super::types::Primitive;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct TypeOfPrimitive {

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct TypingTextStrAlias;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use itertools::Itertools;
 use log::error;
 use ruff_macros::derive_message_formats;
@@ -7,9 +5,10 @@ use rustpython_ast::{Alias, AliasData, Located};
 use rustpython_parser::ast::Stmt;
 
 use crate::ast::types::Range;
-use crate::autofix;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
+use crate::{autofix, define_violation};
 
 define_violation!(
     pub struct UnnecessaryBuiltinImport {

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -1,13 +1,13 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use ruff_macros::derive_message_formats;
+use rustpython_ast::Location;
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
 use crate::violation::AlwaysAutofixableViolation;
-
-use once_cell::sync::Lazy;
-use regex::Regex;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::Location;
 
 define_violation!(
     pub struct PEP3120UnnecessaryCodingComment;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Keyword};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::{Diagnostic, Rule};
 use crate::source_code::Locator;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UnnecessaryEncodeUTF8;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use itertools::Itertools;
 use log::error;
 use ruff_macros::derive_message_formats;
@@ -7,9 +5,10 @@ use rustpython_ast::{Alias, AliasData, Located};
 use rustpython_parser::ast::Stmt;
 
 use crate::ast::types::Range;
-use crate::autofix;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
+use crate::{autofix, define_violation};
 
 define_violation!(
     pub struct UnnecessaryFutureImport {

--- a/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind};
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct RewriteListComprehension;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::Expr;
 
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UsePEP585Annotation {

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Constant, Expr, ExprKind, Location, Operator};
 
 use crate::ast::helpers::unparse_expr;
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UsePEP604Annotation;

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -1,5 +1,3 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use log::error;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Stmt};
@@ -7,7 +5,9 @@ use rustpython_ast::{Expr, ExprKind, Stmt};
 use crate::ast::types::Range;
 use crate::autofix::helpers;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UselessMetaclassType;

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -1,12 +1,12 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprKind, Keyword, Stmt};
 
 use super::super::fixes;
 use crate::ast::types::{Binding, BindingKind, Range, Scope};
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::registry::Diagnostic;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct UselessObjectInheritance {

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1,16 +1,16 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use once_cell::sync::Lazy;
 use ruff_macros::derive_message_formats;
 use rustc_hash::FxHashMap;
 
 use crate::ast::types::Range;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::message::Location;
 use crate::registry::{Diagnostic, DiagnosticKind};
 use crate::rules::ruff::rules::Context;
 use crate::settings::{flags, Settings};
 use crate::source_code::Locator;
+use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
     pub struct AmbiguousUnicodeCharacterString {

--- a/crates/ruff/src/rules/ruff/rules/keyword_argument_before_star_argument.rs
+++ b/crates/ruff/src/rules/ruff/rules/keyword_argument_before_star_argument.rs
@@ -1,9 +1,10 @@
+use ruff_macros::derive_message_formats;
+use rustpython_ast::{Expr, ExprKind, Keyword, KeywordData};
+
 use crate::ast::types::Range;
 use crate::define_violation;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
-use ruff_macros::derive_message_formats;
-use rustpython_ast::{Expr, ExprKind, Keyword, KeywordData};
 
 define_violation!(
     pub struct KeywordArgumentBeforeStarArgument {

--- a/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
+++ b/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
@@ -1,13 +1,13 @@
-use crate::define_violation;
-use crate::violation::Violation;
 use ruff_macros::derive_message_formats;
 use rustpython_ast::{Expr, ExprContext, ExprKind, Operator};
 
 use crate::ast::helpers::{create_expr, has_comments, unparse_expr};
 use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
+use crate::define_violation;
 use crate::fix::Fix;
 use crate::registry::Diagnostic;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct UnpackInsteadOfConcatenatingToCollectionLiteral {

--- a/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
@@ -1,8 +1,9 @@
-use crate::define_violation;
-use crate::violation::AlwaysAutofixableViolation;
 use itertools::Itertools;
 use ruff_macros::derive_message_formats;
 use serde::{Deserialize, Serialize};
+
+use crate::define_violation;
+use crate::violation::AlwaysAutofixableViolation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnusedCodes {

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -9,6 +9,8 @@ use globset::Glob;
 use rustc_hash::{FxHashMap, FxHashSet};
 use strum::IntoEnumIterator;
 
+use self::hashable::{HashableGlobMatcher, HashableGlobSet, HashableHashSet, HashableRegex};
+use self::rule_table::RuleTable;
 use crate::cache::cache_dir;
 use crate::registry::{Rule, INCOMPATIBLE_CODES};
 use crate::rule_selector::{RuleSelector, Specificity};
@@ -21,9 +23,6 @@ use crate::rules::{
 use crate::settings::configuration::Configuration;
 use crate::settings::types::{PerFileIgnore, PythonVersion, SerializationFormat};
 use crate::warn_user_once;
-
-use self::hashable::{HashableGlobMatcher, HashableGlobSet, HashableHashSet, HashableRegex};
-use self::rule_table::RuleTable;
 
 pub mod configuration;
 pub mod defaults;
@@ -380,8 +379,8 @@ impl From<&Configuration> for RuleTable {
             }
         }
 
-        // Validate that we didn't enable any incompatible rules. Use this awkward approach to
-        // give each pair it's own `warn_user_once`.
+        // Validate that we didn't enable any incompatible rules. Use this awkward
+        // approach to give each pair it's own `warn_user_once`.
         let [pair1, pair2] = INCOMPATIBLE_CODES;
         let (preferred, expendable, message) = pair1;
         if rules.enabled(preferred) && rules.enabled(expendable) {
@@ -427,11 +426,10 @@ pub fn resolve_per_file_ignores(
 mod tests {
     use rustc_hash::FxHashSet;
 
+    use super::configuration::RuleSelection;
     use crate::registry::{Rule, RuleCodePrefix};
     use crate::settings::configuration::Configuration;
     use crate::settings::rule_table::RuleTable;
-
-    use super::configuration::RuleSelection;
 
     #[allow(clippy::needless_pass_by_value)]
     fn resolve_rules(selections: impl IntoIterator<Item = RuleSelection>) -> FxHashSet<Rule> {

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -189,8 +189,8 @@ pub struct Options {
             fixable = ["E", "F"]
         "#
     )]
-    /// A list of rule codes or prefixes to consider autofixable. By default, all rules are
-    /// considered autofixable.
+    /// A list of rule codes or prefixes to consider autofixable. By default,
+    /// all rules are considered autofixable.
     pub fixable: Option<Vec<RuleSelector>>,
     #[option(
         default = r#""text""#,

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -10,11 +10,10 @@ use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
+use super::hashable::HashableHashSet;
 use crate::registry::Rule;
 use crate::rule_selector::RuleSelector;
 use crate::{fs, warn_user_once};
-
-use super::hashable::HashableHashSet;
 
 #[derive(
     Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Serialize, Deserialize, Hash, JsonSchema,

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -4,17 +4,13 @@ use std::path::Path;
 use anyhow::Result;
 use rustpython_parser::lexer::LexResult;
 
-use crate::linter::LinterResult;
-use crate::{
-    autofix::fix_file,
-    directives, fs,
-    linter::check_path,
-    packaging::detect_package_root,
-    registry::Diagnostic,
-    rustpython_helpers,
-    settings::{flags, Settings},
-    source_code::{Indexer, Locator, Stylist},
-};
+use crate::autofix::fix_file;
+use crate::linter::{check_path, LinterResult};
+use crate::packaging::detect_package_root;
+use crate::registry::Diagnostic;
+use crate::settings::{flags, Settings};
+use crate::source_code::{Indexer, Locator, Stylist};
+use crate::{directives, fs, rustpython_helpers};
 
 pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
     Path::new("./resources/test/").join(path)

--- a/crates/ruff_cli/src/commands.rs
+++ b/crates/ruff_cli/src/commands.rs
@@ -1,6 +1,5 @@
 use std::fs::remove_dir_all;
-use std::io::Write;
-use std::io::{self, BufWriter, Read};
+use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -12,9 +11,6 @@ use log::{debug, error};
 use path_absolutize::path_dedot;
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
-use serde::Serialize;
-use walkdir::WalkDir;
-
 use ruff::cache::CACHE_DIR_NAME;
 use ruff::linter::add_noqa_to_path;
 use ruff::logging::LogLevel;
@@ -23,6 +19,8 @@ use ruff::registry::{Linter, Rule, RuleNamespace};
 use ruff::resolver::PyprojectDiscovery;
 use ruff::settings::flags;
 use ruff::{fix, fs, packaging, resolver, warn_user_once, AutofixAvailability, IOError};
+use serde::Serialize;
+use walkdir::WalkDir;
 
 use crate::args::{HelpFormat, Overrides};
 use crate::cache;

--- a/crates/ruff_cli/src/commands/linter.rs
+++ b/crates/ruff_cli/src/commands/linter.rs
@@ -1,8 +1,7 @@
 use itertools::Itertools;
+use ruff::registry::{Linter, RuleNamespace, UpstreamCategory};
 use serde::Serialize;
 use strum::IntoEnumIterator;
-
-use ruff::registry::{Linter, RuleNamespace, UpstreamCategory};
 
 use crate::args::HelpFormat;
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -16,8 +16,8 @@ pub fn command_help() -> String {
 pub fn subcommand_help() -> String {
     let mut cmd = args::Args::command();
 
-    // The build call is necessary for the help output to contain `Usage: ruff check` instead of `Usage: check`
-    // see https://github.com/clap-rs/clap/issues/4685
+    // The build call is necessary for the help output to contain `Usage: ruff
+    // check` instead of `Usage: check` see https://github.com/clap-rs/clap/issues/4685
     cmd.build();
 
     cmd.find_subcommand_mut("check")

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -3,17 +3,16 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::mpsc::channel;
 
-use anyhow::Result;
-use clap::{CommandFactory, Parser, Subcommand};
-use colored::Colorize;
-use notify::{recommended_watcher, RecursiveMode, Watcher};
-
 use ::ruff::logging::{set_up_logging, LogLevel};
 use ::ruff::resolver::PyprojectDiscovery;
 use ::ruff::settings::types::SerializationFormat;
 use ::ruff::settings::CliSettings;
 use ::ruff::{fix, fs, warn_user_once};
+use anyhow::Result;
 use args::{Args, CheckArgs, Command};
+use clap::{CommandFactory, Parser, Subcommand};
+use colored::Colorize;
+use notify::{recommended_watcher, RecursiveMode, Watcher};
 use printer::{Printer, Violations};
 
 pub(crate) mod args;
@@ -257,7 +256,8 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitCode> {
 
         if update_check {
             warn_user_once!(
-                "update-check has been removed; setting it will cause an error in a future version."
+                "update-check has been removed; setting it will cause an error in a future \
+                 version."
             );
         }
 

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -376,8 +376,8 @@ impl<'a> Printer<'a> {
         let mut stdout = BufWriter::new(io::stdout().lock());
         match self.format {
             SerializationFormat::Text => {
-                // Compute the maximum number of digits in the count and code, for all messages, to enable
-                // pretty-printing.
+                // Compute the maximum number of digits in the count and code, for all messages,
+                // to enable pretty-printing.
                 let count_width = num_digits(
                     statistics
                         .iter()

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -1,9 +1,11 @@
 //! Generate CLI help.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use crate::utils::replace_readme_section;
-use anyhow::Result;
 use std::str;
+
+use anyhow::Result;
+
+use crate::utils::replace_readme_section;
 
 const COMMAND_HELP_BEGIN_PRAGMA: &str = "<!-- Begin auto-generated command help. -->\n";
 const COMMAND_HELP_END_PRAGMA: &str = "<!-- End auto-generated command help. -->";

--- a/crates/ruff_macros/src/rule_code_prefix.rs
+++ b/crates/ruff_macros/src/rule_code_prefix.rs
@@ -144,7 +144,8 @@ fn generate_impls<'a>(
     }
 }
 
-/// If all values in an iterator are the same, return that value. Otherwise, return `None`.
+/// If all values in an iterator are the same, return that value. Otherwise,
+/// return `None`.
 fn if_all_same<T: PartialEq>(iter: impl Iterator<Item = T>) -> Option<T> {
     let mut iter = iter.peekable();
     let first = iter.next()?;


### PR DESCRIPTION
This PR runs `rustfmt` with our previous nightly options as a one-time change to make some upcoming refactors cleaner.