### PR TITLE
Avoid PEP 585 rewrites when builtins are shadowed

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP006.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP006.py
@@ -28,3 +28,10 @@ def f(x: IList[str]) -> None:
 
 def f(x: "List[str]") -> None:
     ...
+
+
+list = "abc"
+
+
+def f(x: List[str]) -> None:
+    ...

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -26,7 +26,7 @@ impl AlwaysAutofixableViolation for DeprecatedCollectionType {
 
     fn autofix_title(&self) -> String {
         let DeprecatedCollectionType { name } = self;
-        format!("Replace `{name}` with `{}`", name.to_lowercase(),)
+        format!("Replace `{name}` with `{}`", name.to_lowercase())
     }
 }
 
@@ -43,11 +43,14 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
             Range::from_located(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
-                binding.to_lowercase(),
-                expr.location,
-                expr.end_location.unwrap(),
-            ));
+            let binding = binding.to_lowercase();
+            if checker.is_builtin(&binding) {
+                diagnostic.amend(Fix::replacement(
+                    binding,
+                    expr.location,
+                    expr.end_location.unwrap(),
+                ));
+            }
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
@@ -74,4 +74,15 @@ expression: diagnostics
       row: 25
       column: 14
   parent: ~
+- kind:
+    DeprecatedCollectionType:
+      name: List
+  location:
+    row: 36
+    column: 9
+  end_location:
+    row: 36
+    column: 13
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
This just avoids attempting to fix these -- so it doesn't solve the issue as-described, but it avoids breaking the user's code.

Closes #3284.
