### PR TITLE
Remove duplicate underline in B007 autofix message

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -75,7 +75,7 @@ impl Violation for UnusedLoopControlVariable {
         if matches!(certainty, Certainty::Certain) && rename.is_some() {
             Some(|UnusedLoopControlVariable { name, rename, .. }| {
                 let rename = rename.as_ref().unwrap();
-                format!("Rename unused `{name}` to `_{rename}`")
+                format!("Rename unused `{name}` to `{rename}`")
             })
         } else {
             None


### PR DESCRIPTION
fixes #3020

In the case of #3020, `rename` already contains an underscore (i.e. `_i`), so the error message contains two underscores (i.e. `__i`) and `__` is lost because of https://github.com/rust-lang/annotate-snippets-rs/issues/53. So the final output has no underscore (i.e. `i`)

The output after applying this fix is shown below:

```text
test.py:1:5: B007 [*] Loop control variable `i` not used within loop body
  |
1 | for i in range(0, 100):
  |     ^ B007
  |
  = help: Rename unused `i` to `_i`
```