### PR TITLE
Include entire prefix when reporting rule selector errors

### DIFF
--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -51,7 +51,7 @@ impl FromStr for RuleSelector {
 
             Ok(Self::Prefix {
                 prefix: RuleCodePrefix::parse(&linter, code)
-                    .map_err(|_| ParseError::Unknown(code.to_string()))?,
+                    .map_err(|_| ParseError::Unknown(s.to_string()))?,
                 redirected_from,
             })
         }
@@ -60,7 +60,7 @@ impl FromStr for RuleSelector {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
-    #[error("Unknown rule selector `{0}`")]
+    #[error("Unknown rule selector: `{0}`")]
     // TODO(martin): tell the user how to discover rule codes via the CLI once such a command is
     // implemented (but that should of course be done only in ruff_cli and not here)
     Unknown(String),

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use clap::{command, Parser};
 use regex::Regex;
@@ -112,6 +113,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -121,6 +123,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -131,6 +134,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -140,6 +144,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide = true
     )]
@@ -170,6 +175,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -180,6 +186,7 @@ pub struct CheckArgs {
         long,
         value_delimiter = ',',
         value_name = "RULE_CODE",
+        value_parser = parse_rule_selector,
         help_heading = "Rule selection",
         hide_possible_values = true
     )]
@@ -401,6 +408,11 @@ impl CheckArgs {
             },
         )
     }
+}
+
+fn parse_rule_selector(env: &str) -> Result<RuleSelector, std::io::Error> {
+    RuleSelector::from_str(env)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
 }
 
 fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {


### PR DESCRIPTION
This is a little more intuitive:

```shell
❯ cargo run -p ruff_cli -- foo.py --select BUG
    Finished dev [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/ruff foo.py --select BUG`
error: invalid value 'BUG' for '--select <RULE_CODE>': Unknown rule selector: `BUG`

For more information, try '--help'.
```

It also now looks like a proper Clippy error:

![Screen Shot 2023-03-06 at 7 00 21 PM](https://user-images.githubusercontent.com/1309177/223284010-ba0f242c-e3a4-4a3b-8e2a-9c19b38ac26b.png)

Closes #3374.