### PR TITLE
[`flake8-tidy-imports`] add documentation for `banned-api`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,7 +1267,7 @@ For more, see [flake8-tidy-imports](https://pypi.org/project/flake8-tidy-imports
 
 | Code | Name | Message | Fix |
 | ---- | ---- | ------- | --- |
-| TID251 | banned-api | `{name}` is banned: {message} |  |
+| TID251 | [banned-api](https://github.com/charliermarsh/ruff/blob/main/docs/rules/banned-api.md) | `{name}` is banned: {message} |  |
 | TID252 | [relative-imports](https://github.com/charliermarsh/ruff/blob/main/docs/rules/relative-imports.md) | Relative imports from parent modules are banned | 🛠 |
 
 ### flake8-type-checking (TCH)

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -24,14 +24,19 @@ define_violation!(
     /// Checks for banned imports.
     ///
     /// ## Why is this bad?
-    /// Projects may want to ensure that specific modules or module members are not be imported or accessed. Security or other company policies may
-    /// be a reason to impose restrictions on importing external Python libraries. This rule enforces certain import conventions project-wide in an
+    /// Projects may want to ensure that specific modules or module members are
+    /// not be imported or accessed.
+    ///
+    /// Security or other company policies may be a reason to impose
+    /// restrictions on importing external Python libraries. In some cases,
+    /// projects may adopt conventions around the use of certain modules or
+    /// module members that are not enforceable by the language itself.
+    ///
+    /// This rule enforces certain import conventions project-wide in an
     /// automatic way.
     ///
     /// ## Options
-    ///
     /// * `flake8-tidy-imports.banned-api`
-    ///
     pub struct BannedApi {
         pub name: String,
         pub message: String,

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -20,6 +20,18 @@ pub struct ApiBan {
 }
 
 define_violation!(
+    /// ## What it does
+    /// Checks for banned imports.
+    ///
+    /// ## Why is this bad?
+    /// Projects may want to ensure that specific modules or module members are not be imported or accessed. Security or other company policies may
+    /// be a reason to impose restrictions on importing external Python libraries. This rule enforces certain import conventions project-wide in an
+    /// automatic way.
+    ///
+    /// ## Options
+    ///
+    /// * `flake8-tidy-imports.banned-api`
+    ///
     pub struct BannedApi {
         pub name: String,
         pub message: String,

--- a/docs/rules/banned-api.md
+++ b/docs/rules/banned-api.md
@@ -6,10 +6,16 @@ Derived from the **flake8-tidy-imports** linter.
 Checks for banned imports.
 
 ## Why is this bad?
-Projects may want to ensure that specific modules or module members are not be imported or accessed. Security or other company policies may
-be a reason to impose restrictions on importing external Python libraries. This rule enforces certain import conventions project-wide in an
+Projects may want to ensure that specific modules or module members are
+not be imported or accessed.
+
+Security or other company policies may be a reason to impose
+restrictions on importing external Python libraries. In some cases,
+projects may adopt conventions around the use of certain modules or
+module members that are not enforceable by the language itself.
+
+This rule enforces certain import conventions project-wide in an
 automatic way.
 
 ## Options
-
 * `flake8-tidy-imports.banned-api`

--- a/docs/rules/banned-api.md
+++ b/docs/rules/banned-api.md
@@ -1,0 +1,15 @@
+# banned-api (TID251)
+
+Derived from the **flake8-tidy-imports** linter.
+
+## What it does
+Checks for banned imports.
+
+## Why is this bad?
+Projects may want to ensure that specific modules or module members are not be imported or accessed. Security or other company policies may
+be a reason to impose restrictions on importing external Python libraries. This rule enforces certain import conventions project-wide in an
+automatic way.
+
+## Options
+
+* `flake8-tidy-imports.banned-api`


### PR DESCRIPTION
Complete docs for `flake8-tidy-imports` (https://github.com/charliermarsh/ruff/issues/2646)

(option will be linked by https://github.com/charliermarsh/ruff/pull/2777)