### PR TITLE
docs(pycodestyle): document rules

### DIFF
--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
@@ -4,6 +4,22 @@ use ruff_python_ast::types::Range;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 
+/// ## What it does
+/// Checks for the use of the characters 'l', 'O', or 'I' as class names.
+///
+/// ## Why is this bad?
+/// In some fonts, these characters are indistinguishable from the
+/// numerals one and zero. When tempted to use 'l', use 'L' instead.
+///
+/// ## Example
+/// ```python
+/// class I(object):
+/// ```
+///
+/// Use instead:
+/// ```python
+/// class Integer(object):
+/// ```
 #[violation]
 pub struct AmbiguousClassName(pub String);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
@@ -14,11 +14,13 @@ use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 /// ## Example
 /// ```python
 /// class I(object):
+///     ...
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// class Integer(object):
+///     ...
 /// ```
 #[violation]
 pub struct AmbiguousClassName(pub String);

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
@@ -14,11 +14,13 @@ use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 /// ## Example
 /// ```python
 /// def l(x):
+///     ...
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// def long_name(x):
+///     ...
 /// ```
 #[violation]
 pub struct AmbiguousFunctionName(pub String);

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
@@ -4,6 +4,22 @@ use ruff_python_ast::types::Range;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 
+/// ## What it does
+/// Checks for the use of the characters 'l', 'O', or 'I' as function names.
+///
+/// ## Why is this bad?
+/// In some fonts, these characters are indistinguishable from the
+/// numerals one and zero. When tempted to use 'l', use 'L' instead.
+///
+/// ## Example
+/// ```python
+/// def l(x):
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def long_name(x):
+/// ```
 #[violation]
 pub struct AmbiguousFunctionName(pub String);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
@@ -4,6 +4,49 @@ use ruff_python_ast::types::Range;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 
+/// ## What it does
+/// Checks for the use of the characters 'l', 'O', or 'I' as variable names.
+///
+/// ## Why is this bad?
+/// In some fonts, these characters are indistinguishable from the
+/// numerals one and zero. When tempted to use 'l', use 'L' instead.
+///
+/// ## Example
+/// ```python
+/// l = 0
+/// O = 123
+/// I = 42
+/// except AttributeError as O:
+/// with lock as l:
+/// global I
+/// nonlocal l
+/// def foo(l):
+/// def foo(l=12):
+/// l = foo(l=12)
+/// for l in range(10):
+/// [l for l in lines if l]
+/// lambda l: None
+/// lambda a=x[1:5], l: None
+/// lambda **l:
+/// def f(**l):
+/// ```
+///
+/// Use instead:
+/// ```python
+/// L = 0
+/// o = 123
+/// i = 42
+/// except AttributeError as o:
+/// with lock as L:
+/// foo(l=12)
+/// foo(l=I)
+/// for a in foo(l=12):
+/// lambda arg: arg * l
+/// lambda a=l[I:5]: None
+/// lambda x=a.I: None
+/// if l >= 12:
+/// ```
+
 #[violation]
 pub struct AmbiguousVariableName(pub String);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
@@ -16,19 +16,6 @@ use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 /// l = 0
 /// O = 123
 /// I = 42
-/// except AttributeError as O:
-/// with lock as l:
-/// global I
-/// nonlocal l
-/// def foo(l):
-/// def foo(l=12):
-/// l = foo(l=12)
-/// for l in range(10):
-/// [l for l in lines if l]
-/// lambda l: None
-/// lambda a=x[1:5], l: None
-/// lambda **l:
-/// def f(**l):
 /// ```
 ///
 /// Use instead:
@@ -36,15 +23,6 @@ use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 /// L = 0
 /// o = 123
 /// i = 42
-/// except AttributeError as o:
-/// with lock as L:
-/// foo(l=12)
-/// foo(l=I)
-/// for a in foo(l=12):
-/// lambda arg: arg * l
-/// lambda a=l[I:5]: None
-/// lambda x=a.I: None
-/// if l >= 12:
 /// ```
 
 #[violation]

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -10,27 +10,14 @@ use crate::registry::Rule;
 use crate::settings::{flags, Settings};
 
 /// ## What it does
-/// Checks for multiline statements on one line.
+/// Checks for compound statements (multiple statements on the same line).
 ///
 /// ## Why is this bad?
-/// Compound statements (on the same line) are generally
-/// discouraged.
-///
-/// While sometimes it's okay to put an if/for/while with a small body
-/// on the same line, never do this for multi-clause statements.
-/// Also avoid folding such long lines!
+/// Per PEP 8, "compound statements are generally discouraged".
 ///
 /// ## Example
 /// ```python
 /// if foo == 'blah': do_blah_thing()
-/// for x in lst: total += x
-/// while t < 10: t = delay()
-/// if foo == 'blah': do_blah_thing()
-/// else: do_non_blah_thing()
-/// try: something()
-/// finally: cleanup()
-/// if foo == 'blah': one(); two(); three()
-///
 /// ```
 ///
 /// Use instead:
@@ -38,6 +25,9 @@ use crate::settings::{flags, Settings};
 /// if foo == 'blah':
 ///     do_blah_thing()
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#other-recommendations)
 #[violation]
 pub struct MultipleStatementsOnOneLineColon;
 
