### PR TITLE
Introduce a new CST element for slice segments

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/slices.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/slices.py
@@ -29,3 +29,35 @@ ham[lower:upper], ham[lower:upper:], ham[lower::step]
 # ham[lower+offset : upper+offset]
 ham[: upper_fn(x) : step_fn(x)], ham[:: step_fn(x)]
 ham[lower + offset : upper + offset]
+
+slice[::, ::]
+slice[
+    # A
+    :
+    # B
+    :
+    # C
+]
+slice[
+    # A
+    1:
+    # B
+    2:
+    # C
+    3
+]
+
+slice[
+    # A
+    1
+    + 2 :
+    # B
+    3 :
+    # C
+    4
+]
+x[
+    1:  # A
+    2:  # B
+    3  # C
+]

--- a/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/slices.py.expect
+++ b/crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/slices.py.expect
@@ -29,3 +29,31 @@ ham[lower:upper], ham[lower:upper:], ham[lower::step]
 # ham[lower+offset : upper+offset]
 ham[: upper_fn(x) : step_fn(x)], ham[:: step_fn(x)]
 ham[lower + offset : upper + offset]
+
+slice[::, ::]
+slice[
+    # A
+    :
+    # B
+    :
+    # C
+]
+slice[
+    # A
+    1:
+    # B
+    2:
+    # C
+    3
+]
+
+slice[
+    # A
+    1
+    + 2 :
+    # B
+    3 :
+    # C
+    4
+]
+x[1:2:3]  # A  # B  # C

--- a/crates/ruff_python_formatter/src/attachment.rs
+++ b/crates/ruff_python_formatter/src/attachment.rs
@@ -1,6 +1,6 @@
 use crate::core::visitor;
 use crate::core::visitor::Visitor;
-use crate::cst::{Expr, Stmt};
+use crate::cst::{Alias, Excepthandler, Expr, SliceIndex, Stmt};
 use crate::trivia::{decorate_trivia, TriviaIndex, TriviaToken};
 
 struct AttachmentVisitor {
@@ -22,6 +22,30 @@ impl<'a> Visitor<'a> for AttachmentVisitor {
             expr.trivia.extend(comments);
         }
         visitor::walk_expr(self, expr);
+    }
+
+    fn visit_alias(&mut self, alias: &'a mut Alias) {
+        let trivia = self.index.alias.remove(&alias.id());
+        if let Some(comments) = trivia {
+            alias.trivia.extend(comments);
+        }
+        visitor::walk_alias(self, alias);
+    }
+
+    fn visit_excepthandler(&mut self, excepthandler: &'a mut Excepthandler) {
+        let trivia = self.index.excepthandler.remove(&excepthandler.id());
+        if let Some(comments) = trivia {
+            excepthandler.trivia.extend(comments);
+        }
+        visitor::walk_excepthandler(self, excepthandler);
+    }
+
+    fn visit_slice_index(&mut self, slice_index: &'a mut SliceIndex) {
+        let trivia = self.index.slice_index.remove(&slice_index.id());
+        if let Some(comments) = trivia {
+            slice_index.trivia.extend(comments);
+        }
+        visitor::walk_slice_index(self, slice_index);
     }
 }
 

--- a/crates/ruff_python_formatter/src/core/visitor.rs
+++ b/crates/ruff_python_formatter/src/core/visitor.rs
@@ -2,8 +2,8 @@ use rustpython_parser::ast::Constant;
 
 use crate::cst::{
     Alias, Arg, Arguments, Boolop, Cmpop, Comprehension, Excepthandler, ExcepthandlerKind, Expr,
-    ExprContext, ExprKind, Keyword, MatchCase, Operator, Pattern, PatternKind, SliceSegment,
-    SliceSegmentKind, Stmt, StmtKind, Unaryop, Withitem,
+    ExprContext, ExprKind, Keyword, MatchCase, Operator, Pattern, PatternKind, SliceIndex,
+    SliceIndexKind, Stmt, StmtKind, Unaryop, Withitem,
 };
 
 pub trait Visitor<'a> {
