### PR TITLE
Implement `config` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Usage: ruff [OPTIONS] <COMMAND>
 Commands:
   check   Run Ruff on the given files or directories (default)
   rule    Explain a rule
+  config  List or describe the available configuration options
   linter  List all supported upstream linters
   clean   Clear any caches in the current directory and any subdirectories
   help    Print this message or the help of the given subcommand(s)

--- a/crates/ruff/src/settings/options_base.rs
+++ b/crates/ruff/src/settings/options_base.rs
@@ -1,24 +1,17 @@
 pub trait ConfigurationOptions {
-    fn get_available_options() -> Vec<OptionEntry>;
+    fn get_available_options() -> Vec<(&'static str, OptionEntry)>;
 }
 
 #[derive(Debug)]
 pub enum OptionEntry {
     Field(OptionField),
-    Group(OptionGroup),
+    Group(Vec<(&'static str, OptionEntry)>),
 }
 
 #[derive(Debug)]
 pub struct OptionField {
-    pub name: &'static str,
     pub doc: &'static str,
     pub default: &'static str,
     pub value_type: &'static str,
     pub example: &'static str,
-}
-
-#[derive(Debug)]
-pub struct OptionGroup {
-    pub name: &'static str,
-    pub fields: Vec<OptionEntry>,
 }

--- a/crates/ruff/src/settings/options_base.rs
+++ b/crates/ruff/src/settings/options_base.rs
@@ -1,7 +1,11 @@
+pub trait ConfigurationOptions {
+    fn get_available_options() -> Vec<OptionEntry>;
+}
+
 #[derive(Debug)]
-pub struct OptionGroup {
-    pub name: &'static str,
-    pub fields: Vec<OptionEntry>,
+pub enum OptionEntry {
+    Field(OptionField),
+    Group(OptionGroup),
 }
 
 #[derive(Debug)]
@@ -14,11 +18,7 @@ pub struct OptionField {
 }
 
 #[derive(Debug)]
-pub enum OptionEntry {
-    Field(OptionField),
-    Group(OptionGroup),
-}
-
-pub trait ConfigurationOptions {
-    fn get_available_options() -> Vec<OptionEntry>;
+pub struct OptionGroup {
+    pub name: &'static str,
+    pub fields: Vec<OptionEntry>,
 }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -44,6 +44,8 @@ pub enum Command {
         #[arg(long, value_enum, default_value = "markdown")]
         format: HelpFormat,
     },
+    /// List or describe the available configuration options
+    Config { option: Option<String> },
     /// List all supported upstream linters
     Linter {
         /// Output format

--- a/crates/ruff_cli/src/commands/config.rs
+++ b/crates/ruff_cli/src/commands/config.rs
@@ -1,0 +1,48 @@
+use ruff::settings::{
+    options::Options,
+    options_base::{ConfigurationOptions, OptionEntry, OptionField},
+};
+
+use crate::ExitStatus;
+
+#[allow(clippy::print_stdout)]
+pub(crate) fn config(option: Option<&str>) -> ExitStatus {
+    let entries = Options::get_available_options();
+    let mut entries = &entries;
+
+    let mut parts_iter = option.iter().flat_map(|s| s.split('.'));
+
+    while let Some(part) = parts_iter.next() {
+        let Some((_, field)) = entries.iter().find(|(name, _)| *name == part) else {
+            println!("Unknown option");
+            return ExitStatus::Error;
+        };
+        match field {
+            OptionEntry::Field(OptionField {
+                doc,
+                default,
+                value_type,
+                example,
+            }) => {
+                if parts_iter.next().is_some() {
+                    println!("Unknown option");
+                    return ExitStatus::Error;
+                }
+
+                println!("{doc}");
+                println!();
+                println!("Default value: {default}");
+                println!("Type: {value_type}");
+                println!("Example usage:\n```toml\n{example}\n```");
+                return ExitStatus::Success;
+            }
+            OptionEntry::Group(fields) => {
+                entries = fields;
+            }
+        }
+    }
+    for (name, _) in entries {
+        println!("{name}");
+    }
+    ExitStatus::Success
+}

--- a/crates/ruff_cli/src/commands/mod.rs
+++ b/crates/ruff_cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub use show_settings::show_settings;
 
 mod add_noqa;
 mod clean;
+pub mod config;
 mod linter;
 mod rule;
 mod run;

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -101,6 +101,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
 
     match command {
         Command::Rule { rule, format } => commands::rule(&rule, format)?,
+        Command::Config { option } => return Ok(commands::config::config(option.as_deref())),
         Command::Linter { format } => commands::linter(format)?,
         Command::Clean => commands::clean(log_level)?,
         Command::GenerateShellCompletion { shell } => {

--- a/crates/ruff_macros/src/config.rs
+++ b/crates/ruff_macros/src/config.rs
@@ -45,11 +45,11 @@ pub fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
             }
 
             Ok(quote! {
-              use crate::settings::options_base::{OptionEntry, OptionField, OptionGroup, ConfigurationOptions};
+              use crate::settings::options_base::{OptionEntry, OptionField, ConfigurationOptions};
 
               #[automatically_derived]
               impl ConfigurationOptions for #ident {
-                  fn get_available_options() -> Vec<OptionEntry> {
+                  fn get_available_options() -> Vec<(&'static str, OptionEntry)> {
                       vec![#(#output),*]
                   }
               }
@@ -86,10 +86,7 @@ fn handle_option_group(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
                 let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
                 Ok(quote_spanned!(
-                    ident.span() => OptionEntry::Group(OptionGroup {
-                        name: #kebab_name,
-                        fields: #path::get_available_options(),
-                    })
+                    ident.span() => (#kebab_name, OptionEntry::Group(#path::get_available_options()))
                 ))
             }
             _ => Err(syn::Error::new(
@@ -148,13 +145,12 @@ fn handle_option(
     let kebab_name = LitStr::new(&ident.to_string().replace('_', "-"), ident.span());
 
     Ok(quote_spanned!(
-        ident.span() => OptionEntry::Field(OptionField {
-            name: #kebab_name,
+        ident.span() => (#kebab_name, OptionEntry::Field(OptionField {
             doc: &#doc,
             default: &#default,
             value_type: &#value_type,
             example: &#example,
-        })
+        }))
     ))
 }
 


### PR DESCRIPTION
The synopsis is as follows.

List all top-level config keys:

    $ ruff config
    allowed-confusables
    builtins
    cache-dir
    ... etc.

List all config keys in a specific section:

    $ ruff config mccabe
    max-complexity

Describe a specific config option:

    $ ruff config mccabe.max-complexity
    The maximum McCabe complexity to allow before triggering `C901` errors.

    Default value: 10
    Type: int
    Example usage:
    ```toml
    # Flag errors (`C901`) whenever the complexity level exceeds 5.
    max-complexity = 5
    ```