### PR TITLE
Implement `From<Located>` for `Range`

### DIFF
--- a/crates/ruff/src/autofix/helpers.rs
+++ b/crates/ruff/src/autofix/helpers.rs
@@ -12,7 +12,7 @@ use crate::fix::Fix;
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::to_absolute;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-use ruff_python_ast::types::Range;
+
 use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 /// Determine if a body contains only a single statement, taking into account
@@ -227,7 +227,7 @@ pub fn remove_unused_imports<'a>(
     indexer: &Indexer,
     stylist: &Stylist,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(stmt));
+    let module_text = locator.slice(stmt);
     let mut tree = match_module(module_text)?;
 
     let Some(Statement::Simple(body)) = tree.body.first_mut() else {

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -198,7 +198,7 @@ where
                     // Add the binding to the current scope.
                     let context = self.ctx.execution_context();
                     let scope = &mut self.ctx.scopes[scope_index];
-                    let usage = Some((scope.id, Range::from_located(stmt)));
+                    let usage = Some((scope.id, Range::from(stmt)));
                     for (name, range) in names.iter().zip(ranges.iter()) {
                         let index = self.ctx.bindings.len();
                         self.ctx.bindings.push(Binding {
@@ -227,7 +227,7 @@ where
                 if scope_index != GLOBAL_SCOPE_INDEX {
                     let context = self.ctx.execution_context();
                     let scope = &mut self.ctx.scopes[scope_index];
-                    let usage = Some((scope.id, Range::from_located(stmt)));
+                    let usage = Some((scope.id, Range::from(stmt)));
                     for (name, range) in names.iter().zip(ranges.iter()) {
                         // Add a binding to the current scope.
                         let index = self.ctx.bindings.len();
@@ -668,7 +668,7 @@ where
                         runtime_usage: None,
                         synthetic_usage: None,
                         typing_usage: None,
-                        range: Range::from_located(stmt),
+                        range: Range::from(stmt),
                         source: Some(self.ctx.current_stmt().clone()),
                         context,
                     },
@@ -865,10 +865,10 @@ where
                                         .last()
                                         .expect("No current scope found"))]
                                     .id,
-                                    Range::from_located(alias),
+                                    Range::from(alias),
                                 )),
                                 typing_usage: None,
-                                range: Range::from_located(alias),
+                                range: Range::from(alias),
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
                             },
@@ -879,7 +879,7 @@ where
                         {
                             self.diagnostics.push(Diagnostic::new(
                                 pyflakes::rules::LateFutureImport,
-                                Range::from_located(stmt),
+                                Range::from(stmt),
                             ));
                         }
                     } else if alias.node.name.contains('.') && alias.node.asname.is_none() {
@@ -900,13 +900,13 @@ where
                                             .last()
                                             .expect("No current scope found"))]
                                         .id,
-                                        Range::from_located(alias),
+                                        Range::from(alias),
                                     ))
                                 } else {
                                     None
                                 },
                                 typing_usage: None,
-                                range: Range::from_located(alias),
+                                range: Range::from(alias),
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
                             },
@@ -938,13 +938,13 @@ where
                                             .last()
                                             .expect("No current scope found"))]
                                         .id,
-                                        Range::from_located(alias),
+                                        Range::from(alias),
                                     ))
                                 } else {
                                     None
                                 },
                                 typing_usage: None,
-                                range: Range::from_located(alias),
+                                range: Range::from(alias),
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
                             },
@@ -1211,10 +1211,10 @@ where
                                         .last()
                                         .expect("No current scope found"))]
                                     .id,
-                                    Range::from_located(alias),
+                                    Range::from(alias),
                                 )),
                                 typing_usage: None,
-                                range: Range::from_located(alias),
+                                range: Range::from(alias),
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
                             },
@@ -1233,7 +1233,7 @@ where
                         {
                             self.diagnostics.push(Diagnostic::new(
                                 pyflakes::rules::LateFutureImport,
-                                Range::from_located(stmt),
+                                Range::from(stmt),
                             ));
                         }
                     } else if alias.node.name == "*" {
@@ -1250,13 +1250,13 @@ where
                                             .last()
                                             .expect("No current scope found"))]
                                         .id,
-                                        Range::from_located(alias),
+                                        Range::from(alias),
                                     ))
                                 } else {
                                     None
                                 },
                                 typing_usage: None,
-                                range: Range::from_located(stmt),
+                                range: Range::from(stmt),
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
                             },
@@ -1273,7 +1273,7 @@ where
                                             module.as_deref(),
                                         ),
                                     },
-                                    Range::from_located(stmt),
+                                    Range::from(stmt),
                                 ));
                             }
                         }
@@ -1286,7 +1286,7 @@ where
                                         module.as_deref(),
                                     ),
                                 },
-                                Range::from_located(stmt),
+                                Range::from(stmt),
                             ));
                         }
 
@@ -1328,13 +1328,13 @@ where
                                             .last()
                                             .expect("No current scope found"))]
                                         .id,
-                                        Range::from_located(alias),
+                                        Range::from(alias),
                                     ))
                                 } else {
                                     None
                                 },
                                 typing_usage: None,
-                                range: Range::from_located(alias),
+                                range: Range::from(alias),
 
                                 source: Some(self.ctx.current_stmt().clone()),
                                 context: self.ctx.execution_context(),
@@ -1956,7 +1956,7 @@ where
                             runtime_usage: None,
                             synthetic_usage: None,
                             typing_usage: None,
-                            range: Range::from_located(stmt),
+                            range: Range::from(stmt),
                             source: Some(RefEquality(stmt)),
                             context: self.ctx.execution_context(),
                         });
@@ -2021,7 +2021,7 @@ where
                             runtime_usage: None,
                             synthetic_usage: None,
                             typing_usage: None,
-                            range: Range::from_located(stmt),
+                            range: Range::from(*stmt),
                             source: Some(RefEquality(stmt)),
                             context: self.ctx.execution_context(),
                         });
@@ -2164,7 +2164,7 @@ where
                         runtime_usage: None,
                         synthetic_usage: None,
                         typing_usage: None,
-                        range: Range::from_located(stmt),
+                        range: Range::from(stmt),
                         source: Some(self.ctx.current_stmt().clone()),
                         context: self.ctx.execution_context(),
                     },
@@ -2194,7 +2194,7 @@ where
             } = &expr.node
             {
                 self.deferred.string_type_definitions.push((
-                    Range::from_located(expr),
+                    Range::from(expr),
                     value,
                     (self.ctx.in_annotation, self.ctx.in_type_checking_block),
                     (self.ctx.scope_stack.clone(), self.ctx.parents.clone()),
@@ -2260,7 +2260,7 @@ where
                         elts,
                         check_too_many_expressions,
                         check_two_starred_expressions,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     ) {
                         self.diagnostics.push(diagnostic);
                     }
@@ -2295,10 +2295,9 @@ where
                     }
                     ExprContext::Store => {
                         if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
-                            if let Some(diagnostic) = pycodestyle::rules::ambiguous_variable_name(
-                                id,
-                                Range::from_located(expr),
-                            ) {
+                            if let Some(diagnostic) =
+                                pycodestyle::rules::ambiguous_variable_name(id, Range::from(expr))
+                            {
                                 self.diagnostics.push(diagnostic);
                             }
                         }
@@ -2383,7 +2382,7 @@ where
                         {
                             if attr == "format" {
                                 // "...".format(...) call
-                                let location = Range::from_located(expr);
+                                let location = Range::from(expr);
                                 match pyflakes::format::FormatSummary::try_from(value.as_ref()) {
                                     Err(e) => {
                                         if self
@@ -2779,22 +2778,14 @@ where
                         func,
                         args,
                         keywords,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
                 if self.settings.rules.enabled(&Rule::CallDatetimeToday) {
-                    flake8_datetimez::rules::call_datetime_today(
-                        self,
-                        func,
-                        Range::from_located(expr),
-                    );
+                    flake8_datetimez::rules::call_datetime_today(self, func, Range::from(expr));
                 }
                 if self.settings.rules.enabled(&Rule::CallDatetimeUtcnow) {
-                    flake8_datetimez::rules::call_datetime_utcnow(
-                        self,
-                        func,
-                        Range::from_located(expr),
-                    );
+                    flake8_datetimez::rules::call_datetime_utcnow(self, func, Range::from(expr));
                 }
                 if self
                     .settings
@@ -2804,7 +2795,7 @@ where
                     flake8_datetimez::rules::call_datetime_utcfromtimestamp(
                         self,
                         func,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
                 if self
@@ -2817,7 +2808,7 @@ where
                         func,
                         args,
                         keywords,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
                 if self
@@ -2830,7 +2821,7 @@ where
                         func,
                         args,
                         keywords,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
                 if self
@@ -2842,18 +2833,14 @@ where
                         self,
                         func,
                         args,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
                 if self.settings.rules.enabled(&Rule::CallDateToday) {
-                    flake8_datetimez::rules::call_date_today(self, func, Range::from_located(expr));
+                    flake8_datetimez::rules::call_date_today(self, func, Range::from(expr));
                 }
                 if self.settings.rules.enabled(&Rule::CallDateFromtimestamp) {
-                    flake8_datetimez::rules::call_date_fromtimestamp(
-                        self,
-                        func,
-                        Range::from_located(expr),
-                    );
+                    flake8_datetimez::rules::call_date_fromtimestamp(self, func, Range::from(expr));
                 }
 
                 // pygrep-hooks
@@ -3082,7 +3069,7 @@ where
                             .rules
                             .enabled(&Rule::PercentFormatUnsupportedFormatCharacter)
                     {
-                        let location = Range::from_located(expr);
+                        let location = Range::from(expr);
                         match pyflakes::cformat::CFormatSummary::try_from(value.as_str()) {
                             Err(CFormatError {
                                 typ: CFormatErrorType::UnsupportedFormatChar(c),
@@ -3271,7 +3258,7 @@ where
                         left,
                         ops,
                         comparators,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     );
                 }
 
@@ -3279,7 +3266,7 @@ where
                     self.diagnostics.extend(pycodestyle::rules::type_comparison(
                         ops,
                         comparators,
-                        Range::from_located(expr),
+                        Range::from(expr),
                     ));
                 }
 
@@ -3356,7 +3343,7 @@ where
             } => {
                 if self.ctx.in_type_definition && !self.ctx.in_literal {
                     self.deferred.string_type_definitions.push((
-                        Range::from_located(expr),
+                        Range::from(expr),
                         value,
                         (self.ctx.in_annotation, self.ctx.in_type_checking_block),
                         (self.ctx.scope_stack.clone(), self.ctx.parents.clone()),
@@ -3369,7 +3356,7 @@ where
                 {
                     if let Some(diagnostic) = flake8_bandit::rules::hardcoded_bind_all_interfaces(
                         value,
-                        &Range::from_located(expr),
+                        &Range::from(expr),
                     ) {
                         self.diagnostics.push(diagnostic);
                     }
@@ -3952,7 +3939,7 @@ where
                 runtime_usage: None,
                 synthetic_usage: None,
                 typing_usage: None,
-                range: Range::from_located(arg),
+                range: Range::from(arg),
                 source: Some(self.ctx.current_stmt().clone()),
                 context: self.ctx.execution_context(),
             },
@@ -3960,7 +3947,7 @@ where
 
         if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
             if let Some(diagnostic) =
-                pycodestyle::rules::ambiguous_variable_name(&arg.node.arg, Range::from_located(arg))
+                pycodestyle::rules::ambiguous_variable_name(&arg.node.arg, Range::from(arg))
             {
                 self.diagnostics.push(diagnostic);
             }
@@ -3995,7 +3982,7 @@ where
                     runtime_usage: None,
                     synthetic_usage: None,
                     typing_usage: None,
-                    range: Range::from_located(pattern),
+                    range: Range::from(pattern),
                     source: Some(self.ctx.current_stmt().clone()),
                     context: self.ctx.execution_context(),
                 },
@@ -4206,7 +4193,7 @@ impl<'a> Checker<'a> {
             if let Some(index) = scope.bindings.get(&id.as_str()) {
                 // Mark the binding as used.
                 let context = self.ctx.execution_context();
-                self.ctx.bindings[*index].mark_used(scope_id, Range::from_located(expr), context);
+                self.ctx.bindings[*index].mark_used(scope_id, Range::from(expr), context);
 
                 if self.ctx.bindings[*index].kind.is_annotation()
                     && !self.ctx.in_deferred_string_type_definition
@@ -4236,7 +4223,7 @@ impl<'a> Checker<'a> {
                             if let Some(index) = scope.bindings.get(full_name) {
                                 self.ctx.bindings[*index].mark_used(
                                     scope_id,
-                                    Range::from_located(expr),
+                                    Range::from(expr),
                                     context,
                                 );
                             }
@@ -4253,7 +4240,7 @@ impl<'a> Checker<'a> {
                             if let Some(index) = scope.bindings.get(full_name.as_str()) {
                                 self.ctx.bindings[*index].mark_used(
                                     scope_id,
-                                    Range::from_located(expr),
+                                    Range::from(expr),
                                     context,
                                 );
                             }
@@ -4295,7 +4282,7 @@ impl<'a> Checker<'a> {
                         name: id.to_string(),
                         sources: from_list,
                     },
-                    Range::from_located(expr),
+                    Range::from(expr),
                 ));
             }
             return;
@@ -4326,7 +4313,7 @@ impl<'a> Checker<'a> {
 
             self.diagnostics.push(Diagnostic::new(
                 pyflakes::rules::UndefinedName { name: id.clone() },
-                Range::from_located(expr),
+                Range::from(expr),
             ));
         }
     }
@@ -4398,7 +4385,7 @@ impl<'a> Checker<'a> {
                     runtime_usage: None,
                     synthetic_usage: None,
                     typing_usage: None,
-                    range: Range::from_located(expr),
+                    range: Range::from(expr),
                     source: Some(self.ctx.current_stmt().clone()),
                     context: self.ctx.execution_context(),
                 },
@@ -4418,7 +4405,7 @@ impl<'a> Checker<'a> {
                     runtime_usage: None,
                     synthetic_usage: None,
                     typing_usage: None,
-                    range: Range::from_located(expr),
+                    range: Range::from(expr),
                     source: Some(self.ctx.current_stmt().clone()),
                     context: self.ctx.execution_context(),
                 },
@@ -4434,7 +4421,7 @@ impl<'a> Checker<'a> {
                     runtime_usage: None,
                     synthetic_usage: None,
                     typing_usage: None,
-                    range: Range::from_located(expr),
+                    range: Range::from(expr),
                     source: Some(self.ctx.current_stmt().clone()),
                     context: self.ctx.execution_context(),
                 },
@@ -4499,7 +4486,7 @@ impl<'a> Checker<'a> {
                         runtime_usage: None,
                         synthetic_usage: None,
                         typing_usage: None,
-                        range: Range::from_located(expr),
+                        range: Range::from(expr),
                         source: Some(self.ctx.current_stmt().clone()),
                         context: self.ctx.execution_context(),
                     },
@@ -4515,7 +4502,7 @@ impl<'a> Checker<'a> {
                 runtime_usage: None,
                 synthetic_usage: None,
                 typing_usage: None,
-                range: Range::from_located(expr),
+                range: Range::from(expr),
                 source: Some(self.ctx.current_stmt().clone()),
                 context: self.ctx.execution_context(),
             },
@@ -4546,7 +4533,7 @@ impl<'a> Checker<'a> {
             pyflakes::rules::UndefinedName {
                 name: id.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 
@@ -5286,7 +5273,7 @@ impl<'a> Checker<'a> {
 
                 // Extract a `Docstring` from a `Definition`.
                 let expr = definition.docstring.unwrap();
-                let contents = self.locator.slice(Range::from_located(expr));
+                let contents = self.locator.slice(expr);
                 let indentation = self.locator.slice(Range::new(
                     Location::new(expr.location.row(), 0),
                     Location::new(expr.location.row(), expr.location.column()),

--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -144,7 +144,7 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                     {
                         checker.diagnostics.push(Diagnostic::new(
                             SysVersionSlice1Referenced,
-                            Range::from_located(value),
+                            Range::from(value),
                         ));
                     } else if *i == BigInt::from(3)
                         && checker
@@ -154,7 +154,7 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                     {
                         checker.diagnostics.push(Diagnostic::new(
                             SysVersionSlice3Referenced,
-                            Range::from_located(value),
+                            Range::from(value),
                         ));
                     }
                 }
@@ -167,17 +167,15 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                 if *i == BigInt::from(2)
                     && checker.settings.rules.enabled(&Rule::SysVersion2Referenced)
                 {
-                    checker.diagnostics.push(Diagnostic::new(
-                        SysVersion2Referenced,
-                        Range::from_located(value),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(SysVersion2Referenced, Range::from(value)));
                 } else if *i == BigInt::from(0)
                     && checker.settings.rules.enabled(&Rule::SysVersion0Referenced)
                 {
-                    checker.diagnostics.push(Diagnostic::new(
-                        SysVersion0Referenced,
-                        Range::from_located(value),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(SysVersion0Referenced, Range::from(value)));
                 }
             }
 
@@ -216,7 +214,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                         {
                             checker.diagnostics.push(Diagnostic::new(
                                 SysVersionInfo0Eq3Referenced,
-                                Range::from_located(left),
+                                Range::from(left),
                             ));
                         }
                     }
@@ -234,10 +232,9 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                     ) = (ops, comparators)
                     {
                         if checker.settings.rules.enabled(&Rule::SysVersionInfo1CmpInt) {
-                            checker.diagnostics.push(Diagnostic::new(
-                                SysVersionInfo1CmpInt,
-                                Range::from_located(left),
-                            ));
+                            checker
+                                .diagnostics
+                                .push(Diagnostic::new(SysVersionInfo1CmpInt, Range::from(left)));
                         }
                     }
                 }
@@ -266,7 +263,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         SysVersionInfoMinorCmpInt,
-                        Range::from_located(left),
+                        Range::from(left),
                     ));
                 }
             }
@@ -290,16 +287,14 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
         {
             if s.len() == 1 {
                 if checker.settings.rules.enabled(&Rule::SysVersionCmpStr10) {
-                    checker.diagnostics.push(Diagnostic::new(
-                        SysVersionCmpStr10,
-                        Range::from_located(left),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(SysVersionCmpStr10, Range::from(left)));
                 }
             } else if checker.settings.rules.enabled(&Rule::SysVersionCmpStr3) {
-                checker.diagnostics.push(Diagnostic::new(
-                    SysVersionCmpStr3,
-                    Range::from_located(left),
-                ));
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(SysVersionCmpStr3, Range::from(left)));
             }
         }
     }
@@ -314,6 +309,6 @@ pub fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     {
         checker
             .diagnostics
-            .push(Diagnostic::new(SixPY3Referenced, Range::from_located(expr)));
+            .push(Diagnostic::new(SixPY3Referenced, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/flake8_annotations/fixes.rs
+++ b/crates/ruff/src/rules/flake8_annotations/fixes.rs
@@ -9,7 +9,7 @@ use crate::fix::Fix;
 
 /// ANN204
 pub fn add_return_none_annotation(locator: &Locator, stmt: &Stmt) -> Result<Fix> {
-    let range = Range::from_located(stmt);
+    let range = Range::from(stmt);
     let contents = locator.slice(range);
 
     // Find the colon (following the `def` keyword).

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -446,7 +446,7 @@ fn check_dynamically_typed<F>(
     if checker.ctx.match_typing_expr(annotation, "Any") {
         diagnostics.push(Diagnostic::new(
             AnyType { name: func() },
-            Range::from_located(annotation),
+            Range::from(annotation),
         ));
     };
 }
@@ -513,7 +513,7 @@ pub fn definition(
                             MissingTypeFunctionArgument {
                                 name: arg.node.arg.to_string(),
                             },
-                            Range::from_located(arg),
+                            Range::from(arg),
                         ));
                     }
                 }
@@ -544,7 +544,7 @@ pub fn definition(
                             MissingTypeArgs {
                                 name: arg.node.arg.to_string(),
                             },
-                            Range::from_located(arg),
+                            Range::from(arg),
                         ));
                     }
                 }
@@ -575,7 +575,7 @@ pub fn definition(
                             MissingTypeKwargs {
                                 name: arg.node.arg.to_string(),
                             },
-                            Range::from_located(arg),
+                            Range::from(arg),
                         ));
                     }
                 }
@@ -592,7 +592,7 @@ pub fn definition(
                                 MissingTypeCls {
                                     name: arg.node.arg.to_string(),
                                 },
-                                Range::from_located(arg),
+                                Range::from(arg),
                             ));
                         }
                     } else {
@@ -601,7 +601,7 @@ pub fn definition(
                                 MissingTypeSelf {
                                     name: arg.node.arg.to_string(),
                                 },
-                                Range::from_located(arg),
+                                Range::from(arg),
                             ));
                         }
                     }

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -114,7 +114,7 @@ pub fn bad_file_permissions(
                 if (int_value & WRITE_WORLD > 0) || (int_value & EXECUTE_GROUP > 0) {
                     checker.diagnostics.push(Diagnostic::new(
                         BadFilePermissions { mask: int_value },
-                        Range::from_located(mode_arg),
+                        Range::from(mode_arg),
                     ));
                 }
             }

