### PR TITLE
Implement `property-decorators` configuration option for pydocstyle

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D401.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D401.py
@@ -2,6 +2,8 @@
 
 from functools import cached_property
 
+from gi.repository import GObject
+
 # Bad examples
 
 def bad_liouiwnlkjl():
@@ -73,6 +75,11 @@ class Thingy:
 
     @property
     def good_property(self):
+        """This property method docstring does not need to be written in imperative mood."""
+        return self._beep
+
+    @GObject.Property
+    def good_custom_property(self):
         """This property method docstring does not need to be written in imperative mood."""
         return self._beep
 

--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -5611,7 +5611,11 @@ impl<'a> Checker<'a> {
                     pydocstyle::rules::ends_with_period(self, &docstring);
                 }
                 if self.settings.rules.enabled(&Rule::NonImperativeMood) {
-                    pydocstyle::rules::non_imperative_mood(self, &docstring);
+                    pydocstyle::rules::non_imperative_mood(
+                        self,
+                        &docstring,
+                        &self.settings.pydocstyle.property_decorators,
+                    );
                 }
                 if self.settings.rules.enabled(&Rule::NoSignature) {
                     pydocstyle::rules::no_signature(self, &docstring);

--- a/crates/ruff/src/flake8_to_ruff/converter.rs
+++ b/crates/ruff/src/flake8_to_ruff/converter.rs
@@ -577,6 +577,7 @@ mod tests {
             pydocstyle: Some(pydocstyle::settings::Options {
                 convention: Some(Convention::Numpy),
                 ignore_decorators: None,
+                property_decorators: None,
             }),
             ..default_options([Linter::Pydocstyle.into()])
         });

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use ruff_python::str::{
     SINGLE_QUOTE_PREFIXES, SINGLE_QUOTE_SUFFIXES, TRIPLE_QUOTE_PREFIXES, TRIPLE_QUOTE_SUFFIXES,
 };
+use rustpython_parser::ast::Expr;
 
 use crate::ast::cast;
 use crate::ast::helpers::{map_callable, to_call_path};
@@ -96,4 +97,26 @@ pub fn should_ignore_definition(
         }
     }
     false
+}
+
+/// Returns `true` if a method is defined as one of supplied decorators in
+/// `property_decorators`.
+pub fn is_property(
+    checker: &Checker,
+    decorator_list: &[Expr],
+    property_decorators: &BTreeSet<String>,
+) -> bool {
+    if property_decorators.is_empty() {
+        return false;
+    }
+
+    decorator_list.iter().any(|expr| {
+        checker
+            .resolve_call_path(map_callable(expr))
+            .map_or(false, |call_path| {
+                property_decorators
+                    .iter()
+                    .any(|decorator| to_call_path(decorator) == call_path)
+            })
+    })
 }

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -77,6 +77,9 @@ mod tests {
                 pydocstyle: Settings {
                     convention: None,
                     ignore_decorators: BTreeSet::from_iter(["functools.wraps".to_string()]),
+                    property_decorators: BTreeSet::from_iter([
+                        "gi.repository.GObject.Property".to_string()
+                    ]),
                 },
                 ..settings::Settings::for_rule(rule_code)
             },
@@ -95,6 +98,7 @@ mod tests {
                 pydocstyle: Settings {
                     convention: None,
                     ignore_decorators: BTreeSet::new(),
+                    property_decorators: BTreeSet::new(),
                 },
                 ..settings::Settings::for_rule(Rule::UndocumentedParam)
             },
@@ -112,6 +116,7 @@ mod tests {
                 pydocstyle: Settings {
                     convention: Some(Convention::Google),
                     ignore_decorators: BTreeSet::new(),
+                    property_decorators: BTreeSet::new(),
                 },
                 ..settings::Settings::for_rule(Rule::UndocumentedParam)
             },
@@ -129,6 +134,7 @@ mod tests {
                 pydocstyle: Settings {
                     convention: Some(Convention::Numpy),
                     ignore_decorators: BTreeSet::new(),
+                    property_decorators: BTreeSet::new(),
                 },
                 ..settings::Settings::for_rule(Rule::UndocumentedParam)
             },

--- a/crates/ruff/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff/src/rules/pydocstyle/settings.rs
@@ -97,12 +97,25 @@ pub struct Options {
     /// specified decorators. Unlike the `pydocstyle`, Ruff accepts an array
     /// of fully-qualified module identifiers, instead of a regular expression.
     pub ignore_decorators: Option<Vec<String>>,
+    #[option(
+        default = r#"[]"#,
+        value_type = "list[str]",
+        example = r#"
+            property-decorators = ["gi.repository.GObject.Property"]
+        "#
+    )]
+    /// Consider any method decorated with one of these decorators as a property,
+    /// and consequently allow a docstring which is not in imperative mood.
+    /// Unlike pydocstyle, supplying this option doesn't disable standard
+    /// property decorators - `@property` and `@cached_property`.
+    pub property_decorators: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Hash)]
 pub struct Settings {
     pub convention: Option<Convention>,
     pub ignore_decorators: BTreeSet<String>,
+    pub property_decorators: BTreeSet<String>,
 }
 
 impl From<Options> for Settings {
@@ -110,6 +123,9 @@ impl From<Options> for Settings {
         Self {
             convention: options.convention,
             ignore_decorators: BTreeSet::from_iter(options.ignore_decorators.unwrap_or_default()),
+            property_decorators: BTreeSet::from_iter(
+                options.property_decorators.unwrap_or_default(),
+            ),
         }
     }
 }
@@ -119,6 +135,7 @@ impl From<Settings> for Options {
         Self {
             convention: settings.convention,
             ignore_decorators: Some(settings.ignore_decorators.into_iter().collect()),
+            property_decorators: Some(settings.property_decorators.into_iter().collect()),
         }
     }
 }

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D401_D401.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D401_D401.py.snap
@@ -1,74 +1,74 @@
 ---
-source: src/rules/pydocstyle/mod.rs
+source: crates/ruff/src/rules/pydocstyle/mod.rs
 expression: diagnostics
 ---
 - kind:
     NonImperativeMood: Returns foo.
   location:
-    row: 8
+    row: 10
     column: 4
   end_location:
-    row: 8
+    row: 10
     column: 22
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: Constructor for a foo.
   location:
-    row: 12
+    row: 14
     column: 4
   end_location:
-    row: 12
+    row: 14
     column: 32
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: Constructor for a boa.
   location:
-    row: 16
+    row: 18
     column: 4
   end_location:
-    row: 20
+    row: 22
     column: 7
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: Runs something
   location:
-    row: 24
+    row: 26
     column: 4
   end_location:
-    row: 24
+    row: 26
     column: 24
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: "Runs other things, nested"
   location:
-    row: 27
+    row: 29
     column: 8
   end_location:
-    row: 27
+    row: 29
     column: 39
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: Writes a logical line that
   location:
-    row: 33
+    row: 35
     column: 4
   end_location:
-    row: 35
+    row: 37
     column: 7
   fix: ~
   parent: ~
 - kind:
     NonImperativeMood: This method docstring should be written in imperative mood.
   location:
-    row: 72
+    row: 74
     column: 8
   end_location:
-    row: 72
+    row: 74
     column: 73
   fix: ~
   parent: ~

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1268,6 +1268,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "property-decorators": {
+          "description": "Consider any method decorated with one of these decorators as a property, and consequently allow a docstring which is not in imperative mood. Unlike pydocstyle, supplying this option doesn't disable standard property decorators - `@property` and `@cached_property`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Implements the second part of #2205.
(I did not run pre-commit locally as it's installing the environment indefinitely)