### PR TITLE
Fix isort `no-lines-before` preceded by an empty section

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/no_lines_before_with_empty_sections.py
+++ b/crates/ruff/resources/test/fixtures/isort/no_lines_before_with_empty_sections.py
@@ -1,0 +1,3 @@
+from __future__ import annotations
+from typing import Any
+from . import my_local_folder_object

--- a/crates/ruff/src/rules/isort/categorize.rs
+++ b/crates/ruff/src/rules/isort/categorize.rs
@@ -6,12 +6,13 @@ use log::debug;
 use ruff_python::sys::KNOWN_STANDARD_LIBRARY;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 
 use super::types::{ImportBlock, Importable};
 use crate::settings::types::PythonVersion;
 
 #[derive(
-    Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema, Hash,
+    Debug, PartialOrd, Ord, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema, Hash, EnumIter,
 )]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub enum ImportType {

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before_with_empty_sections.py_no_lines_before_with_empty_sections.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before_with_empty_sections.py_no_lines_before_with_empty_sections.py.snap
@@ -1,0 +1,22 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+expression: diagnostics
+---
+- kind:
+    UnsortedImports: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 4
+    column: 0
+  fix:
+    content: "from __future__ import annotations\nfrom typing import Any\n\nfrom . import my_local_folder_object\n"
+    location:
+      row: 1
+      column: 0
+    end_location:
+      row: 4
+      column: 0
+  parent: ~
+


### PR DESCRIPTION
Fix #3138.