### PR TITLE
Introduce a standalone `ruff_linter_eradicate` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,7 @@ dependencies = [
  "result-like",
  "ruff_cache",
  "ruff_diagnostics",
+ "ruff_linter_eradicate",
  "ruff_macros",
  "ruff_python_ast",
  "ruff_python_stdlib",
@@ -2100,6 +2101,18 @@ dependencies = [
  "serde",
  "tracing",
  "unicode-width",
+]
+
+[[package]]
+name = "ruff_linter_eradicate"
+version = "0.0.0"
+dependencies = [
+ "once_cell",
+ "regex",
+ "ruff_diagnostics",
+ "ruff_macros",
+ "ruff_python_ast",
+ "rustpython-parser",
 ]
 
 [[package]]

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [dependencies]
 ruff_cache = { path = "../ruff_cache" }
 ruff_diagnostics = { path = "../ruff_diagnostics", features = ["serde"] }
+ruff_linter_eradicate = { path = "../ruff_linter_eradicate" }
 ruff_macros = { path = "../ruff_macros" }
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -94,9 +94,13 @@ pub fn check_tokens(
     if enforce_commented_out_code {
         for (start, tok, end) in tokens.iter().flatten() {
             if matches!(tok, Tok::Comment(_)) {
-                if let Some(diagnostic) =
-                    eradicate::rules::commented_out_code(locator, *start, *end, settings, autofix)
-                {
+                if let Some(diagnostic) = eradicate::rules::commented_out_code(
+                    locator,
+                    *start,
+                    *end,
+                    &settings.task_tags,
+                    autofix.into() && settings.rules.should_fix(&Rule::CommentedOutCode),
+                ) {
                     diagnostics.push(diagnostic);
                 }
             }

--- a/crates/ruff/src/rules/eradicate/mod.rs
+++ b/crates/ruff/src/rules/eradicate/mod.rs
@@ -1,6 +1,6 @@
 //! Rules from [eradicate](https://pypi.org/project/eradicate/).
-pub(crate) mod detection;
-pub(crate) mod rules;
+
+pub use ruff_linter_eradicate::rules;
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruff_linter_eradicate/Cargo.toml
+++ b/crates/ruff_linter_eradicate/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ruff_linter_eradicate"
+version = "0.0.0"
+publish = false
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+
+[dependencies]
+ruff_python_ast = { path = "../ruff_python_ast" }
+ruff_macros = { path = "../ruff_macros" }
+ruff_diagnostics = { path = "../ruff_diagnostics" }
+
+once_cell = { workspace = true }
+regex = { workspace = true }
+rustpython-parser = { workspace = true }

--- a/crates/ruff_linter_eradicate/src/detection.rs
+++ b/crates/ruff_linter_eradicate/src/detection.rs
@@ -1,4 +1,5 @@
-/// See: [eradicate.py](https://github.com/myint/eradicate/blob/98f199940979c94447a461d50d27862b118b282d/eradicate.py)
+//! See: [eradicate.py](https://github.com/myint/eradicate/blob/98f199940979c94447a461d50d27862b118b282d/eradicate.py)
+
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser as parser;

--- a/crates/ruff_linter_eradicate/src/lib.rs
+++ b/crates/ruff_linter_eradicate/src/lib.rs
@@ -1,0 +1,4 @@
+#![allow(clippy::useless_format)]
+
+mod detection;
+pub mod rules;

--- a/crates/ruff_linter_eradicate/src/rules.rs
+++ b/crates/ruff_linter_eradicate/src/rules.rs
@@ -5,9 +5,6 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::registry::Rule;
-use crate::settings::{flags, Settings};
-
 use super::detection::comment_contains_code;
 
 /// ## What it does
@@ -51,17 +48,17 @@ pub fn commented_out_code(
     locator: &Locator,
     start: Location,
     end: Location,
-    settings: &Settings,
-    autofix: flags::Autofix,
+    task_tags: &[String],
+    fix: bool,
 ) -> Option<Diagnostic> {
     let location = Location::new(start.row(), 0);
     let end_location = Location::new(end.row() + 1, 0);
     let line = locator.slice(Range::new(location, end_location));
 
     // Verify that the comment is on its own line, and that it contains code.
-    if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
+    if is_standalone_comment(line) && comment_contains_code(line, task_tags) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, Range::new(start, end));
-        if autofix.into() && settings.rules.should_fix(&Rule::CommentedOutCode) {
+        if fix {
             diagnostic.amend(Fix::deletion(location, end_location));
         }
         Some(diagnostic)


### PR DESCRIPTION
Trying to push to the point at which this is actually possible, to figure out what breaks.