@@ -52,12 +42,8 @@ impl Violation for MultipleStatementsOnOneLineColon {
 /// Checks for multiline statements on one line.
 ///
 /// ## Why is this bad?
-/// Compound statements (on the same line) are generally
+/// Per PEP 8, including multi-clause statements on the same line is
 /// discouraged.
-///
-/// While sometimes it's okay to put an if/for/while with a small body
-/// on the same line, never do this for multi-clause statements.
-/// Also avoid folding such long lines!
 ///
 /// ## Example
 /// ```python
@@ -70,6 +56,9 @@ impl Violation for MultipleStatementsOnOneLineColon {
 /// do_two()
 /// do_three()
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#other-recommendations)
 #[violation]
 pub struct MultipleStatementsOnOneLineSemicolon;
 
@@ -81,10 +70,10 @@ impl Violation for MultipleStatementsOnOneLineSemicolon {
 }
 
 /// ## What it does
-/// Checks for statements that end with a semicolon.
+/// Checks for statements that end with an unnecessary semicolon.
 ///
 /// ## Why is this bad?
-///
+/// A trailing semicolon is unnecessary and should be removed.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -38,7 +38,6 @@ use crate::settings::{flags, Settings};
 /// if foo == 'blah':
 ///     do_blah_thing()
 /// ```
-/// """
 #[violation]
 pub struct MultipleStatementsOnOneLineColon;
 
@@ -71,7 +70,6 @@ impl Violation for MultipleStatementsOnOneLineColon {
 /// do_two()
 /// do_three()
 /// ```
-/// """
 #[violation]
 pub struct MultipleStatementsOnOneLineSemicolon;
 
@@ -97,7 +95,6 @@ impl Violation for MultipleStatementsOnOneLineSemicolon {
 /// ```python
 /// do_four()
 /// ```
-/// """
 #[violation]
 pub struct UselessSemicolon;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -9,6 +9,36 @@ use ruff_python_ast::types::Range;
 use crate::registry::Rule;
 use crate::settings::{flags, Settings};
 
+/// ## What it does
+/// Checks for multiline statements on one line.
+///
+/// ## Why is this bad?
+/// Compound statements (on the same line) are generally
+/// discouraged.
+///
+/// While sometimes it's okay to put an if/for/while with a small body
+/// on the same line, never do this for multi-clause statements.
+/// Also avoid folding such long lines!
+///
+/// ## Example
+/// ```python
+/// if foo == 'blah': do_blah_thing()
+/// for x in lst: total += x
+/// while t < 10: t = delay()
+/// if foo == 'blah': do_blah_thing()
+/// else: do_non_blah_thing()
+/// try: something()
+/// finally: cleanup()
+/// if foo == 'blah': one(); two(); three()
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if foo == 'blah':
+///     do_blah_thing()
+/// ```
+/// """
 #[violation]
 pub struct MultipleStatementsOnOneLineColon;
 
@@ -19,6 +49,29 @@ impl Violation for MultipleStatementsOnOneLineColon {
     }
 }
 
+/// ## What it does
+/// Checks for multiline statements on one line.
+///
+/// ## Why is this bad?
+/// Compound statements (on the same line) are generally
+/// discouraged.
+///
+/// While sometimes it's okay to put an if/for/while with a small body
+/// on the same line, never do this for multi-clause statements.
+/// Also avoid folding such long lines!
+///
+/// ## Example
+/// ```python
+/// do_one(); do_two(); do_three()
+/// ```
+///
+/// Use instead:
+/// ```python
+/// do_one()
+/// do_two()
+/// do_three()
+/// ```
+/// """
 #[violation]
 pub struct MultipleStatementsOnOneLineSemicolon;
 
@@ -29,6 +82,22 @@ impl Violation for MultipleStatementsOnOneLineSemicolon {
     }
 }
 
+/// ## What it does
+/// Checks for statements that end with a semicolon.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// do_four();  # useless semicolon
+/// ```
+///
+/// Use instead:
+/// ```python
+/// do_four()
+/// ```
+/// """
 #[violation]
 pub struct UselessSemicolon;
 
@@ -43,6 +112,7 @@ impl AlwaysAutofixableViolation for UselessSemicolon {
     }
 }
 
+/// E701, E702, E703
 pub fn compound_statements(
     lxr: &[LexResult],
     settings: &Settings,

--- a/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -8,11 +8,11 @@ use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
 
 /// ## What it does
-/// Checks for all doc lines to a maximum of e.g. 72 characters.
+/// Checks for doc lines that exceed the specified maximum character length.
 ///
 /// ## Why is this bad?
-/// For flowing long blocks of text (docstrings or comments), limiting
-/// the length to 72 characters is recommended.
+/// For flowing long blocks of text (docstrings or comments), overlong lines
+/// can hurt readability.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -7,6 +7,27 @@ use ruff_python_ast::types::Range;
 use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
 
+/// ## What it does
+/// Checks for all doc lines to a maximum of e.g. 72 characters.
+///
+/// ## Why is this bad?
+/// For flowing long blocks of text (docstrings or comments), limiting
+/// the length to 72 characters is recommended.
+///
+/// ## Example
+/// ```python
+/// def function(x):
+///     """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis auctor purus ut ex fermentum, at maximus est hendrerit."""
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def function(x):
+///     """
+///     Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+///     Duis auctor purus ut ex fermentum, at maximus est hendrerit.
+///     """
+/// ```
 #[violation]
 pub struct DocLineTooLong(pub usize, pub usize);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/errors.rs
@@ -9,6 +9,7 @@ pub struct IOError {
     pub message: String,
 }
 
+/// E902
 impl Violation for IOError {
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -30,6 +31,7 @@ impl Violation for SyntaxError {
     }
 }
 
+/// E901
 pub fn syntax_error(diagnostics: &mut Vec<Diagnostic>, parse_error: &ParseError) {
     diagnostics.push(Diagnostic::new(
         SyntaxError {

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -26,7 +26,6 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```python
 /// spam(ham[1], {eggs: 2})
 /// ```
-/// """
 #[violation]
 pub struct WhitespaceAfterOpenBracket;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -7,6 +7,26 @@ use ruff_diagnostics::DiagnosticKind;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for the use of extraneous whitespace after "(".
+///
+/// ## Why is this bad?
+/// Avoid extraneous whitespace in these situations:
+/// - Immediately inside parentheses, brackets or braces.
+/// - Immediately before a comma, semicolon, or colon.
+///
+/// ## Example
+/// ```python
+/// spam( ham[1], {eggs: 2})
+/// spam(ham[ 1], {eggs: 2})
+/// spam(ham[1], { eggs: 2})
+/// ```
+///
+/// Use instead:
+/// ```python
+/// spam(ham[1], {eggs: 2})
+/// ```
+/// """
 #[violation]
 pub struct WhitespaceAfterOpenBracket;
 
@@ -17,6 +37,25 @@ impl Violation for WhitespaceAfterOpenBracket {
     }
 }
 
+/// ## What it does
+/// Checks for the use of extraneous whitespace before ")".
+///
+/// ## Why is this bad?
+/// Avoid extraneous whitespace in these situations:
+/// - Immediately inside parentheses, brackets or braces.
+/// - Immediately before a comma, semicolon, or colon.
+///
+/// ## Example
+/// ```python
+/// spam(ham[1], {eggs: 2} )
+/// spam(ham[1 ], {eggs: 2})
+/// spam(ham[1], {eggs: 2 })
+/// ```
+///
+/// Use instead:
+/// ```python
+/// spam(ham[1], {eggs: 2})
+/// ```
 #[violation]
 pub struct WhitespaceBeforeCloseBracket;
 
@@ -27,6 +66,25 @@ impl Violation for WhitespaceBeforeCloseBracket {
     }
 }
 
+/// ## What it does
+/// Checks for the use of extraneous whitespace before ",", ";" or ":".
+///
+/// ## Why is this bad?
+/// Avoid extraneous whitespace in these situations:
+/// - Immediately inside parentheses, brackets or braces.
+/// - Immediately before a comma, semicolon, or colon.
+///
+/// ## Example
+/// ```python
+/// if x == 4: print(x, y); x, y = y , x
+/// if x == 4: print(x, y) ; x, y = y, x
+/// if x == 4 : print(x, y); x, y = y, x
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if x == 4: print(x, y); x, y = y, x
+/// ```
 #[violation]
 pub struct WhitespaceBeforePunctuation;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -11,9 +11,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// Checks for the use of extraneous whitespace after "(".
 ///
 /// ## Why is this bad?
-/// Avoid extraneous whitespace in these situations:
-/// - Immediately inside parentheses, brackets or braces.
-/// - Immediately before a comma, semicolon, or colon.
+/// PEP 8 recommends the omission of whitespace in the following cases:
+/// - "Immediately inside parentheses, brackets or braces."
+/// - "Immediately before a comma, semicolon, or colon."
 ///
 /// ## Example
 /// ```python
@@ -26,6 +26,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```python
 /// spam(ham[1], {eggs: 2})
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#pet-peeves)
 #[violation]
 pub struct WhitespaceAfterOpenBracket;
 
@@ -40,9 +43,9 @@ impl Violation for WhitespaceAfterOpenBracket {
 /// Checks for the use of extraneous whitespace before ")".
 ///
 /// ## Why is this bad?
-/// Avoid extraneous whitespace in these situations:
-/// - Immediately inside parentheses, brackets or braces.
-/// - Immediately before a comma, semicolon, or colon.
+/// PEP 8 recommends the omission of whitespace in the following cases:
+/// - "Immediately inside parentheses, brackets or braces."
+/// - "Immediately before a comma, semicolon, or colon."
 ///
 /// ## Example
 /// ```python
@@ -55,6 +58,9 @@ impl Violation for WhitespaceAfterOpenBracket {
 /// ```python
 /// spam(ham[1], {eggs: 2})
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#pet-peeves)
 #[violation]
 pub struct WhitespaceBeforeCloseBracket;
 
@@ -69,21 +75,22 @@ impl Violation for WhitespaceBeforeCloseBracket {
 /// Checks for the use of extraneous whitespace before ",", ";" or ":".
 ///
 /// ## Why is this bad?
-/// Avoid extraneous whitespace in these situations:
-/// - Immediately inside parentheses, brackets or braces.
-/// - Immediately before a comma, semicolon, or colon.
+/// PEP 8 recommends the omission of whitespace in the following cases:
+/// - "Immediately inside parentheses, brackets or braces."
+/// - "Immediately before a comma, semicolon, or colon."
 ///
 /// ## Example
 /// ```python
 /// if x == 4: print(x, y); x, y = y , x
-/// if x == 4: print(x, y) ; x, y = y, x
-/// if x == 4 : print(x, y); x, y = y, x
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// if x == 4: print(x, y); x, y = y, x
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#pet-peeves)
 #[violation]
 pub struct WhitespaceBeforePunctuation;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -31,7 +31,6 @@ use crate::checkers::ast::Checker;
 /// import os
 /// import sys
 /// ```
-/// """
 #[violation]
 pub struct MultipleImportsOnOneLine;
 
@@ -104,7 +103,6 @@ impl Violation for MultipleImportsOnOneLine {
 /// "Two string"
 /// a = 1
 /// ```
-/// """
 #[violation]
 pub struct ModuleImportNotAtTopOfFile;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -6,6 +6,32 @@ use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Check for multiple imports on one line.
+///
+/// ## Why is this bad?
+/// Place imports on separate lines.
+///
+/// The following are okay:
+/// ```python
+/// from subprocess import Popen, PIPE
+/// from myclas import MyClass
+/// from foo.bar.yourclass import YourClass
+/// import myclass
+/// import foo.bar.yourclass
+/// ```
+///
+/// ## Example
+/// ```python
+/// import sys, os
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import os
+/// import sys
+/// ```
+/// """
 #[violation]
 pub struct MultipleImportsOnOneLine;
 
@@ -16,6 +42,69 @@ impl Violation for MultipleImportsOnOneLine {
     }
 }
 
+/// ## What it does
+///
+///
+/// ## Why is this bad?
+/// Place imports at the top of the file.
+///
+/// Always put imports at the top of the file, just after any module
+/// comments and docstrings, and before module globals and constants.
+///
+/// Exceptions:
+/// ```python
+/// # this is a comment
+/// import os
+/// ```
+///
+/// ```python
+/// '''this is a module docstring'''
+/// import os
+/// ```
+///
+/// ```python
+/// r'''this is a module docstring'''
+/// import os
+/// ```
+///
+/// ```python
+/// try:
+///     import x
+/// except ImportError:
+///     pass
+/// else:
+///     pass
+/// import y
+/// ```
+///
+/// ```python
+/// try:
+///     import x
+/// except ImportError:
+///     pass
+/// finally:
+///     pass
+/// import y
+/// ```
+///
+/// ## Example
+/// ```python
+/// 'One string'
+/// "Two string"
+/// a = 1
+/// import os
+/// from sys import x
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import os
+/// from sys import x
+/// 'One string'
+/// "Two string"
+/// a = 1
+/// ```
+/// """
 #[violation]
 pub struct ModuleImportNotAtTopOfFile;
 
@@ -26,6 +115,7 @@ impl Violation for ModuleImportNotAtTopOfFile {
     }
 }
 
+/// E401
 pub fn multiple_imports_on_one_line(checker: &mut Checker, stmt: &Stmt, names: &[Alias]) {
     if names.len() > 1 {
         checker
@@ -34,6 +124,7 @@ pub fn multiple_imports_on_one_line(checker: &mut Checker, stmt: &Stmt, names: &
     }
 }
 
+/// E402
 pub fn module_import_not_at_top_of_file(checker: &mut Checker, stmt: &Stmt) {
     if checker.ctx.seen_import_boundary && stmt.location.column() == 0 {
         checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -10,16 +10,7 @@ use crate::checkers::ast::Checker;
 /// Check for multiple imports on one line.
 ///
 /// ## Why is this bad?
-/// Place imports on separate lines.
-///
-/// The following are okay:
-/// ```python
-/// from subprocess import Popen, PIPE
-/// from myclas import MyClass
-/// from foo.bar.yourclass import YourClass
-/// import myclass
-/// import foo.bar.yourclass
-/// ```
+/// Per PEP 8, "imports should usually be on separate lines."
 ///
 /// ## Example
 /// ```python
@@ -31,6 +22,9 @@ use crate::checkers::ast::Checker;
 /// import os
 /// import sys
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#imports)
 #[violation]
 pub struct MultipleImportsOnOneLine;
 
@@ -42,49 +36,11 @@ impl Violation for MultipleImportsOnOneLine {
 }
 
 /// ## What it does
-///
+/// Checks for imports that are not at the top of the file.
 ///
 /// ## Why is this bad?
-/// Place imports at the top of the file.
-///
-/// Always put imports at the top of the file, just after any module
-/// comments and docstrings, and before module globals and constants.
-///
-/// Exceptions:
-/// ```python
-/// # this is a comment
-/// import os
-/// ```
-///
-/// ```python
-/// '''this is a module docstring'''
-/// import os
-/// ```
-///
-/// ```python
-/// r'''this is a module docstring'''
-/// import os
-/// ```
-///
-/// ```python
-/// try:
-///     import x
-/// except ImportError:
-///     pass
-/// else:
-///     pass
-/// import y
-/// ```
-///
-/// ```python
-/// try:
-///     import x
-/// except ImportError:
-///     pass
-/// finally:
-///     pass
-/// import y
-/// ```
+/// Per PEP 8, "imports are always put at the top of the file, just after any
+/// module comments and docstrings, and before module globals and constants."
 ///
 /// ## Example
 /// ```python
@@ -103,6 +59,9 @@ impl Violation for MultipleImportsOnOneLine {
 /// "Two string"
 /// a = 1
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#imports)
 #[violation]
 pub struct ModuleImportNotAtTopOfFile;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -7,12 +7,10 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::rules::pycodestyle::logical_lines::LogicalLine;
 
 /// ## What it does
-/// Checks for indentation with invalid multiple of 4 spaces.
+/// Checks for indentation with a non-multiple of 4 spaces.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Per PEP 8, 4 spaces per indentation level should be preferred.
 ///
 /// ## Example
 /// ```python
@@ -25,6 +23,9 @@ use crate::rules::pycodestyle::logical_lines::LogicalLine;
 /// if True:
 ///     a = 1
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct IndentationWithInvalidMultiple {
     pub indent_size: usize,
@@ -39,12 +40,10 @@ impl Violation for IndentationWithInvalidMultiple {
 }
 
 /// ## What it does
-/// Checks for indentation of comments with invalid multiple of 4 spaces.
+/// Checks for indentation of comments with a non-multiple of 4 spaces.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Per PEP 8, 4 spaces per indentation level should be preferred.
 ///
 /// ## Example
 /// ```python
@@ -57,6 +56,9 @@ impl Violation for IndentationWithInvalidMultiple {
 /// if True:
 ///     # a = 1
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct IndentationWithInvalidMultipleComment {
     pub indent_size: usize,
@@ -71,12 +73,11 @@ impl Violation for IndentationWithInvalidMultipleComment {
 }
 
 /// ## What it does
-/// Checks for missing indented block.
+/// Checks for indented blocks that are lacking indentation.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// All indented blocks should be indented; otherwise, they are not valid
+/// Python syntax.
 ///
 /// ## Example
 /// ```python
@@ -90,6 +91,9 @@ impl Violation for IndentationWithInvalidMultipleComment {
 /// for item in items:
 ///     pass
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct NoIndentedBlock;
 
@@ -101,12 +105,11 @@ impl Violation for NoIndentedBlock {
 }
 
 /// ## What it does
-/// Checks for missing indented comment in a block.
+/// Checks for comments in a code blocks that are lacking indentation.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Comments within an indented block should themselves be indented, to
+/// indicate that they are part of the block.
 ///
 /// ## Example
 /// ```python
@@ -121,6 +124,9 @@ impl Violation for NoIndentedBlock {
 ///     # Hi
 ///     pass
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct NoIndentedBlockComment;
 
@@ -135,9 +141,7 @@ impl Violation for NoIndentedBlockComment {
 /// Checks for unexpected indentation.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Indentation outside of a code block is not valid Python syntax.
 ///
 /// ## Example
 /// ```python
@@ -150,6 +154,9 @@ impl Violation for NoIndentedBlockComment {
 /// a = 1
 /// b = 2
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct UnexpectedIndentation;
 
@@ -164,9 +171,7 @@ impl Violation for UnexpectedIndentation {
 /// Checks for unexpected indentation of comment.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Comments should match the indentation of the containing code block.
 ///
 /// ## Example
 /// ```python
@@ -179,6 +184,9 @@ impl Violation for UnexpectedIndentation {
 /// a = 1
 /// # b = 2
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct UnexpectedIndentationComment;
 
@@ -190,12 +198,12 @@ impl Violation for UnexpectedIndentationComment {
 }
 
 /// ## What it does
-/// Checks for over indented code.
+/// Checks for over-indented code.
 ///
 /// ## Why is this bad?
-/// Use indent_size (PEP8 says 4) spaces per indentation level.
-/// For really old code that you don't want to mess up, you can continue
-/// to use 8-space tabs.
+/// Per PEP 8, 4 spaces per indentation level should be preferred. Increased
+/// indentation can lead to inconsistent formatting, which can hurt
+/// readability.
 ///
 /// ## Example
 /// ```python
@@ -208,6 +216,9 @@ impl Violation for UnexpectedIndentationComment {
 /// for item in items:
 ///     pass
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#indentation)
 #[violation]
 pub struct OverIndented;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -6,6 +6,26 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::rules::pycodestyle::logical_lines::LogicalLine;
 
+/// ## What it does
+/// Checks for indentation with invalid multiple of 4 spaces.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// if True:
+///    a = 1
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if True:
+///     a = 1
+/// ```
+/// """
 #[violation]
 pub struct IndentationWithInvalidMultiple {
     pub indent_size: usize,
@@ -19,6 +39,26 @@ impl Violation for IndentationWithInvalidMultiple {
     }
 }
 
+/// ## What it does
+/// Checks for indentation of comments with invalid multiple of 4 spaces.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// if True:
+///    # a = 1
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if True:
+///     # a = 1
+/// ```
+/// """
 #[violation]
 pub struct IndentationWithInvalidMultipleComment {
     pub indent_size: usize,
@@ -32,6 +72,27 @@ impl Violation for IndentationWithInvalidMultipleComment {
     }
 }
 
+/// ## What it does
+/// Checks for missing indented block.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// for item in items:
+/// pass
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// for item in items:
+///     pass
+/// ```
+/// """
 #[violation]
 pub struct NoIndentedBlock;
 
@@ -42,6 +103,28 @@ impl Violation for NoIndentedBlock {
     }
 }
 
+/// ## What it does
+/// Checks for missing indented comment in a block.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// for item in items:
+/// # Hi
+///     pass
+/// ```
+///
+/// Use instead:
+/// ```python
+/// for item in items:
+///     # Hi
+///     pass
+/// ```
+/// """
 #[violation]
 pub struct NoIndentedBlockComment;
 
@@ -52,6 +135,26 @@ impl Violation for NoIndentedBlockComment {
     }
 }
 
+/// ## What it does
+/// Checks for unexpected indentation.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// a = 1
+///     b = 2
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 1
+/// b = 2
+/// ```
+/// """
 #[violation]
 pub struct UnexpectedIndentation;
 
@@ -62,6 +165,26 @@ impl Violation for UnexpectedIndentation {
     }
 }
 
+/// ## What it does
+/// Checks for unexpected indentation of comment.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// a = 1
+///     # b = 2
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 1
+/// # b = 2
+/// ```
+/// """
 #[violation]
 pub struct UnexpectedIndentationComment;
 
@@ -72,6 +195,26 @@ impl Violation for UnexpectedIndentationComment {
     }
 }
 
+/// ## What it does
+/// Checks for over indented code.
+///
+/// ## Why is this bad?
+/// Use indent_size (PEP8 says 4) spaces per indentation level.
+/// For really old code that you don't want to mess up, you can continue
+/// to use 8-space tabs.
+///
+/// ## Example
+/// ```python
+/// for item in items:
+///       pass
+/// ```
+///
+/// Use instead:
+/// ```python
+/// for item in items:
+///     pass
+/// ```
+/// """
 #[violation]
 pub struct OverIndented;
 
@@ -82,7 +225,7 @@ impl Violation for OverIndented {
     }
 }
 
-/// E111
+/// E111, E114, E112, E113, E115, E116, E117
 #[cfg(feature = "logical_lines")]
 pub fn indentation(
     logical_line: &LogicalLine,

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -25,7 +25,6 @@ use crate::rules::pycodestyle::logical_lines::LogicalLine;
 /// if True:
 ///     a = 1
 /// ```
-/// """
 #[violation]
 pub struct IndentationWithInvalidMultiple {
     pub indent_size: usize,
@@ -58,7 +57,6 @@ impl Violation for IndentationWithInvalidMultiple {
 /// if True:
 ///     # a = 1
 /// ```
-/// """
 #[violation]
 pub struct IndentationWithInvalidMultipleComment {
     pub indent_size: usize,
@@ -92,7 +90,6 @@ impl Violation for IndentationWithInvalidMultipleComment {
 /// for item in items:
 ///     pass
 /// ```
-/// """
 #[violation]
 pub struct NoIndentedBlock;
 
@@ -124,7 +121,6 @@ impl Violation for NoIndentedBlock {
 ///     # Hi
 ///     pass
 /// ```
-/// """
 #[violation]
 pub struct NoIndentedBlockComment;
 
@@ -154,7 +150,6 @@ impl Violation for NoIndentedBlockComment {
 /// a = 1
 /// b = 2
 /// ```
-/// """
 #[violation]
 pub struct UnexpectedIndentation;
 
@@ -184,7 +179,6 @@ impl Violation for UnexpectedIndentation {
 /// a = 1
 /// # b = 2
 /// ```
-/// """
 #[violation]
 pub struct UnexpectedIndentationComment;
 
@@ -214,7 +208,6 @@ impl Violation for UnexpectedIndentationComment {
 /// for item in items:
 ///     pass
 /// ```
-/// """
 #[violation]
 pub struct OverIndented;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -7,6 +7,22 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
+/// ## What it does
+/// Checks for invalid escape sequences.
+///
+/// ## Why is this bad?
+/// Invalid escape sequences are deprecated in Python 3.6.
+///
+/// ## Example
+/// ```python
+/// regex = '\.png$'
+/// ```
+///
+/// Use instead:
+/// ```python
+/// regex = r'\.png$'
+/// ```
+/// """
 #[violation]
 pub struct InvalidEscapeSequence(pub char);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -22,7 +22,6 @@ use ruff_python_ast::types::Range;
 /// ```python
 /// regex = r'\.png$'
 /// ```
-/// """
 #[violation]
 pub struct InvalidEscapeSequence(pub char);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -10,6 +10,26 @@ use ruff_python_ast::whitespace::leading_space;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
+/// ## What it does
+/// Checks for lambda expressions which are assigned to a variable.
+///
+/// ## Why is this bad?
+/// Compound statements (on the same line) are generally discouraged.
+/// Always use a def statement instead of an assignment statement that
+/// binds a lambda expression directly to a name.
+///
+///
+/// ## Example
+/// ```python
+/// f = lambda x: 2*x
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def f(x):
+///    return 2 * x
+/// ```
+/// """
 #[violation]
 pub struct LambdaAssignment {
     pub name: String,

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -29,7 +29,6 @@ use crate::registry::AsRule;
 /// def f(x):
 ///    return 2 * x
 /// ```
-/// """
 #[violation]
 pub struct LambdaAssignment {
     pub name: String,

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -14,10 +14,12 @@ use crate::registry::AsRule;
 /// Checks for lambda expressions which are assigned to a variable.
 ///
 /// ## Why is this bad?
-/// Compound statements (on the same line) are generally discouraged.
-/// Always use a def statement instead of an assignment statement that
-/// binds a lambda expression directly to a name.
+/// Per PEP 8, you should "Always use a def statement instead of an assignment
+/// statement that binds a lambda expression directly to an identifier."
 ///
+/// Using a `def` statement leads to better tracebacks, and the assignment
+/// itself negates the primary benefit of using a `lambda` expression (i.e.,
+/// that it can be embedded inside another expression).
 ///
 /// ## Example
 /// ```python
@@ -29,6 +31,9 @@ use crate::registry::AsRule;
 /// def f(x):
 ///    return 2 * x
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)
 #[violation]
 pub struct LambdaAssignment {
     pub name: String,

--- a/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
@@ -30,7 +30,6 @@ use crate::settings::Settings;
 ///     param6, param7, param8, param9, param10
 /// )
 /// ```
-/// """
 #[violation]
 pub struct LineTooLong(pub usize, pub usize);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
@@ -8,15 +8,10 @@ use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
 
 /// ## What it does
-/// Checks if all lines stay in the specified maximum character length.
+/// Checks for lines that exceed the specified maximum character length.
 ///
 /// ## Why is this bad?
-/// There are still many devices around that are limited to 80 character
-/// lines; plus, limiting windows to 80 characters makes it possible to
-/// have several windows side-by-side. The default wrapping on such
-/// devices looks ugly. Therefore, please limit all lines to a maximum
-/// of 79 characters. For flowing long blocks of text (docstrings or
-/// comments), limiting the length to 72 characters is recommended.
+/// Overlong lines can hurt readability.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
@@ -7,6 +7,30 @@ use ruff_python_ast::types::Range;
 use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
 
+/// ## What it does
+/// Checks if all lines stay in the specified maximum character length.
+///
+/// ## Why is this bad?
+/// There are still many devices around that are limited to 80 character
+/// lines; plus, limiting windows to 80 characters makes it possible to
+/// have several windows side-by-side. The default wrapping on such
+/// devices looks ugly. Therefore, please limit all lines to a maximum
+/// of 79 characters. For flowing long blocks of text (docstrings or
+/// comments), limiting the length to 72 characters is recommended.
+///
+/// ## Example
+/// ```python
+/// my_function(param1, param2, param3, param4, param5, param6, param7, param8, param9, param10)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// my_function(
+///     param1, param2, param3, param4, param5,
+///     param6, param7, param8, param9, param10
+/// )
+/// ```
+/// """
 #[violation]
 pub struct LineTooLong(pub usize, pub usize);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -28,6 +28,31 @@ impl From<&Cmpop> for EqCmpop {
     }
 }
 
+/// ## What it does
+/// Checks for comparisons to `None` which are not using the `is` operator.
+///
+/// ## Why is this bad?
+/// Comparison to singletons should use `is` or `is not`.
+///
+/// Comparisons to singletons like None should always be done
+/// with `is` or `is not`, never the equality operators.
+///
+/// Also, beware of writing `if x` when you really mean `if x is not None`
+/// -- e.g. when testing whether a variable or argument that defaults to
+/// None was set to some other value.  The other value might have a type
+/// (such as a container) that could be false in a boolean context!
+///
+/// ## Example
+/// ```python
+/// if arg != None:
+/// if None == arg:
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if arg is not None:
+/// ```
+/// """
 #[violation]
 pub struct NoneComparison(pub EqCmpop);
 
@@ -50,6 +75,27 @@ impl AlwaysAutofixableViolation for NoneComparison {
     }
 }
 
+/// ## What it does
+/// Checks for comparisons to booleans which are not using the `is` operator.
+///
+/// ## Why is this bad?
+/// Comparison to singletons should use `is` or `is not`.
+///
+/// Comparisons to singletons like `True` or `False` should always be done
+/// with `is` or `is not`, never the equality operators.
+///
+/// ## Example
+/// ```python
+/// if arg == True:
+/// if False == arg:
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if arg:
+/// if not arg:
+/// ```
+/// """
 #[violation]
 pub struct TrueFalseComparison(pub bool, pub EqCmpop);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -32,15 +32,8 @@ impl From<&Cmpop> for EqCmpop {
 /// Checks for comparisons to `None` which are not using the `is` operator.
 ///
 /// ## Why is this bad?
-/// Comparison to singletons should use `is` or `is not`.
-///
-/// Comparisons to singletons like None should always be done
-/// with `is` or `is not`, never the equality operators.
-///
-/// Also, beware of writing `if x` when you really mean `if x is not None`
-/// -- e.g. when testing whether a variable or argument that defaults to
-/// None was set to some other value.  The other value might have a type
-/// (such as a container) that could be false in a boolean context!
+/// Per PEP 8, "Comparisons to singletons like None should always be done with
+/// is or is not, never the equality operators."
 ///
 /// ## Example
 /// ```python
@@ -52,6 +45,9 @@ impl From<&Cmpop> for EqCmpop {
 /// ```python
 /// if arg is not None:
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)
 #[violation]
 pub struct NoneComparison(pub EqCmpop);
 
@@ -78,10 +74,8 @@ impl AlwaysAutofixableViolation for NoneComparison {
 /// Checks for comparisons to booleans which are not using the `is` operator.
 ///
 /// ## Why is this bad?
-/// Comparison to singletons should use `is` or `is not`.
-///
-/// Comparisons to singletons like `True` or `False` should always be done
-/// with `is` or `is not`, never the equality operators.
+/// Per PEP 8, "Comparisons to singletons like None should always be done with
+/// is or is not, never the equality operators."
 ///
 /// ## Example
 /// ```python
@@ -91,9 +85,12 @@ impl AlwaysAutofixableViolation for NoneComparison {
 ///
 /// Use instead:
 /// ```python
-/// if arg:
-/// if not arg:
+/// if arg is True:
+/// if arg is False:
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#programming-recommendations)
 #[violation]
 pub struct TrueFalseComparison(pub bool, pub EqCmpop);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -52,7 +52,6 @@ impl From<&Cmpop> for EqCmpop {
 /// ```python
 /// if arg is not None:
 /// ```
-/// """
 #[violation]
 pub struct NoneComparison(pub EqCmpop);
 
@@ -95,7 +94,6 @@ impl AlwaysAutofixableViolation for NoneComparison {
 /// if arg:
 /// if not arg:
 /// ```
-/// """
 #[violation]
 pub struct TrueFalseComparison(pub bool, pub EqCmpop);
 

--- a/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -25,7 +25,6 @@ use ruff_python_ast::whitespace::leading_space;
 /// ```python
 /// if a == 0:\n    a = 1\n    b = 1
 /// ```
-/// """
 #[violation]
 pub struct MixedSpacesAndTabs;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -5,6 +5,27 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::leading_space;
 
+/// ## What it does
+/// Checks for mixed tabs and spaces in indentation.
+///
+/// ## Why is this bad?
+/// Never mix tabs and spaces.
+///
+/// The most popular way of indenting Python is with spaces only. The
+/// second-most popular way is with tabs only. Code indented with a
+/// mixture of tabs and spaces should be converted to using spaces
+/// exclusively.
+///
+/// ## Example
+/// ```python
+/// if a == 0:\n        a = 1\n\tb = 1
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if a == 0:\n    a = 1\n    b = 1
+/// ```
+/// """
 #[violation]
 pub struct MixedSpacesAndTabs;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
@@ -5,6 +5,23 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 
+/// ## What it does
+/// Checks for files missing a new line at the end of the file.
+///
+/// ## Why is this bad?
+/// Trailing blank lines are superfluous.
+/// However the last line should end with a new line.
+///
+/// ## Example
+/// ```python
+/// spam(1)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// spam(1)\n
+/// ```
+/// """
 #[violation]
 pub struct NoNewLineAtEndOfFile;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
@@ -21,7 +21,6 @@ use ruff_python_ast::types::Range;
 /// ```python
 /// spam(1)\n
 /// ```
-/// """
 #[violation]
 pub struct NoNewLineAtEndOfFile;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -8,6 +8,26 @@ use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::compare;
 
+/// ## What it does
+/// Checks for negative comparison using `not {foo} in {bar}`.
+///
+/// ## Why is this bad?
+/// Negative comparison should be done using `not in`.
+///
+/// ## Example
+/// ```python
+/// Z = not X in Y
+/// if not X.B in Y:\n    pass
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if x not in y:\n    pass
+/// assert (X in Y or X is Z)
+///
+/// ```
+/// """
 #[violation]
 pub struct NotInTest;
 
@@ -22,6 +42,26 @@ impl AlwaysAutofixableViolation for NotInTest {
     }
 }
 
+/// ## What it does
+/// Checks for negative comparison using `not {foo} is {bar}`.
+///
+/// ## Why is this bad?
+/// Negative comparison should be done using `is not`.
+///
+/// ## Example
+/// ```python
+/// if not X is Y:
+///     pass
+/// Z = not X.B is Y
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if not (X in Y):
+///     pass
+/// zz = x is not y
+/// ```
+/// """
 #[violation]
 pub struct NotIsTest;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -27,7 +27,6 @@ use crate::rules::pycodestyle::helpers::compare;
 /// assert (X in Y or X is Z)
 ///
 /// ```
-/// """
 #[violation]
 pub struct NotInTest;
 
@@ -61,7 +60,6 @@ impl AlwaysAutofixableViolation for NotInTest {
 ///     pass
 /// zz = x is not y
 /// ```
-/// """
 #[violation]
 pub struct NotIsTest;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
@@ -11,7 +11,8 @@ use ruff_macros::{derive_message_formats, violation};
 /// Checks for extraneous tabs before an operator.
 ///
 /// ## Why is this bad?
-///
+/// Per PEP 8, operators should be surrounded by at most a single space on either
+/// side.
 ///
 /// ## Example
 /// ```python
@@ -22,6 +23,9 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```python
 /// a = 12 + 3
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements)
 #[violation]
 pub struct TabBeforeOperator;
 
@@ -36,7 +40,8 @@ impl Violation for TabBeforeOperator {
 /// Checks for extraneous whitespace before an operator.
 ///
 /// ## Why is this bad?
-///
+/// Per PEP 8, operators should be surrounded by at most a single space on either
+/// side.
 ///
 /// ## Example
 /// ```python
@@ -47,6 +52,9 @@ impl Violation for TabBeforeOperator {
 /// ```python
 /// a = 12 + 3
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements)
 #[violation]
 pub struct MultipleSpacesBeforeOperator;
 
@@ -61,7 +69,8 @@ impl Violation for MultipleSpacesBeforeOperator {
 /// Checks for extraneous tabs after an operator.
 ///
 /// ## Why is this bad?
-///
+/// Per PEP 8, operators should be surrounded by at most a single space on either
+/// side.
 ///
 /// ## Example
 /// ```python
@@ -72,6 +81,9 @@ impl Violation for MultipleSpacesBeforeOperator {
 /// ```python
 /// a = 12 + 3
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements)
 #[violation]
 pub struct TabAfterOperator;
 
@@ -86,7 +98,8 @@ impl Violation for TabAfterOperator {
 /// Checks for extraneous whitespace after an operator.
 ///
 /// ## Why is this bad?
-///
+/// Per PEP 8, operators should be surrounded by at most a single space on either
+/// side.
 ///
 /// ## Example
 /// ```python
@@ -97,6 +110,9 @@ impl Violation for TabAfterOperator {
 /// ```python
 /// a = 12 + 3
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements)
 #[violation]
 pub struct MultipleSpacesAfterOperator;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
@@ -7,6 +7,21 @@ use ruff_diagnostics::DiagnosticKind;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for extraneous tabs before an operator.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// a = 4\t+ 5
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 12 + 3
+/// ```
 #[violation]
 pub struct TabBeforeOperator;
 
@@ -17,6 +32,21 @@ impl Violation for TabBeforeOperator {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous whitespace before an operator.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// a = 4  + 5
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 12 + 3
+/// ```
 #[violation]
 pub struct MultipleSpacesBeforeOperator;
 
@@ -27,6 +57,21 @@ impl Violation for MultipleSpacesBeforeOperator {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous tabs after an operator.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// a = 4 +\t5
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 12 + 3
+/// ```
 #[violation]
 pub struct TabAfterOperator;
 
@@ -37,6 +82,21 @@ impl Violation for TabAfterOperator {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous whitespace after an operator.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// a = 4 +  5
+/// ```
+///
+/// Use instead:
+/// ```python
+/// a = 12 + 3
+/// ```
 #[violation]
 pub struct MultipleSpacesAfterOperator;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -9,10 +9,10 @@ use crate::settings::{flags, Settings};
 
 /// ## What it does
 /// Checks for superfluous trailing whitespace.
-/// The warning returned varies on whether the line itself is blank,
-/// for easier filtering for those who want to indent their blank lines.
 ///
 /// ## Why is this bad?
+/// Per PEP 8, "avoid trailing whitespace anywhere. Because it’s usually
+/// invisible, it can be confusing"
 ///
 /// ## Example
 /// ```python
@@ -23,6 +23,9 @@ use crate::settings::{flags, Settings};
 /// ```python
 /// spam(1)\n#
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#other-recommendations)
 #[violation]
 pub struct TrailingWhitespace;
 
@@ -39,11 +42,10 @@ impl AlwaysAutofixableViolation for TrailingWhitespace {
 
 /// ## What it does
 /// Checks for superfluous whitespace in blank lines.
-/// The warning returned varies on whether the line itself is blank,
-/// for easier filtering for those who want to indent their blank lines.
 ///
 /// ## Why is this bad?
-///
+/// Per PEP 8, "avoid trailing whitespace anywhere. Because it’s usually
+/// invisible, it can be confusing"
 ///
 /// ## Example
 /// ```python
@@ -55,6 +57,9 @@ impl AlwaysAutofixableViolation for TrailingWhitespace {
 /// ```python
 /// class Foo(object):\n\n    bang = 12
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#other-recommendations)
 #[violation]
 pub struct BlankLineContainsWhitespace;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -23,7 +23,6 @@ use crate::settings::{flags, Settings};
 /// ```python
 /// spam(1)\n#
 /// ```
-/// """
 #[violation]
 pub struct TrailingWhitespace;
 
@@ -56,7 +55,6 @@ impl AlwaysAutofixableViolation for TrailingWhitespace {
 /// ```python
 /// class Foo(object):\n\n    bang = 12
 /// ```
-/// """
 #[violation]
 pub struct BlankLineContainsWhitespace;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -7,6 +7,23 @@ use ruff_python_ast::types::Range;
 use crate::registry::Rule;
 use crate::settings::{flags, Settings};
 
+/// ## What it does
+/// Checks for superfluous trailing whitespace.
+/// The warning returned varies on whether the line itself is blank,
+/// for easier filtering for those who want to indent their blank lines.
+///
+/// ## Why is this bad?
+///
+/// ## Example
+/// ```python
+/// spam(1) \n#
+/// ```
+///
+/// Use instead:
+/// ```python
+/// spam(1)\n#
+/// ```
+/// """
 #[violation]
 pub struct TrailingWhitespace;
 
@@ -21,6 +38,25 @@ impl AlwaysAutofixableViolation for TrailingWhitespace {
     }
 }
 
+/// ## What it does
+/// Checks for superfluous whitespace in blank lines.
+/// The warning returned varies on whether the line itself is blank,
+/// for easier filtering for those who want to indent their blank lines.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// class Foo(object):\n    \n    bang = 12
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// class Foo(object):\n\n    bang = 12
+/// ```
+/// """
 #[violation]
 pub struct BlankLineContainsWhitespace;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -5,6 +5,25 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
+/// ## What it does
+/// Checks for object type comparisons without using isinstance().
+///
+/// ## Why is this bad?
+/// Do not compare types directly.
+/// When checking if an object is a instance of a certain type, keep in mind that it might
+/// be subclassed. E.g. `bool` inherits from `int` or `Exception` inherits from `BaseException`.
+///
+/// ## Example
+/// ```python
+/// if type(obj) is type(1):
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if isinstance(obj, int):
+/// if type(a1) is type(b1):
+/// ```
+/// """
 #[violation]
 pub struct TypeComparison;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -23,7 +23,6 @@ use ruff_python_ast::types::Range;
 /// if isinstance(obj, int):
 /// if type(a1) is type(b1):
 /// ```
-/// """
 #[violation]
 pub struct TypeComparison;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
@@ -22,7 +22,6 @@ use ruff_macros::{derive_message_formats, violation};
 /// ```python
 /// True and False
 /// ```
-/// """
 #[violation]
 pub struct MultipleSpacesAfterKeyword;
 
@@ -49,7 +48,6 @@ impl Violation for MultipleSpacesAfterKeyword {
 /// ```python
 /// True and False
 /// ```
-/// """
 #[violation]
 pub struct MultipleSpacesBeforeKeyword;
 
@@ -76,7 +74,6 @@ impl Violation for MultipleSpacesBeforeKeyword {
 /// ```python
 /// True and False
 /// ```
-/// """
 #[violation]
 pub struct TabAfterKeyword;
 
@@ -103,7 +100,6 @@ impl Violation for TabAfterKeyword {
 /// ```python
 /// True and False
 /// ```
-/// """
 #[violation]
 pub struct TabBeforeKeyword;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
@@ -7,6 +7,22 @@ use ruff_diagnostics::DiagnosticKind;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for extraneous whitespace after keywords.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// True and  False
+/// ```
+///
+/// Use instead:
+/// ```python
+/// True and False
+/// ```
+/// """
 #[violation]
 pub struct MultipleSpacesAfterKeyword;
 
@@ -17,6 +33,23 @@ impl Violation for MultipleSpacesAfterKeyword {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous whitespace before keywords.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// True  and False
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// True and False
+/// ```
+/// """
 #[violation]
 pub struct MultipleSpacesBeforeKeyword;
 
@@ -27,6 +60,23 @@ impl Violation for MultipleSpacesBeforeKeyword {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous tabs after keywords.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// True and\tFalse
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// True and False
+/// ```
+/// """
 #[violation]
 pub struct TabAfterKeyword;
 
@@ -37,6 +87,23 @@ impl Violation for TabAfterKeyword {
     }
 }
 
+/// ## What it does
+/// Checks for extraneous tabs before keywords.
+///
+/// ## Why is this bad?
+///
+///
+/// ## Example
+/// ```python
+/// True\tand False
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// True and False
+/// ```
+/// """
 #[violation]
 pub struct TabBeforeKeyword;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -9,6 +9,25 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
+/// ## What it does
+/// Checks if inline comments are separated by at least two spaces.
+///
+/// ## Why is this bad?
+/// An inline comment is a comment on the same line as a statement.
+/// Inline comments should be separated by at least two spaces from the
+/// statement. They should start with a # and a single space.
+///
+/// ## Example
+/// ```python
+/// x = x + 1 # Increment x
+/// ```
+///
+/// Use instead:
+/// ```python
+/// x = x + 1  # Increment x
+/// x = x + 1    # Increment x
+/// ```
+/// """
 #[violation]
 pub struct TooFewSpacesBeforeInlineComment;
 
@@ -19,6 +38,27 @@ impl Violation for TooFewSpacesBeforeInlineComment {
     }
 }
 
+/// ## What it does
+/// Checks if one space is used after inline comments.
+///
+/// ## Why is this bad?
+/// An inline comment is a comment on the same line as a statement.
+/// Inline comments should be separated by at least two spaces from the
+/// statement. They should start with a # and a single space.
+///
+/// ## Example
+/// ```python
+/// x = x + 1  #Increment x
+/// x = x + 1  #  Increment x
+/// x = x + 1  # \xa0Increment x
+/// ```
+///
+/// Use instead:
+/// ```python
+/// x = x + 1  # Increment x
+/// x = x + 1    # Increment x
+/// ```
+/// """
 #[violation]
 pub struct NoSpaceAfterInlineComment;
 
@@ -29,6 +69,25 @@ impl Violation for NoSpaceAfterInlineComment {
     }
 }
 
+/// ## What it does
+/// Checks if one space is used after block comments.
+///
+/// ## Why is this bad?
+/// Each line of a block comment starts with a # and one or multiple
+/// spaces as there can be indented text inside the comment.
+///
+/// ## Example
+/// ```python
+/// #Block comment
+/// ```
+///
+/// Use instead:
+/// ```python
+/// # Block comments:
+/// #  - Block comment list
+/// # \xa0- Block comment list
+/// ```
+/// """
 #[violation]
 pub struct NoSpaceAfterBlockComment;
 
@@ -39,6 +98,26 @@ impl Violation for NoSpaceAfterBlockComment {
     }
 }
 
+/// ## What it does
+/// Checks if block comments start with a single "#".
+///
+/// ## Why is this bad?
+/// Each line of a block comment starts with a # and one or multiple
+/// spaces as there can be indented text inside the comment.
+///
+/// ## Example
+/// ```python
+/// ### Block comment
+///
+/// ```
+///
+/// Use instead:
+/// ```python
+/// # Block comments:
+/// #  - Block comment list
+/// # \xa0- Block comment list
+/// ```
+/// """
 #[violation]
 pub struct MultipleLeadingHashesForBlockComment;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -27,7 +27,6 @@ use ruff_python_ast::types::Range;
 /// x = x + 1  # Increment x
 /// x = x + 1    # Increment x
 /// ```
-/// """
 #[violation]
 pub struct TooFewSpacesBeforeInlineComment;
 
@@ -58,7 +57,6 @@ impl Violation for TooFewSpacesBeforeInlineComment {
 /// x = x + 1  # Increment x
 /// x = x + 1    # Increment x
 /// ```
-/// """
 #[violation]
 pub struct NoSpaceAfterInlineComment;
 
@@ -87,7 +85,6 @@ impl Violation for NoSpaceAfterInlineComment {
 /// #  - Block comment list
 /// # \xa0- Block comment list
 /// ```
-/// """
 #[violation]
 pub struct NoSpaceAfterBlockComment;
 
@@ -117,7 +114,6 @@ impl Violation for NoSpaceAfterBlockComment {
 /// #  - Block comment list
 /// # \xa0- Block comment list
 /// ```
-/// """
 #[violation]
 pub struct MultipleLeadingHashesForBlockComment;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -14,8 +14,9 @@ use ruff_python_ast::types::Range;
 ///
 /// ## Why is this bad?
 /// An inline comment is a comment on the same line as a statement.
-/// Inline comments should be separated by at least two spaces from the
-/// statement. They should start with a # and a single space.
+///
+/// Per PEP8, inline comments should be separated by at least two spaces from
+/// the preceding statement.
 ///
 /// ## Example
 /// ```python
@@ -42,8 +43,8 @@ impl Violation for TooFewSpacesBeforeInlineComment {
 ///
 /// ## Why is this bad?
 /// An inline comment is a comment on the same line as a statement.
-/// Inline comments should be separated by at least two spaces from the
-/// statement. They should start with a # and a single space.
+///
+/// Per PEP8, inline comments should start with a # and a single space.
 ///
 /// ## Example
 /// ```python
@@ -57,6 +58,9 @@ impl Violation for TooFewSpacesBeforeInlineComment {
 /// x = x + 1  # Increment x
 /// x = x + 1    # Increment x
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#comments)
 #[violation]
 pub struct NoSpaceAfterInlineComment;
 
@@ -71,8 +75,10 @@ impl Violation for NoSpaceAfterInlineComment {
 /// Checks if one space is used after block comments.
 ///
 /// ## Why is this bad?
-/// Each line of a block comment starts with a # and one or multiple
-/// spaces as there can be indented text inside the comment.
+/// Per PEP8, "Block comments generally consist of one or more paragraphs built
+/// out of complete sentences, with each sentence ending in a period."
+///
+/// Block comments should start with a # and a single space.
 ///
 /// ## Example
 /// ```python
@@ -85,6 +91,9 @@ impl Violation for NoSpaceAfterInlineComment {
 /// #  - Block comment list
 /// # \xa0- Block comment list
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#comments)
 #[violation]
 pub struct NoSpaceAfterBlockComment;
 
@@ -99,8 +108,10 @@ impl Violation for NoSpaceAfterBlockComment {
 /// Checks if block comments start with a single "#".
 ///
 /// ## Why is this bad?
-/// Each line of a block comment starts with a # and one or multiple
-/// spaces as there can be indented text inside the comment.
+/// Per PEP8, "Block comments generally consist of one or more paragraphs built
+/// out of complete sentences, with each sentence ending in a period."
+///
+/// Each line of a block comment should start with a # and a single space.
 ///
 /// ## Example
 /// ```python
@@ -114,6 +125,9 @@ impl Violation for NoSpaceAfterBlockComment {
 /// #  - Block comment list
 /// # \xa0- Block comment list
 /// ```
+///
+/// ## References
+/// - [PEP 8](https://peps.python.org/pep-0008/#comments)
 #[violation]
 pub struct MultipleLeadingHashesForBlockComment;
 


### PR DESCRIPTION
rip of the descriptions used by pycodestyle itself.

Sometimes the `Why is this bad?` doesn't fit and should better be `Explanation` - but I am not sure if this is a free-format?
Sometimes a `Exceptions` or `Okay variants` section would help.
It's meant as a starting point which can be improved.