### PR TITLE
fix(isort): comply with isort when sorting sub-package modules

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/pyproject.toml
+++ b/crates/ruff/resources/test/fixtures/isort/pyproject.toml
@@ -4,5 +4,3 @@ line-length = 88
 [tool.ruff.isort]
 lines-after-imports = 3
 lines-between-types = 2
-known-local-folder = ["ruff"]
-force-to-top = ["lib1", "lib3", "lib5", "lib3.lib4", "z"]

--- a/crates/ruff/resources/test/fixtures/isort/separate_subpackage_first_and_third_party_imports.py
+++ b/crates/ruff/resources/test/fixtures/isort/separate_subpackage_first_and_third_party_imports.py
@@ -1,0 +1,8 @@
+import sys
+import baz
+from foo import bar, baz
+from foo.bar import blah, blub
+from foo.bar.baz import something
+import foo
+import foo.bar
+import foo.bar.baz

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -92,7 +92,7 @@ fn fix_banned_relative_import(
     module_path: Option<&Vec<String>>,
     stylist: &Stylist,
 ) -> Option<Fix> {
-    // Only fix is the module path is known.
+    // Only fix if the module path is known.
     if let Some(mut parts) = module_path.cloned() {
         // Remove relative level from module path.
         for _ in 0..*level? {

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -150,15 +150,13 @@ pub fn typing_only_runtime_import(
         && binding.runtime_usage.is_none()
         && binding.synthetic_usage.is_none()
     {
-        // Extract the module base and level from the full name.
-        // Ex) `foo.bar.baz` -> `foo`, `0`
+        // Extract the module level from the full name.
         // Ex) `.foo.bar.baz` -> `foo`, `1`
-        let module_base = full_name.split('.').next().unwrap();
         let level = full_name.chars().take_while(|c| *c == '.').count();
 
         // Categorize the import.
         match categorize(
-            module_base,
+            full_name,
             Some(&level),
             &settings.src,
             package,

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -400,6 +400,47 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]
+    fn separate_modules(path: &Path) -> Result<()> {
+        let snapshot = format!("1_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &Settings {
+                isort: super::settings::Settings {
+                    known_first_party: BTreeSet::from(["foo.bar".to_string(), "baz".to_string()]),
+                    known_third_party: BTreeSet::from([
+                        "foo".to_string(),
+                        "__future__".to_string(),
+                    ]),
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..Settings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test_case(Path::new("separate_subpackage_first_and_third_party_imports.py"))]
+    fn separate_modules_first_party(path: &Path) -> Result<()> {
+        let snapshot = format!("2_{}", path.to_string_lossy());
+        let diagnostics = test_path(
+            Path::new("isort").join(path).as_path(),
+            &Settings {
+                isort: super::settings::Settings {
+                    known_first_party: BTreeSet::from(["foo".to_string()]),
+                    known_third_party: BTreeSet::from(["foo.bar".to_string()]),
+                    ..super::settings::Settings::default()
+                },
+                src: vec![test_resource_path("fixtures/isort")],
+                ..Settings::for_rule(Rule::UnsortedImports)
+            },
+        )?;
+        assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
     // Test currently disabled as line endings are automatically converted to
     // platform-appropriate ones in CI/CD #[test_case(Path::new("
     // line_ending_crlf.py"))] #[test_case(Path::new("line_ending_lf.py"))]

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__1_separate_subpackage_first_and_third_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__1_separate_subpackage_first_and_third_party_imports.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnsortedImports: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 9
+    column: 0
+  fix:
+    content: "import sys\n\nimport foo\nfrom foo import bar, baz\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 9
+      column: 0
+  parent: ~
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__2_separate_subpackage_first_and_third_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__2_separate_subpackage_first_and_third_party_imports.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnsortedImports: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 9
+    column: 0
+  fix:
+    content: "import sys\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n\nimport foo\nfrom foo import bar, baz\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 9
+      column: 0
+  parent: ~
+


### PR DESCRIPTION
e.g. packages named "foo.bar"

additionally make sure `__future__` imports are always sorted at the very top.

Fixes #3059