### PR TITLE
Avoid unnecessary-else violations in `elif` branches

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET508.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET508.py
@@ -136,3 +136,24 @@ def nested2(x, y, z):
                 break
         else:
             a = z
+
+
+def elif1(x, y, w, z):
+    for i in x:
+        if i > y:
+            a = z
+        elif i > w:
+            break
+        else:
+            a = z
+
+
+def elif2(x, y, w, z):
+    for i in x:
+        if i > y:
+            a = z
+        else:
+            if i > w:
+                break
+            else:
+                a = z

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -423,13 +423,7 @@ fn superfluous_elif(checker: &mut Checker, stack: &Stack) -> bool {
 
 /// RET505, RET506, RET507, RET508
 fn superfluous_else(checker: &mut Checker, stack: &Stack) -> bool {
-    for stmt in &stack.ifs {
-        let StmtKind::If { orelse, .. } = &stmt.node else {
-            continue;
-        };
-        if orelse.is_empty() {
-            continue;
-        }
+    for stmt in &stack.elses {
         if superfluous_else_node(checker, stmt, Branch::Else) {
             return true;
         }


### PR DESCRIPTION
Long-time source of confusion -- two reports over 1800 issues apart.

Closes #1035.

Closes #2879.
