### PR TITLE
Un-modify `tupleassign` and `function2` tests

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/function2.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/function2.py.expect
@@ -5,8 +5,7 @@ def f(
     with cache_dir():
         if something:
             result = CliRunner().invoke(
-                black.main,
-                [str(src1), str(src2), "--diff", "--check"],
+                black.main, [str(src1), str(src2), "--diff", "--check"]
             )
     limited.append(-limited.pop())  # negate top
     return A(

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/tupleassign.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/tupleassign.py.expect
@@ -4,11 +4,7 @@
     sdfjsdfjlksdljkfsdlkf,
     sdfsdjfklsdfjlksdljkf,
     sdsfsdfjskdflsfsdf,
-) = (
-    1,
-    2,
-    3,
-)
+) = (1, 2, 3)
 
 # This is as well.
 (this_will_be_wrapped_in_parens,) = struct.unpack(b"12345678901234567890")

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__function2_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__function2_py.snap
@@ -1,0 +1,222 @@
+---
+source: crates/ruff_python_formatter/src/lib.rs
+expression: snapshot
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/function2.py
+---
+## Input
+
+```py
+def f(
+  a,
+  **kwargs,
+) -> A:
+    with cache_dir():
+        if something:
+            result = (
+                CliRunner().invoke(black.main, [str(src1), str(src2), "--diff", "--check"])
+            )
+    limited.append(-limited.pop())  # negate top
+    return A(
+        very_long_argument_name1=very_long_value_for_the_argument,
+        very_long_argument_name2=-very.long.value.for_the_argument,
+        **kwargs,
+    )
+def g():
+    "Docstring."
+    def inner():
+        pass
+    print("Inner defs should breathe a little.")
+def h():
+    def inner():
+        pass
+    print("Inner defs should breathe a little.")
+
+
+if os.name == "posix":
+    import termios
+    def i_should_be_followed_by_only_one_newline():
+        pass
+elif os.name == "nt":
+    try:
+        import msvcrt
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+    except ImportError:
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+elif False:
+
+    class IHopeYouAreHavingALovelyDay:
+        def __call__(self):
+            print("i_should_be_followed_by_only_one_newline")
+else:
+
+    def foo():
+        pass
+
+with hmm_but_this_should_get_two_preceding_newlines():
+    pass
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -5,7 +5,8 @@
+     with cache_dir():
+         if something:
+             result = CliRunner().invoke(
+-                black.main, [str(src1), str(src2), "--diff", "--check"]
++                black.main,
++                [str(src1), str(src2), "--diff", "--check"],
+             )
+     limited.append(-limited.pop())  # negate top
+     return A(
+```
+
+## Ruff Output
+
+```py
+def f(
+    a,
+    **kwargs,
+) -> A:
+    with cache_dir():
+        if something:
+            result = CliRunner().invoke(
+                black.main,
+                [str(src1), str(src2), "--diff", "--check"],
+            )
+    limited.append(-limited.pop())  # negate top
+    return A(
+        very_long_argument_name1=very_long_value_for_the_argument,
+        very_long_argument_name2=-very.long.value.for_the_argument,
+        **kwargs,
+    )
+
+
+def g():
+    "Docstring."
+
+    def inner():
+        pass
+
+    print("Inner defs should breathe a little.")
+
+
+def h():
+    def inner():
+        pass
+
+    print("Inner defs should breathe a little.")
+
+
+if os.name == "posix":
+    import termios
+
+    def i_should_be_followed_by_only_one_newline():
+        pass
+
+elif os.name == "nt":
+    try:
+        import msvcrt
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+    except ImportError:
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+elif False:
+
+    class IHopeYouAreHavingALovelyDay:
+        def __call__(self):
+            print("i_should_be_followed_by_only_one_newline")
+
+else:
+
+    def foo():
+        pass
+
+
+with hmm_but_this_should_get_two_preceding_newlines():
+    pass
+```
+
+## Black Output
+
+```py
+def f(
+    a,
+    **kwargs,
+) -> A:
+    with cache_dir():
+        if something:
+            result = CliRunner().invoke(
+                black.main, [str(src1), str(src2), "--diff", "--check"]
+            )
+    limited.append(-limited.pop())  # negate top
+    return A(
+        very_long_argument_name1=very_long_value_for_the_argument,
+        very_long_argument_name2=-very.long.value.for_the_argument,
+        **kwargs,
+    )
+
+
+def g():
+    "Docstring."
+
+    def inner():
+        pass
+
+    print("Inner defs should breathe a little.")
+
+
+def h():
+    def inner():
+        pass
+
+    print("Inner defs should breathe a little.")
+
+
+if os.name == "posix":
+    import termios
+
+    def i_should_be_followed_by_only_one_newline():
+        pass
+
+elif os.name == "nt":
+    try:
+        import msvcrt
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+    except ImportError:
+
+        def i_should_be_followed_by_only_one_newline():
+            pass
+
+elif False:
+
+    class IHopeYouAreHavingALovelyDay:
+        def __call__(self):
+            print("i_should_be_followed_by_only_one_newline")
+
+else:
+
+    def foo():
+        pass
+
+
+with hmm_but_this_should_get_two_preceding_newlines():
+    pass
+```
+
+

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__tupleassign_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__tupleassign_py.snap
@@ -20,15 +20,11 @@ this_will_be_wrapped_in_parens, = struct.unpack(b"12345678901234567890")
 ```diff
 --- Black
 +++ Ruff
-@@ -4,11 +4,7 @@
+@@ -4,7 +4,7 @@
      sdfjsdfjlksdljkfsdlkf,
      sdfsdjfklsdfjlksdljkf,
      sdsfsdfjskdflsfsdf,
--) = (
--    1,
--    2,
--    3,
--)
+-) = (1, 2, 3)
 +) = 1, 2, 3
  
  # This is as well.
@@ -61,11 +57,7 @@ this_will_be_wrapped_in_parens, = struct.unpack(b"12345678901234567890")
     sdfjsdfjlksdljkfsdlkf,
     sdfsdjfklsdfjlksdljkf,
     sdsfsdfjskdflsfsdf,
-) = (
-    1,
-    2,
-    3,
-)
+) = (1, 2, 3)
 
 # This is as well.
 (this_will_be_wrapped_in_parens,) = struct.unpack(b"12345678901234567890")


### PR DESCRIPTION
I manually changed these in #3080 and #3083 to get the tests passing (with notes around the deviations) -- but that's no longer necessary, now that we have proper testing that takes deviations into account.