### PR TITLE
Add `noqa_row` to diagnostics JSON format

### DIFF
--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -331,7 +331,9 @@ pub fn lint_only(
                 } else {
                     None
                 };
-                Message::from_diagnostic(diagnostic, path_lossy.to_string(), source)
+                let lineno = diagnostic.location.row();
+                let noqa_line = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
+                Message::from_diagnostic(diagnostic, path_lossy.to_string(), source, noqa_line)
             })
             .collect()
     })
@@ -469,7 +471,14 @@ This indicates a bug in `{}`. If you could open an issue at:
                         } else {
                             None
                         };
-                        Message::from_diagnostic(diagnostic, path_lossy.to_string(), source)
+                        let lineno = diagnostic.location.row();
+                        let noqa_line = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
+                        Message::from_diagnostic(
+                            diagnostic,
+                            path_lossy.to_string(),
+                            source,
+                            noqa_line,
+                        )
                     })
                     .collect()
             }),

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -332,8 +332,8 @@ pub fn lint_only(
                     None
                 };
                 let lineno = diagnostic.location.row();
-                let noqa_line = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
-                Message::from_diagnostic(diagnostic, path_lossy.to_string(), source, noqa_line)
+                let noqa_row = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
+                Message::from_diagnostic(diagnostic, path_lossy.to_string(), source, noqa_row)
             })
             .collect()
     })
@@ -472,12 +472,12 @@ This indicates a bug in `{}`. If you could open an issue at:
                             None
                         };
                         let lineno = diagnostic.location.row();
-                        let noqa_line = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
+                        let noqa_row = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
                         Message::from_diagnostic(
                             diagnostic,
                             path_lossy.to_string(),
                             source,
-                            noqa_line,
+                            noqa_row,
                         )
                     })
                     .collect()

--- a/crates/ruff/src/message.rs
+++ b/crates/ruff/src/message.rs
@@ -16,6 +16,7 @@ pub struct Message {
     pub fix: Option<Fix>,
     pub filename: String,
     pub source: Option<Source>,
+    pub noqa_line: usize,
 }
 
 impl Message {
@@ -23,6 +24,7 @@ impl Message {
         diagnostic: Diagnostic,
         filename: String,
         source: Option<Source>,
+        noqa_line: usize,
     ) -> Self {
         Self {
             kind: diagnostic.kind,
@@ -34,6 +36,7 @@ impl Message {
             fix: diagnostic.fix,
             filename,
             source,
+            noqa_line,
         }
     }
 }

--- a/crates/ruff/src/message.rs
+++ b/crates/ruff/src/message.rs
@@ -16,7 +16,7 @@ pub struct Message {
     pub fix: Option<Fix>,
     pub filename: String,
     pub source: Option<Source>,
-    pub noqa_line: usize,
+    pub noqa_row: usize,
 }
 
 impl Message {
@@ -24,7 +24,7 @@ impl Message {
         diagnostic: Diagnostic,
         filename: String,
         source: Option<Source>,
-        noqa_line: usize,
+        noqa_row: usize,
     ) -> Self {
         Self {
             kind: diagnostic.kind,
@@ -36,7 +36,7 @@ impl Message {
             fix: diagnostic.fix,
             filename,
             source,
-            noqa_line,
+            noqa_row,
         }
     }
 }

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -114,6 +114,7 @@ pub fn run(
                             ),
                             format!("{}", path.display()),
                             None,
+                            1,
                         )])
                     } else {
                         Diagnostics::default()

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -50,6 +50,7 @@ struct ExpandedMessage<'a> {
     location: Location,
     end_location: Location,
     filename: &'a str,
+    noqa_line: usize,
 }
 
 #[derive(Serialize)]
@@ -197,6 +198,7 @@ impl Printer {
                                 location: message.location,
                                 end_location: message.end_location,
                                 filename: &message.filename,
+                                noqa_line: message.noqa_line,
                             })
                             .collect::<Vec<_>>()
                     )?

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -50,7 +50,7 @@ struct ExpandedMessage<'a> {
     location: Location,
     end_location: Location,
     filename: &'a str,
-    noqa_line: usize,
+    noqa_row: usize,
 }
 
 #[derive(Serialize)]
@@ -198,7 +198,7 @@ impl Printer {
                                 location: message.location,
                                 end_location: message.end_location,
                                 filename: &message.filename,
-                                noqa_line: message.noqa_line,
+                                noqa_row: message.noqa_row,
                             })
                             .collect::<Vec<_>>()
                     )?

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -112,7 +112,8 @@ fn test_stdin_json() -> Result<()> {
       "row": 1,
       "column": 10
     }},
-    "filename": "{file_path}"
+    "filename": "{file_path}",
+    "noqa_line": 1
   }}
 ]
 "#

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -113,7 +113,7 @@ fn test_stdin_json() -> Result<()> {
       "column": 10
     }},
     "filename": "{file_path}",
-    "noqa_line": 1
+    "noqa_row": 1
   }}
 ]
 "#


### PR DESCRIPTION
In ruff-lsp (https://github.com/charliermarsh/ruff-lsp/pull/76) we want to add a "Disable \<rule\> for this line" quickfix. However, finding the correct line into which the `noqa` comment should be inserted is non-trivial (multi-line strings for example).

Ruff already has this info, so expose it in the JSON output for use by ruff-lsp.