--- a/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
@@ -24,5 +24,5 @@ pub fn exec_used(expr: &Expr, func: &Expr) -> Option<Diagnostic> {
     if id != "exec" {
         return None;
     }
-    Some(Diagnostic::new(ExecBuiltin, Range::from_located(expr)))
+    Some(Diagnostic::new(ExecBuiltin, Range::from(expr)))
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
@@ -31,7 +31,7 @@ fn check_password_kwarg(arg: &Arg, default: &Expr) -> Option<Diagnostic> {
         HardcodedPasswordDefault {
             string: string.to_string(),
         },
-        Range::from_located(default),
+        Range::from(default),
     ))
 }
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
@@ -35,7 +35,7 @@ pub fn hardcoded_password_func_arg(keywords: &[Keyword]) -> Vec<Diagnostic> {
                 HardcodedPasswordFuncArg {
                     string: string.to_string(),
                 },
-                Range::from_located(keyword),
+                Range::from(keyword),
             ))
         })
         .collect()

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -54,7 +54,7 @@ pub fn compare_to_hardcoded_password_string(left: &Expr, comparators: &[Expr]) -
                 HardcodedPasswordString {
                     string: string.to_string(),
                 },
-                Range::from_located(comp),
+                Range::from(comp),
             ))
         })
         .collect()
@@ -69,7 +69,7 @@ pub fn assign_hardcoded_password_string(value: &Expr, targets: &[Expr]) -> Optio
                     HardcodedPasswordString {
                         string: string.to_string(),
                     },
-                    Range::from_located(value),
+                    Range::from(value),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -97,10 +97,9 @@ fn unparse_string_format_expression(checker: &mut Checker, expr: &Expr) -> Optio
 pub fn hardcoded_sql_expression(checker: &mut Checker, expr: &Expr) {
     match unparse_string_format_expression(checker, expr) {
         Some(string) if matches_sql_statement(&string) => {
-            checker.diagnostics.push(Diagnostic::new(
-                HardcodedSQLExpression,
-                Range::from_located(expr),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(HardcodedSQLExpression, Range::from(expr)));
         }
         _ => (),
     }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -33,7 +33,7 @@ pub fn hardcoded_tmp_directory(
             HardcodedTempFile {
                 string: value.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ))
     } else {
         None

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -75,7 +75,7 @@ pub fn hashlib_insecure_hash_functions(
                                 HashlibInsecureHashFunction {
                                     string: hash_func_name.to_string(),
                                 },
-                                Range::from_located(name_arg),
+                                Range::from(name_arg),
                             ));
                         }
                     }
