### PR TITLE
Add missing `tool.ruff` in configuration documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ ignore = ["E501"]
 unfixable = ["B"]
 
 # Ignore `E402` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
-[per-file-ignores]
+[tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
 "path/to/file.py" = ["E402"]
 ```


### PR DESCRIPTION
The documentation includes a configuration example that shows one can configure ruff's per-file ignore patterns by adding the following section to `pyproject.toml`:

```
# Ignore `E402` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
[per-file-ignores]
"__init__.py" = ["E402"]
"path/to/file.py" = ["E402"]
```

It should be `[tool.ruff.per-file-ignores]`

This one caused me a few hours of issues, so I decided to contribute a fix.