### PR TITLE
Add Azure Devops as a `-format` option.

### DIFF
--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -194,7 +194,7 @@ pub struct Options {
     pub fixable: Option<Vec<RuleSelector>>,
     #[option(
         default = r#""text""#,
-        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azuredevops""#,
+        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure-devops""#,
         example = r#"
             # Group violations by containing file.
             format = "grouped"
@@ -205,7 +205,7 @@ pub struct Options {
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
     /// `"pylint"` (Pylint text format) or
-    /// `"azuredevops"` (Azure Devops Pipeline logging commands).
+    /// `"azure-devops"` (Azure Devops Pipeline logging commands).
     pub format: Option<SerializationFormat>,
     #[option(
         default = r#"false"#,

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -194,7 +194,7 @@ pub struct Options {
     pub fixable: Option<Vec<RuleSelector>>,
     #[option(
         default = r#""text""#,
-        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure-devops""#,
+        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azure""#,
         example = r#"
             # Group violations by containing file.
             format = "grouped"
@@ -204,8 +204,7 @@ pub struct Options {
     /// (default), `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
     /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
-    /// `"pylint"` (Pylint text format) or
-    /// `"azure-devops"` (Azure Devops Pipeline logging commands).
+    /// `"pylint"` (Pylint text format) or `"azure"` (Azure Pipeline logging commands).
     pub format: Option<SerializationFormat>,
     #[option(
         default = r#"false"#,

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -194,7 +194,7 @@ pub struct Options {
     pub fixable: Option<Vec<RuleSelector>>,
     #[option(
         default = r#""text""#,
-        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint""#,
+        value_type = r#""text" | "json" | "junit" | "github" | "gitlab" | "pylint" | "azuredevops""#,
         example = r#"
             # Group violations by containing file.
             format = "grouped"
@@ -203,8 +203,9 @@ pub struct Options {
     /// The style in which violation messages should be formatted: `"text"`
     /// (default), `"grouped"` (group messages by file), `"json"`
     /// (machine-readable), `"junit"` (machine-readable XML), `"github"` (GitHub
-    /// Actions annotations), `"gitlab"` (GitLab CI code quality report), or
-    /// `"pylint"` (Pylint text format).
+    /// Actions annotations), `"gitlab"` (GitLab CI code quality report),
+    /// `"pylint"` (Pylint text format) or
+    /// `"azuredevops"` (Azure Devops Pipeline logging commands).
     pub format: Option<SerializationFormat>,
     #[option(
         default = r#"false"#,

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -216,6 +216,7 @@ pub enum SerializationFormat {
     Github,
     Gitlab,
     Pylint,
+    AzureDevops
 }
 
 impl Default for SerializationFormat {

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -216,7 +216,7 @@ pub enum SerializationFormat {
     Github,
     Gitlab,
     Pylint,
-    AzureDevops
+    AzureDevops,
 }
 
 impl Default for SerializationFormat {

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -216,7 +216,7 @@ pub enum SerializationFormat {
     Github,
     Gitlab,
     Pylint,
-    AzureDevops,
+    Azure,
 }
 
 impl Default for SerializationFormat {

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -375,6 +375,7 @@ impl Printer {
                 }
             }
             SerializationFormat::AzureDevops => {
+                // Generate error logging commands in Azure Devops format.
                 // See https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
                 for message in &diagnostics.messages {
                     let label = format!(

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -374,8 +374,8 @@ impl Printer {
                     writeln!(stdout, "{label}")?;
                 }
             }
-            SerializationFormat::AzureDevops => {
-                // Generate error logging commands in Azure Devops format.
+            SerializationFormat::Azure => {
+                // Generate error logging commands for Azure Pipelines format.
                 // See https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
                 for message in &diagnostics.messages {
                     let label = format!(

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -374,6 +374,32 @@ impl Printer {
                     writeln!(stdout, "{label}")?;
                 }
             }
+            SerializationFormat::AzureDevops => {
+                // See https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
+                for message in &diagnostics.messages {
+                    let label = format!(
+                        "{}{}{}{}{}{} {} {}",
+                        relativize_path(Path::new(&message.filename)),
+                        ":",
+                        message.location.row(),
+                        ":",
+                        message.location.column(),
+                        ":",
+                        message.kind.rule().noqa_code(),
+                        message.kind.body(),
+                    );
+                    writeln!(
+                        stdout,
+                        "##vso[task.logissue type=error\
+                        ;sourcepath={};linenumber={};columnnumber={};code={};]{}",
+                        message.filename,
+                        message.location.row(),
+                        message.location.column(),
+                        message.kind.rule().noqa_code(),
+                        label,
+                    )?;
+                }
+            }
         }
 
         stdout.flush()?;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,7 +209,7 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint]
+          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure-devops]
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported
       --config <CONFIG>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,7 +209,7 @@ Options:
       --ignore-noqa
           Ignore any `# noqa` comments
       --format <FORMAT>
-          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure-devops]
+          Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
       --target-version <TARGET_VERSION>
           The minimum Python version that should be supported
       --config <CONFIG>

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -272,7 +272,7 @@
       ]
     },
     "format": {
-      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure-devops\"` (Azure Devops Pipeline logging commands).",
+      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure\"` (Azure Pipeline logging commands).",
       "anyOf": [
         {
           "$ref": "#/definitions/SerializationFormat"
@@ -2179,7 +2179,7 @@
         "github",
         "gitlab",
         "pylint",
-        "azure-devops"
+        "azure"
       ]
     },
     "Strictness": {

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -272,7 +272,7 @@
       ]
     },
     "format": {
-      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), or `\"pylint\"` (Pylint text format).",
+      "description": "The style in which violation messages should be formatted: `\"text\"` (default), `\"grouped\"` (group messages by file), `\"json\"` (machine-readable), `\"junit\"` (machine-readable XML), `\"github\"` (GitHub Actions annotations), `\"gitlab\"` (GitLab CI code quality report), `\"pylint\"` (Pylint text format) or `\"azure-devops\"` (Azure Devops Pipeline logging commands).",
       "anyOf": [
         {
           "$ref": "#/definitions/SerializationFormat"
@@ -2178,7 +2178,8 @@
         "grouped",
         "github",
         "gitlab",
-        "pylint"
+        "pylint",
+        "azure-devops"
       ]
     },
     "Strictness": {


### PR DESCRIPTION
Adds option to print messages in an error format for azure pipelines, following https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#usage.

In the command line it looks like:
```bash
> cargo run -p ruff_cli -- check ../python_testing/example_tag.py --no-cache --format azure-devops
##vso[task.logissue type=error;sourcepath=/home/stefan/dev/python_testing/example_tag.py;linenumber=2;columnnumber=8;code=F401;]/home/stefan/dev/python_testing/example_tag.py:2:8: F401 `math` imported but unused
##vso[task.logissue type=error;sourcepath=/home/stefan/dev/python_testing/example_tag.py;linenumber=3;columnnumber=8;code=F401;]/home/stefan/dev/python_testing/example_tag.py:3:8: F401 `sys` imported but unused
```

In the pipeline logs it shows as:
![image](https://user-images.githubusercontent.com/28559054/222903613-7322cf5a-70eb-4cfd-8cbc-ce492395e5b4.png)
And in the pipeline summary it shows as:
![image](https://user-images.githubusercontent.com/28559054/222903639-b90ea063-0286-4afb-b4af-1b1bda1ca3e4.png)

Which isn't particularly pretty but apparently how Azure Devops think it should be displayed.