@@ -92,7 +92,7 @@ pub fn hashlib_insecure_hash_functions(
                     HashlibInsecureHashFunction {
                         string: (*func_name).to_string(),
                     },
-                    Range::from_located(func),
+                    Range::from(func),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -58,20 +58,20 @@ pub fn jinja2_autoescape_false(
                         if id.as_str() != "select_autoescape" {
                             checker.diagnostics.push(Diagnostic::new(
                                 Jinja2AutoescapeFalse { value: true },
-                                Range::from_located(autoescape_arg),
+                                Range::from(autoescape_arg),
                             ));
                         }
                     }
                 }
                 _ => checker.diagnostics.push(Diagnostic::new(
                     Jinja2AutoescapeFalse { value: true },
-                    Range::from_located(autoescape_arg),
+                    Range::from(autoescape_arg),
                 )),
             }
         } else {
             checker.diagnostics.push(Diagnostic::new(
                 Jinja2AutoescapeFalse { value: false },
-                Range::from_located(func),
+                Range::from(func),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -37,7 +37,7 @@ pub fn logging_config_insecure_listen(
         if call_args.get_argument("verify", None).is_none() {
             checker.diagnostics.push(Diagnostic::new(
                 LoggingConfigInsecureListen,
-                Range::from_located(func),
+                Range::from(func),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -67,7 +67,7 @@ pub fn request_with_no_cert_validation(
                     RequestWithNoCertValidation {
                         string: target.to_string(),
                     },
-                    Range::from_located(verify_arg),
+                    Range::from(verify_arg),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -57,13 +57,13 @@ pub fn request_without_timeout(
                     RequestWithoutTimeout {
                         timeout: Some(timeout),
                     },
-                    Range::from_located(timeout_arg),
+                    Range::from(timeout_arg),
                 ));
             }
         } else {
             checker.diagnostics.push(Diagnostic::new(
                 RequestWithoutTimeout { timeout: None },
-                Range::from_located(func),
+                Range::from(func),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -43,7 +43,7 @@ pub fn snmp_insecure_version(
                 if value.is_zero() || value.is_one() {
                     checker.diagnostics.push(Diagnostic::new(
                         SnmpInsecureVersion,
-                        Range::from_located(mp_model_arg),
+                        Range::from(mp_model_arg),
                     ));
                 }
             }

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -37,10 +37,9 @@ pub fn snmp_weak_cryptography(
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if call_args.len() < 3 {
-            checker.diagnostics.push(Diagnostic::new(
-                SnmpWeakCryptography,
-                Range::from_located(func),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(SnmpWeakCryptography, Range::from(func)));
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
@@ -33,7 +33,7 @@ pub fn try_except_continue(
     {
         checker.diagnostics.push(Diagnostic::new(
             TryExceptContinue,
-            Range::from_located(excepthandler),
+            Range::from(excepthandler),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
@@ -31,9 +31,8 @@ pub fn try_except_pass(
         && body[0].node == StmtKind::Pass
         && (check_typed_exception || is_untyped_exception(type_, checker))
     {
-        checker.diagnostics.push(Diagnostic::new(
-            TryExceptPass,
-            Range::from_located(excepthandler),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(TryExceptPass, Range::from(excepthandler)));
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -56,13 +56,13 @@ pub fn unsafe_yaml_load(checker: &mut Checker, func: &Expr, args: &[Expr], keywo
                 };
                 checker.diagnostics.push(Diagnostic::new(
                     UnsafeYAMLLoad { loader },
-                    Range::from_located(loader_arg),
+                    Range::from(loader_arg),
                 ));
             }
         } else {
             checker.diagnostics.push(Diagnostic::new(
                 UnsafeYAMLLoad { loader: None },
-                Range::from_located(func),
+                Range::from(func),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_blind_except/rules.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules.rs
@@ -85,7 +85,7 @@ pub fn blind_except(
                 BlindExcept {
                     name: id.to_string(),
                 },
-                Range::from_located(type_),
+                Range::from(type_),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
@@ -92,7 +92,7 @@ fn add_if_boolean(checker: &mut Checker, arg: &Expr, kind: DiagnosticKind) {
     if is_boolean_arg(arg) {
         checker
             .diagnostics
-            .push(Diagnostic::new(kind, Range::from_located(arg)));
+            .push(Diagnostic::new(kind, Range::from(arg)));
     }
 }
 
@@ -135,7 +135,7 @@ pub fn check_positional_boolean_in_def(
         }
         checker.diagnostics.push(Diagnostic::new(
             BooleanPositionalArgInFunctionDefinition,
-            Range::from_located(arg),
+            Range::from(arg),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -128,7 +128,7 @@ pub fn abstract_base_class(
                 EmptyMethodWithoutAbstractDecorator {
                     name: format!("{name}.{method_name}"),
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     }
@@ -142,7 +142,7 @@ pub fn abstract_base_class(
                 AbstractBaseClassWithoutAbstractMethod {
                     name: name.to_string(),
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -62,7 +62,7 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
         return;
     };
 
-    let mut diagnostic = Diagnostic::new(AssertFalse, Range::from_located(test));
+    let mut diagnostic = Diagnostic::new(AssertFalse, Range::from(test));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             unparse_stmt(&assertion_error(msg), checker.stylist),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -62,8 +62,7 @@ pub fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items: &[With
         return;
     }
 
-    checker.diagnostics.push(Diagnostic::new(
-        AssertRaisesException,
-        Range::from_located(stmt),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(AssertRaisesException, Range::from(stmt)));
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -34,8 +34,7 @@ pub fn assignment_to_os_environ(checker: &mut Checker, targets: &[Expr]) {
     if id != "os" {
         return;
     }
-    checker.diagnostics.push(Diagnostic::new(
-        AssignmentToOsEnviron,
-        Range::from_located(target),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(AssignmentToOsEnviron, Range::from(target)));
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -53,7 +53,7 @@ pub fn cached_instance_method(checker: &mut Checker, decorator_list: &[Expr]) {
         ) {
             checker.diagnostics.push(Diagnostic::new(
                 CachedInstanceMethod,
-                Range::from_located(decorator),
+                Range::from(decorator),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
@@ -22,8 +22,7 @@ pub fn cannot_raise_literal(checker: &mut Checker, expr: &Expr) {
     let ExprKind::Constant { .. } = &expr.node else {
         return;
     };
-    checker.diagnostics.push(Diagnostic::new(
-        CannotRaiseLiteral,
-        Range::from_located(expr),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(CannotRaiseLiteral, Range::from(expr)));
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -95,7 +95,7 @@ fn duplicate_handler_exceptions<'a>(
                         .sorted()
                         .collect::<Vec<String>>(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
@@ -157,7 +157,7 @@ pub fn duplicate_exceptions(checker: &mut Checker, handlers: &[Excepthandler]) {
                     DuplicateTryBlockException {
                         name: name.join("."),
                     },
-                    Range::from_located(expr),
+                    Range::from(expr),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
@@ -30,7 +30,7 @@ pub fn except_with_empty_tuple(checker: &mut Checker, excepthandler: &Excepthand
     if elts.is_empty() {
         checker.diagnostics.push(Diagnostic::new(
             ExceptWithEmptyTuple,
-            Range::from_located(excepthandler),
+            Range::from(excepthandler),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -75,7 +75,7 @@ where
                             name: compose_call_path(func),
                         }
                         .into(),
-                        Range::from_located(expr),
+                        Range::from(expr),
                     ));
                 }
                 visitor::walk_expr(self, expr);

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -40,8 +40,8 @@ where
     fn visit_expr(&mut self, expr: &'b Expr) {
         match &expr.node {
             ExprKind::Name { id, ctx } => match ctx {
-                ExprContext::Load => self.loaded.push((id, expr, Range::from_located(expr))),
-                ExprContext::Store => self.stored.push((id, expr, Range::from_located(expr))),
+                ExprContext::Load => self.loaded.push((id, expr, Range::from(expr))),
+                ExprContext::Store => self.stored.push((id, expr, Range::from(expr))),
                 ExprContext::Del => {}
             },
             _ => visitor::walk_expr(self, expr),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -63,7 +63,7 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(GetAttrWithConstant, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(GetAttrWithConstant, Range::from(expr));
 
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
@@ -34,7 +34,7 @@ fn walk_stmt(checker: &mut Checker, body: &[Stmt], f: fn(&Stmt) -> bool) {
                         ),
                     },
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
         match &stmt.node {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -75,7 +75,7 @@ pub fn loop_variable_overrides_iterator(checker: &mut Checker, target: &Expr, it
                 LoopVariableOverridesIterator {
                     name: name.to_string(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -171,7 +171,7 @@ pub fn mutable_argument_default(checker: &mut Checker, arguments: &Arguments) {
         {
             checker.diagnostics.push(Diagnostic::new(
                 MutableArgumentDefault,
-                Range::from_located(default),
+                Range::from(default),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -46,7 +46,7 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             RedundantTupleInExceptionHandler {
                 name: unparse_expr(elt, checker.stylist),
             },
-            Range::from_located(type_),
+            Range::from(type_),
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -78,7 +78,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     // (i.e., it's directly within an `StmtKind::Expr`).
     if let StmtKind::Expr { value: child } = &checker.ctx.current_stmt().node {
         if expr == child.as_ref() {
-            let mut diagnostic = Diagnostic::new(SetAttrWithConstant, Range::from_located(expr));
+            let mut diagnostic = Diagnostic::new(SetAttrWithConstant, Range::from(expr));
 
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
@@ -44,7 +44,7 @@ pub fn star_arg_unpacking_after_keyword_arg(
         }
         checker.diagnostics.push(Diagnostic::new(
             StarArgUnpackingAfterKeywordArg,
-            Range::from_located(arg),
+            Range::from(arg),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -39,9 +39,8 @@ pub fn strip_with_multi_characters(checker: &mut Checker, expr: &Expr, func: &Ex
 
     let num_chars = value.chars().count();
     if num_chars > 1 && num_chars != value.chars().unique().count() {
-        checker.diagnostics.push(Diagnostic::new(
-            StripWithMultiCharacters,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(StripWithMultiCharacters, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
@@ -47,8 +47,7 @@ pub fn unary_prefix_increment(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
     if !matches!(op, Unaryop::UAdd) {
         return;
     }
-    checker.diagnostics.push(Diagnostic::new(
-        UnaryPrefixIncrement,
-        Range::from_located(expr),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(UnaryPrefixIncrement, Range::from(expr)));
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
@@ -50,7 +50,7 @@ pub fn unintentional_type_annotation(
             if matches!(&value.node, ExprKind::Name { .. }) {
                 checker.diagnostics.push(Diagnostic::new(
                     UnintentionalTypeAnnotation,
-                    Range::from_located(stmt),
+                    Range::from(stmt),
                 ));
             }
         }
@@ -59,7 +59,7 @@ pub fn unintentional_type_annotation(
                 if id != "self" {
                     checker.diagnostics.push(Diagnostic::new(
                         UnintentionalTypeAnnotation,
-                        Range::from_located(stmt),
+                        Range::from(stmt),
                     ));
                 }
             }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -41,8 +41,7 @@ pub fn unreliable_callable_check(checker: &mut Checker, expr: &Expr, func: &Expr
     if s != "__call__" {
         return;
     }
-    checker.diagnostics.push(Diagnostic::new(
-        UnreliableCallableCheck,
-        Range::from_located(expr),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(UnreliableCallableCheck, Range::from(expr)));
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -159,7 +159,7 @@ pub fn unused_loop_control_variable(
                 rename: rename.clone(),
                 certainty,
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if let Some(rename) = rename {
             if certainty.into() && checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -22,9 +22,8 @@ impl Violation for UselessComparison {
 
 pub fn useless_comparison(checker: &mut Checker, expr: &Expr) {
     if matches!(expr.node, ExprKind::Compare { .. }) {
-        checker.diagnostics.push(Diagnostic::new(
-            UselessComparison,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(UselessComparison, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -32,7 +32,7 @@ pub fn useless_contextlib_suppress(checker: &mut Checker, expr: &Expr, func: &Ex
     {
         checker.diagnostics.push(Diagnostic::new(
             UselessContextlibSuppress,
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -23,18 +23,16 @@ pub fn useless_expression(checker: &mut Checker, body: &[Stmt]) {
         if let StmtKind::Expr { value } = &stmt.node {
             match &value.node {
                 ExprKind::List { .. } | ExprKind::Dict { .. } | ExprKind::Set { .. } => {
-                    checker.diagnostics.push(Diagnostic::new(
-                        UselessExpression,
-                        Range::from_located(value),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(UselessExpression, Range::from(value)));
                 }
                 ExprKind::Constant { value: val, .. } => match &val {
                     Constant::Str { .. } | Constant::Ellipsis => {}
                     _ => {
-                        checker.diagnostics.push(Diagnostic::new(
-                            UselessExpression,
-                            Range::from_located(value),
-                        ));
+                        checker
+                            .diagnostics
+                            .push(Diagnostic::new(UselessExpression, Range::from(value)));
                     }
                 },
                 _ => {}

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -35,10 +35,9 @@ pub fn zip_without_explicit_strict(
                     .map_or(false, |name| name == "strict")
             })
         {
-            checker.diagnostics.push(Diagnostic::new(
-                ZipWithoutExplicitStrict,
-                Range::from_located(expr),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(ZipWithoutExplicitStrict, Range::from(expr)));
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/rules.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules.rs
@@ -192,7 +192,7 @@ pub fn builtin_shadowing<T>(
                 }
                 .into(),
             },
-            Range::from_located(located),
+            Range::from(located),
         ))
     } else {
         None

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -8,7 +8,6 @@ use libcst_native::{
 };
 
 use ruff_python_ast::source_code::{Locator, Stylist};
-use ruff_python_ast::types::Range;
 
 use crate::cst::matchers::{match_expr, match_module};
 use crate::fix::Fix;
@@ -36,7 +35,7 @@ pub fn fix_unnecessary_generator_list(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(GeneratorExp)))) -> Expr(ListComp)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -83,7 +82,7 @@ pub fn fix_unnecessary_generator_set(
     parent: Option<&rustpython_parser::ast::Expr>,
 ) -> Result<Fix> {
     // Expr(Call(GeneratorExp)))) -> Expr(SetComp)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -140,7 +139,7 @@ pub fn fix_unnecessary_generator_dict(
     expr: &rustpython_parser::ast::Expr,
     parent: Option<&rustpython_parser::ast::Expr>,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -214,7 +213,7 @@ pub fn fix_unnecessary_list_comprehension_set(
 ) -> Result<Fix> {
     // Expr(Call(ListComp)))) ->
     // Expr(SetComp)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -258,7 +257,7 @@ pub fn fix_unnecessary_list_comprehension_dict(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -357,7 +356,7 @@ pub fn fix_unnecessary_literal_set(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(Set)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let mut call = match_call(body)?;
@@ -408,7 +407,7 @@ pub fn fix_unnecessary_literal_dict(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(Dict)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -481,7 +480,7 @@ pub fn fix_unnecessary_collection_call(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call("list" | "tuple" | "dict")))) -> Expr(List|Tuple|Dict)
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -596,7 +595,7 @@ pub fn fix_unnecessary_literal_within_tuple_call(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -655,7 +654,7 @@ pub fn fix_unnecessary_literal_within_list_call(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -717,7 +716,7 @@ pub fn fix_unnecessary_list_call(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(Call(List|Tuple)))) -> Expr(List|Tuple)))
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;
@@ -747,7 +746,7 @@ pub fn fix_unnecessary_call_around_sorted(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let outer_call = match_call(body)?;
@@ -874,7 +873,7 @@ pub fn fix_unnecessary_double_cast_or_process(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let body = match_expr(&mut tree)?;
     let mut outer_call = match_call(body)?;
@@ -913,7 +912,7 @@ pub fn fix_unnecessary_comprehension(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 
@@ -989,7 +988,7 @@ pub fn fix_unnecessary_map(
     parent: Option<&rustpython_parser::ast::Expr>,
     kind: &str,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
     let call = match_call(body)?;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -84,7 +84,7 @@ pub fn unnecessary_call_around_sorted(
         UnnecessaryCallAroundSorted {
             func: outer.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_call_around_sorted(checker.locator, checker.stylist, expr) {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -64,7 +64,7 @@ pub fn unnecessary_collection_call(
         UnnecessaryCollectionCall {
             obj_type: id.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_collection_call(checker.locator, checker.stylist, expr) {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -65,7 +65,7 @@ pub fn unnecessary_comprehension(
         UnnecessaryComprehension {
             obj_type: id.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_comprehension(checker.locator, checker.stylist, expr) {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -112,7 +112,7 @@ pub fn unnecessary_double_cast_or_process(
         || (outer == "set" && inner == "set")
         || ((outer == "list" || outer == "tuple") && (inner == "list" || inner == "tuple"))
     {
-        let mut diagnostic = create_diagnostic(inner, outer, Range::from_located(expr));
+        let mut diagnostic = create_diagnostic(inner, outer, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             if let Ok(fix) = fixes::fix_unnecessary_double_cast_or_process(
                 checker.locator,

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -58,8 +58,7 @@ pub fn unnecessary_generator_dict(
     if let ExprKind::GeneratorExp { elt, .. } = argument {
         match &elt.node {
             ExprKind::Tuple { elts, .. } if elts.len() == 2 => {
-                let mut diagnostic =
-                    Diagnostic::new(UnnecessaryGeneratorDict, Range::from_located(expr));
+                let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorDict, Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
                     match fixes::fix_unnecessary_generator_dict(
                         checker.locator,

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -58,7 +58,7 @@ pub fn unnecessary_generator_list(
         return;
     }
     if let ExprKind::GeneratorExp { .. } = argument {
-        let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorList, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorList, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_generator_list(checker.locator, checker.stylist, expr) {
                 Ok(fix) => {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -59,7 +59,7 @@ pub fn unnecessary_generator_set(
         return;
     }
     if let ExprKind::GeneratorExp { .. } = argument {
-        let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorSet, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(UnnecessaryGeneratorSet, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_generator_set(
                 checker.locator,

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -36,7 +36,7 @@ pub fn unnecessary_list_call(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     if !matches!(argument, ExprKind::ListComp { .. }) {
         return;
     }
-    let mut diagnostic = Diagnostic::new(UnnecessaryListCall, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(UnnecessaryListCall, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_list_call(checker.locator, checker.stylist, expr) {
             Ok(fix) => {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -48,8 +48,7 @@ pub fn unnecessary_list_comprehension_dict(
     if elts.len() != 2 {
         return;
     }
-    let mut diagnostic =
-        Diagnostic::new(UnnecessaryListComprehensionDict, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionDict, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_list_comprehension_dict(checker.locator, checker.stylist, expr)
         {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -40,8 +40,7 @@ pub fn unnecessary_list_comprehension_set(
         return;
     }
     if let ExprKind::ListComp { .. } = &argument {
-        let mut diagnostic =
-            Diagnostic::new(UnnecessaryListComprehensionSet, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             match fixes::fix_unnecessary_list_comprehension_set(
                 checker.locator,

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -58,7 +58,7 @@ pub fn unnecessary_literal_dict(
         UnnecessaryLiteralDict {
             obj_type: kind.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_dict(checker.locator, checker.stylist, expr) {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -51,7 +51,7 @@ pub fn unnecessary_literal_set(
         UnnecessaryLiteralSet {
             obj_type: kind.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_set(checker.locator, checker.stylist, expr) {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -66,7 +66,7 @@ pub fn unnecessary_literal_within_list_call(
         UnnecessaryLiteralWithinListCall {
             literal: argument_kind.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_within_list_call(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -67,7 +67,7 @@ pub fn unnecessary_literal_within_tuple_call(
         UnnecessaryLiteralWithinTupleCall {
             literal: argument_kind.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         match fixes::fix_unnecessary_literal_within_tuple_call(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -104,7 +104,7 @@ pub fn unnecessary_map(
             };
 
             if args.len() == 2 && matches!(&args[0].node, ExprKind::Lambda { .. }) {
-                let mut diagnostic = create_diagnostic("generator", Range::from_located(expr));
+                let mut diagnostic = create_diagnostic("generator", Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
                     match fixes::fix_unnecessary_map(
                         checker.locator,
@@ -136,7 +136,7 @@ pub fn unnecessary_map(
                         return;
                     };
                     if let ExprKind::Lambda { .. } = argument {
-                        let mut diagnostic = create_diagnostic(id, Range::from_located(expr));
+                        let mut diagnostic = create_diagnostic(id, Range::from(expr));
                         if checker.patch(diagnostic.kind.rule()) {
                             match fixes::fix_unnecessary_map(
                                 checker.locator,
@@ -169,7 +169,7 @@ pub fn unnecessary_map(
                     if let ExprKind::Lambda { body, .. } = &argument {
                         if matches!(&body.node, ExprKind::Tuple { elts, .. } | ExprKind::List { elts, .. } if elts.len() == 2)
                         {
-                            let mut diagnostic = create_diagnostic(id, Range::from_located(expr));
+                            let mut diagnostic = create_diagnostic(id, Range::from(expr));
                             if checker.patch(diagnostic.kind.rule()) {
                                 match fixes::fix_unnecessary_map(
                                     checker.locator,

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -73,6 +73,6 @@ pub fn unnecessary_subscript_reversal(
         UnnecessarySubscriptReversal {
             func: id.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     ));
 }

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -57,7 +57,7 @@ pub fn debugger_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
             Debugger {
                 using_type: DebuggerUsingType::Call(format_call_path(target)),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }
@@ -78,7 +78,7 @@ pub fn debugger_import(stmt: &Stmt, module: Option<&str>, name: &str) -> Option<
                 Debugger {
                     using_type: DebuggerUsingType::Import(format_call_path(&call_path)),
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     } else {
@@ -91,7 +91,7 @@ pub fn debugger_import(stmt: &Stmt, module: Option<&str>, name: &str) -> Option<
                 Debugger {
                     using_type: DebuggerUsingType::Import(name.to_string()),
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -76,18 +76,12 @@ pub fn all_with_model_form(checker: &Checker, bases: &[Expr], body: &[Stmt]) -> 
                 match &value {
                     Constant::Str(s) => {
                         if s == "__all__" {
-                            return Some(Diagnostic::new(
-                                AllWithModelForm,
-                                Range::from_located(element),
-                            ));
+                            return Some(Diagnostic::new(AllWithModelForm, Range::from(element)));
                         }
                     }
                     Constant::Bytes(b) => {
                         if b == "__all__".as_bytes() {
-                            return Some(Diagnostic::new(
-                                AllWithModelForm,
-                                Range::from_located(element),
-                            ));
+                            return Some(Diagnostic::new(AllWithModelForm, Range::from(element)));
                         }
                     }
                     _ => (),

--- a/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -68,10 +68,7 @@ pub fn exclude_with_model_form(
                     continue;
                 };
                 if id == "exclude" {
-                    return Some(Diagnostic::new(
-                        ExcludeWithModelForm,
-                        Range::from_located(target),
-                    ));
+                    return Some(Diagnostic::new(ExcludeWithModelForm, Range::from(target)));
                 }
             }
         }

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -77,10 +77,9 @@ pub fn locals_in_render_function(
         return;
     };
 
-    checker.diagnostics.push(Diagnostic::new(
-        LocalsInRenderFunction,
-        Range::from_located(locals),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(LocalsInRenderFunction, Range::from(locals)));
 }
 
 fn is_locals_call(checker: &Checker, expr: &Expr) -> bool {

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -64,7 +64,7 @@ pub fn model_without_dunder_str(
     if !has_dunder_method(body) {
         return Some(Diagnostic::new(
             ModelWithoutDunderStr,
-            Range::from_located(class_location),
+            Range::from(class_location),
         ));
     }
     None

--- a/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -69,7 +69,7 @@ where
         if i > 0 && is_receiver && !seen_receiver {
             diagnostics.push(Diagnostic::new(
                 NonLeadingReceiverDecorator,
-                Range::from_located(decorator),
+                Range::from(decorator),
             ));
         }
         if !is_receiver && seen_receiver {

--- a/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
@@ -74,7 +74,7 @@ pub fn nullable_model_string_field(checker: &Checker, body: &[Stmt]) -> Vec<Diag
                 NullableModelStringField {
                     field_name: field_name.to_string(),
                 },
-                Range::from_located(value),
+                Range::from(value),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -164,20 +164,18 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                 } => {
                     if checker.settings.rules.enabled(&Rule::RawStringInException) {
                         if string.len() > checker.settings.flake8_errmsg.max_string_length {
-                            checker.diagnostics.push(Diagnostic::new(
-                                RawStringInException,
-                                Range::from_located(first),
-                            ));
+                            checker
+                                .diagnostics
+                                .push(Diagnostic::new(RawStringInException, Range::from(first)));
                         }
                     }
                 }
                 // Check for f-strings
                 ExprKind::JoinedStr { .. } => {
                     if checker.settings.rules.enabled(&Rule::FStringInException) {
-                        checker.diagnostics.push(Diagnostic::new(
-                            FStringInException,
-                            Range::from_located(first),
-                        ));
+                        checker
+                            .diagnostics
+                            .push(Diagnostic::new(FStringInException, Range::from(first)));
                     }
                 }
                 // Check for .format() calls
@@ -187,7 +185,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                             if attr == "format" && matches!(value.node, ExprKind::Constant { .. }) {
                                 checker.diagnostics.push(Diagnostic::new(
                                     DotFormatInException,
-                                    Range::from_located(first),
+                                    Range::from(first),
                                 ));
                             }
                         }

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
@@ -174,7 +174,7 @@ pub fn explicit(expr: &Expr) -> Option<Diagnostic> {
             ) {
                 return Some(Diagnostic::new(
                     ExplicitStringConcatenation,
-                    Range::from_located(expr),
+                    Range::from(expr),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_import_conventions/rules.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/rules.rs
@@ -60,7 +60,7 @@ pub fn check_conventional_import(
         if !is_valid_import {
             return Some(Diagnostic::new(
                 UnconventionalImportAlias(name.to_string(), expected_alias.to_string()),
-                Range::from_located(import_from),
+                Range::from(import_from),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -44,18 +44,16 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         ExprKind::BinOp { op, .. } => match op {
             Operator::Add => {
                 if checker.settings.rules.enabled(&Rule::LoggingStringConcat) {
-                    checker.diagnostics.push(Diagnostic::new(
-                        LoggingStringConcat,
-                        Range::from_located(msg),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(LoggingStringConcat, Range::from(msg)));
                 }
             }
             Operator::Mod => {
                 if checker.settings.rules.enabled(&Rule::LoggingPercentFormat) {
-                    checker.diagnostics.push(Diagnostic::new(
-                        LoggingPercentFormat,
-                        Range::from_located(msg),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(LoggingPercentFormat, Range::from(msg)));
                 }
             }
             _ => {}
@@ -65,7 +63,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
             if checker.settings.rules.enabled(&Rule::LoggingFString) {
                 checker
                     .diagnostics
-                    .push(Diagnostic::new(LoggingFString, Range::from_located(msg)));
+                    .push(Diagnostic::new(LoggingFString, Range::from(msg)));
             }
         }
         // Check for .format() calls.
@@ -73,10 +71,9 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
             if checker.settings.rules.enabled(&Rule::LoggingStringFormat) {
                 if let ExprKind::Attribute { value, attr, .. } = &func.node {
                     if attr == "format" && matches!(value.node, ExprKind::Constant { .. }) {
-                        checker.diagnostics.push(Diagnostic::new(
-                            LoggingStringFormat,
-                            Range::from_located(msg),
-                        ));
+                        checker
+                            .diagnostics
+                            .push(Diagnostic::new(LoggingStringFormat, Range::from(msg)));
                     }
                 }
             }
@@ -99,7 +96,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
                         if RESERVED_ATTRS.contains(&string.as_str()) {
                             checker.diagnostics.push(Diagnostic::new(
                                 LoggingExtraAttrClash(string.to_string()),
-                                Range::from_located(key),
+                                Range::from(key),
                             ));
                         }
                     }
@@ -117,7 +114,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
                         if RESERVED_ATTRS.contains(&key.as_str()) {
                             checker.diagnostics.push(Diagnostic::new(
                                 LoggingExtraAttrClash(key.to_string()),
-                                Range::from_located(keyword),
+                                Range::from(keyword),
                             ));
                         }
                     }
@@ -223,7 +220,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
                             {
                                 checker.diagnostics.push(Diagnostic::new(
                                     LoggingRedundantExcInfo,
-                                    Range::from_located(exc_info),
+                                    Range::from(exc_info),
                                 ));
                             }
                         }

--- a/crates/ruff/src/rules/flake8_pie/fixes.rs
+++ b/crates/ruff/src/rules/flake8_pie/fixes.rs
@@ -2,7 +2,6 @@ use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, Expression, GeneratorExp};
 
 use ruff_python_ast::source_code::{Locator, Stylist};
-use ruff_python_ast::types::Range;
 
 use crate::cst::matchers::{match_call, match_expression};
 use crate::fix::Fix;
@@ -14,7 +13,7 @@ pub fn fix_unnecessary_comprehension_any_all(
     expr: &rustpython_parser::ast::Expr,
 ) -> Result<Fix> {
     // Expr(ListComp) -> Expr(GeneratorExp)
-    let expression_text = locator.slice(Range::from_located(expr));
+    let expression_text = locator.slice(expr);
     let mut tree = match_expression(expression_text)?;
     let call = match_call(&mut tree)?;
 

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -170,8 +170,7 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
             }
         ) {
             if matches!(pass_stmt.node, StmtKind::Pass) {
-                let mut diagnostic =
-                    Diagnostic::new(UnnecessaryPass, Range::from_located(pass_stmt));
+                let mut diagnostic = Diagnostic::new(UnnecessaryPass, Range::from(pass_stmt));
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = match_trailing_comment(pass_stmt, checker.locator) {
                         diagnostic.amend(Fix::deletion(
@@ -240,7 +239,7 @@ pub fn dupe_class_field_definitions<'a, 'b>(
         if !seen_targets.insert(target) {
             let mut diagnostic = Diagnostic::new(
                 DupeClassFieldDefinitions(target.to_string()),
-                Range::from_located(stmt),
+                Range::from(stmt),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
@@ -306,7 +305,7 @@ where
                 PreferUniqueEnums {
                     value: unparse_expr(value, checker.stylist),
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             );
             checker.diagnostics.push(diagnostic);
         }
@@ -320,7 +319,7 @@ pub fn no_unnecessary_spread(checker: &mut Checker, keys: &[Option<Expr>], value
             // We only care about when the key is None which indicates a spread `**`
             // inside a dict.
             if let ExprKind::Dict { .. } = value.node {
-                let diagnostic = Diagnostic::new(UnnecessarySpread, Range::from_located(value));
+                let diagnostic = Diagnostic::new(UnnecessarySpread, Range::from(value));
                 checker.diagnostics.push(diagnostic);
             }
         }
@@ -340,10 +339,8 @@ pub fn unnecessary_comprehension_any_all(
                 return;
             }
             if let ExprKind::ListComp { .. } = args[0].node {
-                let mut diagnostic = Diagnostic::new(
-                    UnnecessaryComprehensionAnyAll,
-                    Range::from_located(&args[0]),
-                );
+                let mut diagnostic =
+                    Diagnostic::new(UnnecessaryComprehensionAnyAll, Range::from(&args[0]));
                 if checker.patch(diagnostic.kind.rule()) {
                     match fixes::fix_unnecessary_comprehension_any_all(
                         checker.locator,
@@ -386,8 +383,7 @@ pub fn no_unnecessary_dict_kwargs(checker: &mut Checker, expr: &Expr, kwargs: &[
                     // handle case of foo(**{**bar})
                     (keys.len() == 1 && keys[0].is_none())
                 {
-                    let diagnostic =
-                        Diagnostic::new(UnnecessaryDictKwargs, Range::from_located(expr));
+                    let diagnostic = Diagnostic::new(UnnecessaryDictKwargs, Range::from(expr));
                     checker.diagnostics.push(diagnostic);
                 }
             }
@@ -424,7 +420,7 @@ pub fn single_starts_ends_with(checker: &mut Checker, values: &[Expr], node: &Bo
                             SingleStartsEndsWith {
                                 attr: attr.to_string(),
                             },
-                            Range::from_located(value),
+                            Range::from(value),
                         ));
                     }
                 }
@@ -446,7 +442,7 @@ pub fn prefer_list_builtin(checker: &mut Checker, expr: &Expr) {
     {
         if let ExprKind::List { elts, .. } = &body.node {
             if elts.is_empty() {
-                let mut diagnostic = Diagnostic::new(PreferListBuiltin, Range::from_located(expr));
+                let mut diagnostic = Diagnostic::new(PreferListBuiltin, Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         "list".to_string(),

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -54,11 +54,11 @@ pub fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
                     }
                 }
             }
-            Diagnostic::new(PrintFound, Range::from_located(func))
+            Diagnostic::new(PrintFound, Range::from(func))
         } else if call_path.as_ref().map_or(false, |call_path| {
             *call_path.as_slice() == ["pprint", "pprint"]
         }) {
-            Diagnostic::new(PPrintFound, Range::from_located(func))
+            Diagnostic::new(PPrintFound, Range::from(func))
         } else {
             return;
         }

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -81,7 +81,7 @@ pub fn bad_version_info_comparison(
     }
 
     if !matches!(op, Cmpop::Lt | Cmpop::GtE) {
-        let diagnostic = Diagnostic::new(BadVersionInfoComparison, Range::from_located(expr));
+        let diagnostic = Diagnostic::new(BadVersionInfoComparison, Range::from(expr));
         checker.diagnostics.push(diagnostic);
     }
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
@@ -20,9 +20,8 @@ impl Violation for DocstringInStub {
 /// PYI021
 pub fn docstring_in_stubs(checker: &mut Checker, docstring: Option<&Expr>) {
     if let Some(docstr) = &docstring {
-        checker.diagnostics.push(Diagnostic::new(
-            DocstringInStub,
-            Range::from_located(docstr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(DocstringInStub, Range::from(*docstr)));
     }
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -29,8 +29,7 @@ pub fn non_empty_stub_body(checker: &mut Checker, body: &[Stmt]) {
             }
         }
     }
-    checker.diagnostics.push(Diagnostic::new(
-        NonEmptyStubBody,
-        Range::from_located(&body[0]),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(NonEmptyStubBody, Range::from(&body[0])));
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -25,7 +25,7 @@ pub fn pass_statement_stub_body(checker: &mut Checker, body: &[Stmt]) {
     if matches!(body[0].node, StmtKind::Pass) {
         checker.diagnostics.push(Diagnostic::new(
             PassStatementStubBody,
-            Range::from_located(&body[0]),
+            Range::from(&body[0]),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -88,7 +88,7 @@ pub fn prefix_type_params(checker: &mut Checker, value: &Expr, targets: &[Expr])
         };
         checker.diagnostics.push(Diagnostic::new(
             PrefixTypeParams { kind },
-            Range::from_located(value),
+            Range::from(value),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -57,16 +57,16 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
         ExprKind::Constant {
             value: Constant::Str(..),
             ..
-        } => return checker.locator.slice(Range::from_located(default)).len() <= 50,
+        } => return checker.locator.slice(default).len() <= 50,
         ExprKind::Constant {
             value: Constant::Bytes(..),
             ..
-        } => return checker.locator.slice(Range::from_located(default)).len() <= 50,
+        } => return checker.locator.slice(default).len() <= 50,
         ExprKind::Constant {
             value: Constant::Int(..),
             ..
         } => {
-            return checker.locator.slice(Range::from_located(default)).len() <= 10;
+            return checker.locator.slice(default).len() <= 10;
         }
         ExprKind::UnaryOp {
             op: Unaryop::USub,
@@ -77,7 +77,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                 ..
             } = &operand.node
             {
-                return checker.locator.slice(Range::from_located(operand)).len() <= 10;
+                return checker.locator.slice(operand).len() <= 10;
             }
         }
         ExprKind::BinOp {
@@ -101,7 +101,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                     ..
                 } = &left.node
                 {
-                    return checker.locator.slice(Range::from_located(left)).len() <= 10;
+                    return checker.locator.slice(left).len() <= 10;
                 } else if let ExprKind::UnaryOp {
                     op: Unaryop::USub,
                     operand,
@@ -114,7 +114,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                         ..
                     } = &operand.node
                     {
-                        return checker.locator.slice(Range::from_located(operand)).len() <= 10;
+                        return checker.locator.slice(operand).len() <= 10;
                     }
                 }
             }
@@ -151,7 +151,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                     if !is_valid_default_value_with_annotation(default, checker) {
                         checker.diagnostics.push(Diagnostic::new(
                             TypedArgumentSimpleDefaults,
-                            Range::from_located(default),
+                            Range::from(default),
                         ));
                     }
                 }
@@ -170,7 +170,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                     if !is_valid_default_value_with_annotation(default, checker) {
                         checker.diagnostics.push(Diagnostic::new(
                             TypedArgumentSimpleDefaults,
-                            Range::from_located(default),
+                            Range::from(default),
                         ));
                     }
                 }
@@ -192,7 +192,7 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                     if !is_valid_default_value_with_annotation(default, checker) {
                         checker.diagnostics.push(Diagnostic::new(
                             ArgumentSimpleDefaults,
-                            Range::from_located(default),
+                            Range::from(default),
                         ));
                     }
                 }
@@ -211,7 +211,7 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                     if !is_valid_default_value_with_annotation(default, checker) {
                         checker.diagnostics.push(Diagnostic::new(
                             ArgumentSimpleDefaults,
-                            Range::from_located(default),
+                            Range::from(default),
                         ));
                     }
                 }

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -102,7 +102,7 @@ pub fn unrecognized_platform(
     };
 
     let diagnostic_unrecognized_platform_check =
-        Diagnostic::new(UnrecognizedPlatformCheck, Range::from_located(expr));
+        Diagnostic::new(UnrecognizedPlatformCheck, Range::from(expr));
     if !checker
         .ctx
         .resolve_call_path(left)
@@ -143,7 +143,7 @@ pub fn unrecognized_platform(
                     UnrecognizedPlatformName {
                         platform: value.clone(),
                     },
-                    Range::from_located(right),
+                    Range::from(right),
                 ));
             }
         }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -163,7 +163,7 @@ where
                             AssertInExcept {
                                 name: id.to_string(),
                             },
-                            Range::from_located(current_assert),
+                            Range::from(current_assert),
                         ));
                     }
                 }
@@ -197,13 +197,13 @@ pub fn unittest_assertion(
                 // the assertion is part of a larger expression.
                 let fixable = checker.ctx.current_expr_parent().is_none()
                     && matches!(checker.ctx.current_stmt().node, StmtKind::Expr { .. })
-                    && !has_comments_in(Range::from_located(expr), checker.locator);
+                    && !has_comments_in(Range::from(expr), checker.locator);
                 let mut diagnostic = Diagnostic::new(
                     UnittestAssertion {
                         assertion: unittest_assert.to_string(),
                         fixable,
                     },
-                    Range::from_located(func),
+                    Range::from(func),
                 );
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
@@ -226,10 +226,7 @@ pub fn unittest_assertion(
 /// PT015
 pub fn assert_falsy(stmt: &Stmt, test: &Expr) -> Option<Diagnostic> {
     if is_falsy_constant(test) {
-        Some(Diagnostic::new(
-            AssertAlwaysFalse,
-            Range::from_located(stmt),
-        ))
+        Some(Diagnostic::new(AssertAlwaysFalse, Range::from(stmt)))
     } else {
         None
     }
@@ -435,9 +432,8 @@ pub fn composite_condition(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
     if matches!(composite, CompositionKind::Simple | CompositionKind::Mixed) {
         let fixable = matches!(composite, CompositionKind::Simple)
             && msg.is_none()
-            && !has_comments_in(Range::from_located(stmt), checker.locator);
-        let mut diagnostic =
-            Diagnostic::new(CompositeAssertion { fixable }, Range::from_located(stmt));
+            && !has_comments_in(Range::from(stmt), checker.locator);
+        let mut diagnostic = Diagnostic::new(CompositeAssertion { fixable }, Range::from(stmt));
         if fixable && checker.patch(diagnostic.kind.rule()) {
             if let Ok(fix) = fix_composite_condition(stmt, checker.locator, checker.stylist) {
                 diagnostic.amend(fix);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -27,16 +27,14 @@ pub fn fail_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[
 
         if let Some(msg) = msg {
             if is_empty_or_null_string(msg) {
-                checker.diagnostics.push(Diagnostic::new(
-                    FailWithoutMessage,
-                    Range::from_located(func),
-                ));
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(FailWithoutMessage, Range::from(func)));
             }
         } else {
-            checker.diagnostics.push(Diagnostic::new(
-                FailWithoutMessage,
-                Range::from_located(func),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(FailWithoutMessage, Range::from(func)));
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -246,7 +246,7 @@ fn pytest_fixture_parentheses(
             expected_parens: preferred.to_string(),
             actual_parens: actual.to_string(),
         },
-        Range::from_located(decorator),
+        Range::from(decorator),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(fix);
@@ -292,7 +292,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                     FixturePositionalArgs {
                         function: func_name.to_string(),
                     },
-                    Range::from_located(decorator),
+                    Range::from(decorator),
                 ));
             }
 
@@ -307,10 +307,8 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
 
                 if let Some(scope_keyword) = scope_keyword {
                     if keyword_is_literal(scope_keyword, "function") {
-                        let mut diagnostic = Diagnostic::new(
-                            ExtraneousScopeFunction,
-                            Range::from_located(scope_keyword),
-                        );
+                        let mut diagnostic =
+                            Diagnostic::new(ExtraneousScopeFunction, Range::from(scope_keyword));
                         if checker.patch(diagnostic.kind.rule()) {
                             match fix_extraneous_scope_function(
                                 checker.locator,
@@ -364,7 +362,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
             IncorrectFixtureNameUnderscore {
                 function: func_name.to_string(),
             },
-            Range::from_located(func),
+            Range::from(func),
         ));
     } else if checker
         .settings
@@ -378,7 +376,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
             MissingFixtureNameUnderscore {
                 function: func_name.to_string(),
             },
-            Range::from_located(func),
+            Range::from(func),
         ));
     }
 
@@ -391,7 +389,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
                             UselessYieldFixture {
                                 name: func_name.to_string(),
                             },
-                            Range::from_located(stmt),
+                            Range::from(stmt),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
@@ -420,7 +418,7 @@ fn check_test_function_args(checker: &mut Checker, args: &Arguments) {
                 FixtureParamWithoutValue {
                     name: name.to_string(),
                 },
-                Range::from_located(arg),
+                Range::from(arg),
             ));
         }
     });
@@ -431,7 +429,7 @@ fn check_fixture_decorator_name(checker: &mut Checker, decorator: &Expr) {
     if is_pytest_yield_fixture(decorator, checker) {
         checker.diagnostics.push(Diagnostic::new(
             DeprecatedYieldFixture,
-            Range::from_located(decorator),
+            Range::from(decorator),
         ));
     }
 }
@@ -451,7 +449,7 @@ fn check_fixture_addfinalizer(checker: &mut Checker, args: &Arguments, body: &[S
     if let Some(addfinalizer) = visitor.addfinalizer_call {
         checker.diagnostics.push(Diagnostic::new(
             FixtureFinalizerCallback,
-            Range::from_located(addfinalizer),
+            Range::from(addfinalizer),
         ));
     }
 }
@@ -468,7 +466,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
         {
             if name == "asyncio" {
                 let mut diagnostic =
-                    Diagnostic::new(UnnecessaryAsyncioMarkOnFixture, Range::from_located(mark));
+                    Diagnostic::new(UnnecessaryAsyncioMarkOnFixture, Range::from(mark));
                 if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);
@@ -485,7 +483,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
         {
             if name == "usefixtures" {
                 let mut diagnostic =
-                    Diagnostic::new(ErroneousUseFixturesOnFixture, Range::from_located(mark));
+                    Diagnostic::new(ErroneousUseFixturesOnFixture, Range::from(mark));
                 if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
@@ -27,7 +27,7 @@ pub fn import(import_from: &Stmt, name: &str, asname: Option<&str>) -> Option<Di
             if alias != name {
                 return Some(Diagnostic::new(
                     IncorrectPytestImport,
-                    Range::from_located(import_from),
+                    Range::from(import_from),
                 ));
             }
         }
@@ -52,7 +52,7 @@ pub fn import_from(
         if is_pytest_or_subpackage(module) {
             return Some(Diagnostic::new(
                 IncorrectPytestImport,
-                Range::from_located(import_from),
+                Range::from(import_from),
             ));
         }
     };

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -63,7 +63,7 @@ fn pytest_mark_parentheses(
             expected_parens: preferred.to_string(),
             actual_parens: actual.to_string(),
         },
-        Range::from_located(decorator),
+        Range::from(decorator),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(fix);
@@ -111,8 +111,7 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr) {
     }
 
     if !has_parameters {
-        let mut diagnostic =
-            Diagnostic::new(UseFixturesWithoutParameters, Range::from_located(decorator));
+        let mut diagnostic = Diagnostic::new(UseFixturesWithoutParameters, Range::from(decorator));
         if checker.patch(diagnostic.kind.rule()) {
             let at_start = Location::new(decorator.location.row(), decorator.location.column() - 1);
             diagnostic.amend(Fix::deletion(at_start, decorator.end_location.unwrap()));

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -97,7 +97,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
@@ -130,7 +130,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
@@ -172,7 +172,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
@@ -194,7 +194,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
@@ -223,7 +223,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             diagnostic.amend(Fix::replacement(
@@ -248,7 +248,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             ParametrizeNamesWrongType {
                                 expected: names_type,
                             },
-                            Range::from_located(expr),
+                            Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
@@ -295,7 +295,7 @@ fn check_values(checker: &mut Checker, names: &Expr, values: &Expr) {
                         values: values_type,
                         row: values_row_type,
                     },
-                    Range::from_located(values),
+                    Range::from(values),
                 ));
             }
             if is_multi_named {
@@ -309,7 +309,7 @@ fn check_values(checker: &mut Checker, names: &Expr, values: &Expr) {
                         values: values_type,
                         row: values_row_type,
                     },
-                    Range::from_located(values),
+                    Range::from(values),
                 ));
             }
             if is_multi_named {
@@ -325,7 +325,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
         ParametrizeNamesWrongType {
             expected: types::ParametrizeNameType::Csv,
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
 
     if checker.patch(diagnostic.kind.rule()) {
@@ -353,7 +353,7 @@ fn handle_value_rows(
                             values: values_type,
                             row: values_row_type,
                         },
-                        Range::from_located(elt),
+                        Range::from(elt),
                     ));
                 }
             }
@@ -364,7 +364,7 @@ fn handle_value_rows(
                             values: values_type,
                             row: values_row_type,
                         },
-                        Range::from_located(elt),
+                        Range::from(elt),
                     ));
                 }
             }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
@@ -84,7 +84,7 @@ fn check_patch_call(
             visitor.visit_expr(body);
 
             if !visitor.uses_args {
-                return Some(Diagnostic::new(PatchWithLambda, Range::from_located(call)));
+                return Some(Diagnostic::new(PatchWithLambda, Range::from(call)));
             }
         }
     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -73,10 +73,9 @@ pub fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: 
             .enabled(&Rule::RaisesWithoutException)
         {
             if args.is_empty() && keywords.is_empty() {
-                checker.diagnostics.push(Diagnostic::new(
-                    RaisesWithoutException,
-                    Range::from_located(func),
-                ));
+                checker
+                    .diagnostics
+                    .push(Diagnostic::new(RaisesWithoutException, Range::from(func)));
             }
         }
 
@@ -133,7 +132,7 @@ pub fn complex_raises(checker: &mut Checker, stmt: &Stmt, items: &[Withitem], bo
         if is_too_complex {
             checker.diagnostics.push(Diagnostic::new(
                 RaisesWithMultipleStatements,
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     }
@@ -168,7 +167,7 @@ fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
             RaisesTooBroad {
                 exception: call_path,
             },
-            Range::from_located(exception),
+            Range::from(exception),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -137,7 +137,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         ) {
             continue;
         }
-        let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, Range::from_located(stmt));
+        let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, Range::from(*stmt));
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "return".to_string(),
@@ -155,7 +155,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         if expr.is_some() {
             continue;
         }
-        let mut diagnostic = Diagnostic::new(ImplicitReturnValue, Range::from_located(stmt));
+        let mut diagnostic = Diagnostic::new(ImplicitReturnValue, Range::from(*stmt));
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "return None".to_string(),
@@ -212,7 +212,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
             if let Some(last_stmt) = orelse.last() {
                 implicit_return(checker, last_stmt);
             } else {
-                let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from_located(stmt));
+                let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from(stmt));
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         let mut content = String::new();
@@ -252,7 +252,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
             if let Some(last_stmt) = orelse.last() {
                 implicit_return(checker, last_stmt);
             } else {
-                let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from_located(stmt));
+                let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from(stmt));
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         let mut content = String::new();
@@ -291,7 +291,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     if is_noreturn_func(checker, func)
             ) => {}
         _ => {
-            let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from_located(stmt));
+            let mut diagnostic = Diagnostic::new(ImplicitReturn, Range::from(stmt));
             if checker.patch(diagnostic.kind.rule()) {
                 if let Some(indent) = indentation(checker.locator, stmt) {
                     let mut content = String::new();
@@ -383,10 +383,9 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack, expr: &Expr) {
         }
 
         if !stack.refs.contains_key(id.as_str()) {
-            checker.diagnostics.push(Diagnostic::new(
-                UnnecessaryAssign,
-                Range::from_located(expr),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(UnnecessaryAssign, Range::from(expr)));
             return;
         }
 
@@ -400,10 +399,9 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack, expr: &Expr) {
             return;
         }
 
-        checker.diagnostics.push(Diagnostic::new(
-            UnnecessaryAssign,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(UnnecessaryAssign, Range::from(expr)));
     }
 }
 
@@ -416,7 +414,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
         if matches!(child.node, StmtKind::Return { .. }) {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseReturn { branch },
-                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from(stmt)),
             );
             if checker.settings.rules.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -426,7 +424,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
         if matches!(child.node, StmtKind::Break) {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseBreak { branch },
-                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from(stmt)),
             );
             if checker.settings.rules.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -436,7 +434,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
         if matches!(child.node, StmtKind::Raise { .. }) {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseRaise { branch },
-                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from(stmt)),
             );
             if checker.settings.rules.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
@@ -446,7 +444,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
         if matches!(child.node, StmtKind::Continue) {
             let diagnostic = Diagnostic::new(
                 SuperfluousElseContinue { branch },
-                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from_located(stmt)),
+                elif_else_range(stmt, checker.locator).unwrap_or_else(|| Range::from(stmt)),
             );
             if checker.settings.rules.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -120,7 +120,7 @@ pub fn private_member_access(checker: &mut Checker, expr: &Expr) {
                 PrivateMemberAccess {
                     access: attr.to_string(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -194,7 +194,7 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 DuplicateIsinstanceCall {
                     name: arg_name.to_string(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Grab the types used in each duplicate `isinstance` call.
@@ -340,7 +340,7 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
             CompareWithTuple {
                 replacement: unparse_expr(&in_expr, checker.stylist),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             let unmatched: Vec<Expr> = values
@@ -407,7 +407,7 @@ pub fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     ExprAndNotExpr {
                         name: id.to_string(),
                     },
-                    Range::from_located(expr),
+                    Range::from(expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
@@ -461,7 +461,7 @@ pub fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     ExprOrNotExpr {
                         name: id.to_string(),
                     },
-                    Range::from_located(expr),
+                    Range::from(expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
@@ -490,7 +490,7 @@ pub fn expr_or_true(checker: &mut Checker, expr: &Expr) {
             ..
         } = &value.node
         {
-            let mut diagnostic = Diagnostic::new(ExprOrTrue, Range::from_located(value));
+            let mut diagnostic = Diagnostic::new(ExprOrTrue, Range::from(value));
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     "True".to_string(),
@@ -517,7 +517,7 @@ pub fn expr_and_false(checker: &mut Checker, expr: &Expr) {
             ..
         } = &value.node
         {
-            let mut diagnostic = Diagnostic::new(ExprAndFalse, Range::from_located(value));
+            let mut diagnostic = Diagnostic::new(ExprAndFalse, Range::from(value));
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     "False".to_string(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -67,7 +67,7 @@ pub fn use_capital_environment_variables(checker: &mut Checker, expr: &Expr) {
             expected: capital_env_var.clone(),
             original: env_var.clone(),
         },
-        Range::from_located(arg),
+        Range::from(arg),
     );
     if checker.patch(diagnostic.kind.rule()) {
         let new_env_var = create_expr(ExprKind::Constant {
@@ -109,7 +109,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             expected: capital_env_var.clone(),
             original: env_var.clone(),
         },
-        Range::from_located(slice),
+        Range::from(slice),
     );
     if checker.patch(diagnostic.kind.rule()) {
         let new_env_var = create_expr(ExprKind::Constant {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -275,7 +275,7 @@ pub fn nested_if_statements(
     let mut diagnostic = Diagnostic::new(
         CollapsibleIf { fixable },
         colon.map_or_else(
-            || Range::from_located(stmt),
+            || Range::from(stmt),
             |colon| Range::new(stmt.location, colon.end_location),
         ),
     );
@@ -349,10 +349,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
         && !has_comments(stmt, checker.locator)
         && (matches!(test.node, ExprKind::Compare { .. }) || checker.ctx.is_builtin("bool"));
 
-    let mut diagnostic = Diagnostic::new(
-        NeedlessBool { condition, fixable },
-        Range::from_located(stmt),
-    );
+    let mut diagnostic = Diagnostic::new(NeedlessBool { condition, fixable }, Range::from(stmt));
     if fixable && checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
             // If the condition is a comparison, we can replace it with the condition.
@@ -501,7 +498,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
             contents: contents.clone(),
             fixable,
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
@@ -729,7 +726,7 @@ pub fn manual_dict_lookup(
 
     checker
         .diagnostics
-        .push(Diagnostic::new(ManualDictLookup, Range::from_located(stmt)));
+        .push(Diagnostic::new(ManualDictLookup, Range::from(stmt)));
 }
 
 /// SIM401
@@ -849,7 +846,7 @@ pub fn use_dict_get_with_default(
             contents: contents.clone(),
             fixable,
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -98,7 +98,7 @@ pub fn explicit_true_false_in_ifexpr(
         IfExprWithTrueFalse {
             expr: unparse_expr(test, checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
@@ -153,7 +153,7 @@ pub fn explicit_false_true_in_ifexpr(
         IfExprWithFalseTrue {
             expr: unparse_expr(test, checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
@@ -202,7 +202,7 @@ pub fn twisted_arms_in_ifexpr(
             expr_body: unparse_expr(body, checker.stylist),
             expr_else: unparse_expr(orelse, checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -105,7 +105,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
             left: unparse_expr(left, checker.stylist),
             right: unparse_expr(&comparators[0], checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
@@ -156,7 +156,7 @@ pub fn negation_with_not_equal_op(
             left: unparse_expr(left, checker.stylist),
             right: unparse_expr(&comparators[0], checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
@@ -191,7 +191,7 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
         DoubleNegation {
             expr: unparse_expr(operand, checker.stylist),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -101,7 +101,7 @@ pub fn multiple_with_statements(
         let mut diagnostic = Diagnostic::new(
             MultipleWithStatements { fixable },
             colon.map_or_else(
-                || Range::from_located(with_stmt),
+                || Range::from(with_stmt),
                 |colon| Range::new(with_stmt.location, colon.end_location),
             ),
         );

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -48,8 +48,8 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: Range) {
     }
 
     // Slice exact content to preserve formatting.
-    let left_content = checker.locator.slice(Range::from_located(left));
-    let value_content = checker.locator.slice(Range::from_located(value));
+    let left_content = checker.locator.slice(left);
+    let value_content = checker.locator.slice(value);
 
     let mut diagnostic = Diagnostic::new(
         KeyInDict {
@@ -95,5 +95,5 @@ pub fn key_in_dict_compare(
     }
     let right = comparators.first().unwrap();
 
-    key_in_dict(checker, left, right, Range::from_located(expr));
+    key_in_dict(checker, left, right, Range::from(expr));
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -115,7 +115,7 @@ pub fn open_file_with_context_handler(checker: &mut Checker, func: &Expr) {
 
             checker.diagnostics.push(Diagnostic::new(
                 OpenFileWithContextHandler,
-                Range::from_located(func),
+                Range::from(func),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -220,7 +220,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     ReimplementedBuiltin {
                         repl: contents.clone(),
                     },
-                    Range::from_located(stmt),
+                    Range::from(stmt),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("any") {
                     diagnostic.amend(Fix::replacement(
@@ -297,7 +297,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     ReimplementedBuiltin {
                         repl: contents.clone(),
                     },
-                    Range::from_located(stmt),
+                    Range::from(stmt),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("all") {
                     diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -40,7 +40,7 @@ pub fn return_in_try_except_finally(
         if try_has_return || except_has_return {
             checker.diagnostics.push(Diagnostic::new(
                 ReturnInTryExceptFinally,
-                Range::from_located(finally_return),
+                Range::from(finally_return),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
@@ -65,7 +65,7 @@ pub fn use_contextlib_suppress(
             };
             checker.diagnostics.push(Diagnostic::new(
                 UseContextlibSuppress { exception },
-                Range::from_located(stmt),
+                Range::from(stmt),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -61,7 +61,7 @@ fn is_constant_like(expr: &Expr) -> bool {
 
 /// Generate a fix to reverse a comparison.
 fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Result<String> {
-    let range = Range::from_located(expr);
+    let range = Range::from(expr);
     let contents = locator.slice(range);
 
     let mut expression = match_expression(contents)?;
@@ -160,7 +160,7 @@ pub fn yoda_conditions(
             YodaConditions {
                 suggestion: Some(suggestion.to_string()),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
@@ -173,7 +173,7 @@ pub fn yoda_conditions(
     } else {
         checker.diagnostics.push(Diagnostic::new(
             YodaConditions { suggestion: None },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -63,7 +63,7 @@ pub fn name_is_banned(
                 name: full_name,
                 message: ban.msg.to_string(),
             },
-            Range::from_located(name),
+            Range::from(name),
         ));
     }
     None
@@ -83,7 +83,7 @@ pub fn name_or_parent_is_banned<T>(
                     name: name.to_string(),
                     message: ban.msg.to_string(),
                 },
-                Range::from_located(located),
+                Range::from(located),
             ));
         }
         match name.rfind('.') {
@@ -110,7 +110,7 @@ pub fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
                 name: banned_path.to_string(),
                 message: ban.msg.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -169,7 +169,7 @@ pub fn banned_relative_import(
             RelativeImports {
                 strictness: strictness.clone(),
             },
-            Range::from_located(stmt),
+            Range::from(stmt),
         );
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(fix) =

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -32,7 +32,7 @@ pub fn empty_type_checking_block<'a, 'b>(
     'b: 'a,
 {
     if body.len() == 1 && matches!(body[0].node, StmtKind::Pass) {
-        let mut diagnostic = Diagnostic::new(EmptyTypeCheckingBlock, Range::from_located(&body[0]));
+        let mut diagnostic = Diagnostic::new(EmptyTypeCheckingBlock, Range::from(&body[0]));
 
         // Delete the entire type-checking block.
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
@@ -51,8 +51,7 @@ pub fn replaceable_by_pathlib(checker: &mut Checker, expr: &Expr) {
                 _ => None,
             })
     {
-        let diagnostic =
-            Diagnostic::new::<DiagnosticKind>(diagnostic_kind, Range::from_located(expr));
+        let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, Range::from(expr));
 
         if checker.settings.rules.enabled(diagnostic.kind.rule()) {
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/isort/helpers.rs
+++ b/crates/ruff/src/rules/isort/helpers.rs
@@ -3,14 +3,13 @@ use rustpython_parser::{lexer, Mode, Tok};
 
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::source_code::Locator;
-use ruff_python_ast::types::Range;
 
 use super::types::TrailingComma;
 
 /// Return `true` if a `StmtKind::ImportFrom` statement ends with a magic
 /// trailing comma.
 pub fn trailing_comma(stmt: &Stmt, locator: &Locator) -> TrailingComma {
-    let contents = locator.slice(Range::from_located(stmt));
+    let contents = locator.slice(stmt);
     let mut count: usize = 0;
     let mut trailing_comma = TrailingComma::Absent;
     for (_, tok, _) in lexer::lex_located(contents, Mode::Module, stmt.location).flatten() {

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -69,7 +69,7 @@ pub fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
             NumpyDeprecatedTypeAlias {
                 type_name: type_name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
+++ b/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
@@ -123,7 +123,7 @@ pub fn numpy_legacy_random(checker: &mut Checker, expr: &Expr) {
             NumpyLegacyRandom {
                 method_name: method_name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -28,8 +28,5 @@ pub fn assignment_to_df(targets: &[Expr]) -> Option<Diagnostic> {
     if id != "df" {
         return None;
     }
-    Some(Diagnostic::new(
-        DfIsABadVariableName,
-        Range::from_located(target),
-    ))
+    Some(Diagnostic::new(DfIsABadVariableName, Range::from(target)))
 }

--- a/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
@@ -92,5 +92,5 @@ pub fn check_attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &E
 
     checker
         .diagnostics
-        .push(Diagnostic::new(violation, Range::from_located(attr_expr)));
+        .push(Diagnostic::new(violation, Range::from(attr_expr)));
 }

--- a/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
@@ -105,5 +105,5 @@ pub fn check_call(checker: &mut Checker, func: &Expr) {
 
     checker
         .diagnostics
-        .push(Diagnostic::new(violation, Range::from_located(func)));
+        .push(Diagnostic::new(violation, Range::from(func)));
 }

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -65,8 +65,7 @@ pub fn inplace_argument(
                 _ => false,
             };
             if is_true_literal {
-                let mut diagnostic =
-                    Diagnostic::new(UseOfInplaceArgument, Range::from_located(keyword));
+                let mut diagnostic = Diagnostic::new(UseOfInplaceArgument, Range::from(keyword));
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(fix) = fix_inplace_argument(
                         checker.locator,

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -24,7 +24,7 @@ pub fn use_of_pd_merge(func: &Expr) -> Option<Diagnostic> {
     if let ExprKind::Attribute { attr, value, .. } = &func.node {
         if let ExprKind::Name { id, .. } = &value.node {
             if id == "pd" && attr == "merge" {
-                return Some(Diagnostic::new(UseOfPdMerge, Range::from_located(func)));
+                return Some(Diagnostic::new(UseOfPdMerge, Range::from(func)));
             }
         }
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
@@ -29,7 +29,7 @@ pub fn invalid_argument_name(name: &str, arg: &Arg, ignore_names: &[String]) -> 
             InvalidArgumentName {
                 name: name.to_string(),
             },
-            Range::from_located(arg),
+            Range::from(arg),
         ));
     }
     None

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -89,7 +89,7 @@ pub fn invalid_first_argument_name_for_class_method(
             }
             return Some(Diagnostic::new(
                 InvalidFirstArgumentNameForClassMethod,
-                Range::from_located(arg),
+                Range::from(arg),
             ));
         }
     }

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -88,6 +88,6 @@ pub fn invalid_first_argument_name_for_method(
     }
     Some(Diagnostic::new(
         InvalidFirstArgumentNameForMethod,
-        Range::from_located(arg),
+        Range::from(arg),
     ))
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -42,7 +42,7 @@ pub fn mixed_case_variable_in_class_scope(
             MixedCaseVariableInClassScope {
                 name: name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -42,7 +42,7 @@ pub fn mixed_case_variable_in_global_scope(
             MixedCaseVariableInGlobalScope {
                 name: name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -76,7 +76,7 @@ pub fn non_lowercase_variable_in_function(
             NonLowercaseVariableInFunction {
                 name: name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -29,10 +29,9 @@ impl Violation for ModuleImportNotAtTopOfFile {
 
 pub fn multiple_imports_on_one_line(checker: &mut Checker, stmt: &Stmt, names: &[Alias]) {
     if names.len() > 1 {
-        checker.diagnostics.push(Diagnostic::new(
-            MultipleImportsOnOneLine,
-            Range::from_located(stmt),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(MultipleImportsOnOneLine, Range::from(stmt)));
     }
 }
 
@@ -40,7 +39,7 @@ pub fn module_import_not_at_top_of_file(checker: &mut Checker, stmt: &Stmt) {
     if checker.ctx.seen_import_boundary && stmt.location.column() == 0 {
         checker.diagnostics.push(Diagnostic::new(
             ModuleImportNotAtTopOfFile,
-            Range::from_located(stmt),
+            Range::from(stmt),
         ));
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -48,7 +48,7 @@ pub fn lambda_assignment(checker: &mut Checker, target: &Expr, value: &Expr, stm
                     name: id.to_string(),
                     fixable,
                 },
-                Range::from_located(stmt),
+                Range::from(stmt),
             );
 
             if checker.patch(diagnostic.kind.rule())

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -116,7 +116,7 @@ pub fn literal_comparisons(
         {
             if matches!(op, Cmpop::Eq) {
                 let diagnostic =
-                    Diagnostic::new(NoneComparison(op.into()), Range::from_located(comparator));
+                    Diagnostic::new(NoneComparison(op.into()), Range::from(comparator));
                 if checker.patch(diagnostic.kind.rule()) {
                     bad_ops.insert(0, Cmpop::Is);
                 }
@@ -124,7 +124,7 @@ pub fn literal_comparisons(
             }
             if matches!(op, Cmpop::NotEq) {
                 let diagnostic =
-                    Diagnostic::new(NoneComparison(op.into()), Range::from_located(comparator));
+                    Diagnostic::new(NoneComparison(op.into()), Range::from(comparator));
                 if checker.patch(diagnostic.kind.rule()) {
                     bad_ops.insert(0, Cmpop::IsNot);
                 }
@@ -141,7 +141,7 @@ pub fn literal_comparisons(
                 if matches!(op, Cmpop::Eq) {
                     let diagnostic = Diagnostic::new(
                         TrueFalseComparison(value, op.into()),
-                        Range::from_located(comparator),
+                        Range::from(comparator),
                     );
                     if checker.patch(diagnostic.kind.rule()) {
                         bad_ops.insert(0, Cmpop::Is);
@@ -151,7 +151,7 @@ pub fn literal_comparisons(
                 if matches!(op, Cmpop::NotEq) {
                     let diagnostic = Diagnostic::new(
                         TrueFalseComparison(value, op.into()),
-                        Range::from_located(comparator),
+                        Range::from(comparator),
                     );
                     if checker.patch(diagnostic.kind.rule()) {
                         bad_ops.insert(0, Cmpop::IsNot);
@@ -179,16 +179,14 @@ pub fn literal_comparisons(
             )
         {
             if matches!(op, Cmpop::Eq) {
-                let diagnostic =
-                    Diagnostic::new(NoneComparison(op.into()), Range::from_located(next));
+                let diagnostic = Diagnostic::new(NoneComparison(op.into()), Range::from(next));
                 if checker.patch(diagnostic.kind.rule()) {
                     bad_ops.insert(idx, Cmpop::Is);
                 }
                 diagnostics.push(diagnostic);
             }
             if matches!(op, Cmpop::NotEq) {
-                let diagnostic =
-                    Diagnostic::new(NoneComparison(op.into()), Range::from_located(next));
+                let diagnostic = Diagnostic::new(NoneComparison(op.into()), Range::from(next));
                 if checker.patch(diagnostic.kind.rule()) {
                     bad_ops.insert(idx, Cmpop::IsNot);
                 }
@@ -203,20 +201,16 @@ pub fn literal_comparisons(
             } = next.node
             {
                 if matches!(op, Cmpop::Eq) {
-                    let diagnostic = Diagnostic::new(
-                        TrueFalseComparison(value, op.into()),
-                        Range::from_located(next),
-                    );
+                    let diagnostic =
+                        Diagnostic::new(TrueFalseComparison(value, op.into()), Range::from(next));
                     if checker.patch(diagnostic.kind.rule()) {
                         bad_ops.insert(idx, Cmpop::Is);
                     }
                     diagnostics.push(diagnostic);
                 }
                 if matches!(op, Cmpop::NotEq) {
-                    let diagnostic = Diagnostic::new(
-                        TrueFalseComparison(value, op.into()),
-                        Range::from_located(next),
-                    );
+                    let diagnostic =
+                        Diagnostic::new(TrueFalseComparison(value, op.into()), Range::from(next));
                     if checker.patch(diagnostic.kind.rule()) {
                         bad_ops.insert(idx, Cmpop::IsNot);
                     }

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -59,8 +59,7 @@ pub fn not_tests(
                 match op {
                     Cmpop::In => {
                         if check_not_in {
-                            let mut diagnostic =
-                                Diagnostic::new(NotInTest, Range::from_located(operand));
+                            let mut diagnostic = Diagnostic::new(NotInTest, Range::from(operand));
                             if checker.patch(diagnostic.kind.rule()) && should_fix {
                                 diagnostic.amend(Fix::replacement(
                                     compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
@@ -73,8 +72,7 @@ pub fn not_tests(
                     }
                     Cmpop::Is => {
                         if check_not_is {
-                            let mut diagnostic =
-                                Diagnostic::new(NotIsTest, Range::from_located(operand));
+                            let mut diagnostic = Diagnostic::new(NotIsTest, Range::from(operand));
                             if checker.patch(diagnostic.kind.rule()) && should_fix {
                                 diagnostic.amend(Fix::replacement(
                                     compare(left, &[Cmpop::IsNot], comparators, checker.stylist),

--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -33,7 +33,7 @@ pub fn backslashes(checker: &mut Checker, docstring: &Docstring) {
     if BACKSLASH_REGEX.is_match(contents) {
         checker.diagnostics.push(Diagnostic::new(
             EscapeSequenceInDocstring,
-            Range::from_located(docstring.expr),
+            Range::from(docstring.expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -59,7 +59,7 @@ pub fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
             BlankLineAfterSummary {
                 num_lines: blanks_count,
             },
-            Range::from_located(docstring.expr),
+            Range::from(docstring.expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             if blanks_count > 1 {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -91,7 +91,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                     NoBlankLineBeforeClass {
                         lines: blank_lines_before,
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
@@ -113,7 +113,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                     OneBlankLineBeforeClass {
                         lines: blank_lines_before,
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
@@ -156,7 +156,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 OneBlankLineAfterClass {
                     lines: blank_lines_after,
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -78,7 +78,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
                 NoBlankLineBeforeFunction {
                     num_lines: blank_lines_before,
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
@@ -133,7 +133,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
                 NoBlankLineAfterFunction {
                     num_lines: blank_lines_after,
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -46,6 +46,6 @@ pub fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     };
     checker.diagnostics.push(Diagnostic::new(
         FirstLineCapitalized,
-        Range::from_located(docstring.expr),
+        Range::from(docstring.expr),
     ));
 }

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -60,7 +60,7 @@ pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
         let trimmed = line.trim_end();
 
         if !trimmed.ends_with('.') {
-            let mut diagnostic = Diagnostic::new(EndsInPeriod, Range::from_located(docstring.expr));
+            let mut diagnostic = Diagnostic::new(EndsInPeriod, Range::from(docstring.expr));
             // Best-effort autofix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule())
                 && !trimmed.ends_with(':')

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -59,8 +59,7 @@ pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {
         let line = body.lines().nth(index).unwrap();
         let trimmed = line.trim_end();
         if !(trimmed.ends_with('.') || trimmed.ends_with('!') || trimmed.ends_with('?')) {
-            let mut diagnostic =
-                Diagnostic::new(EndsInPunctuation, Range::from_located(docstring.expr));
+            let mut diagnostic = Diagnostic::new(EndsInPunctuation, Range::from(docstring.expr));
             // Best-effort autofix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule())
                 && !trimmed.ends_with(':')

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -123,7 +123,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
         if has_seen_tab {
             checker.diagnostics.push(Diagnostic::new(
                 IndentWithSpaces,
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             ));
         }
     }

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -59,10 +59,8 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
             .rules
             .enabled(&Rule::MultiLineSummaryFirstLine)
         {
-            let mut diagnostic = Diagnostic::new(
-                MultiLineSummaryFirstLine,
-                Range::from_located(docstring.expr),
-            );
+            let mut diagnostic =
+                Diagnostic::new(MultiLineSummaryFirstLine, Range::from(docstring.expr));
             if checker.patch(diagnostic.kind.rule()) {
                 let location = docstring.expr.location;
                 let mut end_row = location.row() + 1;
@@ -86,10 +84,8 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
             .rules
             .enabled(&Rule::MultiLineSummarySecondLine)
         {
-            let mut diagnostic = Diagnostic::new(
-                MultiLineSummarySecondLine,
-                Range::from_located(docstring.expr),
-            );
+            let mut diagnostic =
+                Diagnostic::new(MultiLineSummarySecondLine, Range::from(docstring.expr));
             if checker.patch(diagnostic.kind.rule()) {
                 let mut indentation = String::from(docstring.indentation);
                 let mut fixable = true;

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -37,10 +37,8 @@ pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring
         if line_count > 1 {
             if let Some(last_line) = contents.lines().last().map(str::trim) {
                 if last_line != "\"\"\"" && last_line != "'''" {
-                    let mut diagnostic = Diagnostic::new(
-                        NewLineAfterLastParagraph,
-                        Range::from_located(docstring.expr),
-                    );
+                    let mut diagnostic =
+                        Diagnostic::new(NewLineAfterLastParagraph, Range::from(docstring.expr));
                     if checker.patch(diagnostic.kind.rule()) {
                         // Insert a newline just before the end-quote(s).
                         let num_trailing_quotes = "'''".len();

--- a/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
@@ -39,8 +39,7 @@ pub fn no_signature(checker: &mut Checker, docstring: &Docstring) {
     if !first_line.contains(&format!("{name}(")) {
         return;
     };
-    checker.diagnostics.push(Diagnostic::new(
-        NoSignature,
-        Range::from_located(docstring.expr),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(NoSignature, Range::from(docstring.expr)));
 }

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -40,8 +40,7 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
     if line == trimmed {
         return;
     }
-    let mut diagnostic =
-        Diagnostic::new(NoSurroundingWhitespace, Range::from_located(docstring.expr));
+    let mut diagnostic = Diagnostic::new(NoSurroundingWhitespace, Range::from(docstring.expr));
     if checker.patch(diagnostic.kind.rule()) {
         if let Some(pattern) = leading_quote(contents) {
             // If removing whitespace would lead to an invalid string of quote

--- a/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -64,7 +64,7 @@ pub fn non_imperative_mood(
     if let Some(false) = MOOD.is_imperative(&first_word_norm) {
         let diagnostic = Diagnostic::new(
             NonImperativeMood(line.to_string()),
-            Range::from_located(docstring.expr),
+            Range::from(docstring.expr),
         );
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
@@ -23,10 +23,9 @@ pub fn not_empty(checker: &mut Checker, docstring: &Docstring) -> bool {
     }
 
     if checker.settings.rules.enabled(&Rule::EmptyDocstring) {
-        checker.diagnostics.push(Diagnostic::new(
-            EmptyDocstring,
-            Range::from_located(docstring.expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(EmptyDocstring, Range::from(docstring.expr)));
     }
     false
 }

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -38,7 +38,7 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
     }
 
     if non_empty_line_count == 1 && line_count > 1 {
-        let mut diagnostic = Diagnostic::new(FitsOnOneLine, Range::from_located(docstring.expr));
+        let mut diagnostic = Diagnostic::new(FitsOnOneLine, Range::from(docstring.expr));
         if checker.patch(diagnostic.kind.rule()) {
             if let (Some(leading), Some(trailing)) = (
                 leading_quote(docstring.contents),

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -359,7 +359,7 @@ fn blanks_and_section_underline(
                 DashedUnderlineAfterSection {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a dashed line (of the appropriate length) under the section header.
@@ -384,7 +384,7 @@ fn blanks_and_section_underline(
                 EmptyDocstringSection {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             ));
         }
         return;
@@ -406,7 +406,7 @@ fn blanks_and_section_underline(
                     SectionUnderlineAfterName {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and the underline.
@@ -444,7 +444,7 @@ fn blanks_and_section_underline(
                     SectionUnderlineMatchesSectionLength {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Replace the existing underline with a line of the appropriate length.
@@ -488,7 +488,7 @@ fn blanks_and_section_underline(
                     SectionUnderlineNotOverIndented {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Replace the existing indentation with whitespace of the appropriate length.
@@ -530,7 +530,7 @@ fn blanks_and_section_underline(
                             EmptyDocstringSection {
                                 name: context.section_name.to_string(),
                             },
-                            Range::from_located(docstring.expr),
+                            Range::from(docstring.expr),
                         ));
                     }
                 } else {
@@ -543,7 +543,7 @@ fn blanks_and_section_underline(
                             NoBlankLinesBetweenHeaderAndContent {
                                 name: context.section_name.to_string(),
                             },
-                            Range::from_located(docstring.expr),
+                            Range::from(docstring.expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
@@ -575,7 +575,7 @@ fn blanks_and_section_underline(
                     EmptyDocstringSection {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 ));
             }
         }
@@ -589,7 +589,7 @@ fn blanks_and_section_underline(
                 DashedUnderlineAfterSection {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a dashed line (of the appropriate length) under the section header.
@@ -619,7 +619,7 @@ fn blanks_and_section_underline(
                     NoBlankLinesBetweenHeaderAndContent {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and content.
@@ -651,7 +651,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 CapitalizeSectionName {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the section title with the capitalized variant. This requires
@@ -688,7 +688,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 SectionNotOverIndented {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the existing indentation with whitespace of the appropriate length.
@@ -721,7 +721,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                     BlankLineAfterLastSection {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
@@ -744,7 +744,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                     BlankLineAfterSection {
                         name: context.section_name.to_string(),
                     },
-                    Range::from_located(docstring.expr),
+                    Range::from(docstring.expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
@@ -774,7 +774,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 BlankLineBeforeSection {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
@@ -969,7 +969,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
                 NewLineAfterSectionName {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the suffix. This requires locating the end of the section name.
@@ -1020,7 +1020,7 @@ fn google_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 SectionNameEndsInColon {
                     name: context.section_name.to_string(),
                 },
-                Range::from_located(docstring.expr),
+                Range::from(docstring.expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix. This requires locating the end of the section name.

--- a/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -34,6 +34,6 @@ pub fn starts_with_this(checker: &mut Checker, docstring: &Docstring) {
     }
     checker.diagnostics.push(Diagnostic::new(
         DocstringStartsWithThis,
-        Range::from_located(docstring.expr),
+        Range::from(docstring.expr),
     ));
 }

--- a/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -42,7 +42,7 @@ pub fn triple_quotes(checker: &mut Checker, docstring: &Docstring) {
     if !starts_with_triple {
         checker.diagnostics.push(Diagnostic::new(
             TripleSingleQuotes,
-            Range::from_located(docstring.expr),
+            Range::from(docstring.expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -17,7 +17,7 @@ pub fn remove_unused_format_arguments_from_dict(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<Fix> {
-    let module_text = locator.slice(Range::from_located(stmt));
+    let module_text = locator.slice(stmt);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
 
@@ -115,7 +115,7 @@ pub fn remove_exception_handler_assignment(
     excepthandler: &Excepthandler,
     locator: &Locator,
 ) -> Result<Fix> {
-    let contents = locator.slice(Range::from_located(excepthandler));
+    let contents = locator.slice(excepthandler);
     let mut fix_start = None;
     let mut fix_end = None;
 

--- a/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
@@ -23,7 +23,7 @@ pub fn assert_tuple(checker: &mut Checker, stmt: &Stmt, test: &Expr) {
         if !elts.is_empty() {
             checker
                 .diagnostics
-                .push(Diagnostic::new(AssertTuple, Range::from_located(stmt)));
+                .push(Diagnostic::new(AssertTuple, Range::from(stmt)));
         }
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -46,6 +46,6 @@ pub fn break_outside_loop<'a>(
     if allowed {
         None
     } else {
-        Some(Diagnostic::new(BreakOutsideLoop, Range::from_located(stmt)))
+        Some(Diagnostic::new(BreakOutsideLoop, Range::from(stmt)))
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -46,9 +46,6 @@ pub fn continue_outside_loop<'a>(
     if allowed {
         None
     } else {
-        Some(Diagnostic::new(
-            ContinueOutsideLoop,
-            Range::from_located(stmt),
-        ))
+        Some(Diagnostic::new(ContinueOutsideLoop, Range::from(stmt)))
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
@@ -23,7 +23,7 @@ pub fn if_tuple(checker: &mut Checker, stmt: &Stmt, test: &Expr) {
         if !elts.is_empty() {
             checker
                 .diagnostics
-                .push(Diagnostic::new(IfTuple, Range::from_located(stmt)));
+                .push(Diagnostic::new(IfTuple, Range::from(stmt)));
         }
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/imports.rs
@@ -138,7 +138,7 @@ pub fn future_feature_not_defined(checker: &mut Checker, alias: &Alias) {
             FutureFeatureNotDefined {
                 name: alias.node.name.to_string(),
             },
-            Range::from_located(alias),
+            Range::from(alias),
         ));
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -28,8 +28,7 @@ pub fn invalid_print_syntax(checker: &mut Checker, left: &Expr) {
     if !checker.ctx.is_builtin("print") {
         return;
     };
-    checker.diagnostics.push(Diagnostic::new(
-        InvalidPrintSyntax,
-        Range::from_located(left),
-    ));
+    checker
+        .diagnostics
+        .push(Diagnostic::new(InvalidPrintSyntax, Range::from(left)));
 }

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -46,7 +46,7 @@ pub fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     let Some(expr) = match_not_implemented(expr) else {
         return;
     };
-    let mut diagnostic = Diagnostic::new(RaiseNotImplemented, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(RaiseNotImplemented, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             "NotImplementedError".to_string(),

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -107,7 +107,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                                     name: unparse_expr(key, checker.stylist),
                                     repeated_value: is_duplicate_value,
                                 },
-                                Range::from_located(key),
+                                Range::from(key),
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
@@ -135,7 +135,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                                     name: dict_key.to_string(),
                                     repeated_value: is_duplicate_value,
                                 },
-                                Range::from_located(key),
+                                Range::from(key),
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -23,10 +23,9 @@ pub fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
             checker.ctx.scopes[index].kind,
             ScopeKind::Class(_) | ScopeKind::Module
         ) {
-            checker.diagnostics.push(Diagnostic::new(
-                ReturnOutsideFunction,
-                Range::from_located(stmt),
-            ));
+            checker
+                .diagnostics
+                .push(Diagnostic::new(ReturnOutsideFunction, Range::from(stmt)));
         }
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -53,7 +53,7 @@ pub fn yield_outside_function(checker: &mut Checker, expr: &Expr) {
         };
         checker.diagnostics.push(Diagnostic::new(
             YieldOutsideFunction { keyword },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -26,9 +26,8 @@ pub fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {
             call_path.as_slice() == ["logging", "warn"]
         })
     {
-        checker.diagnostics.push(Diagnostic::new(
-            DeprecatedLogWarn,
-            Range::from_located(func),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(DeprecatedLogWarn, Range::from(func)));
     }
 }

--- a/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -29,5 +29,5 @@ pub fn no_eval(checker: &mut Checker, func: &Expr) {
     }
     checker
         .diagnostics
-        .push(Diagnostic::new(NoEval, Range::from_located(func)));
+        .push(Diagnostic::new(NoEval, Range::from(func)));
 }

--- a/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
@@ -31,9 +31,8 @@ pub fn await_outside_async(checker: &mut Checker, expr: &Expr) {
         })
         .unwrap_or(true)
     {
-        checker.diagnostics.push(Diagnostic::new(
-            AwaitOutsideAsync,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(AwaitOutsideAsync, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -134,7 +134,7 @@ pub fn bad_str_strip_call(checker: &mut Checker, func: &Expr, args: &[Expr]) {
                             };
                             checker.diagnostics.push(Diagnostic::new(
                                 BadStrStripCall { strip, removal },
-                                Range::from_located(arg),
+                                Range::from(arg),
                             ));
                         }
                     }

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
@@ -244,7 +244,7 @@ fn is_valid_dict(
 /// PLE1307
 pub fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) {
     // Grab each string segment (in case there's an implicit concatenation).
-    let content = checker.locator.slice(Range::from_located(expr));
+    let content = checker.locator.slice(expr);
     let mut strings: Vec<(Location, Location)> = vec![];
     for (start, tok, end) in lexer::lex_located(content, Mode::Module, expr.location).flatten() {
         if matches!(tok, Tok::String { .. }) {
@@ -283,9 +283,8 @@ pub fn bad_string_format_type(checker: &mut Checker, expr: &Expr, right: &Expr) 
         _ => true,
     };
     if !is_valid {
-        checker.diagnostics.push(Diagnostic::new(
-            BadStringFormatType,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(BadStringFormatType, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
+++ b/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
@@ -30,10 +30,7 @@ pub fn collapsible_else_if(orelse: &[Stmt], locator: &Locator) -> Option<Diagnos
                 })
                 .starts_with("if")
             {
-                return Some(Diagnostic::new(
-                    CollapsibleElseIf,
-                    Range::from_located(first),
-                ));
+                return Some(Diagnostic::new(CollapsibleElseIf, Range::from(first)));
             }
         }
     }

--- a/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
@@ -113,7 +113,7 @@ pub fn comparison_of_constant(
                     op: op.into(),
                     right_constant: unparse_constant(right_constant, checker.stylist),
                 },
-                Range::from_located(left),
+                Range::from(left),
             );
 
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
+++ b/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
@@ -115,7 +115,7 @@ pub fn consider_using_sys_exit(checker: &mut Checker, func: &Expr) {
             ConsiderUsingSysExit {
                 name: name.to_string(),
             },
-            Range::from_located(func),
+            Range::from(func),
         );
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(content) = get_member_import_name_alias(checker, "sys", "exit") {

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
@@ -18,5 +18,5 @@ impl Violation for InvalidAllFormat {
 
 /// PLE0605
 pub fn invalid_all_format(expr: &Expr) -> Diagnostic {
-    Diagnostic::new(InvalidAllFormat, Range::from_located(expr))
+    Diagnostic::new(InvalidAllFormat, Range::from(expr))
 }

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
@@ -18,5 +18,5 @@ impl Violation for InvalidAllObject {
 
 /// PLE0604
 pub fn invalid_all_object(expr: &Expr) -> Diagnostic {
-    Diagnostic::new(InvalidAllObject, Range::from_located(expr))
+    Diagnostic::new(InvalidAllObject, Range::from(expr))
 }

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -125,10 +125,9 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
 
                         if checker.settings.rules.enabled(&Rule::LoggingTooManyArgs) {
                             if summary.num_positional < message_args {
-                                checker.diagnostics.push(Diagnostic::new(
-                                    LoggingTooManyArgs,
-                                    Range::from_located(func),
-                                ));
+                                checker
+                                    .diagnostics
+                                    .push(Diagnostic::new(LoggingTooManyArgs, Range::from(func)));
                             }
                         }
 
@@ -137,10 +136,9 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
                                 && call_args.kwargs.is_empty()
                                 && summary.num_positional > message_args
                             {
-                                checker.diagnostics.push(Diagnostic::new(
-                                    LoggingTooFewArgs,
-                                    Range::from_located(func),
-                                ));
+                                checker
+                                    .diagnostics
+                                    .push(Diagnostic::new(LoggingTooFewArgs, Range::from(func)));
                             }
                         }
                     }

--- a/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
@@ -82,7 +82,7 @@ pub fn magic_value_comparison(checker: &mut Checker, left: &Expr, comparators: &
                     MagicValueComparison {
                         value: unparse_expr(comparison_expr, checker.stylist),
                     },
-                    Range::from_located(comparison_expr),
+                    Range::from(comparison_expr),
                 ));
             }
         }

--- a/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
+++ b/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
@@ -69,7 +69,7 @@ pub fn merge_isinstance(checker: &mut Checker, expr: &Expr, op: &Boolop, values:
                         .sorted()
                         .collect(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             ));
         }
     }

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -346,7 +346,7 @@ pub fn redefined_loop_name<'a, 'b>(checker: &'a mut Checker<'b>, node: &Node<'b>
                         outer_kind: outer_assignment_target.binding_kind,
                         inner_kind: inner_assignment_target.binding_kind,
                     },
-                    Range::from_located(inner_assignment_target.expr),
+                    Range::from(inner_assignment_target.expr),
                 ));
             }
         }

--- a/crates/ruff/src/rules/pylint/rules/return_in_init.rs
+++ b/crates/ruff/src/rules/pylint/rules/return_in_init.rs
@@ -67,6 +67,6 @@ pub fn return_in_init(checker: &mut Checker, stmt: &Stmt) {
     if in_dunder_init(checker) {
         checker
             .diagnostics
-            .push(Diagnostic::new(ReturnInInit, Range::from_located(stmt)));
+            .push(Diagnostic::new(ReturnInInit, Range::from(stmt)));
     }
 }

--- a/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -22,7 +22,7 @@ pub fn unnecessary_direct_lambda_call(checker: &mut Checker, expr: &Expr, func: 
     if let ExprKind::Lambda { .. } = &func.node {
         checker.diagnostics.push(Diagnostic::new(
             UnnecessaryDirectLambdaCall,
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 }

--- a/crates/ruff/src/rules/pylint/rules/use_from_import.rs
+++ b/crates/ruff/src/rules/pylint/rules/use_from_import.rs
@@ -52,7 +52,7 @@ pub fn use_from_import(checker: &mut Checker, stmt: &Stmt, alias: &Alias, names:
             name: name.to_string(),
             fixable,
         },
-        Range::from_located(alias),
+        Range::from(alias),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
@@ -34,7 +34,7 @@ pub fn used_prior_global_declaration(checker: &mut Checker, name: &str, expr: &E
                     name: name.to_string(),
                     line: stmt.location.row(),
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             ));
         }
     }

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -34,7 +34,7 @@ pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(UselessImportAlias, Range::from_located(alias));
+    let mut diagnostic = Diagnostic::new(UselessImportAlias, Range::from(alias));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             asname.to_string(),

--- a/crates/ruff/src/rules/pylint/rules/yield_in_init.rs
+++ b/crates/ruff/src/rules/pylint/rules/yield_in_init.rs
@@ -42,6 +42,6 @@ pub fn yield_in_init(checker: &mut Checker, expr: &Expr) {
     if in_dunder_init(checker) {
         checker
             .diagnostics
-            .push(Diagnostic::new(YieldInInit, Range::from_located(expr)));
+            .push(Diagnostic::new(YieldInInit, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -68,7 +68,7 @@ pub fn remove_class_def_base(
 
 /// Generate a fix to remove arguments from a `super` call.
 pub fn remove_super_arguments(locator: &Locator, stylist: &Stylist, expr: &Expr) -> Option<Fix> {
-    let range = Range::from_located(expr);
+    let range = Range::from(expr);
     let contents = locator.slice(range);
 
     let mut tree = libcst_native::parse_module(contents, None).ok()?;

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -203,7 +203,7 @@ pub fn convert_named_tuple_functional_to_class(
             name: typename.to_string(),
             fixable,
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(convert_to_class(

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -251,7 +251,7 @@ pub fn convert_typed_dict_functional_to_class(
             name: class_name.to_string(),
             fixable,
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(convert_to_class(

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -41,10 +41,8 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
         })
     {
         let straight_import = collect_call_path(expr).as_slice() == ["datetime", "timezone", "utc"];
-        let mut diagnostic = Diagnostic::new(
-            DatetimeTimezoneUTC { straight_import },
-            Range::from_located(expr),
-        );
+        let mut diagnostic =
+            Diagnostic::new(DatetimeTimezoneUTC { straight_import }, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             if straight_import {
                 diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -68,7 +68,7 @@ pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
             alias: attr.to_string(),
             target: target.to_string(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -46,7 +46,7 @@ impl<'a> FormatSummaryValues<'a> {
         let mut extracted_kwargs: FxHashMap<&str, String> = FxHashMap::default();
         if let ExprKind::Call { args, keywords, .. } = &expr.node {
             for arg in args {
-                let arg = checker.locator.slice(Range::from_located(arg));
+                let arg = checker.locator.slice(arg);
                 if contains_invalids(arg) {
                     return None;
                 }
@@ -55,7 +55,7 @@ impl<'a> FormatSummaryValues<'a> {
             for keyword in keywords {
                 let KeywordData { arg, value } = &keyword.node;
                 if let Some(key) = arg {
-                    let kwarg = checker.locator.slice(Range::from_located(value));
+                    let kwarg = checker.locator.slice(value);
                     if contains_invalids(kwarg) {
                         return None;
                     }
@@ -126,7 +126,7 @@ fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
         return None;
     };
 
-    let contents = checker.locator.slice(Range::from_located(value));
+    let contents = checker.locator.slice(value);
 
     // Tokenize: we need to avoid trying to fix implicit string concatenations.
     if lexer::lex(contents, Mode::Module)
@@ -259,12 +259,12 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
     };
 
     // Avoid refactors that increase the resulting string length.
-    let existing = checker.locator.slice(Range::from_located(expr));
+    let existing = checker.locator.slice(expr);
     if contents.len() > existing.len() {
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(FString, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(FString, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -87,7 +87,7 @@ fn generate_call(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(Range::from_located(expr));
+    let module_text = locator.slice(expr);
     let mut expression = match_expression(module_text)?;
     let mut call = match_call(&mut expression)?;
 
@@ -140,7 +140,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(FormatLiterals, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(FormatLiterals, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         // Currently, the only issue we know of is in LibCST:
         // https://github.com/Instagram/LibCST/issues/846

--- a/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
@@ -361,7 +361,7 @@ impl<'a> ImportReplacer<'a> {
 
             let matched = ImportReplacer::format_import_from(&matched_names, target);
             let unmatched = fixes::remove_import_members(
-                self.locator.slice(Range::from_located(self.stmt)),
+                self.locator.slice(self.stmt),
                 &matched_names
                     .iter()
                     .map(|name| name.name.as_str())
@@ -454,7 +454,7 @@ pub fn import_replacements(
                     .collect(),
                 fixable: replacement.content.is_some(),
             },
-            Range::from_located(stmt),
+            Range::from(stmt),
         );
         if checker.patch(&Rule::ImportReplacements) {
             if let Some(content) = replacement.content {

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -65,7 +65,7 @@ pub fn native_literals(
                 LiteralType::Str
             } else {
                 LiteralType::Bytes
-            }}, Range::from_located(expr));
+            }}, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     if id == "bytes" {
@@ -117,7 +117,7 @@ pub fn native_literals(
         // rust-python merges adjacent string/bytes literals into one node, but we can't
         // safely remove the outer call in this situation. We're following pyupgrade
         // here and skip.
-        let arg_code = checker.locator.slice(Range::from_located(arg));
+        let arg_code = checker.locator.slice(arg);
         if lexer::lex_located(arg_code, Mode::Module, arg.location)
             .flatten()
             .filter(|(_, tok, _)| matches!(tok, Tok::String { .. }))
@@ -135,7 +135,7 @@ pub fn native_literals(
                     LiteralType::Bytes
                 },
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -29,7 +29,7 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
     {
-        let mut diagnostic = Diagnostic::new(OpenAlias, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(OpenAlias, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "open".to_string(),

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -170,7 +170,7 @@ fn handle_making_changes(
             OSErrorAlias {
                 name: compose_call_path(target),
             },
-            Range::from_located(target),
+            Range::from(target),
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -348,7 +348,7 @@ pub fn outdated_version_block(
                 if op == &Cmpop::Lt || op == &Cmpop::LtE {
                     if compare_version(&version, target, op == &Cmpop::LtE) {
                         let mut diagnostic =
-                            Diagnostic::new(OutdatedVersionBlock, Range::from_located(stmt));
+                            Diagnostic::new(OutdatedVersionBlock, Range::from(stmt));
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(block) = metadata(checker.locator, stmt) {
                                 if let Some(fix) =
@@ -363,7 +363,7 @@ pub fn outdated_version_block(
                 } else if op == &Cmpop::Gt || op == &Cmpop::GtE {
                     if compare_version(&version, target, op == &Cmpop::GtE) {
                         let mut diagnostic =
-                            Diagnostic::new(OutdatedVersionBlock, Range::from_located(stmt));
+                            Diagnostic::new(OutdatedVersionBlock, Range::from(stmt));
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(block) = metadata(checker.locator, stmt) {
                                 if let Some(fix) = fix_py3_block(checker, stmt, test, body, &block)
@@ -382,8 +382,7 @@ pub fn outdated_version_block(
             } => {
                 let version_number = bigint_to_u32(number);
                 if version_number == 2 && op == &Cmpop::Eq {
-                    let mut diagnostic =
-                        Diagnostic::new(OutdatedVersionBlock, Range::from_located(stmt));
+                    let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, Range::from(stmt));
                     if checker.patch(diagnostic.kind.rule()) {
                         if let Some(block) = metadata(checker.locator, stmt) {
                             if let Some(fix) = fix_py2_block(checker, stmt, body, orelse, &block) {
@@ -393,8 +392,7 @@ pub fn outdated_version_block(
                     }
                     checker.diagnostics.push(diagnostic);
                 } else if version_number == 3 && op == &Cmpop::Eq {
-                    let mut diagnostic =
-                        Diagnostic::new(OutdatedVersionBlock, Range::from_located(stmt));
+                    let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, Range::from(stmt));
                     if checker.patch(diagnostic.kind.rule()) {
                         if let Some(block) = metadata(checker.locator, stmt) {
                             if let Some(fix) = fix_py3_block(checker, stmt, test, body, &block) {

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -140,10 +140,7 @@ fn percent_to_format(format_string: &CFormatString) -> String {
 
 /// If a tuple has one argument, remove the comma; otherwise, return it as-is.
 fn clean_params_tuple(checker: &mut Checker, right: &Expr) -> String {
-    let mut contents = checker
-        .locator
-        .slice(Range::from_located(right))
-        .to_string();
+    let mut contents = checker.locator.slice(right).to_string();
     if let ExprKind::Tuple { elts, .. } = &right.node {
         if elts.len() == 1 {
             if right.location.row() == right.end_location.unwrap().row() {
@@ -196,7 +193,7 @@ fn clean_params_dictionary(checker: &mut Checker, right: &Expr) -> Option<String
                             }
                         }
 
-                        let value_string = checker.locator.slice(Range::from_located(value));
+                        let value_string = checker.locator.slice(value);
                         arguments.push(format!("{key_string}={value_string}"));
                     } else {
                         // If there are any non-string keys, abort.
@@ -204,7 +201,7 @@ fn clean_params_dictionary(checker: &mut Checker, right: &Expr) -> Option<String
                     }
                 }
                 None => {
-                    let value_string = checker.locator.slice(Range::from_located(value));
+                    let value_string = checker.locator.slice(value);
                     arguments.push(format!("**{value_string}"));
                 }
             }
@@ -319,12 +316,8 @@ pub(crate) fn printf_string_formatting(
     // Grab each string segment (in case there's an implicit concatenation).
     let mut strings: Vec<(Location, Location)> = vec![];
     let mut extension = None;
-    for (start, tok, end) in lexer::lex_located(
-        checker.locator.slice(Range::from_located(expr)),
-        Mode::Module,
-        expr.location,
-    )
-    .flatten()
+    for (start, tok, end) in
+        lexer::lex_located(checker.locator.slice(expr), Mode::Module, expr.location).flatten()
     {
         if matches!(tok, Tok::String { .. }) {
             strings.push((start, end));
@@ -401,7 +394,7 @@ pub(crate) fn printf_string_formatting(
     // Add the `.format` call.
     contents.push_str(&format!(".format{params_string}"));
 
-    let mut diagnostic = Diagnostic::new(PrintfStringFormatting, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(PrintfStringFormatting, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             contents,

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -113,7 +113,7 @@ fn create_check(
         RedundantOpenModes {
             replacement: replacement_value.clone(),
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if patch {
         if let Some(content) = replacement_value {

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -138,7 +138,7 @@ pub fn replace_stdout_stderr(checker: &mut Checker, expr: &Expr, func: &Expr, kw
             return;
         }
 
-        let mut diagnostic = Diagnostic::new(ReplaceStdoutStderr, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(ReplaceStdoutStderr, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(fix) = generate_fix(checker.stylist, checker.locator, stdout, stderr) {
                 diagnostic.amend(fix);

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -23,9 +23,9 @@ impl AlwaysAutofixableViolation for RewriteCElementTree {
 }
 
 fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
-    let mut diagnostic = Diagnostic::new(RewriteCElementTree, Range::from_located(node));
+    let mut diagnostic = Diagnostic::new(RewriteCElementTree, Range::from(node));
     if checker.patch(diagnostic.kind.rule()) {
-        let contents = checker.locator.slice(Range::from_located(node));
+        let contents = checker.locator.slice(node);
         diagnostic.amend(Fix::replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.location,

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -144,7 +144,7 @@ fn format_import(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(Range::from_located(stmt));
+    let module_text = locator.slice(stmt);
     let mut tree = match_module(module_text)?;
     let mut import = match_import(&mut tree)?;
 
@@ -178,7 +178,7 @@ fn format_import_from(
     locator: &Locator,
     stylist: &Stylist,
 ) -> Result<String> {
-    let module_text = locator.slice(Range::from_located(stmt));
+    let module_text = locator.slice(stmt);
     let mut tree = match_module(module_text).unwrap();
     let mut import = match_import_from(&mut tree)?;
 
@@ -240,7 +240,7 @@ pub fn rewrite_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 RewriteMockImport {
                     reference_type: MockReference::Attribute,
                 },
-                Range::from_located(value),
+                Range::from(value),
             );
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
@@ -287,7 +287,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             RewriteMockImport {
                                 reference_type: MockReference::Import,
                             },
-                            Range::from_located(name),
+                            Range::from(name),
                         );
                         if let Some(content) = content.as_ref() {
                             diagnostic.amend(Fix::replacement(
@@ -315,7 +315,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                     RewriteMockImport {
                         reference_type: MockReference::Import,
                     },
-                    Range::from_located(stmt),
+                    Range::from(stmt),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(indent) = indentation(checker.locator, stmt) {

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
@@ -26,7 +26,7 @@ impl AlwaysAutofixableViolation for RewriteUnicodeLiteral {
 pub fn rewrite_unicode_literal(checker: &mut Checker, expr: &Expr, kind: Option<&str>) {
     if let Some(const_kind) = kind {
         if const_kind.to_lowercase() == "u" {
-            let mut diagnostic = Diagnostic::new(RewriteUnicodeLiteral, Range::from_located(expr));
+            let mut diagnostic = Diagnostic::new(RewriteUnicodeLiteral, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::deletion(
                     expr.location,

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -173,9 +173,9 @@ pub fn rewrite_yield_from(checker: &mut Checker, stmt: &Stmt) {
                 continue;
             }
 
-            let mut diagnostic = Diagnostic::new(RewriteYieldFrom, Range::from_located(item.stmt));
+            let mut diagnostic = Diagnostic::new(RewriteYieldFrom, Range::from(item.stmt));
             if checker.patch(diagnostic.kind.rule()) {
-                let contents = checker.locator.slice(Range::from_located(item.iter));
+                let contents = checker.locator.slice(item.iter);
                 let contents = format!("yield from {contents}");
                 diagnostic.amend(Fix::replacement(
                     contents,

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -95,7 +95,7 @@ pub fn super_call_with_parameters(checker: &mut Checker, expr: &Expr, func: &Exp
         return;
     }
 
-    let mut diagnostic = Diagnostic::new(SuperCallWithParameters, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(SuperCallWithParameters, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         if let Some(fix) = fixes::remove_super_arguments(checker.locator, checker.stylist, expr) {
             diagnostic.amend(fix);

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -46,7 +46,7 @@ pub fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr, args: 
     let Some(primitive) = Primitive::from_constant(value) else {
         return;
     };
-    let mut diagnostic = Diagnostic::new(TypeOfPrimitive { primitive }, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(TypeOfPrimitive { primitive }, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
         diagnostic.amend(Fix::replacement(
             primitive.builtin(),

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -31,7 +31,7 @@ pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
             call_path.as_slice() == ["typing", "Text"]
         })
     {
-        let mut diagnostic = Diagnostic::new(TypingTextStrAlias, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(TypingTextStrAlias, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.amend(Fix::replacement(
                 "str".to_string(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -101,7 +101,7 @@ pub fn unnecessary_builtin_import(
                 .sorted()
                 .collect(),
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
 
     if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -77,13 +77,13 @@ fn delete_default_encode_arg_or_kwarg(
     patch: bool,
 ) -> Option<Diagnostic> {
     if let Some(arg) = args.get(0) {
-        let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from(expr));
         if patch {
             diagnostic.amend(Fix::deletion(arg.location, arg.end_location.unwrap()));
         }
         Some(diagnostic)
     } else if let Some(kwarg) = kwargs.get(0) {
-        let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from_located(expr));
+        let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from(expr));
         if patch {
             diagnostic.amend(Fix::deletion(kwarg.location, kwarg.end_location.unwrap()));
         }
@@ -100,7 +100,7 @@ fn replace_with_bytes_literal(
     locator: &Locator,
     patch: bool,
 ) -> Diagnostic {
-    let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from_located(expr));
+    let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from(expr));
     if patch {
         // Build up a replacement string by prefixing all string tokens with `b`.
         let contents = locator.slice(Range::new(

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -81,7 +81,7 @@ pub fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, names: &[Lo
                 .sorted()
                 .collect(),
         },
-        Range::from_located(stmt),
+        Range::from(stmt),
     );
 
     if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -95,10 +95,9 @@ pub fn unpack_list_comprehension(checker: &mut Checker, targets: &[Expr], value:
                 return;
             }
 
-            let mut diagnostic =
-                Diagnostic::new(RewriteListComprehension, Range::from_located(value));
+            let mut diagnostic = Diagnostic::new(RewriteListComprehension, Range::from(value));
             if checker.patch(diagnostic.kind.rule()) {
-                let existing = checker.locator.slice(Range::from_located(value));
+                let existing = checker.locator.slice(value);
 
                 let mut content = String::with_capacity(existing.len());
                 content.push('(');

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -42,7 +42,7 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
             DeprecatedCollectionType {
                 name: binding.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
             let binding = binding.to_lowercase();

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -97,7 +97,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
 
     match typing_member {
         TypingMember::Optional => {
-            let mut diagnostic = Diagnostic::new(TypingUnion, Range::from_located(expr));
+            let mut diagnostic = Diagnostic::new(TypingUnion, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
                 diagnostic.amend(Fix::replacement(
                     unparse_expr(&optional(slice), checker.stylist),
@@ -108,7 +108,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
             checker.diagnostics.push(diagnostic);
         }
         TypingMember::Union => {
-            let mut diagnostic = Diagnostic::new(TypingUnion, Range::from_located(expr));
+            let mut diagnostic = Diagnostic::new(TypingUnion, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
                 match &slice.node {
                     ExprKind::Slice { .. } => {

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -81,7 +81,7 @@ pub fn use_pep604_isinstance(checker: &mut Checker, expr: &Expr, func: &Expr, ar
         if let Some(types) = args.get(1) {
             if let ExprKind::Tuple { elts, .. } = &types.node {
                 let mut diagnostic =
-                    Diagnostic::new(IsinstanceWithTuple { kind }, Range::from_located(expr));
+                    Diagnostic::new(IsinstanceWithTuple { kind }, Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.amend(Fix::replacement(
                         unparse_expr(&union(elts), checker.stylist),

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -45,7 +45,7 @@ fn rule(targets: &[Expr], value: &Expr, location: Range) -> Option<Diagnostic> {
 /// UP001
 pub fn useless_metaclass_type(checker: &mut Checker, stmt: &Stmt, value: &Expr, targets: &[Expr]) {
     let Some(mut diagnostic) =
-        rule(targets, value, Range::from_located(stmt)) else {
+        rule(targets, value, Range::from(stmt)) else {
             return;
         };
     if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -50,7 +50,7 @@ fn rule(name: &str, bases: &[Expr], scope: &Scope, bindings: &[Binding]) -> Opti
             UselessObjectInheritance {
                 name: name.to_string(),
             },
-            Range::from_located(expr),
+            Range::from(expr),
         ));
     }
 

--- a/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -91,13 +91,13 @@ where
                 AsyncioDanglingTask {
                     method: Method::CreateTask,
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             )),
             Some(["asyncio", "ensure_future"]) => Some(Diagnostic::new(
                 AsyncioDanglingTask {
                     method: Method::EnsureFuture,
                 },
-                Range::from_located(expr),
+                Range::from(expr),
             )),
             _ => None,
         }

--- a/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
+++ b/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
@@ -110,7 +110,7 @@ pub fn unpack_instead_of_concatenating_to_collection_literal(checker: &mut Check
             expr: contents.clone(),
             fixable,
         },
-        Range::from_located(expr),
+        Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
         if fixable {

--- a/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -31,10 +31,9 @@ pub fn error_instead_of_exception(checker: &mut Checker, handlers: &[Excepthandl
         for (expr, func) in calls {
             if let ExprKind::Attribute { attr, .. } = &func.node {
                 if attr == "error" {
-                    checker.diagnostics.push(Diagnostic::new(
-                        ErrorInsteadOfException,
-                        Range::from_located(expr),
-                    ));
+                    checker
+                        .diagnostics
+                        .push(Diagnostic::new(ErrorInsteadOfException, Range::from(expr)));
                 }
             }
         }

--- a/crates/ruff/src/rules/tryceratops/rules/prefer_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/prefer_type_error.rs
@@ -135,7 +135,7 @@ fn check_raise(checker: &mut Checker, exc: &Expr, item: &Stmt) {
     if check_raise_type(checker, exc) {
         checker
             .diagnostics
-            .push(Diagnostic::new(PreferTypeError, Range::from_located(item)));
+            .push(Diagnostic::new(PreferTypeError, Range::from(item)));
     }
 }
 

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -48,7 +48,7 @@ pub fn raise_vanilla_args(checker: &mut Checker, expr: &Expr) {
             {
                 checker
                     .diagnostics
-                    .push(Diagnostic::new(RaiseVanillaArgs, Range::from_located(expr)));
+                    .push(Diagnostic::new(RaiseVanillaArgs, Range::from(expr)));
             }
         }
     }

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -73,9 +73,8 @@ pub fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
         })
         .map_or(false, |call_path| call_path.as_slice() == ["", "Exception"])
     {
-        checker.diagnostics.push(Diagnostic::new(
-            RaiseVanillaClass,
-            Range::from_located(expr),
-        ));
+        checker
+            .diagnostics
+            .push(Diagnostic::new(RaiseVanillaClass, Range::from(expr)));
     }
 }

--- a/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
@@ -49,6 +49,6 @@ pub fn raise_within_try(checker: &mut Checker, body: &[Stmt]) {
     for stmt in raises {
         checker
             .diagnostics
-            .push(Diagnostic::new(RaiseWithinTry, Range::from_located(stmt)));
+            .push(Diagnostic::new(RaiseWithinTry, Range::from(stmt)));
     }
 }

--- a/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
@@ -24,7 +24,7 @@ pub fn try_consider_else(checker: &mut Checker, body: &[Stmt], orelse: &[Stmt]) 
             if let StmtKind::Return { .. } = &stmt.node {
                 checker
                     .diagnostics
-                    .push(Diagnostic::new(TryConsiderElse, Range::from_located(stmt)));
+                    .push(Diagnostic::new(TryConsiderElse, Range::from(stmt)));
             }
         }
     }

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
@@ -97,10 +97,9 @@ pub fn verbose_log_message(checker: &mut Checker, handlers: &[Excepthandler]) {
                     };
                     for (id, expr) in names {
                         if id == target {
-                            checker.diagnostics.push(Diagnostic::new(
-                                VerboseLogMessage,
-                                Range::from_located(expr),
-                            ));
+                            checker
+                                .diagnostics
+                                .push(Diagnostic::new(VerboseLogMessage, Range::from(expr)));
                         }
                     }
                 }

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
@@ -73,7 +73,7 @@ pub fn verbose_raise(checker: &mut Checker, handlers: &[Excepthandler]) {
                         if id == exception_name {
                             checker
                                 .diagnostics
-                                .push(Diagnostic::new(VerboseRaise, Range::from_located(exc)));
+                                .push(Diagnostic::new(VerboseRaise, Range::from(exc)));
                         }
                     }
                 }

--- a/crates/ruff_python_ast/src/source_code/locator.rs
+++ b/crates/ruff_python_ast/src/source_code/locator.rs
@@ -125,8 +125,9 @@ impl<'a> Locator<'a> {
     }
 
     /// Take the source code between the given [`Range`].
-    pub fn slice(&self, range: Range) -> &'a str {
+    pub fn slice<R: Into<Range>>(&self, range: R) -> &'a str {
         let index = self.get_or_init_index();
+        let range = range.into();
         let start = truncate(range.location, index, self.contents);
         let end = truncate(range.end_location, index, self.contents);
         &self.contents[start..end]

--- a/crates/ruff_python_ast/src/types.rs
+++ b/crates/ruff_python_ast/src/types.rs
@@ -28,13 +28,17 @@ impl Range {
             end_location,
         }
     }
+}
 
-    pub fn from_located<T, U>(located: &Located<T, U>) -> Self {
+impl<T> From<&Located<T>> for Range {
+    fn from(located: &Located<T>) -> Self {
         Range::new(located.location, located.end_location.unwrap())
     }
+}
 
-    pub fn contains(&self, other: &Range) -> bool {
-        self.location <= other.location && self.end_location >= other.end_location
+impl<T> From<&Box<Located<T>>> for Range {
+    fn from(located: &Box<Located<T>>) -> Self {
+        Range::new(located.location, located.end_location.unwrap())
     }
 }
 

--- a/crates/ruff_python_ast/src/whitespace.rs
+++ b/crates/ruff_python_ast/src/whitespace.rs
@@ -7,7 +7,7 @@ use crate::types::Range;
 
 /// Extract the leading indentation from a line.
 pub fn indentation<'a, T>(locator: &'a Locator, located: &'a Located<T>) -> Option<&'a str> {
-    let range = Range::from_located(located);
+    let range = Range::from(located);
     let indentation = locator.slice(Range::new(
         Location::new(range.location.row(), 0),
         Location::new(range.location.row(), range.location.column()),

--- a/crates/ruff_python_formatter/src/cst.rs
+++ b/crates/ruff_python_formatter/src/cst.rs
@@ -43,6 +43,18 @@ impl<T> Located<T> {
     }
 }
 
+impl<T> From<&Located<T>> for Range {
+    fn from(located: &Located<T>) -> Self {
+        Range::new(located.location, located.end_location.unwrap())
+    }
+}
+
+impl<T> From<&Box<Located<T>>> for Range {
+    fn from(located: &Box<Located<T>>) -> Self {
+        Range::new(located.location, located.end_location.unwrap())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ExprContext {
     Load,

--- a/crates/ruff_python_formatter/src/format/expr.rs
+++ b/crates/ruff_python_formatter/src/format/expr.rs
@@ -39,7 +39,7 @@ fn format_name(
     expr: &Expr,
     _id: &str,
 ) -> FormatResult<()> {
-    write!(f, [literal(Range::from_located(expr))])?;
+    write!(f, [literal(Range::from(expr))])?;
     write!(f, [end_of_line_comments(expr)])?;
     Ok(())
 }
@@ -577,7 +577,7 @@ fn format_joined_str(
     expr: &Expr,
     _values: &[Expr],
 ) -> FormatResult<()> {
-    write!(f, [literal(Range::from_located(expr))])?;
+    write!(f, [literal(Range::from(expr))])?;
     write!(f, [end_of_line_comments(expr)])?;
     Ok(())
 }
@@ -598,11 +598,11 @@ fn format_constant(
                 write!(f, [text("False")])?;
             }
         }
-        Constant::Int(_) => write!(f, [int_literal(Range::from_located(expr))])?,
-        Constant::Float(_) => write!(f, [float_literal(Range::from_located(expr))])?,
+        Constant::Int(_) => write!(f, [int_literal(Range::from(expr))])?,
+        Constant::Float(_) => write!(f, [float_literal(Range::from(expr))])?,
         Constant::Str(_) => write!(f, [string_literal(expr)])?,
         Constant::Bytes(_) => write!(f, [string_literal(expr)])?,
-        Constant::Complex { .. } => write!(f, [complex_literal(Range::from_located(expr))])?,
+        Constant::Complex { .. } => write!(f, [complex_literal(Range::from(expr))])?,
         Constant::Tuple(_) => unreachable!("Constant::Tuple should be handled by format_tuple"),
     }
     write!(f, [end_of_line_comments(expr)])?;

--- a/crates/ruff_python_formatter/src/format/strings.rs
+++ b/crates/ruff_python_formatter/src/format/strings.rs
@@ -126,7 +126,7 @@ impl Format<ASTFormatContext<'_>> for StringLiteral<'_> {
 
         // TODO(charlie): This tokenization needs to happen earlier, so that we can attach
         // comments to individual string literals.
-        let (source, start, end) = f.context().locator().slice(Range::from_located(expr));
+        let (source, start, end) = f.context().locator().slice(Range::from(expr));
         let elts =
             rustpython_parser::lexer::lex_located(&source[start..end], Mode::Module, expr.location)
                 .flatten()

--- a/crates/ruff_python_formatter/src/parentheses.rs
+++ b/crates/ruff_python_formatter/src/parentheses.rs
@@ -154,7 +154,7 @@ impl<'a> Visitor<'a> for ParenthesesNormalizer<'_> {
                         ..
                     },
                 ) {
-                    let (source, start, end) = self.locator.slice(Range::from_located(value));
+                    let (source, start, end) = self.locator.slice(Range::from(&*value));
                     // TODO(charlie): Encode this in the AST via separate node types.
                     if !is_radix_literal(&source[start..end]) {
                         value.parentheses = Parenthesize::Always;


### PR DESCRIPTION
## Summary

Rather than using a custom `Range::from_located`, we can just implement `From` and use a more idiomatic conversion.

No functional changes, purely a refactor.
