### PR TITLE
Add `--exit-non-zero-on-fix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,8 @@ Miscellaneous:
           The name of the file when passing it through stdin
   -e, --exit-zero
           Exit with status code "0", even upon detecting lint violations
+      --exit-non-zero-on-fix
+          Exit with a non-zero status code if any files were modified via autofix, even if no lint violations remain
 
 Log levels:
   -v, --verbose  Enable verbose logging

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -209,8 +209,17 @@ pub struct CheckArgs {
     #[arg(long, help_heading = "Miscellaneous")]
     pub stdin_filename: Option<PathBuf>,
     /// Exit with status code "0", even upon detecting lint violations.
-    #[arg(short, long, help_heading = "Miscellaneous")]
+    #[arg(
+        short,
+        long,
+        help_heading = "Miscellaneous",
+        conflicts_with = "exit_non_zero_on_fix"
+    )]
     pub exit_zero: bool,
+    /// Exit with a non-zero status code if any files were modified via
+    /// autofix, even if no lint violations remain.
+    #[arg(long, help_heading = "Miscellaneous", conflicts_with = "exit_zero")]
+    pub exit_non_zero_on_fix: bool,
     /// Does nothing and will be removed in the future.
     #[arg(
         long,
@@ -334,6 +343,7 @@ impl CheckArgs {
                 config: self.config,
                 diff: self.diff,
                 exit_zero: self.exit_zero,
+                exit_non_zero_on_fix: self.exit_non_zero_on_fix,
                 files: self.files,
                 isolated: self.isolated,
                 no_cache: self.no_cache,
@@ -390,6 +400,7 @@ pub struct Arguments {
     pub config: Option<PathBuf>,
     pub diff: bool,
     pub exit_zero: bool,
+    pub exit_non_zero_on_fix: bool,
     pub files: Vec<PathBuf>,
     pub isolated: bool,
     pub no_cache: bool,

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -78,7 +78,6 @@ quoting the executed command, along with the relevant file contents and `pyproje
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut io::stdout());
         }
-
         Command::Check(args) => return check(args, log_level),
     }
 
@@ -266,8 +265,14 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitCode> {
                 if diagnostics.fixed > 0 {
                     return Ok(ExitCode::FAILURE);
                 }
-            } else if !diagnostics.messages.is_empty() {
-                return Ok(ExitCode::FAILURE);
+            } else if cli.exit_non_zero_on_fix {
+                if diagnostics.fixed > 0 || !diagnostics.messages.is_empty() {
+                    return Ok(ExitCode::FAILURE);
+                }
+            } else {
+                if !diagnostics.messages.is_empty() {
+                    return Ok(ExitCode::FAILURE);
+                }
             }
         }
     }


### PR DESCRIPTION
When enabled, we exit zero if any errors are fixed, even if the fixes result in there being no remaining lint violations.

Closes #2633.