### PR TITLE
Abort when unable to fix relative imports past module root

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID252/my_package/sublib/api/application.py
+++ b/crates/ruff/resources/test/fixtures/flake8_tidy_imports/TID252/my_package/sublib/api/application.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING, Any, ClassVar
- 
+
 import attrs
 
+from ....import unknown
 from ..protocol import commands, definitions, responses
 from ..server import example
 from .. import server

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -94,6 +94,10 @@ fn fix_banned_relative_import(
 ) -> Option<Fix> {
     // Only fix is the module path is known.
     if let Some(mut parts) = module_path.cloned() {
+        if *level? >= parts.len() {
+            return None;
+        }
+
         // Remove relative level from module path.
         for _ in 0..*level? {
             parts.pop();

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
@@ -10,50 +10,25 @@ expression: diagnostics
     column: 0
   end_location:
     row: 5
-    column: 55
-  fix:
-    content: "from my_package.sublib.protocol import commands, definitions, responses"
-    location:
-      row: 5
-      column: 0
-    end_location:
-      row: 5
-      column: 55
+    column: 23
+  fix: ~
   parent: ~
 - kind:
     RelativeImports:
       strictness: parents
   location:
-    row: 5
+    row: 6
     column: 0
   end_location:
-    row: 5
+    row: 6
     column: 55
   fix:
     content: "from my_package.sublib.protocol import commands, definitions, responses"
     location:
-      row: 5
+      row: 6
       column: 0
     end_location:
-      row: 5
-      column: 55
-  parent: ~
-- kind:
-    RelativeImports:
-      strictness: parents
-  location:
-    row: 5
-    column: 0
-  end_location:
-    row: 5
-    column: 55
-  fix:
-    content: "from my_package.sublib.protocol import commands, definitions, responses"
-    location:
-      row: 5
-      column: 0
-    end_location:
-      row: 5
+      row: 6
       column: 55
   parent: ~
 - kind:
@@ -64,32 +39,68 @@ expression: diagnostics
     column: 0
   end_location:
     row: 6
+    column: 55
+  fix:
+    content: "from my_package.sublib.protocol import commands, definitions, responses"
+    location:
+      row: 6
+      column: 0
+    end_location:
+      row: 6
+      column: 55
+  parent: ~
+- kind:
+    RelativeImports:
+      strictness: parents
+  location:
+    row: 6
+    column: 0
+  end_location:
+    row: 6
+    column: 55
+  fix:
+    content: "from my_package.sublib.protocol import commands, definitions, responses"
+    location:
+      row: 6
+      column: 0
+    end_location:
+      row: 6
+      column: 55
+  parent: ~
+- kind:
+    RelativeImports:
+      strictness: parents
+  location:
+    row: 7
+    column: 0
+  end_location:
+    row: 7
     column: 28
   fix:
     content: from my_package.sublib.server import example
     location:
-      row: 6
+      row: 7
       column: 0
     end_location:
-      row: 6
+      row: 7
       column: 28
   parent: ~
 - kind:
     RelativeImports:
       strictness: parents
   location:
-    row: 7
+    row: 8
     column: 0
   end_location:
-    row: 7
+    row: 8
     column: 21
   fix:
     content: from my_package.sublib import server
     location:
-      row: 7
+      row: 8
       column: 0
     end_location:
-      row: 7
+      row: 8
       column: 21
   parent: ~
 


### PR DESCRIPTION
Closes the syntax error portion of #3318.