### PR TITLE
[`flake8-tidy-imports`] fix autofix for relative imports

### DIFF
--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -108,8 +108,8 @@ fn fix_banned_relative_import(
             }
             call_path.as_slice().join(".")
         } else if parts.len() > 1 {
-            let module = parts.last().unwrap();
-            let call_path = from_relative_import(&parts, module);
+            let module = parts.pop().unwrap();
+            let call_path = from_relative_import(&parts, &module);
             // Require import to be a valid PEP 8 module:
             // https://python.org/dev/peps/pep-0008/#package-and-module-names
             if !call_path.iter().all(|part| is_module_name(part)) {

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
@@ -84,7 +84,7 @@ expression: diagnostics
     row: 7
     column: 21
   fix:
-    content: from my_package.sublib.sublib import server
+    content: from my_package.sublib import server
     location:
       row: 7
       column: 0


### PR DESCRIPTION
The [previous PR to improve the autofix for TID252](https://github.com/charliermarsh/ruff/pull/2990) contains a bug: notice how `from .. import server` becomes `from my_package.sublib.sublib import server` in the test (`sublib` becomes incorrectly duplicated). This PR fixes that issue, although I admit I don't fully understand the code here.