### PR TITLE
Mark `typing.assert_never` as no return

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET503.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET503.py
@@ -3,6 +3,8 @@ import os
 import posix
 from posix import abort
 import sys as std_sys
+import typing
+import typing_extensions
 import _thread
 import _winapi
 
@@ -209,6 +211,18 @@ def noreturn_sys_exit():
     if x > 0:
         return 1
     std_sys.exit(0)
+
+
+def noreturn_typing_assert_never():
+    if x > 0:
+        return 1
+    typing.assert_never(0)
+
+
+def noreturn_typing_extensions_assert_never():
+    if x > 0:
+        return 1
+    typing_extensions.assert_never(0)
 
 
 def noreturn__thread_exit():

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -179,6 +179,8 @@ const NORETURN_FUNCS: &[&[&str]] = &[
     &["posix", "_exit"],
     &["posix", "abort"],
     &["sys", "exit"],
+    &["typing", "assert_never"],
+    &["typing_extensions", "assert_never"],
     &["_thread", "exit"],
     &["_winapi", "ExitProcess"],
     // third-party modules

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET503_RET503.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET503_RET503.py.snap
@@ -5,239 +5,239 @@ expression: diagnostics
 - kind:
     ImplicitReturn: ~
   location:
-    row: 18
+    row: 20
     column: 4
   end_location:
-    row: 19
+    row: 21
     column: 16
   fix:
     content: "\n    return None"
     location:
-      row: 19
+      row: 21
       column: 16
     end_location:
-      row: 19
+      row: 21
       column: 16
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 25
+    row: 27
     column: 8
   end_location:
-    row: 25
+    row: 27
     column: 15
   fix:
     content: "\n        return None"
     location:
-      row: 25
+      row: 27
       column: 15
     end_location:
-      row: 25
+      row: 27
       column: 15
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 34
+    row: 36
     column: 4
   end_location:
-    row: 34
+    row: 36
     column: 11
   fix:
     content: "\n    return None"
     location:
-      row: 34
+      row: 36
       column: 11
     end_location:
-      row: 34
+      row: 36
       column: 11
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 39
+    row: 41
     column: 4
   end_location:
-    row: 41
+    row: 43
     column: 20
   fix:
     content: "\n    return None"
     location:
-      row: 41
+      row: 43
       column: 20
     end_location:
-      row: 41
+      row: 43
       column: 20
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 50
+    row: 52
     column: 8
   end_location:
-    row: 50
+    row: 52
     column: 15
   fix:
     content: "\n        return None"
     location:
-      row: 50
+      row: 52
       column: 15
     end_location:
-      row: 50
+      row: 52
       column: 15
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 57
+    row: 59
     column: 4
   end_location:
-    row: 57
+    row: 59
     column: 22
   fix:
     content: "\n    return None"
     location:
-      row: 57
+      row: 59
       column: 22
     end_location:
-      row: 57
+      row: 59
       column: 22
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 64
+    row: 66
     column: 4
   end_location:
-    row: 64
+    row: 66
     column: 21
   fix:
     content: "\n    return None"
     location:
-      row: 64
+      row: 66
       column: 21
     end_location:
-      row: 64
+      row: 66
       column: 21
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 80
+    row: 82
     column: 4
   end_location:
-    row: 83
+    row: 85
     column: 14
   fix:
     content: "\n    return None"
     location:
-      row: 83
+      row: 85
       column: 14
     end_location:
-      row: 83
+      row: 85
       column: 14
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 111
+    row: 113
     column: 4
   end_location:
-    row: 114
+    row: 116
     column: 16
   fix:
     content: "\n    return None"
     location:
-      row: 114
+      row: 116
       column: 16
     end_location:
-      row: 114
+      row: 116
       column: 16
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 118
+    row: 120
     column: 4
   end_location:
-    row: 124
+    row: 126
     column: 19
   fix:
     content: "\n    return None"
     location:
-      row: 124
+      row: 126
       column: 19
     end_location:
-      row: 124
+      row: 126
       column: 19
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 128
+    row: 130
     column: 4
   end_location:
-    row: 131
+    row: 133
     column: 16
   fix:
     content: "\n    return None"
     location:
-      row: 131
+      row: 133
       column: 16
     end_location:
-      row: 131
+      row: 133
       column: 16
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 135
+    row: 137
     column: 4
   end_location:
-    row: 141
+    row: 143
     column: 19
   fix:
     content: "\n    return None"
     location:
-      row: 141
+      row: 143
       column: 19
     end_location:
-      row: 141
+      row: 143
       column: 19
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 260
+    row: 274
     column: 4
   end_location:
-    row: 261
+    row: 275
     column: 20
   fix:
     content: "\n    return None"
     location:
-      row: 261
+      row: 275
       column: 20
     end_location:
-      row: 261
+      row: 275
       column: 20
   parent: ~
 - kind:
     ImplicitReturn: ~
   location:
-    row: 277
+    row: 291
     column: 12
   end_location:
-    row: 277
+    row: 291
     column: 19
   fix:
     content: "\n            return None"
     location:
-      row: 277
+      row: 291
       column: 19
     end_location:
-      row: 277
+      row: 291
       column: 19
   parent: ~
 


### PR DESCRIPTION
[This function](https://docs.python.org/3/library/typing.html#typing.assert_never) always raises, so RET503 shouldn't trigger for it.