### PR TITLE
Omit non-.py[i] files from module naming rules

### DIFF
--- a/crates/ruff/src/rules/pep8_naming/mod.rs
+++ b/crates/ruff/src/rules/pep8_naming/mod.rs
@@ -43,6 +43,7 @@ mod tests {
     #[test_case(Rule::InvalidModuleName, Path::new("N999/module/valid_name/__main__.py"); "N999_10")]
     #[test_case(Rule::InvalidModuleName, Path::new("N999/module/valid_name/0001_initial.py"); "N999_11")]
     #[test_case(Rule::InvalidModuleName, Path::new("N999/module/valid_name/__setup__.py"); "N999_12")]
+    #[test_case(Rule::InvalidModuleName, Path::new("N999/module/valid_name/file-with-dashes"); "N999_13")]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
@@ -43,6 +43,13 @@ impl Violation for InvalidModuleName {
 
 /// N999
 pub fn invalid_module_name(path: &Path, package: Option<&Path>) -> Option<Diagnostic> {
+    if !path
+        .extension()
+        .map_or(false, |ext| ext == "py" || ext == "pyi")
+    {
+        return None;
+    }
+
     if let Some(package) = package {
         let module_name = if path.file_name().map_or(false, |file_name| {
             file_name == "__init__.py"

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N999_N999__module__valid_name__file-with-dashes.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N999_N999__module__valid_name__file-with-dashes.snap
@@ -1,0 +1,6 @@
+---
+source: crates/ruff/src/rules/pep8_naming/mod.rs
+expression: diagnostics
+---
+[]
+


### PR DESCRIPTION
Closes #3151.