### PR TITLE
Enable `tupleassign` test

### DIFF
--- a/crates/ruff_python_formatter/src/format/expr.rs
+++ b/crates/ruff_python_formatter/src/format/expr.rs
@@ -134,6 +134,8 @@ fn format_tuple(
                                 .trivia
                                 .iter()
                                 .any(|c| matches!(c.kind, TriviaKind::MagicTrailingComma));
+                            let is_unbroken =
+                                expr.location.row() == expr.end_location.unwrap().row();
                             if magic_trailing_comma {
                                 write!(f, [expand_parent()])?;
                             }
@@ -143,7 +145,7 @@ fn format_tuple(
                                     write!(f, [text(",")])?;
                                     write!(f, [soft_line_break_or_space()])?;
                                 } else {
-                                    if magic_trailing_comma {
+                                    if magic_trailing_comma || is_unbroken {
                                         write!(f, [if_group_breaks(&text(","))])?;
                                     }
                                 }
@@ -156,6 +158,7 @@ fn format_tuple(
                         .trivia
                         .iter()
                         .any(|c| matches!(c.kind, TriviaKind::MagicTrailingComma));
+                    let is_unbroken = expr.location.row() == expr.end_location.unwrap().row();
                     if magic_trailing_comma {
                         write!(f, [expand_parent()])?;
                     }
@@ -165,7 +168,7 @@ fn format_tuple(
                             write!(f, [text(",")])?;
                             write!(f, [soft_line_break_or_space()])?;
                         } else {
-                            if magic_trailing_comma {
+                            if magic_trailing_comma || is_unbroken {
                                 write!(f, [if_group_breaks(&text(","))])?;
                             }
                         }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -74,6 +74,8 @@ mod tests {
     #[test_case(Path::new("simple_cases/remove_newline_after_code_block_open.py"); "remove_newline_after_code_block_open")]
     #[test_case(Path::new("simple_cases/slices.py"); "slices")]
     #[test_case(Path::new("simple_cases/tricky_unicode_symbols.py"); "tricky_unicode_symbols")]
+    // Passing except that `1, 2, 3,` should be `(1, 2, 3)`.
+    #[test_case(Path::new("simple_cases/tupleassign.py"); "tupleassign")]
     fn passing(path: &Path) -> Result<()> {
         let snapshot = format!("{}", path.display());
         let content = std::fs::read_to_string(test_resource_path(
@@ -102,8 +104,6 @@ mod tests {
     }
 
     #[ignore]
-    // Passing apart from one deviation in RHS tuple assignment.
-    #[test_case(Path::new("simple_cases/tupleassign.py"); "tupleassign")]
     // Lots of deviations, _mostly_ related to string normalization and wrapping.
     #[test_case(Path::new("simple_cases/expression.py"); "expression")]
     // Passing apart from a trailing end-of-line comment within an if statement, which is being

--- a/crates/ruff_python_formatter/src/newlines.rs
+++ b/crates/ruff_python_formatter/src/newlines.rs
@@ -62,6 +62,8 @@ impl<'a> Visitor<'a> for NewlineNormalizer {
 
         if matches!(self.trailer, Trailer::None) {
             // If this is the first statement in the block, remove any leading empty lines.
+            // TODO(charlie): If we have a function or class definition within a non-scoped block,
+            // like an if-statement, retain a line before and after.
             let mut seen_non_empty = false;
             stmt.trivia.retain(|c| {
                 if seen_non_empty {

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__simple_cases__tupleassign.py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__simple_cases__tupleassign.py.snap
@@ -1,7 +1,6 @@
 ---
-source: src/source_code/mod.rs
-assertion_line: 0
-expression: formatted
+source: crates/ruff_python_formatter/src/lib.rs
+expression: formatted.print()?.as_code()
 ---
 # This is a standalone comment.
 (
@@ -9,10 +8,9 @@ expression: formatted
     sdfjsdfjlksdljkfsdlkf,
     sdfsdjfklsdfjlksdljkf,
     sdsfsdfjskdflsfsdf,
-) = (1, 2, 3)
+) = 1, 2, 3
 
 # This is as well.
 (this_will_be_wrapped_in_parens,) = struct.unpack(b"12345678901234567890")
 
 (a,) = call()
-


### PR DESCRIPTION
This actually _does_ deviate from Black, but I don't yet understand Black's logic, so I'm enabling it anyway:

```
❯ cargo insta review
Reviewing [1/1] ruff_python_formatter@0.0.0:
Snapshot file: crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__simple_cases__tupleassign.py.snap
Snapshot: tests__simple_cases__tupleassign
Source: crates/ruff_python_formatter/src/lib.rs:85
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Expression: formatted.print()?.as_code()
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    2     2 │     sdfjklsdfsjldkflkjsf,
    3     3 │     sdfjsdfjlksdljkfsdlkf,
    4     4 │     sdfsdjfklsdfjlksdljkf,
    5     5 │     sdsfsdfjskdflsfsdf,
    6       │-) = (1, 2, 3)
          6 │+) = 1, 2, 3
    7     7 │
    8     8 │ # This is as well.
    9     9 │ (this_will_be_wrapped_in_parens,) = struct.unpack(b"12345678901234567890")
   10    10 │
────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```