### PR TITLE
Increase expected size of FormatElement

### DIFF
--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -385,4 +385,4 @@ static_assert!(std::mem::size_of::<crate::format_element::Tag>() == 16usize);
 
 #[cfg(not(debug_assertions))]
 #[cfg(target_pointer_width = "64")]
-static_assert!(std::mem::size_of::<crate::FormatElement>() == 24usize);
+static_assert!(std::mem::size_of::<crate::FormatElement>() == 32usize);


### PR DESCRIPTION
It looks like this is now `32usize` due to `StaticTextSlice`. We should revisit this.