### PR TITLE
Allow compound statements of single ellipsis

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E70.py
@@ -46,3 +46,11 @@ if a := 1:
     pass
 #:
 func = lambda x: x** 2 if cond else lambda x:x
+#:
+class C: ...
+#:
+def f(): ...
+#: E701:1:8 E702:1:13
+class C: ...; x = 1
+#: E701:1:8 E702:1:13
+class C: ...; ...

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E701_E70.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E701_E70.py.snap
@@ -112,4 +112,24 @@ expression: diagnostics
     column: 15
   fix: ~
   parent: ~
+- kind:
+    MultipleStatementsOnOneLineColon: ~
+  location:
+    row: 54
+    column: 7
+  end_location:
+    row: 54
+    column: 8
+  fix: ~
+  parent: ~
+- kind:
+    MultipleStatementsOnOneLineColon: ~
+  location:
+    row: 56
+    column: 7
+  end_location:
+    row: 56
+    column: 8
+  fix: ~
+  parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E702_E70.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E702_E70.py.snap
@@ -42,4 +42,24 @@ expression: diagnostics
     column: 11
   fix: ~
   parent: ~
+- kind:
+    MultipleStatementsOnOneLineSemicolon: ~
+  location:
+    row: 54
+    column: 12
+  end_location:
+    row: 54
+    column: 13
+  fix: ~
+  parent: ~
+- kind:
+    MultipleStatementsOnOneLineSemicolon: ~
+  location:
+    row: 56
+    column: 12
+  end_location:
+    row: 56
+    column: 13
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
This allows `class C: ...`-style compound statements in stub files.

Closes #2835.