### PR TITLE
Skip byte-order-mark at start of file

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/bom.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/bom.py
@@ -1,0 +1,1 @@
+﻿''' SAM macro definitions '''

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test_case(Rule::PublicMethod, Path::new("setter.py"); "D102_1")]
     #[test_case(Rule::PublicModule, Path::new("D.py"); "D100")]
     #[test_case(Rule::PublicNestedClass, Path::new("D.py"); "D106")]
-    #[test_case(Rule::PublicPackage, Path::new("D.py"); "D104")]
+    #[test_case(Rule::PublicPackage, Path::new("D.py"); "D104_0")]
     #[test_case(Rule::PublicPackage, Path::new("D104/__init__.py"); "D104_1")]
     #[test_case(Rule::SectionNameEndsInColon, Path::new("D.py"); "D416")]
     #[test_case(Rule::SectionNotOverIndented, Path::new("sections.py"); "D214")]
@@ -85,6 +85,16 @@ mod tests {
             },
         )?;
         assert_yaml_snapshot!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn bom() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pydocstyle/bom.py"),
+            &settings::Settings::for_rule(Rule::TripleSingleQuotes),
+        )?;
+        assert_yaml_snapshot!(diagnostics);
         Ok(())
     }
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__bom.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__bom.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ruff/src/rules/pydocstyle/mod.rs
+expression: diagnostics
+---
+- kind:
+    TripleSingleQuotes: ~
+  location:
+    row: 1
+    column: 0
+  end_location:
+    row: 1
+    column: 29
+  fix: ~
+  parent: ~
+

--- a/crates/ruff/src/source_code/locator.rs
+++ b/crates/ruff/src/source_code/locator.rs
@@ -35,6 +35,12 @@ fn index_utf8(contents: &str) -> Vec<Vec<usize>> {
     let mut current_byte_offset = 0;
     let mut previous_char = '\0';
     for char in contents.chars() {
+        // Skip BOM.
+        if previous_char == '\0' && char == '\u{feff}' {
+            current_byte_offset += char.len_utf8();
+            continue;
+        }
+
         current_row.push(current_byte_offset);
         if char == '\n' {
             if previous_char == '\r' {


### PR DESCRIPTION
This mirrors RustPython's own logic for skipping the `feff` character at start-of-file:

https://github.com/RustPython/RustPython/blob/ab7971de424cd1b8f5ebc1f8931992a1b54af444/compiler/parser/src/lexer.rs#L243

Closes #3336.
