### PR TITLE
Update `PASSWORD_NAMES` to include `api_key` and remove `pass`

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff/src/rules/flake8_bandit/helpers.rs
@@ -2,9 +2,7 @@ use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
 use crate::checkers::ast::Checker;
 
-const PASSWORD_NAMES: [&str; 7] = [
-    "password", "pass", "passwd", "pwd", "secret", "token", "secrete",
-];
+const PASSWORD_NAMES: [&str; 6] = ["password", "passwd", "pwd", "secret", "token", "api_key"];
 
 pub fn string_literal(expr: &Expr) -> Option<&str> {
     match &expr.node {

--- a/crates/ruff/src/rules/flake8_bandit/snapshots/ruff__rules__flake8_bandit__tests__S105_S105.py.snap
+++ b/crates/ruff/src/rules/flake8_bandit/snapshots/ruff__rules__flake8_bandit__tests__S105_S105.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/flake8_bandit/mod.rs
+source: crates/ruff/src/rules/flake8_bandit/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -11,17 +11,6 @@ expression: diagnostics
   end_location:
     row: 13
     column: 19
-  fix: ~
-  parent: ~
-- kind:
-    HardcodedPasswordString:
-      string: s3cr3t
-  location:
-    row: 14
-    column: 8
-  end_location:
-    row: 14
-    column: 16
   fix: ~
   parent: ~
 - kind:
@@ -110,17 +99,6 @@ expression: diagnostics
   end_location:
     row: 23
     column: 24
-  fix: ~
-  parent: ~
-- kind:
-    HardcodedPasswordString:
-      string: s3cr3t
-  location:
-    row: 24
-    column: 12
-  end_location:
-    row: 24
-    column: 20
   fix: ~
   parent: ~
 - kind:
@@ -226,17 +204,6 @@ expression: diagnostics
     HardcodedPasswordString:
       string: s3cr3t
   location:
-    row: 40
-    column: 16
-  end_location:
-    row: 40
-    column: 24
-  fix: ~
-  parent: ~
-- kind:
-    HardcodedPasswordString:
-      string: s3cr3t
-  location:
     row: 41
     column: 17
   end_location:
@@ -297,17 +264,6 @@ expression: diagnostics
   end_location:
     row: 47
     column: 20
-  fix: ~
-  parent: ~
-- kind:
-    HardcodedPasswordString:
-      string: s3cr3t
-  location:
-    row: 48
-    column: 9
-  end_location:
-    row: 48
-    column: 17
   fix: ~
   parent: ~
 - kind:


### PR DESCRIPTION
This updates `PASSWORD_NAMES` in `crates/ruff/src/rules/flake8_bandit/helpers.rs` as per #2384 