### PR TITLE
Ignore colon-after-lambda in compound statement rules

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
@@ -44,3 +44,5 @@ a: List[str] = []
 #:
 if a := 1:
     pass
+#:
+func = lambda x: x** 2 if cond else lambda x:x

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -182,6 +182,21 @@ pub fn compound_statements(lxr: &[LexResult]) -> Vec<Diagnostic> {
         }
 
         match tok {
+            Tok::Lambda => {
+                // Reset.
+                def = None;
+                colon = None;
+                class = None;
+                elif = None;
+                else_ = None;
+                except = None;
+                finally = None;
+                for_ = None;
+                if_ = None;
+                try_ = None;
+                while_ = None;
+                with = None;
+            }
             Tok::If => {
                 if_ = Some((start, end));
             }


### PR DESCRIPTION
Closes #2759.

Closes #2765.