### PR TITLE
Regex hack for mkdocs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ dependencies = [
  "itertools",
  "libcst",
  "once_cell",
+ "regex",
  "ruff",
  "ruff_cli",
  "rustpython-common",

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -9,6 +9,7 @@ clap = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 once_cell = { workspace = true }
+regex.workspace = true
 ruff = { path = "../ruff" }
 ruff_cli = { path = "../ruff_cli" }
 rustpython-common = { workspace = true }

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -40,11 +40,8 @@ def main() -> None:
         raise ValueError(msg)
     content = content.replace(DOCUMENTATION_LINK, "")
 
-    # Replace all GitHub links with relative links.
-    content = content.replace(
-        "https://github.com/charliermarsh/ruff/blob/main/docs/rules/",
-        "rules/",
-    )
+    # Make the documentation links in the README more relative.
+    content = content.replace("https://beta.ruff.rs", "")
 
     Path("docs").mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Given that we apparently do not want to switch to mdBook with proper CommonMark support (see #2847), this PR instead fixes the broken links via a regex hack.

(See the 2nd commit message for more details.)