### PR TITLE
Disable autofix for flake8-print rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,8 +1121,8 @@ For more, see [flake8-print](https://pypi.org/project/flake8-print/) on PyPI.
 
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
-| T201 | print-found | `print` found | 🛠 |
-| T203 | p-print-found | `pprint` found | 🛠 |
+| T201 | print-found | `print` found |  |
+| T203 | p-print-found | `pprint` found |  |
 
 ### flake8-pytest-style (PT)
 

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -1,45 +1,36 @@
-use log::error;
+use rustpython_parser::ast::{Expr, Keyword};
+
 use ruff_macros::{define_violation, derive_message_formats};
-use rustpython_parser::ast::{Expr, Keyword, Stmt, StmtKind};
 
 use crate::ast::helpers::is_const_none;
 use crate::ast::types::Range;
-use crate::autofix::helpers;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
-use crate::violation::AlwaysAutofixableViolation;
+use crate::violation::Violation;
 
 define_violation!(
     pub struct PrintFound;
 );
-impl AlwaysAutofixableViolation for PrintFound {
+impl Violation for PrintFound {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("`print` found")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `print`".to_string()
     }
 }
 
 define_violation!(
     pub struct PPrintFound;
 );
-impl AlwaysAutofixableViolation for PPrintFound {
+impl Violation for PPrintFound {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("`pprint` found")
-    }
-
-    fn autofix_title(&self) -> String {
-        "Remove `pprint`".to_string()
     }
 }
 
 /// T201, T203
 pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
-    let mut diagnostic = {
+    let diagnostic = {
         let call_path = checker.resolve_call_path(func);
         if call_path
             .as_ref()
@@ -75,34 +66,6 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
 
     if !checker.settings.rules.enabled(diagnostic.kind.rule()) {
         return;
-    }
-
-    if checker.patch(diagnostic.kind.rule()) {
-        let defined_by = checker.current_stmt();
-        let defined_in = checker.current_stmt_parent();
-        if matches!(defined_by.node, StmtKind::Expr { .. }) {
-            let deleted: Vec<&Stmt> = checker
-                .deletions
-                .iter()
-                .map(std::convert::Into::into)
-                .collect();
-            match helpers::delete_stmt(
-                defined_by.into(),
-                defined_in.map(std::convert::Into::into),
-                &deleted,
-                checker.locator,
-                checker.indexer,
-                checker.stylist,
-            ) {
-                Ok(fix) => {
-                    if fix.content.is_empty() || fix.content == "pass" {
-                        checker.deletions.insert(defined_by.clone());
-                    }
-                    diagnostic.amend(fix);
-                }
-                Err(e) => error!("Failed to remove print call: {e}"),
-            }
-        }
     }
 
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_print/snapshots/ruff__rules__flake8_print__tests__T201_T201.py.snap
+++ b/crates/ruff/src/rules/flake8_print/snapshots/ruff__rules__flake8_print__tests__T201_T201.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/flake8_print/mod.rs
+source: crates/ruff/src/rules/flake8_print/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -10,15 +10,7 @@ expression: diagnostics
   end_location:
     row: 4
     column: 5
-  fix:
-    content:
-      - ""
-    location:
-      row: 4
-      column: 0
-    end_location:
-      row: 5
-      column: 0
+  fix: ~
   parent: ~
 - kind:
     PrintFound: ~
@@ -28,15 +20,7 @@ expression: diagnostics
   end_location:
     row: 5
     column: 5
-  fix:
-    content:
-      - ""
-    location:
-      row: 5
-      column: 0
-    end_location:
-      row: 6
-      column: 0
+  fix: ~
   parent: ~
 - kind:
     PrintFound: ~
@@ -46,15 +30,7 @@ expression: diagnostics
   end_location:
     row: 6
     column: 5
-  fix:
-    content:
-      - ""
-    location:
-      row: 6
-      column: 0
-    end_location:
-      row: 7
-      column: 0
+  fix: ~
   parent: ~
 - kind:
     PrintFound: ~
@@ -64,14 +40,6 @@ expression: diagnostics
   end_location:
     row: 7
     column: 5
-  fix:
-    content:
-      - ""
-    location:
-      row: 7
-      column: 0
-    end_location:
-      row: 8
-      column: 0
+  fix: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_print/snapshots/ruff__rules__flake8_print__tests__T203_T203.py.snap
+++ b/crates/ruff/src/rules/flake8_print/snapshots/ruff__rules__flake8_print__tests__T203_T203.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/flake8_print/mod.rs
+source: crates/ruff/src/rules/flake8_print/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -10,15 +10,7 @@ expression: diagnostics
   end_location:
     row: 3
     column: 6
-  fix:
-    content:
-      - ""
-    location:
-      row: 3
-      column: 0
-    end_location:
-      row: 4
-      column: 0
+  fix: ~
   parent: ~
 - kind:
     PPrintFound: ~
@@ -28,14 +20,6 @@ expression: diagnostics
   end_location:
     row: 7
     column: 13
-  fix:
-    content:
-      - ""
-    location:
-      row: 7
-      column: 0
-    end_location:
-      row: 8
-      column: 0
+  fix: ~
   parent: ~
 


### PR DESCRIPTION
These are more confusing than they are helpful.

Closes #2648.