### PR TITLE
implemented option lines-between-types for isort

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,13 +135,13 @@ Finally, regenerate the documentation and generated code with `cargo dev generat
 
 #### Rule naming convention
 
-The rule name should make sense when read as "allow *rule-name*" or "allow *rule-name* items".
+The rule name should make sense when read as "allow _rule-name_" or "allow _rule-name_ items".
 
 This implies that rule names:
 
-* should state the bad thing being checked for
+- should state the bad thing being checked for
 
-* should not contain instructions on what you what you should use instead
+- should not contain instructions on what you what you should use instead
   (these belong in the rule documentation and the `autofix_title` for rules that have autofix)
 
 ### Example: Adding a new configuration option

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,13 +135,13 @@ Finally, regenerate the documentation and generated code with `cargo dev generat
 
 #### Rule naming convention
 
-The rule name should make sense when read as "allow _rule-name_" or "allow _rule-name_ items".
+The rule name should make sense when read as "allow *rule-name*" or "allow *rule-name* items".
 
 This implies that rule names:
 
-- should state the bad thing being checked for
+* should state the bad thing being checked for
 
-- should not contain instructions on what you what you should use instead
+* should not contain instructions on what you what you should use instead
   (these belong in the rule documentation and the `autofix_title` for rules that have autofix)
 
 ### Example: Adding a new configuration option

--- a/README.md
+++ b/README.md
@@ -3533,6 +3533,24 @@ lines-after-imports = 1
 
 ---
 
+#### [`lines-between-types`](#lines-between-types)
+
+The number of lines to place between direct and from imports.
+
+**Default value**: `0`
+
+**Type**: `int`
+
+**Example usage**:
+
+```toml
+[tool.ruff.isort]
+# Use a single line between direct and from import
+lines-between-types = 1
+```
+
+---
+
 #### [`no-lines-before`](#no-lines-before)
 
 A list of sections that should _not_ be delineated from the previous

--- a/README.md
+++ b/README.md
@@ -3480,8 +3480,7 @@ known-first-party = ["src"]
 #### [`known-local-folder`](#known-local-folder)
 
 A list of modules to consider being a local folder.
-Generally, this is reserved for relative
-imports (from . import module).
+Generally, this is reserved for relative imports (`from . import module`).
 
 **Default value**: `[]`
 
@@ -3517,7 +3516,7 @@ known-third-party = ["src"]
 #### [`lines-after-imports`](#lines-after-imports)
 
 The number of blank lines to place after imports.
--1 for automatic determination.
+Use `-1` for automatic determination.
 
 **Default value**: `-1`
 
@@ -3535,7 +3534,7 @@ lines-after-imports = 1
 
 #### [`lines-between-types`](#lines-between-types)
 
-The number of lines to place between direct and from imports.
+The number of lines to place between "direct" and `import from` imports.
 
 **Default value**: `0`
 

--- a/crates/ruff/resources/test/fixtures/isort/lines_between_types.py
+++ b/crates/ruff/resources/test/fixtures/isort/lines_between_types.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import datetime
+import json
+
+
+from binascii import hexlify
+
+import requests
+
+
+from sanic import Sanic
+from loguru import Logger
+
+from . import config
+from .data import Data

--- a/crates/ruff/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/isort/pyproject.toml
@@ -3,4 +3,5 @@ line-length = 88
 
 [tool.ruff.isort]
 lines-after-imports = 3
+lines-between-types = 2
 known-local-folder = ["ruff"]

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -137,6 +137,7 @@ pub fn organize_imports(
         &settings.isort.variables,
         &settings.isort.no_lines_before,
         settings.isort.lines_after_imports,
+        settings.isort.lines_between_types,
         &settings.isort.forced_separate,
         settings.target_version,
     );

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -236,6 +236,16 @@ pub struct Options {
     /// -1 for automatic determination.
     pub lines_after_imports: Option<isize>,
     #[option(
+        default = r#"0"#,
+        value_type = "int",
+        example = r#"
+            # Use a single line between direct and from import
+            lines-between-types = 1
+        "#
+    )]
+    /// The number of lines to place between direct and from imports.
+    pub lines_between_types: Option<usize>,
+    #[option(
         default = r#"[]"#,
         value_type = "Vec<String>",
         example = r#"
