### PR TITLE
Allow non-verbose raise when cause is present

### DIFF
--- a/crates/ruff/resources/test/fixtures/tryceratops/TRY201.py
+++ b/crates/ruff/resources/test/fixtures/tryceratops/TRY201.py
@@ -27,12 +27,21 @@ def good():
         logger.exception("process failed")
         raise
 
+
 def still_good():
     try:
         process()
     except MyException as e:
         print(e)
         raise
+
+
+def still_good_too():
+    try:
+        process()
+    except MyException as e:
+        print(e)
+        raise e from None
 
 
 def still_actually_good():
@@ -60,5 +69,6 @@ def bad_that_needs_recursion_2():
     except MyException as e:
         logger.exception("process failed")
         if True:
+
             def foo():
                 raise e

--- a/crates/ruff/src/rules/tryceratops/snapshots/ruff__rules__tryceratops__tests__verbose-raise_TRY201.py.snap
+++ b/crates/ruff/src/rules/tryceratops/snapshots/ruff__rules__tryceratops__tests__verbose-raise_TRY201.py.snap
@@ -1,5 +1,5 @@
 ---
-source: src/rules/tryceratops/mod.rs
+source: crates/ruff/src/rules/tryceratops/mod.rs
 expression: diagnostics
 ---
 - kind:
@@ -15,20 +15,20 @@ expression: diagnostics
 - kind:
     VerboseRaise: ~
   location:
-    row: 54
+    row: 63
     column: 18
   end_location:
-    row: 54
+    row: 63
     column: 19
   fix: ~
   parent: ~
 - kind:
     VerboseRaise: ~
   location:
-    row: 64
+    row: 74
     column: 22
   end_location:
-    row: 64
+    row: 74
     column: 23
   fix: ~
   parent: ~


### PR DESCRIPTION
The motivating issue here is of the following form:

```py
try:
    raise Exception("We want to hide this error message")
except Exception:
    try:
        raise Exception("We want to show this")
    except Exception as exc:
        raise exc from None
```

However, I think we should avoid this if _any_ cause is present, since causes require a named exception.

Closes #2814.