### PR TITLE
Track fix counts by rule kind

### DIFF
--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use log::error;
+use rustc_hash::FxHashMap;
 use rustpython_parser::error::ParseError;
 use rustpython_parser::lexer::LexResult;
 
@@ -341,11 +342,15 @@ pub fn lint_fix<'a>(
     path: &Path,
     package: Option<&Path>,
     settings: &Settings,
-) -> Result<(LinterResult<Vec<Message>>, Cow<'a, str>, usize)> {
+) -> Result<(
+    LinterResult<Vec<Message>>,
+    Cow<'a, str>,
+    FxHashMap<&'static Rule, usize>,
+)> {
     let mut transformed = Cow::Borrowed(contents);
 
     // Track the number of fixed errors across iterations.
-    let mut fixed = 0;
+    let mut fixed = FxHashMap::default();
 
     // As an escape hatch, bail after 100 iterations.
     let mut iterations = 0;
@@ -419,7 +424,9 @@ This indicates a bug in `{}`. If you could open an issue at:
         if let Some((fixed_contents, applied)) = fix_file(&result.data, &locator) {
             if iterations < MAX_ITERATIONS {
                 // Count the number of fixed errors.
-                fixed += applied;
+                for (rule, count) in applied {
+                    *fixed.entry(rule).or_default() += count;
+                }
 
                 // Store the fixed contents.
                 transformed = Cow::Owned(fixed_contents);

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -282,11 +282,11 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
 
         if !cli.exit_zero {
             if cli.diff || fix_only {
-                if diagnostics.fixed > 0 {
+                if !diagnostics.fixed.is_empty() {
                     return Ok(ExitStatus::Failure);
                 }
             } else if cli.exit_non_zero_on_fix {
-                if diagnostics.fixed > 0 || !diagnostics.messages.is_empty() {
+                if !diagnostics.fixed.is_empty() || !diagnostics.messages.is_empty() {
                     return Ok(ExitStatus::Failure);
                 }
             } else {


### PR DESCRIPTION
This will enable us to report the number of fixes by rule in `Printer`, per #2661.