### PR TITLE
Fix unused multi-assignments in a single pass

### DIFF
--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -201,31 +201,7 @@ fn remove_unused_variable(
             range.location == target.location && range.end_location == target.end_location.unwrap()
         }) {
             if matches!(target.node, ExprKind::Name { .. }) {
-                return if targets.len() > 1 {
-                    // Construct a deletion by concatenating everything before the target to
-                    // everything after it. This ensures that our edit spans the entire statement,
-                    // which in turn ensures that we only apply one edit per pass.
-                    Some((
-                        DeletionKind::Partial,
-                        Fix::replacement(
-                            format!(
-                                "{}{}",
-                                checker.locator.slice_source_code_range(&Range::new(
-                                    stmt.location,
-                                    target.location
-                                )),
-                                checker.locator.slice_source_code_range(&Range::new(
-                                    match_token_after(target, checker.locator, |tok| tok
-                                        == Tok::Equal)
-                                    .location,
-                                    stmt.end_location.unwrap()
-                                ))
-                            ),
-                            stmt.location,
-                            stmt.end_location.unwrap(),
-                        ),
-                    ))
-                } else if contains_effect(checker, value) {
+                return if targets.len() > 1 || contains_effect(checker, value) {
                     // If the expression is complex (`x = foo()`), remove the assignment,
                     // but preserve the right-hand side.
                     Some((

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
@@ -92,13 +92,13 @@ expression: diagnostics
     column: 16
   fix:
     content:
-      - "(x, y) = bar"
+      - ""
     location:
       row: 26
-      column: 4
+      column: 13
     end_location:
       row: 26
-      column: 22
+      column: 19
   parent: ~
 - kind:
     UnusedVariable:

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
@@ -35,13 +35,13 @@ expression: diagnostics
     column: 19
   fix:
     content:
-      - "(x, y) = 1, 2"
+      - ""
     location:
       row: 16
-      column: 4
+      column: 13
     end_location:
       row: 16
-      column: 26
+      column: 22
   parent: ~
 - kind:
     UnusedVariable:
@@ -54,13 +54,13 @@ expression: diagnostics
     column: 10
   fix:
     content:
-      - "(x, y) = 1, 2"
+      - ""
     location:
       row: 20
       column: 4
     end_location:
       row: 20
-      column: 26
+      column: 13
   parent: ~
 - kind:
     UnusedVariable:

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
@@ -187,13 +187,13 @@ expression: diagnostics
     column: 22
   fix:
     content:
-      - "(x2, y2) = (1, 2)"
+      - ""
     location:
       row: 33
-      column: 4
+      column: 15
     end_location:
       row: 33
-      column: 31
+      column: 25
   parent: ~
 - kind:
     UnusedVariable:
@@ -206,13 +206,13 @@ expression: diagnostics
     column: 11
   fix:
     content:
-      - "(x3, y3) = (1, 2)"
+      - ""
     location:
       row: 34
       column: 4
     end_location:
       row: 34
-      column: 31
+      column: 14
   parent: ~
 - kind:
     UnusedVariable:
@@ -377,13 +377,13 @@ expression: diagnostics
     column: 12
   fix:
     content:
-      - tt = lexer.get_token()
+      - ""
     location:
       row: 87
       column: 4
     end_location:
       row: 87
-      column: 37
+      column: 15
   parent: ~
 - kind:
     UnusedVariable:
@@ -396,13 +396,13 @@ expression: diagnostics
     column: 12
   fix:
     content:
-      - tt = lexer.get_token()
+      - ""
     location:
       row: 93
       column: 4
     end_location:
       row: 93
-      column: 37
+      column: 15
   parent: ~
 - kind:
     UnusedVariable:
@@ -415,13 +415,13 @@ expression: diagnostics
     column: 17
   fix:
     content:
-      - toplevel = lexer.get_token()
+      - ""
     location:
       row: 93
-      column: 4
+      column: 15
     end_location:
       row: 93
-      column: 37
+      column: 20
   parent: ~
 - kind:
     UnusedVariable:
@@ -434,13 +434,13 @@ expression: diagnostics
     column: 12
   fix:
     content:
-      - "(a, b) = lexer.get_token()"
+      - ""
     location:
       row: 97
       column: 4
     end_location:
       row: 97
-      column: 41
+      column: 15
   parent: ~
 - kind:
     UnusedVariable:
@@ -453,13 +453,13 @@ expression: diagnostics
     column: 21
   fix:
     content:
-      - "(a, b) = lexer.get_token()"
+      - ""
     location:
       row: 101
-      column: 4
+      column: 13
     end_location:
       row: 101
-      column: 41
+      column: 24
   parent: ~
 - kind:
     UnusedVariable:
@@ -472,13 +472,13 @@ expression: diagnostics
     column: 12
   fix:
     content:
-      - tt = 1
+      - ""
     location:
       row: 105
       column: 4
     end_location:
       row: 105
-      column: 21
+      column: 15
   parent: ~
 - kind:
     UnusedVariable:
@@ -491,12 +491,12 @@ expression: diagnostics
     column: 17
   fix:
     content:
-      - toplevel = 1
+      - ""
     location:
       row: 105
-      column: 4
+      column: 15
     end_location:
       row: 105
-      column: 21
+      column: 20
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -73,13 +73,13 @@ expression: diagnostics
     column: 16
   fix:
     content:
-      - "(x, y) = bar"
+      - ""
     location:
       row: 26
-      column: 4
+      column: 13
     end_location:
       row: 26
-      column: 22
+      column: 19
   parent: ~
 - kind:
     UnusedVariable:


### PR DESCRIPTION
This can leave behind a constant expression (`toplevel = tt = 1` gets fixed to `1`, rather than `pass`), but it's a lot more efficient and clearer.