### PR TITLE
Gate PEP604 isinstance rewrites behind Python 3.10+

### DIFF
--- a/crates/ruff/src/checkers/ast.rs
+++ b/crates/ruff/src/checkers/ast.rs
@@ -2631,7 +2631,10 @@ where
                 if self.settings.rules.enabled(&Rule::OSErrorAlias) {
                     pyupgrade::rules::os_error_alias(self, &expr);
                 }
-                if self.settings.rules.enabled(&Rule::IsinstanceWithTuple) {
+                if self.settings.rules.enabled(&Rule::IsinstanceWithTuple)
+                    && !self.settings.pyupgrade.keep_runtime_typing
+                    && self.settings.target_version >= PythonVersion::Py310
+                {
                     pyupgrade::rules::use_pep604_isinstance(self, expr, func, args);
                 }
 

--- a/crates/ruff/src/rules/pyupgrade/settings.rs
+++ b/crates/ruff/src/rules/pyupgrade/settings.rs
@@ -26,8 +26,8 @@ pub struct Options {
     /// `from __future__ import annotations`. Note that this setting is only
     /// applicable when the target Python version is below 3.9 and 3.10
     /// respectively, and enabling it is equivalent to disabling
-    /// `use-pep585-annotation` (`UP006`) and `use-pep604-annotation`
-    /// (`UP007`) entirely.
+    /// `use-pep585-annotation` (`UP006`), `use-pep604-annotation`
+    /// (`UP007`), and `use-pep604-isinstance` (`UP038`) entirely.
     pub keep_runtime_typing: Option<bool>,
 }
 

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -1214,7 +1214,7 @@
       "type": "object",
       "properties": {
         "keep-runtime-typing": {
-          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and enabling it is equivalent to disabling `use-pep585-annotation` (`UP006`) and `use-pep604-annotation` (`UP007`) entirely.",
+          "description": "Whether to avoid PEP 585 (`List[int]` -> `list[int]`) and PEP 604 (`Optional[str]` -> `str | None`) rewrites even if a file imports `from __future__ import annotations`. Note that this setting is only applicable when the target Python version is below 3.9 and 3.10 respectively, and enabling it is equivalent to disabling `use-pep585-annotation` (`UP006`), `use-pep604-annotation` (`UP007`), and `use-pep604-isinstance` (`UP038`) entirely.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
Closes #3326.