### PR TITLE
Use output-stdout pattern for linter command

### DIFF
--- a/crates/ruff_cli/src/commands/linter.rs
+++ b/crates/ruff_cli/src/commands/linter.rs
@@ -1,11 +1,34 @@
+use std::io;
+use std::io::BufWriter;
+use std::io::Write;
+
+use anyhow::Result;
 use itertools::Itertools;
-use ruff::registry::{Linter, RuleNamespace, UpstreamCategory};
 use serde::Serialize;
 use strum::IntoEnumIterator;
 
+use ruff::registry::{Linter, RuleNamespace, UpstreamCategory};
+
 use crate::args::HelpFormat;
 
-pub fn linter(format: HelpFormat) {
+#[derive(Serialize)]
+struct LinterInfo {
+    prefix: &'static str,
+    name: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    categories: Option<Vec<LinterCategoryInfo>>,
+}
+
+#[derive(Serialize)]
+struct LinterCategoryInfo {
+    prefix: &'static str,
+    name: &'static str,
+}
+
+pub fn linter(format: HelpFormat) -> Result<()> {
+    let mut stdout = BufWriter::new(io::stdout().lock());
+    let mut output = String::new();
+
     match format {
         HelpFormat::Text => {
             for linter in Linter::iter() {
@@ -18,11 +41,7 @@ pub fn linter(format: HelpFormat) {
                         .join("/"),
                     prefix => prefix.to_string(),
                 };
-
-                #[allow(clippy::print_stdout)]
-                {
-                    println!("{:>4} {}", prefix, linter.name());
-                }
+                output.push_str(&format!("{:>4} {}\n", prefix, linter.name()));
             }
         }
 
@@ -41,19 +60,14 @@ pub fn linter(format: HelpFormat) {
                     }),
                 })
                 .collect();
-
-            #[allow(clippy::print_stdout)]
-            {
-                println!("{}", serde_json::to_string_pretty(&linters).unwrap());
-            }
+            output.push_str(&serde_json::to_string_pretty(&linters)?);
+            output.push('\n');
         }
 
         HelpFormat::Markdown => {
-            #[allow(clippy::print_stdout)]
-            {
-                println!("| {:>6} | {:<27} |", "Prefix", "Name");
-                println!("| {:>6} | {:<27} |", "------", "-".repeat(27));
-            }
+            output.push_str(&format!("| {:>6} | {:<27} |\n", "Prefix", "Name"));
+            output.push_str(&format!("| {:>6} | {:<27} |\n", "------", "-".repeat(27)));
+
             for linter in Linter::iter() {
                 let prefix = match linter.common_prefix() {
                     "" => linter
@@ -64,26 +78,12 @@ pub fn linter(format: HelpFormat) {
                         .join("/"),
                     prefix => prefix.to_string(),
                 };
-
-                #[allow(clippy::print_stdout)]
-                {
-                    println!("| {:>6} | {:<27} |", prefix, linter.name());
-                }
+                output.push_str(&format!("| {:>6} | {:<27} |\n", prefix, linter.name()));
             }
         }
     }
-}
 
-#[derive(Serialize)]
-struct LinterInfo {
-    prefix: &'static str,
-    name: &'static str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    categories: Option<Vec<LinterCategoryInfo>>,
-}
+    write!(stdout, "{output}")?;
 
-#[derive(Serialize)]
-struct LinterCategoryInfo {
-    prefix: &'static str,
-    name: &'static str,
+    Ok(())
 }

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -94,5 +94,6 @@ pub fn rule(rule: &Rule, format: HelpFormat) -> Result<()> {
             mdcat::push_tty(settings, env, &mut stdout, parser)?;
         }
     };
+
     Ok(())
 }

--- a/crates/ruff_cli/src/main.rs
+++ b/crates/ruff_cli/src/main.rs
@@ -101,7 +101,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
 
     match command {
         Command::Rule { rule, format } => commands::rule(&rule, format)?,
-        Command::Linter { format } => commands::linter(format),
+        Command::Linter { format } => commands::linter(format)?,
         Command::Clean => commands::clean(log_level)?,
         Command::GenerateShellCompletion { shell } => {
             shell.generate(&mut Args::command(), &mut io::stdout());


### PR DESCRIPTION
Not "better" but more consistent with `rule.rs`.