### PR TITLE
Pass `Range` struct by value

### DIFF
--- a/crates/ruff/src/ast/helpers.rs
+++ b/crates/ruff/src/ast/helpers.rs
@@ -652,7 +652,7 @@ pub fn has_comments<T>(located: &Located<T>, locator: &Locator) -> bool {
 
 /// Returns `true` if a [`Range`] includes at least one comment.
 pub fn has_comments_in(range: Range, locator: &Locator) -> bool {
-    for tok in lexer::lex_located(locator.slice(&range), Mode::Module, range.location) {
+    for tok in lexer::lex_located(locator.slice(range), Mode::Module, range.location) {
         match tok {
             Ok((_, tok, _)) => {
                 if matches!(tok, Tok::Comment(..)) {
@@ -854,7 +854,7 @@ pub fn to_relative(absolute: Location, base: Location) -> Location {
 /// Return `true` if a [`Located`] has leading content.
 pub fn match_leading_content<T>(located: &Located<T>, locator: &Locator) -> bool {
     let range = Range::new(Location::new(located.location.row(), 0), located.location);
-    let prefix = locator.slice(&range);
+    let prefix = locator.slice(range);
     prefix.chars().any(|char| !char.is_whitespace())
 }
 
@@ -864,7 +864,7 @@ pub fn match_trailing_content<T>(located: &Located<T>, locator: &Locator) -> boo
         located.end_location.unwrap(),
         Location::new(located.end_location.unwrap().row() + 1, 0),
     );
-    let suffix = locator.slice(&range);
+    let suffix = locator.slice(range);
     for char in suffix.chars() {
         if char == '#' {
             return false;
@@ -882,7 +882,7 @@ pub fn match_trailing_comment<T>(located: &Located<T>, locator: &Locator) -> Opt
         located.end_location.unwrap(),
         Location::new(located.end_location.unwrap().row() + 1, 0),
     );
-    let suffix = locator.slice(&range);
+    let suffix = locator.slice(range);
     for (i, char) in suffix.chars().enumerate() {
         if char == '#' {
             return Some(i);
@@ -940,7 +940,7 @@ pub fn identifier_range(stmt: &Stmt, locator: &Locator) -> Range {
             | StmtKind::FunctionDef { .. }
             | StmtKind::AsyncFunctionDef { .. }
     ) {
-        let contents = locator.slice(&Range::from_located(stmt));
+        let contents = locator.slice(Range::from_located(stmt));
         for (start, tok, end) in lexer::lex_located(contents, Mode::Module, stmt.location).flatten()
         {
             if matches!(tok, Tok::Name { .. }) {
@@ -972,7 +972,7 @@ pub fn find_names<'a, T, U>(
     located: &'a Located<T, U>,
     locator: &'a Locator,
 ) -> impl Iterator<Item = Range> + 'a {
-    let contents = locator.slice(&Range::from_located(located));
+    let contents = locator.slice(Range::from_located(located));
     lexer::lex_located(contents, Mode::Module, located.location)
         .flatten()
         .filter(|(_, tok, _)| matches!(tok, Tok::Name { .. }))
@@ -990,7 +990,7 @@ pub fn excepthandler_name_range(handler: &Excepthandler, locator: &Locator) -> O
     match (name, type_) {
         (Some(_), Some(type_)) => {
             let type_end_location = type_.end_location.unwrap();
-            let contents = locator.slice(&Range::new(type_end_location, body[0].location));
+            let contents = locator.slice(Range::new(type_end_location, body[0].location));
             let range = lexer::lex_located(contents, Mode::Module, type_end_location)
                 .flatten()
                 .tuple_windows()
@@ -1014,7 +1014,7 @@ pub fn except_range(handler: &Excepthandler, locator: &Locator) -> Range {
             .expect("Expected body to be non-empty")
             .location
     };
-    let contents = locator.slice(&Range {
+    let contents = locator.slice(Range {
         location: handler.location,
         end_location: end,
     });
@@ -1031,7 +1031,7 @@ pub fn except_range(handler: &Excepthandler, locator: &Locator) -> Range {
 
 /// Find f-strings that don't contain any formatted values in a `JoinedStr`.
 pub fn find_useless_f_strings(expr: &Expr, locator: &Locator) -> Vec<(Range, Range)> {
-    let contents = locator.slice(&Range::from_located(expr));
+    let contents = locator.slice(Range::from_located(expr));
     lexer::lex_located(contents, Mode::Module, expr.location)
         .flatten()
         .filter_map(|(location, tok, end_location)| match tok {
@@ -1039,7 +1039,7 @@ pub fn find_useless_f_strings(expr: &Expr, locator: &Locator) -> Vec<(Range, Ran
                 kind: StringKind::FString | StringKind::RawFString,
                 ..
             } => {
-                let first_char = locator.slice(&Range {
+                let first_char = locator.slice(Range {
                     location,
                     end_location: Location::new(location.row(), location.column() + 1),
                 });
@@ -1079,7 +1079,7 @@ pub fn else_range(stmt: &Stmt, locator: &Locator) -> Option<Range> {
                 .expect("Expected body to be non-empty")
                 .end_location
                 .unwrap();
-            let contents = locator.slice(&Range {
+            let contents = locator.slice(Range {
                 location: body_end,
                 end_location: orelse
                     .first()
@@ -1101,7 +1101,7 @@ pub fn else_range(stmt: &Stmt, locator: &Locator) -> Option<Range> {
 
 /// Return the `Range` of the first `Tok::Colon` token in a `Range`.
 pub fn first_colon_range(range: Range, locator: &Locator) -> Option<Range> {
-    let contents = locator.slice(&range);
+    let contents = locator.slice(range);
     let range = lexer::lex_located(contents, Mode::Module, range.location)
         .flatten()
         .find(|(_, kind, _)| matches!(kind, Tok::Colon))
@@ -1157,7 +1157,7 @@ pub fn elif_else_range(stmt: &Stmt, locator: &Locator) -> Option<Range> {
         [stmt, ..] => stmt.location,
         _ => return None,
     };
-    let contents = locator.slice(&Range::new(start, end));
+    let contents = locator.slice(Range::new(start, end));
     let range = lexer::lex_located(contents, Mode::Module, start)
         .flatten()
         .find(|(_, kind, _)| matches!(kind, Tok::Elif | Tok::Else))

--- a/crates/ruff/src/ast/whitespace.rs
+++ b/crates/ruff/src/ast/whitespace.rs
@@ -8,7 +8,7 @@ use crate::source_code::Locator;
 /// Extract the leading indentation from a line.
 pub fn indentation<'a, T>(locator: &'a Locator, located: &'a Located<T>) -> Option<&'a str> {
     let range = Range::from_located(located);
-    let indentation = locator.slice(&Range::new(
+    let indentation = locator.slice(Range::new(
         Location::new(range.location.row(), 0),
         Location::new(range.location.row(), range.location.column()),
     ));

--- a/crates/ruff/src/autofix/helpers.rs
+++ b/crates/ruff/src/autofix/helpers.rs
@@ -227,7 +227,7 @@ pub fn remove_unused_imports<'a>(
     indexer: &Indexer,
     stylist: &Stylist,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(stmt));
+    let module_text = locator.slice(Range::from_located(stmt));
     let mut tree = match_module(module_text)?;
 
     let Some(Statement::Simple(body)) = tree.body.first_mut() else {

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -54,7 +54,7 @@ fn apply_fixes<'a>(
         }
 
         // Add all contents from `last_pos` to `fix.location`.
-        let slice = locator.slice(&Range::new(last_pos, fix.location));
+        let slice = locator.slice(Range::new(last_pos, fix.location));
         output.push_str(slice);
 
         // Add the patch itself.
@@ -78,7 +78,7 @@ pub(crate) fn apply_fix(fix: &Fix, locator: &Locator) -> String {
     let mut output = String::with_capacity(locator.len());
 
     // Add all contents from `last_pos` to `fix.location`.
-    let slice = locator.slice(&Range::new(Location::new(1, 0), fix.location));
+    let slice = locator.slice(Range::new(Location::new(1, 0), fix.location));
     output.push_str(slice);
 
     // Add the patch itself.

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -5264,8 +5264,8 @@ impl<'a> Checker<'a> {
 
                 // Extract a `Docstring` from a `Definition`.
                 let expr = definition.docstring.unwrap();
-                let contents = self.locator.slice(&Range::from_located(expr));
-                let indentation = self.locator.slice(&Range::new(
+                let contents = self.locator.slice(Range::from_located(expr));
+                let indentation = self.locator.slice(Range::new(
                     Location::new(expr.location.row(), 0),
                     Location::new(expr.location.row(), expr.location.column()),
                 ));

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -57,7 +57,7 @@ pub fn check_logical_lines(
 
         // Extract the indentation level.
         let start_loc = line.mapping[0].1;
-        let start_line = locator.slice(&Range::new(Location::new(start_loc.row(), 0), start_loc));
+        let start_line = locator.slice(Range::new(Location::new(start_loc.row(), 0), start_loc));
         let indent_level = expand_indent(start_line);
         let indent_size = 4;
 

--- a/crates/ruff/src/message.rs
+++ b/crates/ruff/src/message.rs
@@ -74,9 +74,9 @@ impl Source {
         } else {
             Location::new(diagnostic.end_location.row() + 1, 0)
         };
-        let source = locator.slice(&Range::new(location, end_location));
+        let source = locator.slice(Range::new(location, end_location));
         let num_chars_in_range = locator
-            .slice(&Range::new(diagnostic.location, diagnostic.end_location))
+            .slice(Range::new(diagnostic.location, diagnostic.end_location))
             .chars()
             .count();
         Source {

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -126,7 +126,7 @@ pub fn rule_is_ignored(
     locator: &Locator,
 ) -> bool {
     let noqa_lineno = noqa_line_for.get(&lineno).unwrap_or(&lineno);
-    let line = locator.slice(&Range::new(
+    let line = locator.slice(Range::new(
         Location::new(*noqa_lineno, 0),
         Location::new(noqa_lineno + 1, 0),
     ));

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -55,7 +55,7 @@ pub fn commented_out_code(
 ) -> Option<Diagnostic> {
     let location = Location::new(start.row(), 0);
     let end_location = Location::new(end.row() + 1, 0);
-    let line = locator.slice(&Range::new(location, end_location));
+    let line = locator.slice(Range::new(location, end_location));
 
     // Verify that the comment is on its own line, and that it contains code.
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {

--- a/crates/ruff/src/rules/flake8_annotations/fixes.rs
+++ b/crates/ruff/src/rules/flake8_annotations/fixes.rs
@@ -9,7 +9,7 @@ use crate::source_code::Locator;
 /// ANN204
 pub fn add_return_none_annotation(locator: &Locator, stmt: &Stmt) -> Result<Fix> {
     let range = Range::from_located(stmt);
-    let contents = locator.slice(&range);
+    let contents = locator.slice(range);
 
     // Find the colon (following the `def` keyword).
     let mut seen_lpar = false;

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -308,7 +308,7 @@ pub fn trailing_commas(
                 // rather than just inserting a comma at the end. This prevents the UP034 autofix
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
-                let contents = locator.slice(&Range::new(missing_comma.0, missing_comma.2));
+                let contents = locator.slice(Range::new(missing_comma.0, missing_comma.2));
                 diagnostic.amend(Fix::replacement(
                     format!("{contents},"),
                     missing_comma.0,

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -35,7 +35,7 @@ pub fn fix_unnecessary_generator_list(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(GeneratorExp)))) -> Expr(ListComp)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -82,7 +82,7 @@ pub fn fix_unnecessary_generator_set(
     parent: Option<&rustpython_parser::ast::Expr>,
 ) -> Result<Fix> {
     // Expr(Call(GeneratorExp)))) -> Expr(SetComp)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -139,7 +139,7 @@ pub fn fix_unnecessary_generator_dict(
     expr: &rustpython_parser::ast::Expr,
     parent: Option<&rustpython_parser::ast::Expr>,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -213,7 +213,7 @@ pub fn fix_unnecessary_list_comprehension_set(
 ) -> Result<Fix> {
     // Expr(Call(ListComp)))) ->
     // Expr(SetComp)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -257,7 +257,7 @@ pub fn fix_unnecessary_list_comprehension_dict(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -356,7 +356,7 @@ pub fn fix_unnecessary_literal_set(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(Set)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let mut call = match_call(body)?;
@@ -407,7 +407,7 @@ pub fn fix_unnecessary_literal_dict(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(Dict)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -480,7 +480,7 @@ pub fn fix_unnecessary_collection_call(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call("list" | "tuple" | "dict")))) -> Expr(List|Tuple|Dict)
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -595,7 +595,7 @@ pub fn fix_unnecessary_literal_within_tuple_call(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -654,7 +654,7 @@ pub fn fix_unnecessary_literal_within_list_call(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -716,7 +716,7 @@ pub fn fix_unnecessary_list_call(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(List|Tuple)))
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -746,7 +746,7 @@ pub fn fix_unnecessary_call_around_sorted(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let outer_call = match_call(body)?;
@@ -873,7 +873,7 @@ pub fn fix_unnecessary_double_cast_or_process(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let body = match_expr(&mut tree)?;
     let mut outer_call = match_call(body)?;
@@ -912,7 +912,7 @@ pub fn fix_unnecessary_comprehension(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 
@@ -988,7 +988,7 @@ pub fn fix_unnecessary_map(
     parent: Option<&rustpython_parser::ast::Expr>,
     kind: &str,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;

--- a/crates/ruff/src/rules/flake8_pie/fixes.rs
+++ b/crates/ruff/src/rules/flake8_pie/fixes.rs
@@ -13,7 +13,7 @@ pub fn fix_unnecessary_comprehension_any_all(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(ListComp) -> Expr(GeneratorExp)
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -57,16 +57,16 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
         ExprKind::Constant {
             value: Constant::Str(..),
             ..
-        } => return checker.locator.slice(&Range::from_located(default)).len() <= 50,
+        } => return checker.locator.slice(Range::from_located(default)).len() <= 50,
         ExprKind::Constant {
             value: Constant::Bytes(..),
             ..
-        } => return checker.locator.slice(&Range::from_located(default)).len() <= 50,
+        } => return checker.locator.slice(Range::from_located(default)).len() <= 50,
         ExprKind::Constant {
             value: Constant::Int(..),
             ..
         } => {
-            return checker.locator.slice(&Range::from_located(default)).len() <= 10;
+            return checker.locator.slice(Range::from_located(default)).len() <= 10;
         }
         ExprKind::UnaryOp {
             op: Unaryop::USub,
@@ -77,7 +77,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                 ..
             } = &operand.node
             {
-                return checker.locator.slice(&Range::from_located(operand)).len() <= 10;
+                return checker.locator.slice(Range::from_located(operand)).len() <= 10;
             }
         }
         ExprKind::BinOp {
@@ -101,7 +101,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                     ..
                 } = &left.node
                 {
-                    return checker.locator.slice(&Range::from_located(left)).len() <= 10;
+                    return checker.locator.slice(Range::from_located(left)).len() <= 10;
                 } else if let ExprKind::UnaryOp {
                     op: Unaryop::USub,
                     operand,
@@ -114,7 +114,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                         ..
                     } = &operand.node
                     {
-                        return checker.locator.slice(&Range::from_located(operand)).len() <= 10;
+                        return checker.locator.slice(Range::from_located(operand)).len() <= 10;
                     }
                 }
             }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -328,7 +328,7 @@ fn fix_composite_condition(stmt: &Stmt, locator: &Locator, stylist: &Stylist) ->
     };
 
     // Extract the module text.
-    let contents = locator.slice(&Range::new(
+    let contents = locator.slice(Range::new(
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),
     ));

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -264,7 +264,7 @@ fn docstring(
 ) -> Option<Diagnostic> {
     let quotes_settings = &settings.flake8_quotes;
 
-    let text = locator.slice(&Range::new(start, end));
+    let text = locator.slice(Range::new(start, end));
     let trivia: Trivia = text.into();
 
     if trivia
@@ -309,7 +309,7 @@ fn strings(
     let trivia = sequence
         .iter()
         .map(|(start, end)| {
-            let text = locator.slice(&Range::new(*start, *end));
+            let text = locator.slice(Range::new(*start, *end));
             let trivia: Trivia = text.into();
             trivia
         })

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -39,7 +39,7 @@ pub(crate) fn fix_nested_if_statements(
     };
 
     // Extract the module text.
-    let contents = locator.slice(&Range::new(
+    let contents = locator.slice(Range::new(
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),
     ));

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
@@ -20,7 +20,7 @@ pub(crate) fn fix_multiple_with_statements(
     };
 
     // Extract the module text.
-    let contents = locator.slice(&Range::new(
+    let contents = locator.slice(Range::new(
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),
     ));

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -47,8 +47,8 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: Range) {
     }
 
     // Slice exact content to preserve formatting.
-    let left_content = checker.locator.slice(&Range::from_located(left));
-    let value_content = checker.locator.slice(&Range::from_located(value));
+    let left_content = checker.locator.slice(Range::from_located(left));
+    let value_content = checker.locator.slice(Range::from_located(value));
 
     let mut diagnostic = Diagnostic::new(
         KeyInDict {

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -62,7 +62,7 @@ fn is_constant_like(expr: &Expr) -> bool {
 /// Generate a fix to reverse a comparison.
 fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Result<String> {
     let range = Range::from_located(expr);
-    let contents = locator.slice(&range);
+    let contents = locator.slice(range);
 
     let mut expression = match_expression(contents)?;
     let mut comparison = match_comparison(&mut expression)?;

--- a/crates/ruff/src/rules/isort/comments.rs
+++ b/crates/ruff/src/rules/isort/comments.rs
@@ -14,7 +14,7 @@ pub struct Comment<'a> {
 }
 
 /// Collect all comments in an import block.
-pub fn collect_comments<'a>(range: &Range, locator: &'a Locator) -> Vec<Comment<'a>> {
+pub fn collect_comments<'a>(range: Range, locator: &'a Locator) -> Vec<Comment<'a>> {
     let contents = locator.slice(range);
     lexer::lex_located(contents, Mode::Module, range.location)
         .flatten()

--- a/crates/ruff/src/rules/isort/helpers.rs
+++ b/crates/ruff/src/rules/isort/helpers.rs
@@ -9,7 +9,7 @@ use crate::source_code::Locator;
 /// Return `true` if a `StmtKind::ImportFrom` statement ends with a magic
 /// trailing comma.
 pub fn trailing_comma(stmt: &Stmt, locator: &Locator) -> TrailingComma {
-    let contents = locator.slice(&Range::from_located(stmt));
+    let contents = locator.slice(Range::from_located(stmt));
     let mut count: usize = 0;
     let mut trailing_comma = TrailingComma::Absent;
     for (_, tok, _) in lexer::lex_located(contents, Mode::Module, stmt.location).flatten() {

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -83,7 +83,7 @@ pub fn organize_imports(
     autofix: flags::Autofix,
     package: Option<&Path>,
 ) -> Option<Diagnostic> {
-    let indentation = locator.slice(&extract_indentation_range(&block.imports));
+    let indentation = locator.slice(extract_indentation_range(&block.imports));
     let indentation = leading_space(indentation);
 
     let range = extract_range(&block.imports);
@@ -98,7 +98,7 @@ pub fn organize_imports(
 
     // Extract comments. Take care to grab any inline comments from the last line.
     let comments = comments::collect_comments(
-        &Range::new(
+        Range::new(
             range.location,
             Location::new(range.end_location.row() + 1, 0),
         ),
@@ -148,7 +148,7 @@ pub fn organize_imports(
         Location::new(range.location.row(), 0),
         Location::new(range.end_location.row() + 1 + num_trailing_lines, 0),
     );
-    let actual = locator.slice(&range);
+    let actual = locator.slice(range);
     if matches_ignoring_indentation(actual, &expected) {
         None
     } else {

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -50,7 +50,7 @@ pub fn fix_inplace_argument(
 
         // Apply the deletion step.
         // TODO(charlie): Find a way to
-        let contents = locator.slice(&Range::new(expr.location, expr.end_location.unwrap()));
+        let contents = locator.slice(Range::new(expr.location, expr.end_location.unwrap()));
         let output = apply_fix(&fix_me, &Locator::new(contents));
 
         // Obtain the name prefix.

--- a/crates/ruff/src/rules/pycodestyle/logical_lines.rs
+++ b/crates/ruff/src/rules/pycodestyle/logical_lines.rs
@@ -89,7 +89,7 @@ fn build_line<'a>(
             s = format!("\"{}\"", "x".repeat(value.len()).clone());
             &s
         } else {
-            locator.slice(&Range {
+            locator.slice(Range {
                 location: *start,
                 end_location: *end,
             })
@@ -97,7 +97,7 @@ fn build_line<'a>(
 
         if let Some(prev) = prev {
             if prev.row() != start.row() {
-                let prev_text = locator.slice(&Range {
+                let prev_text = locator.slice(Range {
                     location: Location::new(prev.row(), prev.column() - 1),
                     end_location: Location::new(prev.row(), prev.column()),
                 });
@@ -109,7 +109,7 @@ fn build_line<'a>(
                     length += 1;
                 }
             } else if prev.column() != start.column() {
-                let prev_text = locator.slice(&Range {
+                let prev_text = locator.slice(Range {
                     location: *prev,
                     end_location: *start,
                 });

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -52,7 +52,7 @@ pub fn invalid_escape_sequence(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
-    let text = locator.slice(&Range::new(start, end));
+    let text = locator.slice(Range::new(start, end));
 
     // Determine whether the string is single- or triple-quoted.
     let Ok(quote) = extract_quote(text) else {

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -55,7 +55,7 @@ pub fn lambda_assignment(checker: &mut Checker, target: &Expr, value: &Expr, stm
                 && !match_leading_content(stmt, checker.locator)
                 && !match_trailing_content(stmt, checker.locator)
             {
-                let first_line = checker.locator.slice(&Range::new(
+                let first_line = checker.locator.slice(Range::new(
                     Location::new(stmt.location.row(), 0),
                     Location::new(stmt.location.row() + 1, 0),
                 ));

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -59,7 +59,7 @@ pub fn whitespace_before_comment(
     let mut prev_end = Location::new(0, 0);
     for (start, tok, end) in tokens {
         if let Tok::Comment(text) = tok {
-            let line = locator.slice(&Range::new(
+            let line = locator.slice(Range::new(
                 Location::new(start.row(), 0),
                 Location::new(start.row(), start.column()),
             ));

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -73,7 +73,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
     {
         let before = checker
             .locator
-            .slice(&Range::new(parent.location, docstring.expr.location));
+            .slice(Range::new(parent.location, docstring.expr.location));
 
         let blank_lines_before = before
             .lines()
@@ -133,7 +133,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
         .rules
         .enabled(&Rule::OneBlankLineAfterClass)
     {
-        let after = checker.locator.slice(&Range::new(
+        let after = checker.locator.slice(Range::new(
             docstring.expr.end_location.unwrap(),
             parent.end_location.unwrap(),
         ));

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -64,7 +64,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
     {
         let before = checker
             .locator
-            .slice(&Range::new(parent.location, docstring.expr.location));
+            .slice(Range::new(parent.location, docstring.expr.location));
 
         let blank_lines_before = before
             .lines()
@@ -95,7 +95,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
         .rules
         .enabled(&Rule::NoBlankLineAfterFunction)
     {
-        let after = checker.locator.slice(&Range::new(
+        let after = checker.locator.slice(Range::new(
             docstring.expr.end_location.unwrap(),
             parent.end_location.unwrap(),
         ));

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -105,7 +105,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                     | DefinitionKind::NestedFunction(parent)
                     | DefinitionKind::Method(parent) = &docstring.kind
                     {
-                        let parent_indentation = checker.locator.slice(&Range::new(
+                        let parent_indentation = checker.locator.slice(Range::new(
                             Location::new(parent.location.row(), 0),
                             Location::new(parent.location.row(), parent.location.column()),
                         ));

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -16,7 +16,7 @@ pub fn remove_unused_format_arguments_from_dict(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&Range::from_located(stmt));
+    let module_text = locator.slice(Range::from_located(stmt));
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 
@@ -67,7 +67,7 @@ pub fn remove_unused_keyword_arguments_from_format_call(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<Fix> {
-    let module_text = locator.slice(&location);
+    let module_text = locator.slice(location);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 
@@ -114,7 +114,7 @@ pub fn remove_exception_handler_assignment(
     excepthandler: &Excepthandler,
     locator: &Locator,
 ) -> Result<Fix> {
-    let contents = locator.slice(&Range::from_located(excepthandler));
+    let contents = locator.slice(Range::from_located(excepthandler));
     let mut fix_start = None;
     let mut fix_end = None;
 

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -56,7 +56,7 @@ fn fix_f_string_missing_placeholders(
     tok_range: &Range,
     checker: &mut Checker,
 ) -> Fix {
-    let content = checker.locator.slice(&Range::new(
+    let content = checker.locator.slice(Range::new(
         prefix_range.end_location,
         tok_range.end_location,
     ));

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -61,7 +61,7 @@ pub fn invalid_literal_comparison(
     comparators: &[Expr],
     location: Range,
 ) {
-    let located = Lazy::new(|| locate_cmpops(checker.locator.slice(&location)));
+    let located = Lazy::new(|| locate_cmpops(checker.locator.slice(location)));
     let mut left = left;
     for (index, (op, right)) in izip!(ops, comparators).enumerate() {
         if matches!(op, Cmpop::Is | Cmpop::IsNot)

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
@@ -243,7 +243,7 @@ fn is_valid_dict(
 /// PLE1307
 pub fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) {
     // Grab each string segment (in case there's an implicit concatenation).
-    let content = checker.locator.slice(&Range::from_located(expr));
+    let content = checker.locator.slice(Range::from_located(expr));
     let mut strings: Vec<(Location, Location)> = vec![];
     for (start, tok, end) in lexer::lex_located(content, Mode::Module, expr.location).flatten() {
         if matches!(tok, Tok::String { .. }) {
@@ -262,7 +262,7 @@ pub fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) 
     // Parse each string segment.
     let mut format_strings = vec![];
     for (start, end) in &strings {
-        let string = checker.locator.slice(&Range::new(*start, *end));
+        let string = checker.locator.slice(Range::new(*start, *end));
         let (Some(leader), Some(trailer)) = (leading_quote(string), trailing_quote(string)) else {
             return;
         };

--- a/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
+++ b/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
@@ -24,7 +24,7 @@ pub fn collapsible_else_if(orelse: &[Stmt], locator: &Locator) -> Option<Diagnos
         if matches!(first.node, StmtKind::If { .. }) {
             // Determine whether this is an `elif`, or an `if` in an `else` block.
             if locator
-                .slice(&Range {
+                .slice(Range {
                     location: first.location,
                     end_location: first.end_location.unwrap(),
                 })

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -19,7 +19,7 @@ pub fn adjust_indentation(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let contents = locator.slice(&range);
+    let contents = locator.slice(range);
 
     let module_text = format!("def f():{}{contents}", stylist.line_ending().as_str());
 
@@ -68,7 +68,7 @@ pub fn remove_class_def_base(
 /// Generate a fix to remove arguments from a `super` call.
 pub fn remove_super_arguments(locator: &Locator, stylist: &Stylist, expr: &Expr) -> Option<Fix> {
     let range = Range::from_located(expr);
-    let contents = locator.slice(&range);
+    let contents = locator.slice(range);
 
     let mut tree = libcst_native::parse_module(contents, None).ok()?;
 
@@ -150,7 +150,7 @@ pub fn remove_import_members(contents: &str, members: &[&str]) -> String {
         // It's possible that `last_pos` is after `fix.location`, if we're removing the
         // first _two_ members.
         if start_location > last_pos {
-            let slice = locator.slice(&Range::new(last_pos, start_location));
+            let slice = locator.slice(Range::new(last_pos, start_location));
             output.push_str(slice);
         }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -138,7 +138,7 @@ pub fn extraneous_parentheses(
                 let mut diagnostic =
                     Diagnostic::new(ExtraneousParentheses, Range::new(*start, *end));
                 if autofix.into() && settings.rules.should_fix(&Rule::ExtraneousParentheses) {
-                    let contents = locator.slice(&Range::new(*start, *end));
+                    let contents = locator.slice(Range::new(*start, *end));
                     diagnostic.amend(Fix::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         *start,

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -45,7 +45,7 @@ impl<'a> FormatSummaryValues<'a> {
         let mut extracted_kwargs: FxHashMap<&str, String> = FxHashMap::default();
         if let ExprKind::Call { args, keywords, .. } = &expr.node {
             for arg in args {
-                let arg = checker.locator.slice(&Range::from_located(arg));
+                let arg = checker.locator.slice(Range::from_located(arg));
                 if contains_invalids(arg) {
                     return None;
                 }
@@ -54,7 +54,7 @@ impl<'a> FormatSummaryValues<'a> {
             for keyword in keywords {
                 let KeywordData { arg, value } = &keyword.node;
                 if let Some(key) = arg {
-                    let kwarg = checker.locator.slice(&Range::from_located(value));
+                    let kwarg = checker.locator.slice(Range::from_located(value));
                     if contains_invalids(kwarg) {
                         return None;
                     }
@@ -125,7 +125,7 @@ fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
         return None;
     };
 
-    let contents = checker.locator.slice(&Range::from_located(value));
+    let contents = checker.locator.slice(Range::from_located(value));
 
     // Tokenize: we need to avoid trying to fix implicit string concatenations.
     if lexer::lex(contents, Mode::Module)
@@ -258,7 +258,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
     };
 
     // Avoid refactors that increase the resulting string length.
-    let existing = checker.locator.slice(&Range::from_located(expr));
+    let existing = checker.locator.slice(Range::from_located(expr));
     if contents.len() > existing.len() {
         return;
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -86,7 +86,7 @@ fn generate_call(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(&Range::from_located(expr));
+    let module_text = locator.slice(Range::from_located(expr));
     let mut expression = match_expression(module_text)?;
     let mut call = match_call(&mut expression)?;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
@@ -350,7 +350,7 @@ impl<'a> ImportReplacer<'a> {
 
             let matched = ImportReplacer::format_import_from(&matched_names, target);
             let unmatched = fixes::remove_import_members(
-                self.locator.slice(&Range::from_located(self.stmt)),
+                self.locator.slice(Range::from_located(self.stmt)),
                 &matched_names
                     .iter()
                     .map(|name| name.name.as_str())

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -116,7 +116,7 @@ pub fn native_literals(
         // rust-python merges adjacent string/bytes literals into one node, but we can't
         // safely remove the outer call in this situation. We're following pyupgrade
         // here and skip.
-        let arg_code = checker.locator.slice(&Range::from_located(arg));
+        let arg_code = checker.locator.slice(Range::from_located(arg));
         if lexer::lex_located(arg_code, Mode::Module, arg.location)
             .flatten()
             .filter(|(_, tok, _)| matches!(tok, Tok::String { .. }))

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -56,7 +56,7 @@ fn metadata<T>(locator: &Locator, located: &Located<T>) -> Option<BlockMetadata>
 
     // Start the selection at the start-of-line. This ensures consistent indentation
     // in the token stream, in the event that the entire block is indented.
-    let text = locator.slice(&Range::new(
+    let text = locator.slice(Range::new(
         Location::new(located.location.row(), 0),
         located.end_location.unwrap(),
     ));
@@ -198,7 +198,7 @@ fn fix_py2_block(
             Some(Fix::replacement(
                 checker
                     .locator
-                    .slice(&Range::new(start.location, end.end_location.unwrap()))
+                    .slice(Range::new(start.location, end.end_location.unwrap()))
                     .to_string(),
                 stmt.location,
                 stmt.end_location.unwrap(),
@@ -265,7 +265,7 @@ fn fix_py3_block(
                 Some(Fix::replacement(
                     checker
                         .locator
-                        .slice(&Range::new(start.location, end.end_location.unwrap()))
+                        .slice(Range::new(start.location, end.end_location.unwrap()))
                         .to_string(),
                     stmt.location,
                     stmt.end_location.unwrap(),
@@ -297,7 +297,7 @@ fn fix_py3_block(
             // Replace the `elif` with an `else, preserve the body of the elif, and remove
             // the rest.
             let end = body.last().unwrap();
-            let text = checker.locator.slice(&Range::new(
+            let text = checker.locator.slice(Range::new(
                 test.end_location.unwrap(),
                 end.end_location.unwrap(),
             ));

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -142,7 +142,7 @@ fn percent_to_format(format_string: &CFormatString) -> String {
 fn clean_params_tuple(checker: &mut Checker, right: &Expr) -> String {
     let mut contents = checker
         .locator
-        .slice(&Range::from_located(right))
+        .slice(Range::from_located(right))
         .to_string();
     if let ExprKind::Tuple { elts, .. } = &right.node {
         if elts.len() == 1 {
@@ -196,7 +196,7 @@ fn clean_params_dictionary(checker: &mut Checker, right: &Expr) -> Option<String
                             }
                         }
 
-                        let value_string = checker.locator.slice(&Range::from_located(value));
+                        let value_string = checker.locator.slice(Range::from_located(value));
                         arguments.push(format!("{key_string}={value_string}"));
                     } else {
                         // If there are any non-string keys, abort.
@@ -204,7 +204,7 @@ fn clean_params_dictionary(checker: &mut Checker, right: &Expr) -> Option<String
                     }
                 }
                 None => {
-                    let value_string = checker.locator.slice(&Range::from_located(value));
+                    let value_string = checker.locator.slice(Range::from_located(value));
                     arguments.push(format!("**{value_string}"));
                 }
             }
@@ -320,7 +320,7 @@ pub(crate) fn printf_string_formatting(
     let mut strings: Vec<(Location, Location)> = vec![];
     let mut extension = None;
     for (start, tok, end) in lexer::lex_located(
-        checker.locator.slice(&Range::from_located(expr)),
+        checker.locator.slice(Range::from_located(expr)),
         Mode::Module,
         expr.location,
     )
@@ -345,7 +345,7 @@ pub(crate) fn printf_string_formatting(
     // Parse each string segment.
     let mut format_strings = vec![];
     for (start, end) in &strings {
-        let string = checker.locator.slice(&Range::new(*start, *end));
+        let string = checker.locator.slice(Range::new(*start, *end));
         let (Some(leader), Some(trailer)) = (leading_quote(string), trailing_quote(string)) else {
             return;
         };
@@ -383,10 +383,10 @@ pub(crate) fn printf_string_formatting(
         // Add the content before the string segment.
         match prev {
             None => {
-                contents.push_str(checker.locator.slice(&Range::new(expr.location, *start)));
+                contents.push_str(checker.locator.slice(Range::new(expr.location, *start)));
             }
             Some(prev) => {
-                contents.push_str(checker.locator.slice(&Range::new(prev, *start)));
+                contents.push_str(checker.locator.slice(Range::new(prev, *start)));
             }
         }
         // Add the string itself.
@@ -395,7 +395,7 @@ pub(crate) fn printf_string_formatting(
     }
 
     if let Some((.., end)) = extension {
-        contents.push_str(checker.locator.slice(&Range::new(prev.unwrap(), end)));
+        contents.push_str(checker.locator.slice(Range::new(prev.unwrap(), end)));
     }
 
     // Add the `.format` call.

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -134,7 +134,7 @@ fn create_check(
 }
 
 fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) -> Result<Fix> {
-    let content = locator.slice(&Range::new(expr.location, expr.end_location.unwrap()));
+    let content = locator.slice(Range::new(expr.location, expr.end_location.unwrap()));
     // Find the last comma before mode_param and create a deletion fix
     // starting from the comma and ending after mode_param.
     let mut fix_start: Option<Location> = None;

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -81,7 +81,7 @@ fn generate_fix(
     };
     let mut contents = String::from("capture_output=True");
     if let Some(middle) =
-        extract_middle(locator.slice(&Range::new(first.end_location.unwrap(), last.location)))
+        extract_middle(locator.slice(Range::new(first.end_location.unwrap(), last.location)))
     {
         if middle.multi_line {
             let Some(indent) = indentation(locator, first) else {

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -24,7 +24,7 @@ impl AlwaysAutofixableViolation for RewriteCElementTree {
 fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic = Diagnostic::new(RewriteCElementTree, Range::from_located(node));
     if checker.patch(diagnostic.kind.rule()) {
-        let contents = checker.locator.slice(&Range::from_located(node));
+        let contents = checker.locator.slice(Range::from_located(node));
         diagnostic.amend(Fix::replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.location,

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -143,7 +143,7 @@ fn format_import(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(&Range::from_located(stmt));
+    let module_text = locator.slice(Range::from_located(stmt));
     let mut tree = match_module(module_text)?;
     let mut import = match_import(&mut tree)?;
 
@@ -177,7 +177,7 @@ fn format_import_from(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(&Range::from_located(stmt));
+    let module_text = locator.slice(Range::from_located(stmt));
     let mut tree = match_module(module_text).unwrap();
     let mut import = match_import_from(&mut tree)?;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -174,7 +174,7 @@ pub fn rewrite_yield_from(checker: &mut Checker, stmt: &Stmt) {
 
             let mut diagnostic = Diagnostic::new(RewriteYieldFrom, Range::from_located(item.stmt));
             if checker.patch(diagnostic.kind.rule()) {
-                let contents = checker.locator.slice(&Range::from_located(item.iter));
+                let contents = checker.locator.slice(Range::from_located(item.iter));
                 let contents = format!("yield from {contents}");
                 diagnostic.amend(Fix::replacement(
                     contents,

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -100,7 +100,7 @@ fn replace_with_bytes_literal(
 ) -> Diagnostic {
     let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from_located(expr));
     if patch {
-        let content = locator.slice(&Range::new(
+        let content = locator.slice(Range::new(
             constant.location,
             constant.end_location.unwrap(),
         ));

--- a/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -97,7 +97,7 @@ pub fn unpack_list_comprehension(checker: &mut Checker, targets: &[Expr], value:
             let mut diagnostic =
                 Diagnostic::new(RewriteListComprehension, Range::from_located(value));
             if checker.patch(diagnostic.kind.rule()) {
-                let existing = checker.locator.slice(&Range::from_located(value));
+                let existing = checker.locator.slice(Range::from_located(value));
 
                 let mut content = String::with_capacity(existing.len());
                 content.push('(');

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1693,7 +1693,7 @@ pub fn ambiguous_unicode_character(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
-    let text = locator.slice(&Range::new(start, end));
+    let text = locator.slice(Range::new(start, end));
 
     let mut col_offset = 0;
     let mut row_offset = 0;

--- a/crates/ruff/src/source_code/locator.rs
+++ b/crates/ruff/src/source_code/locator.rs
@@ -125,7 +125,7 @@ impl<'a> Locator<'a> {
     }
 
     /// Take the source code between the given [`Range`].
-    pub fn slice(&self, range: &Range) -> &'a str {
+    pub fn slice(&self, range: Range) -> &'a str {
         let index = self.get_or_init_index();
         let start = truncate(range.location, index, self.contents);
         let end = truncate(range.end_location, index, self.contents);

--- a/crates/ruff/src/source_code/stylist.rs
+++ b/crates/ruff/src/source_code/stylist.rs
@@ -167,7 +167,7 @@ fn detect_indentation(contents: &str, locator: &Locator) -> Option<Indentation> 
     for (_start, tok, end) in lexer::lex(contents, Mode::Module).flatten() {
         if let Tok::Indent { .. } = tok {
             let start = Location::new(end.row(), 0);
-            let whitespace = locator.slice(&Range::new(start, end));
+            let whitespace = locator.slice(Range::new(start, end));
             return Some(Indentation(whitespace.to_string()));
         }
     }
@@ -178,7 +178,7 @@ fn detect_indentation(contents: &str, locator: &Locator) -> Option<Indentation> 
 fn detect_quote(contents: &str, locator: &Locator) -> Option<Quote> {
     for (start, tok, end) in lexer::lex(contents, Mode::Module).flatten() {
         if let Tok::String { .. } = tok {
-            let content = locator.slice(&Range::new(start, end));
+            let content = locator.slice(Range::new(start, end));
             if let Some(pattern) = leading_quote(content) {
                 if pattern.contains("\"\"\"") {
                     continue;


### PR DESCRIPTION
I ran a basic hyperfine benchmark and this was ~unchanged (`215.7 ms ±   3.9` before, `215.1 ms ±   3.9 ms` after), it seems a bit simpler and more consistent with how we treat `Location`.
