### PR TITLE
Relax conditions in bad-string-format-type

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/bad_string_format_type.py
+++ b/crates/ruff/resources/test/fixtures/pylint/bad_string_format_type.py
@@ -4,14 +4,15 @@ print("foo %(foo)d bar %(bar)d" % {"foo": "1", "bar": "2"})
 "foo %e bar %s" % ("1", 2)
 
 "%d" % "1"
+"%o" % "1"
 "%(key)d" % {"key": "1"}
 "%x" % 1.1
 "%(key)x" % {"key": 1.1}
 "%d" % []
 "%d" % ([],)
 "%(key)d" % {"key": []}
-
 print("%d" % ("%s" % ("nested",),))
+"%d" % ((1, 2, 3),)
 
 # False negatives
 WORD = "abc"
@@ -22,15 +23,11 @@ VALUES_TO_FORMAT = (1, "2", 3.0)
 
 # OK
 "%d %s %f" % VALUES_TO_FORMAT
-
 "%s" % "1"
-
 "%s %s %s" % ("1", 2, 3.5)
-
 print("%d %d"
       %
 (1, 1.1))
-
 "%s" % 1
 "%d" % 1
 "%f" % 1
@@ -50,3 +47,11 @@ print("%s" % ("%s" % ("nested",),))
 print("%s" % ("%d" % (5,),))
 "%d %d" % "1"
 "%d" "%d" % "1"
+"-%f" % time.time()
+"%r" % (object['dn'],)
+r'\%03o' % (ord(c),)
+('%02X' % int(_) for _ in o)
+"%s;range=%d-*" % (attr, upper + 1)
+"%d" % (len(foo),)
+'(%r, %r, %r, %r)' % (hostname, address, username, '$PASSWORD')
+'%r' % ({'server_school_roles': server_school_roles, 'is_school_multiserver_domain': is_school_multiserver_domain}, )

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE1307_bad_string_format_type.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/pylint/mod.rs
+source: crates/ruff/src/rules/pylint/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -39,56 +39,56 @@ expression: diagnostics
     column: 0
   end_location:
     row: 7
-    column: 24
-  fix: ~
-  parent: ~
-- kind:
-    BadStringFormatType: ~
-  location:
-    row: 8
-    column: 0
-  end_location:
-    row: 8
     column: 10
   fix: ~
   parent: ~
 - kind:
     BadStringFormatType: ~
   location:
-    row: 9
+    row: 8
     column: 0
   end_location:
-    row: 9
+    row: 8
     column: 24
   fix: ~
   parent: ~
 - kind:
     BadStringFormatType: ~
   location:
-    row: 10
+    row: 9
     column: 0
   end_location:
-    row: 10
-    column: 9
+    row: 9
+    column: 10
   fix: ~
   parent: ~
 - kind:
     BadStringFormatType: ~
   location:
-    row: 11
+    row: 10
     column: 0
   end_location:
-    row: 11
+    row: 10
+    column: 24
+  fix: ~
+  parent: ~
+- kind:
+    BadStringFormatType: ~
+  location:
+    row: 12
+    column: 0
+  end_location:
+    row: 12
     column: 12
   fix: ~
   parent: ~
 - kind:
     BadStringFormatType: ~
   location:
-    row: 12
+    row: 13
     column: 0
   end_location:
-    row: 12
+    row: 13
     column: 23
   fix: ~
   parent: ~
@@ -100,6 +100,16 @@ expression: diagnostics
   end_location:
     row: 14
     column: 34
+  fix: ~
+  parent: ~
+- kind:
+    BadStringFormatType: ~
+  location:
+    row: 15
+    column: 0
+  end_location:
+    row: 15
+    column: 19
   fix: ~
   parent: ~
 


### PR DESCRIPTION
An oversight on my part. We have to be _way_ more conservative here. If we can't identify the type of an expression, we _have_ to assume that it's ok.

Closes #2724.