### PR TITLE
Avoid prefer-list-builtin for lambdas with `*args` or `**kwargs`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pie/PIE807.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pie/PIE807.py
@@ -18,3 +18,10 @@ class Foo:
 
 class FooTable(BaseTable):
     bar = fields.ListField(list)
+
+
+lambda *args, **kwargs: []
+
+lambda *args: []
+
+lambda **kwargs: []

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -358,7 +358,12 @@ pub fn prefer_list_builtin(checker: &mut Checker, expr: &Expr) {
     let ExprKind::Lambda { args, body } = &expr.node else {
         unreachable!("Expected ExprKind::Lambda");
     };
-    if args.args.is_empty() {
+    if args.args.is_empty()
+        && args.kwonlyargs.is_empty()
+        && args.posonlyargs.is_empty()
+        && args.vararg.is_none()
+        && args.kwarg.is_none()
+    {
         if let ExprKind::List { elts, .. } = &body.node {
             if elts.is_empty() {
                 let mut diagnostic = Diagnostic::new(PreferListBuiltin, Range::from_located(expr));


### PR DESCRIPTION
Closes #3097.