### PR TITLE
Remove unused `AsFormat` trait for `Option<T>`

### DIFF
--- a/crates/ruff_python_formatter/src/shared_traits.rs
+++ b/crates/ruff_python_formatter/src/shared_traits.rs
@@ -22,21 +22,6 @@ where
     }
 }
 
-/// Implement [`AsFormat`] for [`Option`] when `T` implements [`AsFormat`]
-///
-/// Allows to call format on optional AST fields without having to unwrap the
-/// field first.
-impl<T, C> AsFormat<C> for Option<T>
-where
-    T: AsFormat<C>,
-{
-    type Format<'a> = Option<T::Format<'a>> where Self: 'a;
-
-    fn format(&self) -> Self::Format<'_> {
-        self.as_ref().map(AsFormat::format)
-    }
-}
-
 /// Used to convert this object into an object that can be formatted.
 ///
 /// The difference to [`AsFormat`] is that this trait takes ownership of `self`.


### PR DESCRIPTION
We should re-add this, but it's currently unused and doesn't compile under 1.66.0.

See: #3039.