### PR TITLE
Avoid rewriting any PEP 604 runtime annotations

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
@@ -41,3 +41,8 @@ def f(x: Union["str", int]) -> None:
 
 def f(x: Union[("str", "int"), float]) -> None:
     ...
+
+
+def f() -> None:
+    x: Optional[str]
+    x = Optional[str]

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -2172,8 +2172,9 @@ where
         // Pre-visit.
         match &expr.node {
             ExprKind::Subscript { value, slice, .. } => {
-                // Ex) Optional[...]
-                if !self.in_deferred_string_type_definition
+                // Ex) Optional[...], Union[...]
+                if self.in_type_definition
+                    && !self.in_deferred_string_type_definition
                     && !self.settings.pyupgrade.keep_runtime_typing
                     && self.settings.rules.enabled(&Rule::TypingUnion)
                     && (self.settings.target_version >= PythonVersion::Py310

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -121,4 +121,21 @@ expression: diagnostics
       row: 26
       column: 40
   parent: ~
+- kind:
+    TypingUnion: ~
+  location:
+    row: 47
+    column: 7
+  end_location:
+    row: 47
+    column: 20
+  fix:
+    content: str | None
+    location:
+      row: 47
+      column: 7
+    end_location:
+      row: 47
+      column: 20
+  parent: ~
 


### PR DESCRIPTION
Following `pyupgrade`, we'll just _never_ touch these.

Closes #2981.

Closes #3215.
