### PR TITLE
Normalize relative markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ An extremely fast Python linter, written in Rust.
 * ⚖️  [Near-parity](https://beta.ruff.rs/docs/faq/#how-does-ruff-compare-to-flake8) with the built-in Flake8 rule set
 * 🔌  Native re-implementations of dozens of Flake8 plugins, like flake8-bugbear
 * ⌨️  First-party editor integrations for [VS Code](https://github.com/charliermarsh/ruff-vscode) and [more](https://github.com/charliermarsh/ruff-lsp)
-* 🌎  Monorepo-friendly, with [hierarchical and cascading configuration](#pyprojecttoml-discovery)
+* 🌎  Monorepo-friendly, with [hierarchical and cascading configuration](https://beta.ruff.rs/docs/configuration/#pyprojecttoml-discovery)
 
 Ruff aims to be orders of magnitude faster than alternative tools while integrating more
 functionality behind a single, common interface.

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -5,7 +5,7 @@ use ruff::registry::{Linter, Rule, RuleNamespace, UpstreamCategory};
 use strum::IntoEnumIterator;
 
 const FIX_SYMBOL: &str = "🛠";
-const URL_PREFIX: &str = "https://beta.ruff.rs/docs/rules";
+const URL_PREFIX: &str = "/docs/rules";
 
 fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>, linter: &Linter) {
     table_out.push_str("| Code | Name | Message | Fix |");

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -201,7 +201,7 @@ and in how Ruff and isort treat inline comments in some cases (see: [#1381](http
 Like isort, Ruff's import sorting is compatible with Black.
 
 Ruff does not yet support all of isort's configuration options, though it does support many of
-them. You can find the supported settings in the [API reference](https://beta.ruff.rs/docs/settings/#isort).
+them. You can find the supported settings in the [API reference](/docs/settings/#isort).
 For example, you can set `known-first-party` like so:
 
 ```toml
@@ -317,7 +317,7 @@ have _complete_ certainty when making changes to code, even for the seemingly tr
 In the future, Ruff will support enabling autofix behavior based on the safety of the patch.
 
 In the meantime, if you find that the autofix is too aggressive, you can disable it on a per-rule or
-per-category basis using the [`unfixable`](https://beta.ruff.rs/docs/settings/#unfixable) mechanic.
+per-category basis using the [`unfixable`](/docs/settings/#unfixable) mechanic.
 For example, to disable autofix for some possibly-unsafe rules, you could add the following to your
 `pyproject.toml`:
 

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -28,10 +28,6 @@ SECTIONS: list[Section] = [
     Section("Contributing", "contributing.md", generated=True),
 ]
 
-DOCUMENTATION_LINK: str = (
-    "For more, see the [documentation](https://beta.ruff.rs/docs/)."
-)
-
 FATHOM_SCRIPT: str = (
     '<script src="https://cdn.usefathom.com/script.js" data-site="DUAEBFLB" defer>'
     "</script>"
@@ -45,12 +41,6 @@ def main() -> None:
 
     with Path("README.md").open(encoding="utf8") as fp:
         content = fp.read()
-
-    # Remove the documentation link, since we're _in_ the docs.
-    if DOCUMENTATION_LINK not in content:
-        msg = "README.md is not in the expected format."
-        raise ValueError(msg)
-    content = content.replace(DOCUMENTATION_LINK, "")
 
     # Convert any inter-documentation links to relative links.
     content = content.replace("https://beta.ruff.rs", "")


### PR DESCRIPTION
Use `/docs/` instead of `https://beta.ruff.rs/docs/`
Fix `hierarchical and cascading configuration` links
Remove outdated `DOCUMENTATION_LINK` removal which is not in `Overview` anymore.