### PR TITLE
Add support for file-scoped `noqa` directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,12 +621,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor.
 """  # noqa: E501
 ```
 
-To ignore all violations across an entire file, Ruff supports Flake8's `# flake8: noqa` directive
-(or, equivalently, `# ruff: noqa`). Adding either of those directives to any part of a file will
-disable enforcement across the entire file.
+To ignore all violations across an entire file, add `# ruff: noqa` to any line in the file, like so:
 
-For targeted exclusions across entire files (e.g., "Ignore all F841 violations in
-`/path/to/file.py`"), see the [`per-file-ignores`](#per-file-ignores) configuration setting.
+```python
+# ruff: noqa
+```
+
+To ignore a specific rule across an entire file, add `# ruff: noqa: {code}` to any line in the file,
+like so:
+
+```python
+# ruff: noqa: F841
+```
+
+Or see the [`per-file-ignores`](#per-file-ignores) configuration setting, which enables the same
+functionality via a `pyproject.toml` file.
+
+Note that Ruff will also respect Flake8's `# flake8: noqa` directive, and will treat it as
+equivalent to `# ruff: noqa`.
 
 #### Automatic error suppression
 

--- a/crates/ruff/resources/test/fixtures/ruff/ruff_targeted_noqa.py
+++ b/crates/ruff/resources/test/fixtures/ruff/ruff_targeted_noqa.py
@@ -1,0 +1,8 @@
+# ruff: noqa: F401
+
+import os
+import foo
+
+
+def f():
+    x = 1

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -109,6 +109,16 @@ mod tests {
     }
 
     #[test]
+    fn ruff_targeted_noqa() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("ruff/ruff_targeted_noqa.py"),
+            &settings::Settings::for_rules(vec![Rule::UnusedImport, Rule::UnusedVariable]),
+        )?;
+        assert_yaml_snapshot!(diagnostics);
+        Ok(())
+    }
+
+    #[test]
     fn redirects() -> Result<()> {
         let diagnostics = test_path(
             Path::new("ruff/redirects.py"),

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_targeted_noqa.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_targeted_noqa.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff/src/rules/ruff/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnusedVariable:
+      name: x
+  location:
+    row: 8
+    column: 4
+  end_location:
+    row: 8
+    column: 5
+  fix:
+    content:
+      - pass
+    location:
+      row: 8
+      column: 4
+    end_location:
+      row: 8
+      column: 9
+  parent: ~
+


### PR DESCRIPTION
# Summary

This allows users to do things like:

```py
# ruff: noqa: F401
```

...to ignore all `F401` directives in a file. It's equivalent to `per-file-ignores`, but allows users to specify the behavior inline.

Note that Flake8 does _not_ support this, so we _don't_ respect `# flake8: noqa: F401`. (Flake8 treats that as equivalent to `# flake8: noqa`, so ignores _all_ errors in the file. I think all of [these usages](https://cs.github.com/?scopeName=All+repos&scope=&q=%22%23+flake8%3A+noqa%3A+%22) are probably mistakes!)

A couple notes on the details:

- If a user has `# ruff: noqa: F401` in the file, but also `# noqa: F401` on a line that would legitimately trigger an `F401` violation, we _do_ mark that as "unused" for `RUF100` purposes. This may be the wrong choice. The `noqa` is legitimately unused, but it's also not "wrong". It's just redundant.
- If a user has `# ruff: noqa: F401`, and runs `--add-noqa`, we _won't_ add `# noqa: F401` to any lines (which seems like the obvious right choice to me).

Closes #1054 (which has some extra pieces that I'll carve out into a separate issue).

Closes #2446.
