### PR TITLE
add delta-rs to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ Ruff is used in a number of major open-source projects, including:
 * [featuretools](https://github.com/alteryx/featuretools)
 * [meson-python](https://github.com/mesonbuild/meson-python)
 * [ZenML](https://github.com/zenml-io/zenml)
+* [delta-rs](https://github.com/delta-io/delta-rs)
 
 ## License
 


### PR DESCRIPTION
The [delta-rs](https://github.com/delta-io/delta-rs) project has adopted `ruff` since [this PR](https://github.com/delta-io/delta-rs/pull/1158).

This PR adds the link to the project to the list of users in the README.md