@@ -268,6 +278,7 @@ pub struct Settings {
     pub variables: BTreeSet<String>,
     pub no_lines_before: BTreeSet<ImportType>,
     pub lines_after_imports: isize,
+    pub lines_between_types: usize,
     pub forced_separate: Vec<String>,
 }
 
@@ -292,6 +303,7 @@ impl Default for Settings {
             variables: BTreeSet::new(),
             no_lines_before: BTreeSet::new(),
             lines_after_imports: -1,
+            lines_between_types: 0,
             forced_separate: Vec::new(),
         }
     }
@@ -322,6 +334,7 @@ impl From<Options> for Settings {
             variables: BTreeSet::from_iter(options.variables.unwrap_or_default()),
             no_lines_before: BTreeSet::from_iter(options.no_lines_before.unwrap_or_default()),
             lines_after_imports: options.lines_after_imports.unwrap_or(-1),
+            lines_between_types: options.lines_between_types.unwrap_or_default(),
             forced_separate: Vec::from_iter(options.forced_separate.unwrap_or_default()),
         }
     }
@@ -348,6 +361,7 @@ impl From<Settings> for Options {
             variables: Some(settings.variables.into_iter().collect()),
             no_lines_before: Some(settings.no_lines_before.into_iter().collect()),
             lines_after_imports: Some(settings.lines_after_imports),
+            lines_between_types: Some(settings.lines_between_types),
             forced_separate: Some(settings.forced_separate.into_iter().collect()),
         }
     }

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -146,8 +146,7 @@ pub struct Options {
         "#
     )]
     /// A list of modules to consider being a local folder.
-    /// Generally, this is reserved for relative
-    /// imports (from . import module).
+    /// Generally, this is reserved for relative imports (`from . import module`).
     pub known_local_folder: Option<Vec<String>>,
     #[option(
         default = r#"[]"#,
@@ -233,7 +232,7 @@ pub struct Options {
         "#
     )]
     /// The number of blank lines to place after imports.
-    /// -1 for automatic determination.
+    /// Use `-1` for automatic determination.
     pub lines_after_imports: Option<isize>,
     #[option(
         default = r#"0"#,
@@ -243,7 +242,7 @@ pub struct Options {
             lines-between-types = 1
         "#
     )]
-    /// The number of lines to place between direct and from imports.
+    /// The number of lines to place between "direct" and `import from` imports.
     pub lines_between_types: Option<usize>,
     #[option(
         default = r#"[]"#,

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_between_typeslines_between_types.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_between_typeslines_between_types.py.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnsortedImports: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 17
+    column: 0
+  fix:
+    content:
+      - from __future__ import annotations
+      - ""
+      - import datetime
+      - import json
+      - ""
+      - ""
+      - from binascii import hexlify
+      - ""
+      - import requests
+      - ""
+      - ""
+      - from loguru import Logger
+      - from sanic import Sanic
+      - ""
+      - from . import config
+      - from .data import Data
+      - ""
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 17
+      column: 0
+  parent: ~
+

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -965,7 +965,7 @@
           }
         },
         "known-local-folder": {
-          "description": "A list of modules to consider being a local folder. Generally, this is reserved for relative imports (from . import module).",
+          "description": "A list of modules to consider being a local folder. Generally, this is reserved for relative imports (`from . import module`).",
           "type": [
             "array",
             "null"
@@ -985,7 +985,7 @@
           }
         },
         "lines-after-imports": {
-          "description": "The number of blank lines to place after imports. -1 for automatic determination.",
+          "description": "The number of blank lines to place after imports. Use `-1` for automatic determination.",
           "type": [
             "integer",
             "null"
@@ -993,7 +993,7 @@
           "format": "int"
         },
         "lines-between-types": {
-          "description": "The number of lines to place between direct and from imports.",
+          "description": "The number of lines to place between \"direct\" and `import from` imports.",
           "type": [
             "integer",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -992,6 +992,15 @@
           ],
           "format": "int"
         },
+        "lines-between-types": {
+          "description": "The number of lines to place between direct and from imports.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "no-lines-before": {
           "description": "A list of sections that should _not_ be delineated from the previous section via empty lines.",
           "type": [


### PR DESCRIPTION
Fixes #2585

Add support for the isort option [lines_between_types](https://pycqa.github.io/isort/docs/configuration/options.html#lines-between-types)