### PR TITLE
Manage LibCST and RustPython with cargo workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = ["crates/*"]
 default-members = ["crates/ruff", "crates/ruff_cli"]
 
+[workspace.dependencies]
+libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
+rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
+
 [profile.release]
 panic = "abort"
 lto = "thin"

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -30,7 +30,7 @@ globset = { version = "0.4.9" }
 ignore = { version = "0.4.18" }
 imperative = { version = "1.0.3" }
 itertools = { version = "0.10.5" }
-libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
+libcst = { workspace = true }
 log = { version = "0.4.17" }
 natord = { version = "1.0.9" }
 nohash-hasher = { version = "0.2.0" }
@@ -42,8 +42,8 @@ regex = { version = "1.6.0" }
 ruff_macros = { version = "0.0.244", path = "../ruff_macros" }
 ruff_python = { version = "0.0.244", path = "../ruff_python" }
 rustc-hash = { version = "1.1.0" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
+rustpython-common = { workspace = true }
+rustpython-parser = { workspace = true }
 schemars = { version = "0.8.11" }
 semver = { version = "1.0.16" }
 serde = { version = "1.0.147", features = ["derive"] }

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2021"
 anyhow = { version = "1.0.66" }
 clap = { version = "4.0.1", features = ["derive"] }
 itertools = { version = "0.10.5" }
-libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
+libcst = { workspace = true }
 once_cell = { version = "1.16.0" }
 ruff = { path = "../ruff" }
 ruff_cli = { path = "../ruff_cli" }
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
-rustpython-parser = { features = ["lalrpop"], git = "https://github.com/RustPython/RustPython.git", rev = "d94d0ac72072eb60bd9363e69b96ff1d5eb401b3" }
+rustpython-common = { workspace = true }
+rustpython-parser = { workspace = true }
 schemars = { version = "0.8.11" }
 serde_json = { version = "1.0.91" }
 strum = { version = "0.24.1", features = ["strum_macros"] }


### PR DESCRIPTION
So you only need to change one file to update versions, easily keep them in sync.

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table