@@ -40,8 +40,8 @@ pub trait Visitor<'a> {
     fn visit_excepthandler(&mut self, excepthandler: &'a mut Excepthandler) {
         walk_excepthandler(self, excepthandler);
     }
-    fn visit_slice_segment(&mut self, slice_segment: &'a mut SliceSegment) {
-        walk_slice_segment(self, slice_segment);
+    fn visit_slice_index(&mut self, slice_index: &'a mut SliceIndex) {
+        walk_slice_index(self, slice_index);
     }
     fn visit_format_spec(&mut self, format_spec: &'a mut Expr) {
         walk_expr(self, format_spec);
@@ -423,10 +423,10 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a mut Exp
             visitor.visit_expr_context(ctx);
         }
         ExprKind::Slice { lower, upper, step } => {
-            visitor.visit_slice_segment(lower);
-            visitor.visit_slice_segment(upper);
+            visitor.visit_slice_index(lower);
+            visitor.visit_slice_index(upper);
             if let Some(expr) = step {
-                visitor.visit_slice_segment(expr);
+                visitor.visit_slice_index(expr);
             }
         }
     }
@@ -465,13 +465,13 @@ pub fn walk_excepthandler<'a, V: Visitor<'a> + ?Sized>(
     }
 }
 
-pub fn walk_slice_segment<'a, V: Visitor<'a> + ?Sized>(
+pub fn walk_slice_index<'a, V: Visitor<'a> + ?Sized>(
     visitor: &mut V,
-    slice_segment: &'a mut SliceSegment,
+    slice_index: &'a mut SliceIndex,
 ) {
-    match &mut slice_segment.node {
-        SliceSegmentKind::Empty => {}
-        SliceSegmentKind::Index { value } => {
+    match &mut slice_index.node {
+        SliceIndexKind::Empty => {}
+        SliceIndexKind::Index { value } => {
             visitor.visit_expr(value);
         }
     }

--- a/crates/ruff_python_formatter/src/core/visitor.rs
+++ b/crates/ruff_python_formatter/src/core/visitor.rs
@@ -2,8 +2,8 @@ use rustpython_parser::ast::Constant;
 
 use crate::cst::{
     Alias, Arg, Arguments, Boolop, Cmpop, Comprehension, Excepthandler, ExcepthandlerKind, Expr,
-    ExprContext, ExprKind, Keyword, MatchCase, Operator, Pattern, PatternKind, Stmt, StmtKind,
-    Unaryop, Withitem,
+    ExprContext, ExprKind, Keyword, MatchCase, Operator, Pattern, PatternKind, SliceSegment,
+    SliceSegmentKind, Stmt, StmtKind, Unaryop, Withitem,
 };
 
 pub trait Visitor<'a> {
@@ -39,6 +39,9 @@ pub trait Visitor<'a> {
     }
     fn visit_excepthandler(&mut self, excepthandler: &'a mut Excepthandler) {
         walk_excepthandler(self, excepthandler);
+    }
+    fn visit_slice_segment(&mut self, slice_segment: &'a mut SliceSegment) {
+        walk_slice_segment(self, slice_segment);
     }
     fn visit_format_spec(&mut self, format_spec: &'a mut Expr) {
         walk_expr(self, format_spec);
@@ -420,14 +423,10 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a mut Exp
             visitor.visit_expr_context(ctx);
         }
         ExprKind::Slice { lower, upper, step } => {
-            if let Some(expr) = lower {
-                visitor.visit_expr(expr);
-            }
-            if let Some(expr) = upper {
-                visitor.visit_expr(expr);
-            }
+            visitor.visit_slice_segment(lower);
+            visitor.visit_slice_segment(upper);
             if let Some(expr) = step {
-                visitor.visit_expr(expr);
+                visitor.visit_slice_segment(expr);
             }
         }
     }
@@ -462,6 +461,18 @@ pub fn walk_excepthandler<'a, V: Visitor<'a> + ?Sized>(
                 visitor.visit_expr(expr);
             }
             visitor.visit_body(body);
+        }
+    }
+}
+
+pub fn walk_slice_segment<'a, V: Visitor<'a> + ?Sized>(
+    visitor: &mut V,
+    slice_segment: &'a mut SliceSegment,
+) {
+    match &mut slice_segment.node {
+        SliceSegmentKind::Empty => {}
+        SliceSegmentKind::Index { value } => {
+            visitor.visit_expr(value);
         }
     }
 }

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__expression_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__expression_py.snap
@@ -292,7 +292,7 @@ last_call()
  }
  Python3 > Python2 > COBOL
  Life is Life
