### PR TITLE
Avoid EXE001 and EXE002 errors from stdin input

### DIFF
--- a/crates/ruff/src/rules/flake8_executable/helpers.rs
+++ b/crates/ruff/src/rules/flake8_executable/helpers.rs
@@ -1,4 +1,6 @@
 #[cfg(target_family = "unix")]
+use anyhow::Result;
+#[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(target_family = "unix")]
 use std::path::Path;
@@ -39,13 +41,11 @@ pub fn extract_shebang(line: &str) -> ShebangDirective {
 }
 
 #[cfg(target_family = "unix")]
-pub fn is_executable(filepath: &Path) -> bool {
+pub fn is_executable(filepath: &Path) -> Result<bool> {
     {
-        let Ok(metadata) = filepath.metadata() else {
-            return false;
-        };
+        let metadata = filepath.metadata()?;
         let permissions = metadata.permissions();
-        permissions.mode() & 0o111 != 0
+        Ok(permissions.mode() & 0o111 != 0)
     }
 }
 

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -23,12 +23,11 @@ impl Violation for ShebangMissingExecutableFile {
 /// EXE002
 #[cfg(target_family = "unix")]
 pub fn shebang_missing(filepath: &Path) -> Option<Diagnostic> {
-    if is_executable(filepath) {
+    if let Ok(true) = is_executable(filepath) {
         let diagnostic = Diagnostic::new(ShebangMissingExecutableFile, Range::default());
-        Some(diagnostic)
-    } else {
-        None
+        return Some(diagnostic);
     }
+    None
 }
 
 #[cfg(not(target_family = "unix"))]

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -31,9 +31,7 @@ pub fn shebang_not_executable(
     shebang: &ShebangDirective,
 ) -> Option<Diagnostic> {
     if let ShebangDirective::Match(_, start, end, _) = shebang {
-        if is_executable(filepath) {
-            None
-        } else {
+        if let Ok(false) = is_executable(filepath) {
             let diagnostic = Diagnostic::new(
                 ShebangNotExecutable,
                 Range::new(
@@ -41,11 +39,10 @@ pub fn shebang_not_executable(
                     Location::new(lineno + 1, *end),
                 ),
             );
-            Some(diagnostic)
+            return Some(diagnostic);
         }
-    } else {
-        None
     }
+    None
 }
 
 #[cfg(not(target_family = "unix"))]


### PR DESCRIPTION
Slightly better would be to pass in a `filename` and `filepath` separately, and only run these if we have a `filepath`. As-is, it's a bit strange because we might flag these if a corresponding file exists on disk with the same name as `--stdin-filename` -- which could be a feature, but is arguably a bug.

Closes #3214.