### PR TITLE
Avoid boolean-trap rules for ConfigParser get() methods

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_boolean_trap/FBT.py
+++ b/crates/ruff/resources/test/fixtures/flake8_boolean_trap/FBT.py
@@ -59,6 +59,10 @@ getattr(someobj, attrname, False)
 mylist.index(True)
 int(True)
 str(int(False))
+cfg.get("hello", True)
+cfg.getint("hello", True)
+cfg.getfloat("hello", True)
+cfg.getboolean("hello", True)
 
 
 class Registry:

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
@@ -56,6 +56,9 @@ const FUNC_CALL_NAME_ALLOWLIST: &[&str] = &[
     "bytes",
     "int",
     "float",
+    "getint",
+    "getfloat",
+    "getboolean",
 ];
 
 const FUNC_DEF_NAME_ALLOWLIST: &[&str] = &["__setitem__"];

--- a/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
+++ b/crates/ruff/src/rules/flake8_boolean_trap/snapshots/ruff__rules__flake8_boolean_trap__tests__FBT001_FBT.py.snap
@@ -85,10 +85,10 @@ expression: diagnostics
 - kind:
     BooleanPositionalArgInFunctionDefinition: ~
   location:
-    row: 77
+    row: 81
     column: 18
   end_location:
-    row: 77
+    row: 81
     column: 29
   fix: ~
   parent: ~


### PR DESCRIPTION
See <https://docs.python.org/3/library/configparser.html#fallback-values>.

Fallback value can be used both as a positional argument and as a keyword argument. But it seems to me that using it as a positional argument is more readable.