### PR TITLE
Skip .pytype directory by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ exclude = [
     ".mypy_cache",
     ".nox",
     ".pants.d",
+    ".pytype",
     ".ruff_cache",
     ".svn",
     ".tox",
@@ -2211,7 +2212,7 @@ For more information on the glob syntax, refer to the [`globset` documentation](
 Note that you'll typically want to use
 [`extend-exclude`](#extend-exclude) to modify the excluded paths.
 
-**Default value**: `[".bzr", ".direnv", ".eggs", ".git", ".hg", ".mypy_cache", ".nox", ".pants.d", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]`
+**Default value**: `[".bzr", ".direnv", ".eggs", ".git", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]`
 
 **Type**: `list[str]`
 

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -40,6 +40,7 @@ pub static EXCLUDE: Lazy<Vec<FilePattern>> = Lazy::new(|| {
         FilePattern::Builtin(".mypy_cache"),
         FilePattern::Builtin(".nox"),
         FilePattern::Builtin(".pants.d"),
+        FilePattern::Builtin(".pytype"),
         FilePattern::Builtin(".ruff_cache"),
         FilePattern::Builtin(".svn"),
         FilePattern::Builtin(".tox"),

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -70,7 +70,7 @@ pub struct Options {
     /// default expression matches `_`, `__`, and `_var`, but not `_var_`.
     pub dummy_variable_rgx: Option<String>,
     #[option(
-        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".hg", ".mypy_cache", ".nox", ".pants.d", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
+        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
         value_type = "list[str]",
         example = r#"
             exclude = [".venv"]


### PR DESCRIPTION
Pytype stores .pyi files in .pytype that ruff shouldn’t check or touch.