### PR TITLE
Add configuration option for C408 to allow dict calls with keyword arguments.

### DIFF
--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -2556,7 +2556,14 @@ where
                     .enabled(&Rule::UnnecessaryCollectionCall)
                 {
                     flake8_comprehensions::rules::unnecessary_collection_call(
-                        self, expr, func, args, keywords,
+                        self,
+                        expr,
+                        func,
+                        args,
+                        keywords,
+                        self.settings
+                            .flake8_comprehensions
+                            .allow_dict_calls_with_keyword_arguments,
                     );
                 }
                 if self

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -2561,9 +2561,7 @@ where
                         func,
                         args,
                         keywords,
-                        self.settings
-                            .flake8_comprehensions
-                            .allow_dict_calls_with_keyword_arguments,
+                        &self.settings.flake8_comprehensions,
                     );
                 }
                 if self

--- a/crates/ruff/src/lib_wasm.rs
+++ b/crates/ruff/src/lib_wasm.rs
@@ -9,10 +9,10 @@ use crate::directives;
 use crate::linter::{check_path, LinterResult};
 use crate::registry::Rule;
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
-    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
-    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
-    pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
+    flake8_errmsg, flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style,
+    flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments,
+    isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 use crate::rustpython_helpers::tokenize;
 use crate::settings::configuration::Configuration;