-@@ -138,33 +141,33 @@
+@@ -138,15 +141,15 @@
  very_long_variable_name_filters: t.List[
      t.Tuple[str, t.Union[str, t.List[t.Optional[str]]]],
  ]
@@ -315,37 +315,6 @@ last_call()
  slice[0]
  slice[0:1]
  slice[0:1:2]
--slice[:]
-+slice[::]
- slice[:-1]
--slice[1:]
-+slice[1::]
- slice[::-1]
- slice[d :: d + 1]
- slice[:c, c - 1]
- numpy[:, 0:1]
- numpy[:, :-1]
--numpy[0, :]
-+numpy[0, ::]
- numpy[:, i]
- numpy[0, :2]
- numpy[:N, 0]
- numpy[:2, :4]
- numpy[2:4, 1:5]
--numpy[4:, 2:]
-+numpy[4:, 2::]
- numpy[:, (0, 1, 2, 5)]
- numpy[0, [0]]
- numpy[:, [i]]
-@@ -172,7 +175,7 @@
- numpy[-(c + 1) :, d]
- numpy[:, l[-2]]
- numpy[:, ::-1]
--numpy[np.newaxis, :]
-+numpy[np.newaxis, ::]
- (str or None) if (sys.version_info[0] > (3,)) else (str or bytes or None)
- {"2.7": dead, "3.7": long_live or die_hard}
- {"2.7", "3.6", "3.7", "3.8", "3.9", "4.0" if gilectomy else "3.10"}
 @@ -201,30 +204,26 @@
  e = (1,).count(1)
  f = 1, *range(10)
@@ -600,21 +569,21 @@ xxxx_xxx_xxxx_xxxxx_xxxx_xxx: Callable[..., List[SomeClass]] = (
 slice[0]
 slice[0:1]
 slice[0:1:2]
-slice[::]
+slice[:]
 slice[:-1]
-slice[1::]
+slice[1:]
 slice[::-1]
 slice[d :: d + 1]
 slice[:c, c - 1]
 numpy[:, 0:1]
 numpy[:, :-1]
-numpy[0, ::]
+numpy[0, :]
 numpy[:, i]
 numpy[0, :2]
 numpy[:N, 0]
 numpy[:2, :4]
 numpy[2:4, 1:5]
-numpy[4:, 2::]
+numpy[4:, 2:]
 numpy[:, (0, 1, 2, 5)]
 numpy[0, [0]]
 numpy[:, [i]]
@@ -622,7 +591,7 @@ numpy[1 : c + 1, c]
 numpy[-(c + 1) :, d]
 numpy[:, l[-2]]
 numpy[:, ::-1]
-numpy[np.newaxis, ::]
+numpy[np.newaxis, :]
 (str or None) if (sys.version_info[0] > (3,)) else (str or bytes or None)
 {"2.7": dead, "3.7": long_live or die_hard}
 {"2.7", "3.6", "3.7", "3.8", "3.9", "4.0" if gilectomy else "3.10"}


### PR DESCRIPTION
In Python, both of these slices have the same AST:

```py
x[::]
x[:]
```

We need a way to differentiate between them, _and_ we need a way to account for comments within empty segments, like:

```py
x[
  :
  # Comment here
  :
]
```

This PR attempts to solve both problems by introducing a new CST node kind, `SliceIndex`, which can either be an expression or empty. The final segment of a `Slice` is now optional; if it's present but empty, we know to include the trailing colon. Since `SliceIndex` is `Located`, we can also attach comments to it.

As an alternative, I also considered creating a new `ExprKind::Placeholder`, which would only be used here. That _might've_ been more succinct, but this felt like less of a dramatic change to the AST structure.
