### PR TITLE
docs(SIM114): fix typo in example Python code

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -118,15 +118,15 @@ define_violation!(
     ///
     /// ### Example
     /// ```python
-    /// if x = 1:
+    /// if x == 1:
     ///     print("Hello")
-    /// elif x = 2:
+    /// elif x == 2:
     ///     print("Hello")
     /// ```
     ///
     /// Use instead:
     /// ```python
-    /// if x = 1 or x = 2:
+    /// if x == 1 or x == 2:
     ///     print("Hello")
     /// ```
     pub struct IfWithSameArms;


### PR DESCRIPTION
I think the original documentation here was probably intended to be more like pseudo-code. But I think it's nice if it is valid Python.