### PR TITLE
Ignore all non-`.py` wrt. implicit namespace package

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_no_pep420/test_pass_script/script
+++ b/crates/ruff/resources/test/fixtures/flake8_no_pep420/test_pass_script/script
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("Hello, INP001!")

--- a/crates/ruff/src/rules/flake8_no_pep420/mod.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/mod.rs
@@ -20,6 +20,7 @@ mod tests {
     #[test_case(Path::new("test_ignored"), Path::new("example.py"); "INP001_4")]
     #[test_case(Path::new("test_pass_namespace_package"), Path::new("example.py"); "INP001_5")]
     #[test_case(Path::new("test_pass_pyi"), Path::new("example.pyi"); "INP001_6")]
+    #[test_case(Path::new("test_pass_script"), Path::new("script"); "INP001_7")]
     fn test_flake8_no_pep420(path: &Path, filename: &Path) -> Result<()> {
         let snapshot = format!("{}", path.to_string_lossy());
         let p = PathBuf::from(format!(

--- a/crates/ruff/src/rules/flake8_no_pep420/rules.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/rules.rs
@@ -26,8 +26,8 @@ pub fn implicit_namespace_package(
     src: &[PathBuf],
 ) -> Option<Diagnostic> {
     if package.is_none()
-        // Ignore `.pyi` files, which don't require an `__init__.py`.
-        && path.extension().map_or(true, |ext| ext != "pyi")
+        // Ignore non-`.py` files, which don't require an `__init__.py`.
+        && path.extension().map_or(false, |ext| ext == "py")
         // Ignore any files that are direct children of the project root.
         && !path
             .parent()

--- a/crates/ruff/src/rules/flake8_no_pep420/snapshots/ruff__rules__flake8_no_pep420__tests__test_pass_script.snap
+++ b/crates/ruff/src/rules/flake8_no_pep420/snapshots/ruff__rules__flake8_no_pep420__tests__test_pass_script.snap
@@ -1,0 +1,6 @@
+---
+source: crates/ruff/src/rules/flake8_no_pep420/mod.rs
+expression: diagnostics
+---
+[]
+


### PR DESCRIPTION
It's not only `.pyi` that should be exempt for this, but also for example scripts which don't have an extension, explicitly passed in command line args.