### PR TITLE
doc: add documentation for TRY002

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,7 +1368,7 @@ For more, see [tryceratops](https://pypi.org/project/tryceratops/1.1.0/) on PyPI
 
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
-| TRY002 | raise-vanilla-class | Create your own exception |  |
+| [TRY002](https://github.com/charliermarsh/ruff/blob/main/docs/rules/raise-vanilla-class.md) | [raise-vanilla-class](https://github.com/charliermarsh/ruff/blob/main/docs/rules/raise-vanilla-class.md) | Create your own exception |  |
 | TRY003 | raise-vanilla-args | Avoid specifying long messages outside the exception class |  |
 | TRY004 | prefer-type-error | Prefer `TypeError` exception for invalid type | 🛠 |
 | TRY200 | reraise-no-cause | Use `raise from` to specify exception cause |  |

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -8,13 +8,19 @@ use crate::violation::Violation;
 
 define_violation!(
     /// ### What it does
-    /// Checks for bare exceptions.
+    /// Checks for code that raises `Exception` directly.
     ///
-    /// ## Why is this bad?
-    /// It's hard to capture generic exceptions making it hard for handling specific scenarios.
+    /// ### Why is this bad?
+    /// Handling such exceptions requires the use of `except Exception`, which
+    /// captures _any_ raised exception, including failed assertions,
+    /// division by zero, and more.
     ///
-    ///## Example
-    ///```py
+    /// Prefer to raise your own exception, or a more specific built-in
+    /// exception, so that you can avoid over-capturing exceptions that you
+    /// don't intend to handle.
+    ///
+    /// ### Example
+    /// ```py
     /// def main_function():
     ///     if not cond:
     ///         raise Exception()
@@ -24,10 +30,11 @@ define_violation!(
     ///         prepare()
     ///         main_function()
     ///     except Exception:
-    ///         logger.error("I have no idea what went wrong!!")
-    ///```
-    ///## How it should be
-    ///```py
+    ///         logger.error("Oops")
+    /// ```
+    ///
+    /// Use instead:
+    /// ```py
     /// def main_function():
     ///     if not cond:
     ///         raise CustomException()
@@ -39,7 +46,7 @@ define_violation!(
     ///     except CustomException:
     ///         logger.error("Main function failed")
     ///     except Exception:
-    ///         logger.error("I have no idea what went wrong!!")
+    ///         logger.error("Oops")
     pub struct RaiseVanillaClass;
 );
 impl Violation for RaiseVanillaClass {

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -7,6 +7,39 @@ use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
 define_violation!(
+    /// ### What it does
+    /// Checks for bare exceptions.
+    ///
+    /// ## Why is this bad?
+    /// It's hard to capture generic exceptions making it hard for handling specific scenarios.
+    ///
+    ///## Example
+    ///```py
+    /// def main_function():
+    ///     if not cond:
+    ///         raise Exception()
+    /// def consumer_func():
+    ///     try:
+    ///         do_step()
+    ///         prepare()
+    ///         main_function()
+    ///     except Exception:
+    ///         logger.error("I have no idea what went wrong!!")
+    ///```
+    ///## How it should be
+    ///```py
+    /// def main_function():
+    ///     if not cond:
+    ///         raise CustomException()
+    /// def consumer_func():
+    ///     try:
+    ///         do_step()
+    ///         prepare()
+    ///         main_function()
+    ///     except CustomException:
+    ///         logger.error("Main function failed")
+    ///     except Exception:
+    ///         logger.error("I have no idea what went wrong!!")
     pub struct RaiseVanillaClass;
 );
 impl Violation for RaiseVanillaClass {

--- a/docs/rules/raise-vanilla-class.md
+++ b/docs/rules/raise-vanilla-class.md
@@ -1,0 +1,44 @@
+# raise-vanilla-class (TRY002)
+
+Derived from the **tryceratops** linter.
+
+### What it does
+Checks for code that raises `Exception` directly.
+
+### Why is this bad?
+Handling such exceptions requires the use of `except Exception`, which
+captures _any_ raised exception, including failed assertions,
+division by zero, and more.
+
+Prefer to raise your own exception, or a more specific built-in
+exception, so that you can avoid over-capturing exceptions that you
+don't intend to handle.
+
+### Example
+```py
+def main_function():
+    if not cond:
+        raise Exception()
+def consumer_func():
+    try:
+        do_step()
+        prepare()
+        main_function()
+    except Exception:
+        logger.error("Oops")
+```
+
+Use instead:
+```py
+def main_function():
+    if not cond:
+        raise CustomException()
+def consumer_func():
+    try:
+        do_step()
+        prepare()
+        main_function()
+    except CustomException:
+        logger.error("Main function failed")
+    except Exception:
+        logger.error("Oops")

--- a/docs/rules/raise_vanilla_class.md
+++ b/docs/rules/raise_vanilla_class.md
@@ -1,0 +1,38 @@
+# raise-vanilla-class (TRY002)
+Derived from the **tryceratops** linter.
+
+### What it does
+Checks for bare exceptions.
+
+## Why is this bad?
+It's hard to capture generic exceptions making it hard for handling specific scenarios.
+
+## Example
+```py
+def main_function():
+    if not cond:
+        raise Exception()
+def consumer_func():
+    try:
+        do_step()
+         prepare()
+        main_function()
+    except Exception:
+        logger.error("I have no idea what went wrong!!")
+```
+
+## How it should be
+```py
+def main_function():
+    if not cond:
+        raise CustomException()
+def consumer_func():
+    try:
+        do_step()
+        prepare()
+        main_function()
+    except CustomException:
+        logger.error("Main function failed")
+    except Exception:
+        logger.error("I have no idea what went wrong!!")
+```


### PR DESCRIPTION
Add documentation for `Tryceratops TC002` or as it's know in Ruff `TRY002`

This is a copy from the upstream Tryceratops repository.
I think there should also be a section for linking the original repository and documentation.

Follows up on issue:
https://github.com/charliermarsh/ruff/issues/1467