### PR TITLE
Ignore multiply-assigned variables in RET504

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
@@ -6,22 +6,6 @@ def x():
     return a  # error
 
 
-def x():
-    a = 1
-    print(a)
-    a = 2
-    return a  # error
-
-
-def x():
-    a = 1
-    if True:
-        return a  # error
-    a = 2
-    print(a)
-    return a
-
-
 # Can be refactored false positives
 # https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
 def get_bar_if_exists(obj):
@@ -165,44 +149,6 @@ def my_func():
     return foo
 
 
-# Refactored incorrect false positives
-# See test cases above marked: "Can be refactored false positives"
-# https://github.com/afonasev/flake8-return/issues/47#issuecomment-1122571066
-def get_bar_if_exists(obj):
-    if hasattr(obj, "bar"):
-        return str(obj.bar)
-    return ""
-
-
-# https://github.com/afonasev/flake8-return/issues/47#issue-641117366
-def x():
-    formatted = _USER_AGENT_FORMATTER.format(format_string, **values)
-    # clean up after any blank components
-    return formatted.replace("()", "").replace("  ", " ").strip()
-
-
-# https://github.com/afonasev/flake8-return/issues/47#issue-641117366
-def user_agent_username(username=None):
-
-    if not username:
-        return ""
-
-    username = username.replace(" ", "_")  # Avoid spaces or %20.
-    try:
-        username.encode("ascii")  # just test,
-        # but not actually use it
-    except UnicodeEncodeError:
-        username = quote(username.encode("utf-8"))
-    else:
-        # % is legal in the default $wgLegalTitleChars
-        # This is so that ops know the real pywikibot will not
-        # allow a useragent in the username to allow through a
-        # hand-coded percent-encoded value.
-        if "%" in username:
-            username = quote(username)
-    return username
-
-
 # https://github.com/afonasev/flake8-return/issues/116#issue-1367575481
 def no_exception_loop():
     success = False
@@ -280,3 +226,24 @@ def default():
         return x
 
     return y
+
+
+def get_queryset(option_1, option_2):
+    queryset: Any = None
+    queryset = queryset.filter(a=1)
+    if option_1:
+        queryset = queryset.annotate(b=Value(2))
+    if option_2:
+        queryset = queryset.filter(c=3)
+    return queryset
+
+
+def get_queryset():
+    queryset = Model.filter(a=1)
+    queryset = queryset.filter(c=3)
+    return queryset
+
+
+def get_queryset():
+    queryset = Model.filter(a=1)
+    return queryset  # error

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -309,6 +309,15 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
     }
 }
 
+fn has_multiple_assigns(id: &str, stack: &Stack) -> bool {
+    if let Some(assigns) = stack.assigns.get(&id) {
+        if assigns.len() > 1 {
+            return true;
+        }
+    }
+    false
+}
+
 fn has_refs_before_next_assign(id: &str, return_location: Location, stack: &Stack) -> bool {
     let mut before_assign: &Location = &Location::default();
     let mut after_assign: Option<&Location> = None;
@@ -389,7 +398,8 @@ fn unnecessary_assign(checker: &mut Checker, stack: &Stack, expr: &Expr) {
             return;
         }
 
-        if has_refs_before_next_assign(id, expr.location, stack)
+        if has_multiple_assigns(id, stack)
+            || has_refs_before_next_assign(id, expr.location, stack)
             || has_refs_or_assigns_within_try_or_loop(id, stack)
         {
             return;

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -21,50 +21,11 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 13
+    row: 249
     column: 11
   end_location:
-    row: 13
-    column: 12
-  fix: ~
-  parent: ~
-- kind:
-    name: UnnecessaryAssign
-    body: "Unnecessary variable assignment before `return` statement"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 19
-    column: 15
-  end_location:
-    row: 19
-    column: 16
-  fix: ~
-  parent: ~
-- kind:
-    name: UnnecessaryAssign
-    body: "Unnecessary variable assignment before `return` statement"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 31
-    column: 11
-  end_location:
-    row: 31
-    column: 17
-  fix: ~
-  parent: ~
-- kind:
-    name: UnnecessaryAssign
-    body: "Unnecessary variable assignment before `return` statement"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 39
-    column: 11
-  end_location:
-    row: 39
-    column: 20
+    row: 249
+    column: 19
   fix: ~
   parent: ~
 


### PR DESCRIPTION
This PR acts on the suggestion from #2950 to avoid RET504 errors when a variable is assigned to multiple times. As-is, we have too many false positives like:

```py
def get_queryset(option_1, option_2):
    queryset = Model.filter(a=1)
    if option_1:
        queryset = queryset.filter(b=2)
    if option_2:
        queryset = queryset.filter(c=3)
    return queryset
```

Instead, this rule will now only flag more trivial cases of "assign-then-return", like:

```py
def get_queryset():
    queryset = Model.filter(a=1)
    return queryset
```

It's possible that this is _too_ conservative, since we no longer flag cases like:

```py
def get_queryset():
    queryset = Model.filter(a=1)
    queryset = queryset.filter(c=3)
    return queryset
```

But, I actually think that's reasonable -- if you're multiply-assigning, you're often doing something like a fluent interface or a conditional assignment, and in those cases, it actually seems totally fine (preferable, even) to separate the operation chain from the return.

Closes #2950.
