### PR TITLE
Don't flag keyword-based logging format strings

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/logging_too_few_args.py
+++ b/crates/ruff/resources/test/fixtures/pylint/logging_too_few_args.py
@@ -16,6 +16,9 @@ logging.error("Example log %s, %s", "foo", "bar", "baz", *args)
 # do not handle calls with **kwargs
 logging.error("Example log %s, %s", "foo", "bar", "baz", **kwargs)
 
+# do not handle keyword arguments
+logging.error("%(objects)d modifications: %(modifications)d errors: %(errors)d")
+
 import warning
 
 warning.warning("Hello %s %s", "World!")

--- a/crates/ruff/resources/test/fixtures/pylint/logging_too_many_args.py
+++ b/crates/ruff/resources/test/fixtures/pylint/logging_too_many_args.py
@@ -12,6 +12,9 @@ logging.error("Example log %s, %s", "foo", "bar", "baz", *args)
 # do not handle calls with **kwargs
 logging.error("Example log %s, %s", "foo", "bar", "baz", **kwargs)
 
+# do not handle keyword arguments
+logging.error("%(objects)d modifications: %(modifications)d errors: %(errors)d", {"objects": 1, "modifications": 1, "errors": 1})
+
 import warning
 
 warning.warning("Hello %s", "World!", "again")

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -117,6 +117,9 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
                         if summary.starred {
                             return;
                         }
+                        if !summary.keywords.is_empty() {
+                            return;
+                        }
 
                         let message_args = call_args.args.len() - 1;
 


### PR DESCRIPTION
This is consistent with Pylint.

Closes #3256.