### PR TITLE
Avoid suggesting 'is' for constant literals

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/constant_literals.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/constant_literals.py
@@ -17,20 +17,16 @@ if None == False:  # E711, E712 (fix)
     pass
 
 ###
-# Unfixable errors
-###
-if "abc" == None:  # E711
-    pass
-if None == "abc":  # E711
-    pass
-if "abc" == False:  # E712
-    pass
-if False == "abc":  # E712
-    pass
-
-###
 # Non-errors
 ###
+if "abc" == None:
+    pass
+if None == "abc":
+    pass
+if "abc" == False:
+    pass
+if False == "abc":
+    pass
 if "def" == "abc":
     pass
 if False is None:

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__constant_literals.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__constant_literals.snap
@@ -164,48 +164,4 @@ expression: diagnostics
       row: 16
       column: 16
   parent: ~
-- kind:
-    NoneComparison: Eq
-  location:
-    row: 22
-    column: 12
-  end_location:
-    row: 22
-    column: 16
-  fix: ~
-  parent: ~
-- kind:
-    NoneComparison: Eq
-  location:
-    row: 24
-    column: 3
-  end_location:
-    row: 24
-    column: 7
-  fix: ~
-  parent: ~
-- kind:
-    TrueFalseComparison:
-      - false
-      - Eq
-  location:
-    row: 26
-    column: 12
-  end_location:
-    row: 26
-    column: 17
-  fix: ~
-  parent: ~
-- kind:
-    TrueFalseComparison:
-      - false
-      - Eq
-  location:
-    row: 28
-    column: 3
-  end_location:
-    row: 28
-    column: 8
-  fix: ~
-  parent: ~
 


### PR DESCRIPTION
We stopped autofixing these at some point, but we actually shouldn't flag them at all.

Closes #3140.