### PR TITLE
Treat callables within type definitions as default-non-types

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F821_11.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F821_11.py
@@ -1,0 +1,23 @@
+"""Test case: strings used within calls within type annotations."""
+
+from typing import Callable
+
+import bpy
+from mypy_extensions import VarArg
+
+from foo import Bar
+
+
+class LightShow(bpy.types.Operator):
+    label = "Create Character"
+    name = "lightshow.letter_creation"
+
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")  # OK
+
+
+def f(x: Callable[[VarArg("os")], None]):  # F821
+    pass
+
+
+f(Callable[["Bar"], None])
+f(Callable[["Baz"], None])

--- a/crates/ruff/resources/test/fixtures/pyflakes/F821_12.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F821_12.py
@@ -1,0 +1,25 @@
+"""Test case: strings used within calls within type annotations."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import bpy
+from mypy_extensions import VarArg
+
+from foo import Bar
+
+
+class LightShow(bpy.types.Operator):
+    label = "Create Character"
+    name = "lightshow.letter_creation"
+
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")  # OK
+
+
+def f(x: Callable[[VarArg("os")], None]):  # F821
+    pass
+
+
+f(Callable[["Bar"], None])
+f(Callable[["Baz"], None])

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -104,6 +104,8 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_8.pyi"); "F821_8")]
     #[test_case(Rule::UndefinedName, Path::new("F821_9.py"); "F821_9")]
     #[test_case(Rule::UndefinedName, Path::new("F821_10.py"); "F821_10")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_11.py"); "F821_11")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_12.py"); "F821_12")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"); "F822_0")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"); "F822_1")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_2.py"); "F822_2")]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_11.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_11.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+expression: diagnostics
+---
+- kind:
+    UndefinedName:
+      name: os
+  location:
+    row: 18
+    column: 26
+  end_location:
+    row: 18
+    column: 30
+  fix: ~
+  parent: ~
+- kind:
+    UndefinedName:
+      name: Baz
+  location:
+    row: 23
+    column: 12
+  end_location:
+    row: 23
+    column: 17
+  fix: ~
+  parent: ~
+

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_12.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_12.py.snap
@@ -1,0 +1,27 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+expression: diagnostics
+---
+- kind:
+    UndefinedName:
+      name: os
+  location:
+    row: 20
+    column: 26
+  end_location:
+    row: 20
+    column: 30
+  fix: ~
+  parent: ~
+- kind:
+    UndefinedName:
+      name: Baz
+  location:
+    row: 25
+    column: 12
+  end_location:
+    row: 25
+    column: 17
+  fix: ~
+  parent: ~
+

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP037.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP037.py.snap
@@ -478,21 +478,4 @@ expression: diagnostics
       row: 67
       column: 49
   parent: ~
-- kind:
-    QuotedAnnotation: ~
-  location:
-    row: 69
-    column: 14
-  end_location:
-    row: 69
-    column: 17
-  fix:
-    content: X
-    location:
-      row: 69
-      column: 14
-    end_location:
-      row: 69
-      column: 17
-  parent: ~
 


### PR DESCRIPTION
We need to avoid treating `"FILE_PATH"`, below, as an undefined reference.

```py
class LIGHTSHOW_OT_letter_creation(bpy.types.Operator):
    bl_label = "Create Character"
    bl_idname = "lightshow.letter_creation"

    filepath: bpy.props.StringProperty(subtype="FILE_PATH")  # OK
```

At the same time, we _do_ want this to raise an undefined reference (if `os` is not imported):

```py
def f(x: Callable[[VarArg("os")], None]):  # F821
    pass
```

Closes #3307.