### PR TITLE
enable navigation in footer in docs

### DIFF
--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -11,6 +11,7 @@ theme:
     - toc.follow
     - navigation.path
     - navigation.top
+    - navigation.footer
     - content.code.copy
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
When reaching the end of a page, the natural next step is to move further. Currently, the user has to scroll up. The footer navigation enables to additionally go to the next and previous page (see [docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#custom-copyright))