### PR TITLE
Rename new `ruff rule` output format to "pretty"

### DIFF
--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -41,7 +41,7 @@ pub enum Command {
         rule: Rule,
 
         /// Output format
-        #[arg(long, value_enum, default_value = "markdown")]
+        #[arg(long, value_enum, default_value = "pretty")]
         format: HelpFormat,
     },
     /// List all supported upstream linters
@@ -284,7 +284,7 @@ pub struct CheckArgs {
 pub enum HelpFormat {
     Text,
     Json,
-    Markdown,
+    Pretty,
 }
 
 #[allow(clippy::module_name_repetitions)]

--- a/crates/ruff_cli/src/commands/linter.rs
+++ b/crates/ruff_cli/src/commands/linter.rs
@@ -64,7 +64,7 @@ pub fn linter(format: HelpFormat) -> Result<()> {
             output.push('\n');
         }
 
-        HelpFormat::Markdown => {
+        HelpFormat::Pretty => {
             output.push_str(&format!("| {:>6} | {:<27} |\n", "Prefix", "Name"));
             output.push_str(&format!("| {:>6} | {:<27} |\n", "------", "-".repeat(27)));
 

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -27,7 +27,7 @@ pub fn rule(rule: &Rule, format: HelpFormat) -> Result<()> {
     let mut output = String::new();
 
     match format {
-        HelpFormat::Text | HelpFormat::Markdown => {
+        HelpFormat::Text | HelpFormat::Pretty => {
             output.push_str(&format!("# {} ({})", rule.as_ref(), rule.code()));
             output.push('\n');
             output.push('\n');
@@ -69,7 +69,7 @@ pub fn rule(rule: &Rule, format: HelpFormat) -> Result<()> {
         HelpFormat::Json | HelpFormat::Text => {
             writeln!(stdout, "{output}")?;
         }
-        HelpFormat::Markdown => {
+        HelpFormat::Pretty => {
             let parser = Parser::new_ext(
                 &output,
                 Options::ENABLE_TASKLISTS | Options::ENABLE_STRIKETHROUGH,


### PR DESCRIPTION
The new `ruff rule` output format introduced in 551b810aebb86f396e4c45a8b6b4406a8cf8cf71 doesn't print Markdown but rather some rich text with escape sequences for colors and links, it's actually the "text" format that prints Markdown, so naming the new format "markdown" is very confusing. This commit therefore renames it to "pretty".

This isn't a breaking change since there hasn't been a release yet.