### PR TITLE
Remove duplicate info in azure format

### DIFF
--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -378,17 +378,6 @@ impl Printer {
                 // Generate error logging commands for Azure Pipelines format.
                 // See https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning
                 for message in &diagnostics.messages {
-                    let label = format!(
-                        "{}{}{}{}{}{} {} {}",
-                        relativize_path(Path::new(&message.filename)),
-                        ":",
-                        message.location.row(),
-                        ":",
-                        message.location.column(),
-                        ":",
-                        message.kind.rule().noqa_code(),
-                        message.kind.body(),
-                    );
                     writeln!(
                         stdout,
                         "##vso[task.logissue type=error\
@@ -397,7 +386,7 @@ impl Printer {
                         message.location.row(),
                         message.location.column(),
                         message.kind.rule().noqa_code(),
-                        label,
+                        message.kind.body(),
                     )?;
                 }
             }


### PR DESCRIPTION
Continuing #3335, which was merged before I removed the duplicate info.

Logs:
![image](https://user-images.githubusercontent.com/28559054/223232418-cb96e720-58c4-4a6c-aa96-4969cf2fafb6.png)
Summary:
![image](https://user-images.githubusercontent.com/28559054/223231943-2b648ec5-07f6-4de3-9d75-98b62b03b27c.png)

It didn't really make sense to duplicate it, I just blindly copied it from the Github format