### PR TITLE
Avoid flagging logging-too-few-args with no arguments

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/logging_too_few_args.py
+++ b/crates/ruff/resources/test/fixtures/pylint/logging_too_few_args.py
@@ -7,6 +7,9 @@ logging.warning("Hello %s", "World!", "again", something="else")
 
 logging.warning("Hello %s", "World!")
 
+# do not handle calls without any args
+logging.info("100% dynamic")
+
 import warning
 
 warning.warning("Hello %s %s", "World!")

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -114,22 +114,22 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
 
                         let message_args = call_args.args.len() - 1;
 
-                        if checker.settings.rules.enabled(&Rule::LoggingTooManyArgs)
-                            && summary.num_positional < message_args
-                        {
-                            checker.diagnostics.push(Diagnostic::new(
-                                LoggingTooManyArgs,
-                                Range::from_located(func),
-                            ));
+                        if checker.settings.rules.enabled(&Rule::LoggingTooManyArgs) {
+                            if summary.num_positional < message_args {
+                                checker.diagnostics.push(Diagnostic::new(
+                                    LoggingTooManyArgs,
+                                    Range::from_located(func),
+                                ));
+                            }
                         }
 
-                        if checker.settings.rules.enabled(&Rule::LoggingTooFewArgs)
-                            && summary.num_positional > message_args
-                        {
-                            checker.diagnostics.push(Diagnostic::new(
-                                LoggingTooFewArgs,
-                                Range::from_located(func),
-                            ));
+                        if checker.settings.rules.enabled(&Rule::LoggingTooFewArgs) {
+                            if message_args > 0 && summary.num_positional > message_args {
+                                checker.diagnostics.push(Diagnostic::new(
+                                    LoggingTooFewArgs,
+                                    Range::from_located(func),
+                                ));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This matches Pylint's behavior.

Closes #3204.