### PR TITLE
refactor(ruff): Implement `doc_lines_from_tokens` as iterator

### DIFF
--- a/crates/ruff/src/fs.rs
+++ b/crates/ruff/src/fs.rs
@@ -1,5 +1,3 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
@@ -87,13 +85,4 @@ pub fn relativize_path(path: impl AsRef<Path>) -> String {
         return format!("{}", path.display());
     }
     format!("{}", path.display())
-}
-
-/// Read a file's contents from disk.
-pub fn read_file<P: AsRef<Path>>(path: P) -> Result<String> {
-    let file = File::open(path)?;
-    let mut buf_reader = BufReader::new(file);
-    let mut contents = String::new();
-    buf_reader.read_to_string(&mut contents)?;
-    Ok(contents)
 }

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -223,7 +223,7 @@ const MAX_ITERATIONS: usize = 100;
 /// Add any missing `# noqa` pragmas to the source code at the given `Path`.
 pub fn add_noqa_to_path(path: &Path, package: Option<&Path>, settings: &Settings) -> Result<usize> {
     // Read the file from disk.
-    let contents = fs::read_file(path)?;
+    let contents = std::fs::read_to_string(path)?;
 
     // Tokenize once.
     let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);

--- a/crates/ruff/src/settings/pyproject.rs
+++ b/crates/ruff/src/settings/pyproject.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
-use crate::fs;
 use crate::settings::options::Options;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,13 +29,13 @@ impl Pyproject {
 
 /// Parse a `ruff.toml` file.
 fn parse_ruff_toml<P: AsRef<Path>>(path: P) -> Result<Options> {
-    let contents = fs::read_file(path)?;
+    let contents = std::fs::read_to_string(path)?;
     toml::from_str(&contents).map_err(Into::into)
 }
 
 /// Parse a `pyproject.toml` file.
 fn parse_pyproject_toml<P: AsRef<Path>>(path: P) -> Result<Pyproject> {
-    let contents = fs::read_file(path)?;
+    let contents = std::fs::read_to_string(path)?;
     toml::from_str(&contents).map_err(Into::into)
 }
 

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -12,7 +12,7 @@ use crate::packaging::detect_package_root;
 use crate::registry::Diagnostic;
 use crate::settings::{flags, Settings};
 use crate::source_code::{Indexer, Locator, Stylist};
-use crate::{directives, fs, rustpython_helpers};
+use crate::{directives, rustpython_helpers};
 
 pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
     Path::new("./resources/test/").join(path)
@@ -22,7 +22,7 @@ pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
 /// asserts that autofixes converge after 10 iterations.
 pub fn test_path(path: &Path, settings: &Settings) -> Result<Vec<Diagnostic>> {
     let path = test_resource_path("fixtures").join(path);
-    let contents = fs::read_file(&path)?;
+    let contents = std::fs::read_to_string(&path)?;
     let tokens: Vec<LexResult> = rustpython_helpers::tokenize(&contents);
     let locator = Locator::new(&contents);
     let stylist = Stylist::from_contents(&contents, &locator);

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -81,7 +81,7 @@ pub fn lint_path(
     };
 
     // Read the file from disk.
-    let contents = fs::read_file(path)?;
+    let contents = std::fs::read_to_string(path)?;
 
     // Lint the file.
     let (


### PR DESCRIPTION
This is a nit refactor... It implements the extraction of document lines as an iterator instead of a Vector to avoid the extra allocation.