### PR TITLE
Move error and warning messages into log macro

### DIFF
--- a/crates/flake8_to_ruff/src/main.rs
+++ b/crates/flake8_to_ruff/src/main.rs
@@ -5,7 +5,9 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use configparser::ini::Ini;
+
 use ruff::flake8_to_ruff::{self, ExternalConfig};
+use ruff::logging::{set_up_logging, LogLevel};
 
 #[derive(Parser)]
 #[command(
@@ -27,6 +29,8 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    set_up_logging(&LogLevel::Default)?;
+
     let args = Args::parse();
 
     // Read the INI file.

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use colored::Colorize;
+use log::error;
 use rustpython_parser::error::ParseError;
 use rustpython_parser::lexer::LexResult;
 
@@ -247,17 +248,12 @@ pub fn add_noqa_to_path(path: &Path, settings: &Settings) -> Result<usize> {
 
     // Log any parse errors.
     if let Some(err) = error {
-        #[allow(clippy::print_stderr)]
-        {
-            eprintln!(
-                "{}{} {}{}{} {err:?}",
-                "error".red().bold(),
-                ":".bold(),
-                "Failed to parse ".bold(),
-                fs::relativize_path(path).bold(),
-                ":".bold()
-            );
-        }
+        error!(
+            "{}{}{} {err:?}",
+            "Failed to parse ".bold(),
+            fs::relativize_path(path).bold(),
+            ":".bold()
+        );
     }
 
     // Add any missing `# noqa` pragmas.

--- a/crates/ruff/src/logging.rs
+++ b/crates/ruff/src/logging.rs
@@ -1,19 +1,18 @@
 use anyhow::Result;
+use colored::Colorize;
 use fern;
+use log::Level;
 
 #[macro_export]
 macro_rules! warn_user_once {
     ($($arg:tt)*) => {
         use colored::Colorize;
+        use log::warn;
+
         static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         if !WARNED.swap(true, std::sync::atomic::Ordering::SeqCst) {
             let message = format!("{}", format_args!($($arg)*));
-            eprintln!(
-                "{}{} {}",
-                "warning".yellow().bold(),
-                ":".bold(),
-                message.bold(),
-            );
+            warn!("{}", message.bold());
         }
     };
 }
@@ -22,13 +21,10 @@ macro_rules! warn_user_once {
 macro_rules! warn_user {
     ($($arg:tt)*) => {
         use colored::Colorize;
+        use log::warn;
+
         let message = format!("{}", format_args!($($arg)*));
-        eprintln!(
-            "{}{} {}",
-            "warning".yellow().bold(),
-            ":".bold(),
-            message.bold(),
-        );
+        warn!("{}", message.bold());
     };
 }
 
@@ -74,14 +70,32 @@ impl LogLevel {
 
 pub fn set_up_logging(level: &LogLevel) -> Result<()> {
     fern::Dispatch::new()
-        .format(|out, message, record| {
-            out.finish(format_args!(
-                "{}[{}][{}] {}",
-                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
-                record.target(),
-                record.level(),
-                message
-            ));
+        .format(|out, message, record| match record.level() {
+            Level::Error => {
+                out.finish(format_args!(
+                    "{}{} {}",
+                    "error".red().bold(),
+                    ":".bold(),
+                    message
+                ));
+            }
+            Level::Warn => {
+                out.finish(format_args!(
+                    "{}{} {}",
+                    "warning".yellow().bold(),
+                    ":".bold(),
+                    message
+                ));
+            }
+            Level::Info | Level::Debug | Level::Trace => {
+                out.finish(format_args!(
+                    "{}[{}][{}] {}",
+                    chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                    record.target(),
+                    record.level(),
+                    message
+                ));
+            }
         })
         .level(level.level_filter())
         .level_for("globset", log::LevelFilter::Warn)

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use colored::Colorize;
-use log::debug;
+use log::{debug, error};
 use ruff::linter::{lint_fix, lint_only, LinterResult};
 use ruff::message::Message;
 use ruff::settings::{flags, AllSettings, Settings};
@@ -105,17 +105,12 @@ pub fn lint_path(
 
     if let Some(err) = parse_error {
         // Notify the user of any parse errors.
-        #[allow(clippy::print_stderr)]
-        {
-            eprintln!(
-                "{}{} {}{}{} {err}",
-                "error".red().bold(),
-                ":".bold(),
-                "Failed to parse ".bold(),
-                fs::relativize_path(path).bold(),
-                ":".bold()
-            );
-        }
+        error!(
+            "{}{}{} {err}",
+            "Failed to parse ".bold(),
+            fs::relativize_path(path).bold(),
+            ":".bold()
+        );
 
         // Purge the cache.
         cache::del(path, package.as_ref(), settings, autofix.into());
@@ -210,15 +205,10 @@ pub fn lint_stdin(
     };
 
     if let Some(err) = parse_error {
-        #[allow(clippy::print_stderr)]
-        {
-            eprintln!(
-                "{}{} Failed to parse {}: {err}",
-                "error".red().bold(),
-                ":".bold(),
-                path.map_or_else(|| "-".into(), fs::relativize_path).bold()
-            );
-        }
+        error!(
+            "Failed to parse {}: {err}",
+            path.map_or_else(|| "-".into(), fs::relativize_path).bold()
+        );
     }
 
     Ok(Diagnostics { messages, fixed })

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -3,16 +3,17 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::mpsc::channel;
 
+use anyhow::Result;
+use clap::{CommandFactory, Parser, Subcommand};
+use colored::Colorize;
+use notify::{recommended_watcher, RecursiveMode, Watcher};
+
 use ::ruff::logging::{set_up_logging, LogLevel};
 use ::ruff::resolver::PyprojectDiscovery;
 use ::ruff::settings::types::SerializationFormat;
 use ::ruff::settings::CliSettings;
 use ::ruff::{fix, fs, warn_user_once};
-use anyhow::Result;
 use args::{Args, CheckArgs, Command};
-use clap::{CommandFactory, Parser, Subcommand};
-use colored::Colorize;
-use notify::{recommended_watcher, RecursiveMode, Watcher};
 use printer::{Printer, Violations};
 
 pub(crate) mod args;


### PR DESCRIPTION
This has the (good) side effect that warnings and errors now respect `--quiet` and `--silent`.