### PR TITLE
Allow ruff.toml file to be dot-prefixed (as .ruff.toml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ alongside any other editor through the [Ruff LSP](https://github.com/charliermar
 
 ### Configuration
 
-Ruff can be configured via a `pyproject.toml` file, a `ruff.toml` file, or through the command line
-(see: [_Configuration_](https://beta.ruff.rs/docs/configuration/), or
-[_Settings_](https://beta.ruff.rs/docs/settings/) for a complete list of all configuration options).
+Ruff can be configured through a `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file (see:
+[_Configuration_](https://beta.ruff.rs/docs/configuration/), or [_Settings_](https://beta.ruff.rs/docs/settings/)
+for a complete list of all configuration options).
 
 If left unspecified, the default configuration is equivalent to:
 

--- a/crates/ruff/src/settings/pyproject.rs
+++ b/crates/ruff/src/settings/pyproject.rs
@@ -48,6 +48,12 @@ pub fn ruff_enabled<P: AsRef<Path>>(path: P) -> Result<bool> {
 /// Return the path to the `pyproject.toml` or `ruff.toml` file in a given
 /// directory.
 pub fn settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
+    // Check for `.ruff.toml`.
+    let ruff_toml = path.as_ref().join(".ruff.toml");
+    if ruff_toml.is_file() {
+        return Ok(Some(ruff_toml));
+    }
+
     // Check for `ruff.toml`.
     let ruff_toml = path.as_ref().join("ruff.toml");
     if ruff_toml.is_file() {
@@ -77,6 +83,14 @@ pub fn find_settings_toml<P: AsRef<Path>>(path: P) -> Result<Option<PathBuf>> {
 /// Find the path to the user-specific `pyproject.toml` or `ruff.toml`, if it
 /// exists.
 pub fn find_user_settings_toml() -> Option<PathBuf> {
+    // Search for a user-specific `.ruff.toml`.
+    let mut path = dirs::config_dir()?;
+    path.push("ruff");
+    path.push(".ruff.toml");
+    if path.is_file() {
+        return Some(path);
+    }
+
     // Search for a user-specific `ruff.toml`.
     let mut path = dirs::config_dir()?;
     path.push("ruff");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuring Ruff
 
-Ruff can be configured through a `pyproject.toml` file, a `ruff.toml` file, or the command line.
+Ruff can be configured through a `pyproject.toml`, `ruff.toml`, or `.ruff.toml` file.
 
 For a complete enumeration of the available configuration options, see
 [_Settings_](settings.md).
@@ -117,11 +117,11 @@ If you're wondering how to configure Ruff, here are some **recommended guideline
 
 ## Using `ruff.toml`
 
-As an alternative to `pyproject.toml`, Ruff will also respect a `ruff.toml` file, which implements
-an equivalent schema (though the `[tool.ruff]` hierarchy can be omitted).
+As an alternative to `pyproject.toml`, Ruff will also respect a `ruff.toml` (or `.ruff.toml`) file,
+which implements an equivalent schema (though the `[tool.ruff]` hierarchy can be omitted).
 
 For example, the `pyproject.toml` described above would be represented via the following
-`ruff.toml`:
+`ruff.toml` (or `.ruff.toml`):
 
 ```toml
 # Enable flake8-bugbear (`B`) rules.
@@ -139,8 +139,7 @@ unfixable = ["B"]
 "path/to/file.py" = ["E402"]
 ```
 
-For a complete enumeration of the available configuration options, see
-[_Settings_](settings.md).
+For a complete enumeration of the available configuration options, see [_Settings_](settings.md).
 
 ## Command-line interface
 
@@ -302,8 +301,9 @@ extend = "../pyproject.toml"
 line-length = 100
 ```
 
-All of the above rules apply equivalently to `ruff.toml` files. If Ruff detects both a `ruff.toml`
-and `pyproject.toml` file, it will defer to the `ruff.toml`.
+All of the above rules apply equivalently to `ruff.toml` and `.ruff.toml`  files. If Ruff detects
+multiple configuration files in the same directory, the `.ruff.toml` file will take precedence over
+the `ruff.toml` file, and the `ruff.toml` file will take precedence over the `pyproject.toml` file.
 
 ## Python file discovery
 


### PR DESCRIPTION
Closes #2988.