### PR TITLE
Treat re-exported annotations as used-at-runtime

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH004_11.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH004_11.py
@@ -1,0 +1,6 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List
+
+__all__ = ("List",)

--- a/crates/ruff/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/mod.rs
@@ -28,6 +28,7 @@ mod tests {
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_8.py"); "TCH004_8")]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_9.py"); "TCH004_9")]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_10.py"); "TCH004_10")]
+    #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_11.py"); "TCH004_11")]
     #[test_case(Rule::EmptyTypeCheckingBlock, Path::new("TCH005.py"); "TCH005")]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("strict.py"); "strict")]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_11.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_11.py.snap
@@ -1,0 +1,16 @@
+---
+source: crates/ruff/src/rules/flake8_type_checking/mod.rs
+expression: diagnostics
+---
+- kind:
+    RuntimeImportInTypeCheckingBlock:
+      full_name: typing.List
+  location:
+    row: 4
+    column: 23
+  end_location:
+    row: 4
+    column: 27
+  fix: ~
+  parent: ~
+

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
@@ -1,8 +1,8 @@
-use ruff_macros::{define_violation, derive_message_formats};
 use rustpython_parser::ast::Expr;
 
+use ruff_macros::{define_violation, derive_message_formats};
+
 use crate::ast::types::Range;
-use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
@@ -17,8 +17,6 @@ impl Violation for InvalidAllFormat {
 }
 
 /// PLE0605
-pub fn invalid_all_format(checker: &mut Checker, expr: &Expr) {
-    checker
-        .diagnostics
-        .push(Diagnostic::new(InvalidAllFormat, Range::from_located(expr)));
+pub fn invalid_all_format(expr: &Expr) -> Diagnostic {
+    Diagnostic::new(InvalidAllFormat, Range::from_located(expr))
 }

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
@@ -1,8 +1,8 @@
-use ruff_macros::{define_violation, derive_message_formats};
 use rustpython_parser::ast::Expr;
 
+use ruff_macros::{define_violation, derive_message_formats};
+
 use crate::ast::types::Range;
-use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::violation::Violation;
 
@@ -17,8 +17,6 @@ impl Violation for InvalidAllObject {
 }
 
 /// PLE0604
-pub fn invalid_all_object(checker: &mut Checker, expr: &Expr) {
-    checker
-        .diagnostics
-        .push(Diagnostic::new(InvalidAllObject, Range::from_located(expr)));
+pub fn invalid_all_object(expr: &Expr) -> Diagnostic {
+    Diagnostic::new(InvalidAllObject, Range::from_located(expr))
 }


### PR DESCRIPTION
Closes #2684.