### PR TITLE
Don't treat all future import accesses as non-runtime

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH002.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH002.py
@@ -46,7 +46,7 @@ def f():
 def f():
     import pandas as pd
 
-    x = dict["pd.DataFrame", "pd.DataFrame"]  # TCH002
+    x = dict["pd.DataFrame", "pd.DataFrame"]
 
 
 def f():

--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH004_12.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH004_12.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+AnyCallable: TypeAlias = Callable[..., Any]

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -3900,11 +3900,7 @@ impl<'a> Checker<'a> {
     }
 
     pub const fn execution_context(&self) -> ExecutionContext {
-        if self.in_type_checking_block
-            || self.in_annotation
-            || self.in_deferred_string_type_definition
-            || self.in_deferred_type_definition
-        {
+        if self.in_type_checking_block || self.in_annotation {
             ExecutionContext::Typing
         } else {
             ExecutionContext::Runtime
@@ -4069,6 +4065,8 @@ impl<'a> Checker<'a> {
                 if let Some(index) = scope.bindings.get(&id.as_str()) {
                     // Mark the binding as used.
                     let context = self.execution_context();
+                    // println!("Marking {:?} as used", id);
+                    // println!("Context: {:?}", context);
                     self.bindings[*index].mark_used(scope_id, Range::from_located(expr), context);
 
                     if matches!(self.bindings[*index].kind, BindingKind::Annotation)
@@ -4694,6 +4692,8 @@ impl<'a> Checker<'a> {
                 vec![]
             }
         };
+
+        // println!("runtime_imports: {:?}", runtime_imports);
 
         let mut diagnostics: Vec<Diagnostic> = vec![];
         for (index, stack) in self.dead_scopes.iter().rev() {

--- a/crates/ruff/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/mod.rs
@@ -29,6 +29,7 @@ mod tests {
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_9.py"); "TCH004_9")]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_10.py"); "TCH004_10")]
     #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_11.py"); "TCH004_11")]
+    #[test_case(Rule::RuntimeImportInTypeCheckingBlock, Path::new("TCH004_12.py"); "TCH004_12")]
     #[test_case(Rule::EmptyTypeCheckingBlock, Path::new("TCH005.py"); "TCH005")]
     #[test_case(Rule::TypingOnlyThirdPartyImport, Path::new("strict.py"); "strict")]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_12.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__runtime-import-in-type-checking-block_TCH004_12.py.snap
@@ -4,13 +4,13 @@ expression: diagnostics
 ---
 - kind:
     RuntimeImportInTypeCheckingBlock:
-      full_name: typing.Any
+      full_name: collections.abc.Callable
   location:
-    row: 5
-    column: 23
+    row: 6
+    column: 32
   end_location:
-    row: 5
-    column: 26
+    row: 6
+    column: 40
   fix: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_TCH002.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_TCH002.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/flake8_type_checking/mod.rs
+source: crates/ruff/src/rules/flake8_type_checking/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -76,17 +76,6 @@ expression: diagnostics
     column: 11
   end_location:
     row: 41
-    column: 23
-  fix: ~
-  parent: ~
-- kind:
-    TypingOnlyThirdPartyImport:
-      full_name: pandas
-  location:
-    row: 47
-    column: 11
-  end_location:
-    row: 47
     column: 23
   fix: ~
   parent: ~


### PR DESCRIPTION
This was just an oversight and misunderstanding on my part. We had some helpful tests, but I misunderstood the "right" behavior so thought they were passing.

Closes #2761.