### PR TITLE
Updated forced-separate type from Rust to abstract

### DIFF
--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -255,7 +255,7 @@ pub struct Options {
     pub lines_between_types: Option<usize>,
     #[option(
         default = r#"[]"#,
-        value_type = "Vec<String>",
+        value_type = "list[str]",
         example = r#"
             forced-separate = ["tests"]
         "#


### PR DESCRIPTION
Really small documentation change. I noticed that most of the types listed in the docs aren't Rust types but more generic, except for `forced-separate` (https://beta.ruff.rs/docs/settings/#forced-separate). It looks like the only that was `Vec<String>` instead of `list[str]`, and I _think_ this is how that is generated?

Let me know if I missed anything or if there is anything else I can throw in here.