### PR TITLE
Implement shell autocompletion for rule codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Options:
       --show-settings
           See the settings Ruff will use to lint a given Python file
   -h, --help
-          Print help
+          Print help (see more with '--help')
 
 Rule selection:
       --select <RULE_CODE>

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -21,7 +21,7 @@ bisection = { version = "0.1.0" }
 bitflags = { version = "1.3.2" }
 cfg-if = { version = "1.0.0" }
 chrono = { version = "0.4.21", default-features = false, features = ["clock"] }
-clap = { workspace = true, features = ["derive", "env"] }
+clap = { workspace = true, features = ["derive", "env", "string"] }
 colored = { version = "2.0.0" }
 dirs = { version = "4.0.0" }
 fern = { version = "0.6.1" }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -109,7 +109,8 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        help_heading = "Rule selection"
+        help_heading = "Rule selection",
+        hide_possible_values = true
     )]
     pub select: Option<Vec<RuleSelector>>,
     /// Comma-separated list of rule codes to disable.
@@ -117,7 +118,8 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        help_heading = "Rule selection"
+        help_heading = "Rule selection",
+        hide_possible_values = true
     )]
     pub ignore: Option<Vec<RuleSelector>>,
     /// Like --select, but adds additional rule codes on top of the selected
@@ -126,7 +128,8 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        help_heading = "Rule selection"
+        help_heading = "Rule selection",
+        hide_possible_values = true
     )]
     pub extend_select: Option<Vec<RuleSelector>>,
     /// Like --ignore. (Deprecated: You can just use --ignore instead.)
@@ -164,7 +167,8 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        help_heading = "Rule selection"
+        help_heading = "Rule selection",
+        hide_possible_values = true
     )]
     pub fixable: Option<Vec<RuleSelector>>,
     /// List of rule codes to treat as ineligible for autofix. Only applicable
@@ -173,7 +177,8 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
-        help_heading = "Rule selection"
+        help_heading = "Rule selection",
+        hide_possible_values = true
     )]
     pub unfixable: Option<Vec<RuleSelector>>,
     /// Respect file exclusions via `.gitignore` and other standard ignore

--- a/crates/ruff_macros/src/register_rules.rs
+++ b/crates/ruff_macros/src/register_rules.rs
@@ -57,6 +57,7 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
             PartialOrd,
             Ord,
             AsRefStr,
+            ::strum_macros::IntoStaticStr,
         )]
         #[strum(serialize_all = "kebab-case")]
         pub enum Rule { #rule_variants }


### PR DESCRIPTION
For example:

    $ ruff check --select=EM<Tab>
    EM          -- flake8-errmsg
    EM10   EM1  --
    EM101       -- raw-string-in-exception
    EM102       -- f-string-in-exception
    EM103       -- dot-format-in-exception

(You will need to enable autocompletion as described
in the Autocompletion section in the README.)

Fixes #2808.