### PR TITLE
Ignore non-imperative-mood in Google docstring convention

### DIFF
--- a/crates/ruff/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff/src/rules/pydocstyle/settings.rs
@@ -26,6 +26,7 @@ impl Convention {
                 Rule::MultiLineSummarySecondLine,
                 Rule::SectionUnderlineNotOverIndented,
                 Rule::EndsInPeriod,
+                Rule::NonImperativeMood,
                 Rule::DocstringStartsWithThis,
                 Rule::NewLineAfterSectionName,
                 Rule::DashedUnderlineAfterSection,


### PR DESCRIPTION
Closes #2897.