### PR TITLE
Add `cargo dev generate-all --check` and catch outdated docs in `cargo test`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,8 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v1
       - run: cargo build --all
-      - run: ./target/debug/ruff_dev generate-all
-      - run: git diff --quiet README.md || echo "::error file=README.md::This file is outdated. Run 'cargo dev generate-all'."
-      - run: git diff --quiet ruff.schema.json || echo "::error file=ruff.schema.json::This file is outdated. Run 'cargo dev generate-all'."
-      - run: git diff --exit-code -- README.md ruff.schema.json docs
+      # Run `cargo dev generate-all` if this fails
+      - run: ./target/debug/ruff_dev generate-all --check
 
   cargo-fmt:
     name: "cargo fmt"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,18 +17,6 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
-  cargo-build:
-    name: "cargo build"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: "Install Rust toolchain"
-        run: rustup show
-      - uses: Swatinem/rust-cache@v1
-      - run: cargo build --all
-      # Run `cargo dev generate-all` if this fails
-      - run: ./target/debug/ruff_dev generate-all --check
-
   cargo-fmt:
     name: "cargo fmt"
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1474,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,6 +1751,18 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
 ]
 
 [[package]]
@@ -2054,6 +2085,7 @@ dependencies = [
  "itertools",
  "libcst",
  "once_cell",
+ "pretty_assertions",
  "regex",
  "ruff",
  "ruff_cli",
@@ -3257,6 +3289,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi-term"

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -184,6 +184,20 @@ impl JsonSchema for RuleSelector {
                 std::iter::once("ALL".to_string())
                     .chain(
                         RuleCodePrefix::iter()
+                            .filter(|p| {
+                                // Once logical lines are active by default, please remove this.
+                                // This is here because generate-all output otherwise depends on
+                                // the feature sets which makes the test running with
+                                // `--all-features` fail
+                                !Rule::from_code(&format!(
+                                    "{}{}",
+                                    p.linter().common_prefix(),
+                                    p.short_code()
+                                ))
+                                .unwrap()
+                                .lint_source()
+                                .is_logical_lines()
+                            })
                             .map(|p| {
                                 let prefix = p.linter().common_prefix();
                                 let code = p.short_code();

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -11,6 +11,7 @@ clap = { workspace = true }
 itertools = { workspace = true }
 libcst = { workspace = true }
 once_cell = { workspace = true }
+pretty_assertions = { version = "1.3.0" }
 regex = { workspace = true }
 ruff = { path = "../ruff" }
 ruff_cli = { path = "../ruff_cli" }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -4,22 +4,30 @@ use anyhow::Result;
 
 use crate::{generate_cli_help, generate_docs, generate_json_schema};
 
+pub const REGENERATE_ALL_COMMAND: &str = "cargo dev generate-all";
+
 #[derive(clap::Args)]
 pub struct Args {
     /// Write the generated artifacts to stdout (rather than to the filesystem).
     #[arg(long)]
     dry_run: bool,
+    /// Don't write to the file, check if the file is up-to-date and error if not
+    #[arg(long)]
+    check: bool,
 }
 
 pub fn main(args: &Args) -> Result<()> {
     generate_docs::main(&generate_docs::Args {
         dry_run: args.dry_run,
+        check: args.check,
     })?;
     generate_json_schema::main(&generate_json_schema::Args {
         dry_run: args.dry_run,
+        check: args.check,
     })?;
     generate_cli_help::main(&generate_cli_help::Args {
         dry_run: args.dry_run,
+        check: args.check,
     })?;
     Ok(())
 }

--- a/crates/ruff_dev/src/generate_all.rs
+++ b/crates/ruff_dev/src/generate_all.rs
@@ -17,10 +17,12 @@ pub struct Args {
 }
 
 pub fn main(args: &Args) -> Result<()> {
-    generate_docs::main(&generate_docs::Args {
-        dry_run: args.dry_run,
-        check: args.check,
-    })?;
+    // Not checked in
+    if !args.check {
+        generate_docs::main(&generate_docs::Args {
+            dry_run: args.dry_run,
+        })?;
+    }
     generate_json_schema::main(&generate_json_schema::Args {
         dry_run: args.dry_run,
         check: args.check,

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -1,8 +1,6 @@
 //! Generate CLI help.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::PathBuf;
 use std::{fs, str};
 
@@ -21,17 +19,22 @@ pub struct Args {
     /// Write the generated help to stdout (rather than to `docs/configuration.md`).
     #[arg(long)]
     pub(crate) dry_run: bool,
+    /// Don't write to the file, check if the file is up-to-date and error if not
+    #[arg(long)]
+    pub(crate) check: bool,
 }
 
 fn trim_lines(s: &str) -> String {
     s.lines().map(str::trim_end).collect::<Vec<_>>().join("\n")
 }
 
-fn replace_docs_section(content: &str, begin_pragma: &str, end_pragma: &str) -> Result<()> {
-    // Read the existing file.
-    let file = PathBuf::from(ROOT_DIR).join("docs/configuration.md");
-    let existing = fs::read_to_string(&file)?;
-
+/// Takes the existing file contents, inserts the section, returns the transformed content
+fn replace_docs_section(
+    existing: &str,
+    section: &str,
+    begin_pragma: &str,
+    end_pragma: &str,
+) -> Result<String> {
     // Extract the prefix.
     let index = existing
         .find(begin_pragma)
@@ -44,13 +47,7 @@ fn replace_docs_section(content: &str, begin_pragma: &str, end_pragma: &str) -> 
         .expect("Unable to find end pragma");
     let suffix = &existing[index..];
 
-    // Write the prefix, new contents, and suffix.
-    let mut f = OpenOptions::new().write(true).truncate(true).open(&file)?;
-    writeln!(f, "{prefix}")?;
-    write!(f, "{content}")?;
-    write!(f, "{suffix}")?;
-
-    Ok(())
+    Ok(format!("{prefix}\n{section}{suffix}"))
 }
 
 pub fn main(args: &Args) -> Result<()> {
@@ -64,17 +61,46 @@ pub fn main(args: &Args) -> Result<()> {
         print!("{command_help}");
         print!("{subcommand_help}");
     } else {
-        replace_docs_section(
+        // Read the existing file.
+        let filename = "docs/configuration.md";
+        let file = PathBuf::from(ROOT_DIR).join(filename);
+        let existing = fs::read_to_string(&file)?;
+
+        let new = replace_docs_section(
+            &existing,
             &format!("```text\n{command_help}\n```\n\n"),
             COMMAND_HELP_BEGIN_PRAGMA,
             COMMAND_HELP_END_PRAGMA,
         )?;
-        replace_docs_section(
+        let new = replace_docs_section(
+            &new,
             &format!("```text\n{subcommand_help}\n```\n\n"),
             SUBCOMMAND_HELP_BEGIN_PRAGMA,
             SUBCOMMAND_HELP_END_PRAGMA,
         )?;
+
+        if args.check {
+            if existing == new {
+                println!("up-to-date: {filename}")
+            }
+        } else {
+            fs::write(file, &new)?;
+        }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{main, Args};
+
+    #[test]
+    fn test_generate_json_schema() {
+        main(&Args {
+            dry_run: false,
+            check: true,
+        })
+        .unwrap()
+    }
 }

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -106,6 +106,6 @@ mod test {
             dry_run: false,
             check: true,
         })
-        .unwrap()
+        .unwrap();
     }
 }

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -99,13 +99,13 @@ pub fn main(args: &Args) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::{main, Args};
+    use anyhow::Result;
 
     #[test]
-    fn test_generate_json_schema() {
+    fn test_generate_json_schema() -> Result<()> {
         main(&Args {
             dry_run: false,
             check: true,
         })
-        .unwrap();
     }
 }

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -3,7 +3,9 @@
 use std::fs;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use crate::generate_all::REGENERATE_ALL_COMMAND;
+use anyhow::{bail, Result};
+use pretty_assertions::StrComparison;
 use ruff::settings::options::Options;
 use schemars::schema_for;
 
@@ -14,17 +16,44 @@ pub struct Args {
     /// Write the generated table to stdout (rather than to `ruff.schema.json`).
     #[arg(long)]
     pub(crate) dry_run: bool,
+    /// Don't write to the file, check if the file is up-to-date and error if not
+    #[arg(long)]
+    pub(crate) check: bool,
 }
 
 pub fn main(args: &Args) -> Result<()> {
     let schema = schema_for!(Options);
     let schema_string = serde_json::to_string_pretty(&schema).unwrap();
+    let filename = "ruff.schema.json";
+    let schema_path = PathBuf::from(ROOT_DIR).join(filename);
 
     if args.dry_run {
         println!("{schema_string}");
+    } else if args.check {
+        let current = fs::read_to_string(schema_path)?;
+        if current == schema_string {
+            println!("up-to-date: {filename}");
+        } else {
+            let comparison = StrComparison::new(&current, &schema_string);
+            bail!("{filename} changed, please run `{REGENERATE_ALL_COMMAND}`:\n{comparison}");
+        }
     } else {
-        let file = PathBuf::from(ROOT_DIR).join("ruff.schema.json");
+        let file = schema_path;
         fs::write(file, schema_string.as_bytes())?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{main, Args};
+
+    #[test]
+    fn test_generate_json_schema() {
+        main(&Args {
+            dry_run: false,
+            check: true,
+        })
+        .unwrap()
+    }
 }

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -54,6 +54,6 @@ mod test {
             dry_run: false,
             check: true,
         })
-        .unwrap()
+        .unwrap();
     }
 }

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -47,13 +47,13 @@ pub fn main(args: &Args) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::{main, Args};
+    use anyhow::Result;
 
     #[test]
-    fn test_generate_json_schema() {
+    fn test_generate_json_schema() -> Result<()> {
         main(&Args {
             dry_run: false,
             check: true,
         })
-        .unwrap();
     }
 }

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Options",
   "type": "object",
   "properties": {

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Options",
   "type": "object",
   "properties": {


### PR DESCRIPTION
`cargo test` now catches outdated generated docs. You can also run the checks manually with `cargo dev generate-all --check`.

Follow up for #3309 which i was too slow for.