### PR TITLE
Remove no longer needed `setup.py` `INP001` ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,3 @@ bindings = "bin"
 manifest-path = "crates/ruff_cli/Cargo.toml"
 python-source = "python"
 strip = true
-
-[tool.ruff.per-file-ignores]
-"setup.py" = ["INP001"]


### PR DESCRIPTION
No longer needed since dd0145624b7d7664239186cb01304669b557563c, #2565.