@@ -139,6 +139,7 @@ pub fn defaultSettings() -> Result<JsValue, JsValue> {
         flake8_bandit: Some(flake8_bandit::settings::Settings::default().into()),
         flake8_bugbear: Some(flake8_bugbear::settings::Settings::default().into()),
         flake8_builtins: Some(flake8_builtins::settings::Settings::default().into()),
+        flake8_comprehensions: Some(flake8_comprehensions::settings::Settings::default().into()),
         flake8_errmsg: Some(flake8_errmsg::settings::Settings::default().into()),
         flake8_pytest_style: Some(flake8_pytest_style::settings::Settings::default().into()),
         flake8_quotes: Some(flake8_quotes::settings::Settings::default().into()),

--- a/crates/ruff/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/mod.rs
@@ -1,6 +1,7 @@
 //! Rules from [flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/).
 mod fixes;
 pub(crate) mod rules;
+pub mod settings;
 
 #[cfg(test)]
 mod tests {
@@ -9,9 +10,10 @@ mod tests {
     use anyhow::Result;
     use test_case::test_case;
 
+    use crate::assert_yaml_snapshot;
     use crate::registry::Rule;
+    use crate::settings::Settings;
     use crate::test::test_path;
-    use crate::{assert_yaml_snapshot, settings};
 
     #[test_case(Rule::UnnecessaryGeneratorList, Path::new("C400.py"); "C400")]
     #[test_case(Rule::UnnecessaryGeneratorSet, Path::new("C401.py"); "C401")]
@@ -34,7 +36,27 @@ mod tests {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("flake8_comprehensions").join(path).as_path(),
-            &settings::Settings::for_rule(rule_code),
+            &Settings::for_rule(rule_code),
+        )?;
+        assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Rule::UnnecessaryCollectionCall, Path::new("C408.py"); "C408")]
+    fn allow_dict_calls_with_keyword_arguments(rule_code: Rule, path: &Path) -> Result<()> {
+        let snapshot = format!(
+            "{}_{}_allow_dict_calls_with_keyword_arguments",
+            rule_code.noqa_code(),
+            path.to_string_lossy()
+        );
+        let diagnostics = test_path(
+            Path::new("flake8_comprehensions").join(path).as_path(),
+            &Settings {
+                flake8_comprehensions: super::settings::Settings {
+                    allow_dict_calls_with_keyword_arguments: true,
+                },
+                ..Settings::for_rule(rule_code)
+            },
         )?;
         assert_yaml_snapshot!(snapshot, diagnostics);
         Ok(())

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -7,6 +7,7 @@ use crate::ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::Diagnostic;
 use crate::rules::flake8_comprehensions::fixes;
+use crate::rules::flake8_comprehensions::settings::Settings;
 use crate::violation::AlwaysAutofixableViolation;
 
 define_violation!(
@@ -33,7 +34,7 @@ pub fn unnecessary_collection_call(
     func: &Expr,
     args: &[Expr],
     keywords: &[Keyword],
-    allow_dict_calls_with_keyword_arguments: bool,
+    settings: &Settings,
 ) {
     if !args.is_empty() {
         return;
@@ -44,7 +45,7 @@ pub fn unnecessary_collection_call(
     match id {
         "dict"
             if keywords.is_empty()
-                || (!allow_dict_calls_with_keyword_arguments
+                || (!settings.allow_dict_calls_with_keyword_arguments
                     && keywords.iter().all(|kw| kw.node.arg.is_some())) =>
         {
             // `dict()` or `dict(a=1)` (as opposed to `dict(**a)`)

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -33,6 +33,7 @@ pub fn unnecessary_collection_call(
     func: &Expr,
     args: &[Expr],
     keywords: &[Keyword],
+    allow_dict_calls_with_keyword_arguments: bool,
 ) {
     if !args.is_empty() {
         return;
@@ -41,7 +42,11 @@ pub fn unnecessary_collection_call(
         return;
     };
     match id {
-        "dict" if keywords.is_empty() || keywords.iter().all(|kw| kw.node.arg.is_some()) => {
+        "dict"
+            if keywords.is_empty()
+                || (!allow_dict_calls_with_keyword_arguments
+                    && keywords.iter().all(|kw| kw.node.arg.is_some())) =>
+        {
             // `dict()` or `dict(a=1)` (as opposed to `dict(**a)`)
         }
         "list" | "tuple" => {

--- a/crates/ruff/src/rules/flake8_comprehensions/settings.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/settings.rs
@@ -1,0 +1,48 @@
+//! Settings for the `flake8-comprehensions` plugin.
+
+use ruff_macros::ConfigurationOptions;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, JsonSchema,
+)]
+#[serde(
+    deny_unknown_fields,
+    rename_all = "kebab-case",
+    rename = "Flake8ComprehensionsOptions"
+)]
+pub struct Options {
+    #[option(
+        default = "false",
+        value_type = "bool",
+        example = "allow-dict-calls-with-keyword-arguments = true"
+    )]
+    /// Allow dict calls with keyword arguments.
+    pub allow_dict_calls_with_keyword_arguments: Option<bool>,
+}
+
+#[derive(Debug, Default, Hash)]
+pub struct Settings {
+    pub allow_dict_calls_with_keyword_arguments: bool,
+}
+
+impl From<Options> for Settings {
+    fn from(options: Options) -> Self {
+        Self {
+            allow_dict_calls_with_keyword_arguments: options
+                .allow_dict_calls_with_keyword_arguments
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<Settings> for Options {
+    fn from(settings: Settings) -> Self {
+        Self {
+            allow_dict_calls_with_keyword_arguments: Some(
+                settings.allow_dict_calls_with_keyword_arguments,
+            ),
+        }
+    }
+}

--- a/crates/ruff/src/rules/flake8_comprehensions/settings.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/settings.rs
@@ -18,7 +18,7 @@ pub struct Options {
         value_type = "bool",
         example = "allow-dict-calls-with-keyword-arguments = true"
     )]
-    /// Allow dict calls with keyword arguments.
+    /// Allow `dict` calls that make use of keyword arguments (e.g., `dict(a=1, b=2)`).
     pub allow_dict_calls_with_keyword_arguments: Option<bool>,
 }
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
@@ -1,0 +1,62 @@
+---
+source: crates/ruff/src/rules/flake8_comprehensions/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnnecessaryCollectionCall:
+      obj_type: tuple
+  location:
+    row: 1
+    column: 4
+  end_location:
+    row: 1
+    column: 11
+  fix:
+    content:
+      - ()
+    location:
+      row: 1
+      column: 4
+    end_location:
+      row: 1
+      column: 11
+  parent: ~
+- kind:
+    UnnecessaryCollectionCall:
+      obj_type: list
+  location:
+    row: 2
+    column: 4
+  end_location:
+    row: 2
+    column: 10
+  fix:
+    content:
+      - "[]"
+    location:
+      row: 2
+      column: 4
+    end_location:
+      row: 2
+      column: 10
+  parent: ~
+- kind:
+    UnnecessaryCollectionCall:
+      obj_type: dict
+  location:
+    row: 3
+    column: 5
+  end_location:
+    row: 3
+    column: 11
+  fix:
+    content:
+      - "{}"
+    location:
+      row: 3
+      column: 5
+    end_location:
+      row: 3
+      column: 11
+  parent: ~
+

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -15,10 +15,10 @@ use shellexpand::LookupError;
 use crate::fs;
 use crate::rule_selector::RuleSelector;
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
-    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
-    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
-    pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
+    flake8_errmsg, flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style,
+    flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments,
+    isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 use crate::settings::options::Options;
 use crate::settings::types::{
@@ -68,6 +68,7 @@ pub struct Configuration {
     pub flake8_bandit: Option<flake8_bandit::settings::Options>,
     pub flake8_bugbear: Option<flake8_bugbear::settings::Options>,
     pub flake8_builtins: Option<flake8_builtins::settings::Options>,
+    pub flake8_comprehensions: Option<flake8_comprehensions::settings::Options>,
     pub flake8_errmsg: Option<flake8_errmsg::settings::Options>,
     pub flake8_implicit_str_concat: Option<flake8_implicit_str_concat::settings::Options>,
     pub flake8_import_conventions: Option<flake8_import_conventions::settings::Options>,
@@ -181,6 +182,7 @@ impl Configuration {
             flake8_bandit: options.flake8_bandit,
             flake8_bugbear: options.flake8_bugbear,
             flake8_builtins: options.flake8_builtins,
+            flake8_comprehensions: options.flake8_comprehensions,
             flake8_errmsg: options.flake8_errmsg,
             flake8_implicit_str_concat: options.flake8_implicit_str_concat,
             flake8_import_conventions: options.flake8_import_conventions,
@@ -244,6 +246,7 @@ impl Configuration {
             flake8_bandit: self.flake8_bandit.or(config.flake8_bandit),
             flake8_bugbear: self.flake8_bugbear.or(config.flake8_bugbear),
             flake8_builtins: self.flake8_builtins.or(config.flake8_builtins),
+            flake8_comprehensions: self.flake8_comprehensions.or(config.flake8_comprehensions),
             flake8_errmsg: self.flake8_errmsg.or(config.flake8_errmsg),
             flake8_implicit_str_concat: self
                 .flake8_implicit_str_concat

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -10,10 +10,10 @@ use crate::codes::{self, RuleCodePrefix};
 use crate::registry::Linter;
 use crate::rule_selector::{prefix_to_selector, RuleSelector};
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
-    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
-    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
-    pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
+    flake8_errmsg, flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style,
+    flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments,
+    isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 
 pub const PREFIXES: &[RuleSelector] = &[
@@ -81,6 +81,7 @@ impl Default for Settings {
             flake8_bandit: flake8_bandit::settings::Settings::default(),
             flake8_bugbear: flake8_bugbear::settings::Settings::default(),
             flake8_builtins: flake8_builtins::settings::Settings::default(),
+            flake8_comprehensions: flake8_comprehensions::settings::Settings::default(),
             flake8_errmsg: flake8_errmsg::settings::Settings::default(),
             flake8_implicit_str_concat: flake8_implicit_str_concat::settings::Settings::default(),
             flake8_import_conventions: flake8_import_conventions::settings::Settings::default(),

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -15,10 +15,10 @@ use crate::cache::cache_dir;
 use crate::registry::{Rule, RuleNamespace, INCOMPATIBLE_CODES};
 use crate::rule_selector::{RuleSelector, Specificity};
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
-    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
-    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
-    pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
+    flake8_errmsg, flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style,
+    flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments,
+    isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 use crate::settings::configuration::Configuration;
 use crate::settings::types::{PerFileIgnore, PythonVersion, SerializationFormat};
@@ -110,6 +110,7 @@ pub struct Settings {
     pub flake8_bandit: flake8_bandit::settings::Settings,
     pub flake8_bugbear: flake8_bugbear::settings::Settings,
     pub flake8_builtins: flake8_builtins::settings::Settings,
+    pub flake8_comprehensions: flake8_comprehensions::settings::Settings,
     pub flake8_errmsg: flake8_errmsg::settings::Settings,
     pub flake8_implicit_str_concat: flake8_implicit_str_concat::settings::Settings,
     pub flake8_import_conventions: flake8_import_conventions::settings::Settings,
@@ -188,6 +189,10 @@ impl Settings {
             flake8_bandit: config.flake8_bandit.map(Into::into).unwrap_or_default(),
             flake8_bugbear: config.flake8_bugbear.map(Into::into).unwrap_or_default(),
             flake8_builtins: config.flake8_builtins.map(Into::into).unwrap_or_default(),
+            flake8_comprehensions: config
+                .flake8_comprehensions
+                .map(Into::into)
+                .unwrap_or_default(),
             flake8_errmsg: config.flake8_errmsg.map(Into::into).unwrap_or_default(),
             flake8_implicit_str_concat: config
                 .flake8_implicit_str_concat

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::rule_selector::RuleSelector;
 use crate::rules::{
-    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_errmsg,
-    flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style, flake8_quotes,
-    flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments, isort, mccabe,
-    pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
+    flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
+    flake8_errmsg, flake8_implicit_str_concat, flake8_import_conventions, flake8_pytest_style,
+    flake8_quotes, flake8_self, flake8_tidy_imports, flake8_type_checking, flake8_unused_arguments,
+    isort, mccabe, pep8_naming, pycodestyle, pydocstyle, pylint, pyupgrade,
 };
 use crate::settings::types::{PythonVersion, SerializationFormat, Version};
 
@@ -435,6 +435,9 @@ pub struct Options {
     #[option_group]
     /// Options for the `flake8-builtins` plugin.
     pub flake8_builtins: Option<flake8_builtins::settings::Options>,
+    #[option_group]
+    /// Options for the `flake8-comprehensions` plugin.
+    pub flake8_comprehensions: Option<flake8_comprehensions::settings::Options>,
     #[option_group]
     /// Options for the `flake8-errmsg` plugin.
     pub flake8_errmsg: Option<flake8_errmsg::settings::Options>,

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -670,7 +670,7 @@
       "type": "object",
       "properties": {
         "allow-dict-calls-with-keyword-arguments": {
-          "description": "Allow dict calls with keyword arguments.",
+          "description": "Allow `dict` calls that make use of keyword arguments (e.g., `dict(a=1, b=2)`).",
           "type": [
             "boolean",
             "null"

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -154,6 +154,17 @@
         }
       ]
     },
+    "flake8-comprehensions": {
+      "description": "Options for the `flake8-comprehensions` plugin.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Flake8ComprehensionsOptions"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "flake8-errmsg": {
       "description": "Options for the `flake8-errmsg` plugin.",
       "anyOf": [
@@ -651,6 +662,19 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Flake8ComprehensionsOptions": {
+      "type": "object",
+      "properties": {
+        "allow-dict-calls-with-keyword-arguments": {
+          "description": "Allow dict calls with keyword arguments.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
When creating a dict with string keys, some prefer to call dict instead of writing a dict literal. For example: `dict(a=1, b=2, c=3)` instead of `{"a": 1, "b": 2, "c": 3}`.