### PR TITLE
Add `StaticTextSlice` kind to `FormatElement` enum

### DIFF
--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::num::NonZeroU8;
+use std::rc::Rc;
 use Tag::*;
 
 /// A line break that only gets printed if the enclosing `Group` doesn't fit on a single line.
@@ -300,6 +301,34 @@ impl<Context> Format<Context> for DynamicText<'_> {
 impl std::fmt::Debug for DynamicText<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::write!(f, "DynamicToken({})", self.text)
+    }
+}
+
+/// Creates a text from a dynamic string and a range of the input source
+pub fn static_text_slice(text: Rc<str>, range: TextRange) -> StaticTextSlice {
+    debug_assert_no_newlines(&text[range]);
+
+    StaticTextSlice { text, range }
+}
+
+#[derive(Eq, PartialEq)]
+pub struct StaticTextSlice {
+    text: Rc<str>,
+    range: TextRange,
+}
+
+impl<Context> Format<Context> for StaticTextSlice {
+    fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
+        f.write_element(FormatElement::StaticTextSlice {
+            text: self.text.clone(),
+            range: self.range,
+        })
+    }
+}
+
+impl std::fmt::Debug for StaticTextSlice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "StaticTextSlice({})", &self.text[self.range])
     }
 }
 

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -79,6 +79,9 @@ impl Document {
                         enclosing.pop();
                         continue;
                     }
+                    FormatElement::StaticTextSlice { text, start, end } => {
+                        text[*start..*end].contains('\n')
+                    }
                     FormatElement::StaticText { text } => text.contains('\n'),
                     FormatElement::DynamicText { text, .. } => text.contains('\n'),
                     FormatElement::SyntaxTokenTextSlice { slice, .. } => slice.contains('\n'),
@@ -192,6 +195,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
 
             match element {
                 element @ FormatElement::Space
+                | element @ FormatElement::StaticTextSlice { .. }
                 | element @ FormatElement::StaticText { .. }
                 | element @ FormatElement::DynamicText { .. }
                 | element @ FormatElement::SyntaxTokenTextSlice { .. } => {

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -79,11 +79,9 @@ impl Document {
                         enclosing.pop();
                         continue;
                     }
-                    FormatElement::StaticTextSlice { text, start, end } => {
-                        text[*start..*end].contains('\n')
-                    }
                     FormatElement::StaticText { text } => text.contains('\n'),
                     FormatElement::DynamicText { text, .. } => text.contains('\n'),
+                    FormatElement::StaticTextSlice { text, range } => text[*range].contains('\n'),
                     FormatElement::SyntaxTokenTextSlice { slice, .. } => slice.contains('\n'),
                     FormatElement::ExpandParent
                     | FormatElement::Line(LineMode::Hard | LineMode::Empty) => true,
@@ -195,9 +193,9 @@ impl Format<IrFormatContext> for &[FormatElement] {
 
             match element {
                 element @ FormatElement::Space
-                | element @ FormatElement::StaticTextSlice { .. }
                 | element @ FormatElement::StaticText { .. }
                 | element @ FormatElement::DynamicText { .. }
+                | element @ FormatElement::StaticTextSlice { .. }
                 | element @ FormatElement::SyntaxTokenTextSlice { .. } => {
                     if !in_text {
                         write!(f, [text("\"")])?;

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -94,14 +94,12 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            FormatElement::StaticTextSlice { text, start, end } => {
-                self.print_text(&text[*start..*end], None)
-            }
             FormatElement::StaticText { text } => self.print_text(text, None),
             FormatElement::DynamicText {
                 text,
                 source_position,
             } => self.print_text(text, Some(*source_position)),
+            FormatElement::StaticTextSlice { text, range } => self.print_text(&text[*range], None),
             FormatElement::SyntaxTokenTextSlice {
                 slice,
                 source_position,
@@ -1002,11 +1000,11 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
-            FormatElement::StaticTextSlice { text, start, end } => {
-                return Ok(self.fits_text(&text[*start..*end]))
-            }
             FormatElement::StaticText { text } => return Ok(self.fits_text(text)),
             FormatElement::DynamicText { text, .. } => return Ok(self.fits_text(text)),
+            FormatElement::StaticTextSlice { text, range } => {
+                return Ok(self.fits_text(&text[*range]))
+            }
             FormatElement::SyntaxTokenTextSlice { slice, .. } => return Ok(self.fits_text(slice)),
 
             FormatElement::LineSuffixBoundary => {

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -94,6 +94,9 @@ impl<'a> Printer<'a> {
                 }
             }
 
+            FormatElement::StaticTextSlice { text, start, end } => {
+                self.print_text(&text[*start..*end], None)
+            }
             FormatElement::StaticText { text } => self.print_text(text, None),
             FormatElement::DynamicText {
                 text,
@@ -999,6 +1002,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 }
             }
 
+            FormatElement::StaticTextSlice { text, start, end } => {
+                return Ok(self.fits_text(&text[*start..*end]))
+            }
             FormatElement::StaticText { text } => return Ok(self.fits_text(text)),
             FormatElement::DynamicText { text, .. } => return Ok(self.fits_text(text)),
             FormatElement::SyntaxTokenTextSlice { slice, .. } => return Ok(self.fits_text(slice)),


### PR DESCRIPTION
Given our current parser abstractions, we need the ability to tell `ruff_formatter` to print a pre-defined slice from a fixed string of source code, which we've introduced here as `FormatElement::StaticTextSlice`.