### PR TITLE
Replace Autofix::is_enabled to result_like::BoolLike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pmutil"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1913,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "result-like"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc7ce6435c33898517a30e85578cd204cbb696875efb93dec19a2d31294f810"
+dependencies = [
+ "result-like-derive",
+]
+
+[[package]]
+name = "result-like-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fabf0a2e54f711c68c50d49f648a1a8a37adcb57353f518ac4df374f0788f42"
+dependencies = [
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "syn-ext",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1982,7 @@ dependencies = [
  "once_cell",
  "path-absolutize",
  "regex",
+ "result-like",
  "ruff_macros",
  "ruff_python",
  "rustc-hash",
@@ -2479,6 +2513,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-ext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b86cb2b68c5b3c078cac02588bc23f3c04bb828c5d3aedd17980876ec6a7be6"
+dependencies = [
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.67.0"
 anyhow = { version = "1.0.66" }
 clap = { version = "4.0.1", features = ["derive"] }
 itertools = { version = "0.10.5" }
+is-macro = { version = "0.2.2" }
 libcst = { git = "https://github.com/charliermarsh/LibCST", rev = "f2f0b7a487a8725d161fe8b3ed73a6758b21e177" }
 once_cell = { version = "1.16.0" }
 regex = { version = "1.6.0" }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -39,6 +39,7 @@ num-traits = "0.2.15"
 once_cell = { workspace = true }
 path-absolutize = { version = "3.0.14", features = ["once_cell_cache", "use_unix_paths_on_wasm"] }
 regex = { workspace = true }
+result-like = "0.4.6"
 ruff_macros = { path = "../ruff_macros" }
 ruff_python = { path = "../ruff_python" }
 rustc-hash = { workspace = true }

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -187,7 +187,7 @@ impl<'a> Checker<'a> {
     /// Return `true` if a patch should be generated under the given autofix
     /// `Mode`.
     pub fn patch(&self, code: &Rule) -> bool {
-        self.autofix.is_enabled() && self.settings.rules.should_fix(code)
+        self.autofix.into() && self.settings.rules.should_fix(code)
     }
 
     /// Return `true` if the `Expr` is a reference to `typing.${target}`.

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -148,8 +148,7 @@ pub fn check_noqa(
                             UnusedNOQA { codes: None },
                             Range::new(Location::new(row + 1, start), Location::new(row + 1, end)),
                         );
-                        if autofix.is_enabled() && settings.rules.should_fix(diagnostic.kind.rule())
-                        {
+                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::deletion(
                                 Location::new(row + 1, start - spaces),
                                 Location::new(row + 1, lines[row].chars().count()),
@@ -216,8 +215,7 @@ pub fn check_noqa(
                             },
                             Range::new(Location::new(row + 1, start), Location::new(row + 1, end)),
                         );
-                        if autofix.is_enabled() && settings.rules.should_fix(diagnostic.kind.rule())
-                        {
+                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
                                 diagnostic.amend(Fix::deletion(
                                     Location::new(row + 1, start - spaces),

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -43,9 +43,9 @@ pub fn check_physical_lines(
     let enforce_bidirectional_unicode = settings.rules.enabled(&Rule::BidirectionalUnicode);
 
     let fix_unnecessary_coding_comment =
-        autofix.is_enabled() && settings.rules.should_fix(&Rule::UTF8EncodingDeclaration);
+        autofix.into() && settings.rules.should_fix(&Rule::UTF8EncodingDeclaration);
     let fix_shebang_whitespace =
-        autofix.is_enabled() && settings.rules.should_fix(&Rule::ShebangWhitespace);
+        autofix.into() && settings.rules.should_fix(&Rule::ShebangWhitespace);
 
     let mut commented_lines_iter = commented_lines.iter().peekable();
     let mut doc_lines_iter = doc_lines.iter().peekable();
@@ -145,7 +145,7 @@ pub fn check_physical_lines(
         if let Some(diagnostic) = no_newline_at_end_of_file(
             stylist,
             contents,
-            autofix.is_enabled() && settings.rules.should_fix(&Rule::NoNewLineAtEndOfFile),
+            autofix.into() && settings.rules.should_fix(&Rule::NoNewLineAtEndOfFile),
         ) {
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -108,7 +108,7 @@ pub fn check_tokens(
                     locator,
                     *start,
                     *end,
-                    autofix.is_enabled() && settings.rules.should_fix(&Rule::InvalidEscapeSequence),
+                    autofix.into() && settings.rules.should_fix(&Rule::InvalidEscapeSequence),
                 ));
             }
         }

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -60,7 +60,7 @@ pub fn commented_out_code(
     // Verify that the comment is on its own line, and that it contains code.
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, Range::new(start, end));
-        if autofix.is_enabled() && settings.rules.should_fix(&Rule::CommentedOutCode) {
+        if autofix.into() && settings.rules.should_fix(&Rule::CommentedOutCode) {
             diagnostic.amend(Fix::deletion(location, end_location));
         }
         Some(diagnostic)

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -257,7 +257,7 @@ pub fn trailing_commas(
                     end_location: comma.2,
                 },
             );
-            if autofix.is_enabled() && settings.rules.should_fix(&Rule::TrailingCommaProhibited) {
+            if autofix.into() && settings.rules.should_fix(&Rule::TrailingCommaProhibited) {
                 diagnostic.amend(Fix::deletion(comma.0, comma.2));
             }
             diagnostics.push(diagnostic);
@@ -301,7 +301,7 @@ pub fn trailing_commas(
                     end_location: missing_comma.2,
                 },
             );
-            if autofix.is_enabled() && settings.rules.should_fix(&Rule::TrailingCommaMissing) {
+            if autofix.into() && settings.rules.should_fix(&Rule::TrailingCommaMissing) {
                 diagnostic.amend(Fix::insertion(",".to_owned(), missing_comma.2));
             }
             diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -280,7 +280,7 @@ fn docstring(
         },
         Range::new(start, end),
     );
-    if autofix.is_enabled() && settings.rules.should_fix(&Rule::BadQuotesDocstring) {
+    if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesDocstring) {
         let quote_count = if trivia.is_multiline { 3 } else { 1 };
         let string_contents = &trivia.raw_text[quote_count..trivia.raw_text.len() - quote_count];
         let quote = good_docstring(&quotes_settings.docstring_quotes).repeat(quote_count);
@@ -355,7 +355,7 @@ fn strings(
                 Range::new(*start, *end),
             );
 
-            if autofix.is_enabled() && settings.rules.should_fix(&Rule::BadQuotesMultilineString) {
+            if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesMultilineString) {
                 let string_contents = &trivia.raw_text[3..trivia.raw_text.len() - 3];
                 let quote = good_multiline(&quotes_settings.multiline_quotes);
                 let mut fixed_contents = String::with_capacity(
@@ -385,9 +385,7 @@ fn strings(
                 {
                     let mut diagnostic =
                         Diagnostic::new(AvoidableEscapedQuote, Range::new(*start, *end));
-                    if autofix.is_enabled()
-                        && settings.rules.should_fix(&Rule::AvoidableEscapedQuote)
-                    {
+                    if autofix.into() && settings.rules.should_fix(&Rule::AvoidableEscapedQuote) {
                         let quote = bad_single(&quotes_settings.inline_quotes);
 
                         let mut fixed_contents =
@@ -446,7 +444,7 @@ fn strings(
                     },
                     Range::new(*start, *end),
                 );
-                if autofix.is_enabled() && settings.rules.should_fix(&Rule::BadQuotesInlineString) {
+                if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesInlineString) {
                     let quote = good_single(&quotes_settings.inline_quotes);
                     let mut fixed_contents =
                         String::with_capacity(trivia.prefix.len() + string_contents.len() + 2);

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -166,7 +166,7 @@ fn add_required_import(
         MissingRequiredImport(required_import.clone()),
         Range::new(Location::default(), Location::default()),
     );
-    if autofix.is_enabled() && settings.rules.should_fix(&Rule::MissingRequiredImport) {
+    if autofix.into() && settings.rules.should_fix(&Rule::MissingRequiredImport) {
         // Determine the location at which the import should be inserted.
         let splice = helpers::find_splice_location(python_ast, locator);
 

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -153,7 +153,7 @@ pub fn organize_imports(
         None
     } else {
         let mut diagnostic = Diagnostic::new(UnsortedImports, range);
-        if autofix.is_enabled() && settings.rules.should_fix(diagnostic.kind.rule()) {
+        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 indent(&expected, indentation),
                 range.location,

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -105,7 +105,7 @@ pub fn compound_statements(
             Tok::Newline => {
                 if let Some((start, end)) = semi {
                     let mut diagnostic = Diagnostic::new(UselessSemicolon, Range::new(start, end));
-                    if autofix.is_enabled() && settings.rules.should_fix(&Rule::UselessSemicolon) {
+                    if autofix.into() && settings.rules.should_fix(&Rule::UselessSemicolon) {
                         diagnostic.amend(Fix::deletion(start, end));
                     };
                     diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -137,7 +137,7 @@ pub fn extraneous_parentheses(
                 };
                 let mut diagnostic =
                     Diagnostic::new(ExtraneousParentheses, Range::new(*start, *end));
-                if autofix.is_enabled() && settings.rules.should_fix(&Rule::ExtraneousParentheses) {
+                if autofix.into() && settings.rules.should_fix(&Rule::ExtraneousParentheses) {
                     let contents = locator.slice(&Range::new(*start, *end));
                     diagnostic.amend(Fix::replacement(
                         contents[1..contents.len() - 1].to_string(),

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1730,8 +1730,7 @@ pub fn ambiguous_unicode_character(
                         Range::new(location, end_location),
                     );
                     if settings.rules.enabled(diagnostic.kind.rule()) {
-                        if autofix.is_enabled() && settings.rules.should_fix(diagnostic.kind.rule())
-                        {
+                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
                                 representant.to_string(),
                                 location,

--- a/crates/ruff/src/settings/flags.rs
+++ b/crates/ruff/src/settings/flags.rs
@@ -1,25 +1,9 @@
 use crate::fix;
 
-#[derive(Debug, Copy, Clone, Hash)]
+#[derive(Debug, Copy, Clone, Hash, result_like::BoolLike)]
 pub enum Autofix {
     Enabled,
     Disabled,
-}
-
-impl Autofix {
-    pub const fn is_enabled(self) -> bool {
-        matches!(self, Self::Enabled)
-    }
-}
-
-impl From<bool> for Autofix {
-    fn from(value: bool) -> Self {
-        if value {
-            Self::Enabled
-        } else {
-            Self::Disabled
-        }
-    }
 }
 
 impl From<fix::FixMode> for Autofix {


### PR DESCRIPTION
And another version of

#3164

BoolLike also provide `.some()`, `.then_some()` and bidirectional `From` but nothing more.