### PR TITLE
Introduce a `ruff_diagnostics` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,7 @@ dependencies = [
  "regex",
  "result-like",
  "ruff_cache",
+ "ruff_diagnostics",
  "ruff_macros",
  "ruff_python_ast",
  "ruff_python_stdlib",
@@ -2042,6 +2043,7 @@ dependencies = [
  "regex",
  "ruff",
  "ruff_cache",
+ "ruff_diagnostics",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2067,6 +2069,7 @@ dependencies = [
  "regex",
  "ruff",
  "ruff_cli",
+ "ruff_diagnostics",
  "rustpython-common",
  "rustpython-parser",
  "schemars",
@@ -2074,6 +2077,15 @@ dependencies = [
  "strum",
  "strum_macros",
  "textwrap",
+]
+
+[[package]]
+name = "ruff_diagnostics"
+version = "0.0.0"
+dependencies = [
+ "ruff_python_ast",
+ "rustpython-parser",
+ "serde",
 ]
 
 [[package]]

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false
 
 [dependencies]
 ruff_cache = { path = "../ruff_cache" }
+ruff_diagnostics = { path = "../ruff_diagnostics", features = ["serde"] }
 ruff_macros = { path = "../ruff_macros" }
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }

--- a/crates/ruff/src/autofix/helpers.rs
+++ b/crates/ruff/src/autofix/helpers.rs
@@ -6,14 +6,14 @@ use libcst_native::{
 use rustpython_parser::ast::{ExcepthandlerKind, Expr, Keyword, Location, Stmt, StmtKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use crate::cst::helpers::compose_module_path;
-use crate::cst::matchers::match_module;
-use crate::fix::Fix;
+use ruff_diagnostics::Fix;
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::to_absolute;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-
 use ruff_python_ast::whitespace::LinesWithTrailingNewline;
+
+use crate::cst::helpers::compose_module_path;
+use crate::cst::matchers::match_module;
 
 /// Determine if a body contains only a single statement, taking into account
 /// deleted.
@@ -450,8 +450,9 @@ mod tests {
     use rustpython_parser as parser;
     use rustpython_parser::ast::Location;
 
-    use crate::autofix::helpers::{next_stmt_break, trailing_semicolon};
     use ruff_python_ast::source_code::Locator;
+
+    use crate::autofix::helpers::{next_stmt_break, trailing_semicolon};
 
     #[test]
     fn find_semicolon() -> Result<()> {

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -13,6 +13,7 @@ use rustpython_parser::ast::{
     Suite,
 };
 
+use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::context::Context;
 use ruff_python_ast::helpers::{
     binding_range, extract_handled_exceptions, to_module_path, Exceptions,
@@ -36,7 +37,7 @@ use crate::checkers::ast::deferred::Deferred;
 use crate::docstrings::definition::{
     transition_scope, Definition, DefinitionKind, Docstring, Documentable,
 };
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rules::{
     flake8_2020, flake8_annotations, flake8_bandit, flake8_blind_except, flake8_boolean_trap,
     flake8_bugbear, flake8_builtins, flake8_comprehensions, flake8_datetimez, flake8_debugger,

--- a/crates/ruff/src/checkers/filesystem.rs
+++ b/crates/ruff/src/checkers/filesystem.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use crate::registry::{Diagnostic, Rule};
+use ruff_diagnostics::Diagnostic;
+
+use crate::registry::Rule;
 use crate::rules::flake8_no_pep420::rules::implicit_namespace_package;
 use crate::rules::pep8_naming::rules::invalid_module_name;
 use crate::settings::Settings;

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -4,13 +4,15 @@ use std::path::Path;
 
 use rustpython_parser::ast::Suite;
 
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+use ruff_python_ast::visitor::Visitor;
+
 use crate::directives::IsortDirectives;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::rules::isort;
 use crate::rules::isort::track::{Block, ImportTracker};
 use crate::settings::{flags, Settings};
-use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-use ruff_python_ast::visitor::Visitor;
 
 #[allow(clippy::too_many_arguments)]
 pub fn check_imports(

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -5,7 +5,11 @@ use itertools::Itertools;
 use rustpython_parser::ast::Location;
 use rustpython_parser::lexer::LexResult;
 
-use crate::registry::{AsRule, Diagnostic, Rule};
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::source_code::{Locator, Stylist};
+use ruff_python_ast::types::Range;
+
+use crate::registry::{AsRule, Rule};
 use crate::rules::pycodestyle::logical_lines::{iter_logical_lines, TokenFlags};
 use crate::rules::pycodestyle::rules::{
     extraneous_whitespace, indentation, missing_whitespace, missing_whitespace_after_keyword,
@@ -14,8 +18,6 @@ use crate::rules::pycodestyle::rules::{
     whitespace_before_parameters,
 };
 use crate::settings::{flags, Settings};
-use ruff_python_ast::source_code::{Locator, Stylist};
-use ruff_python_ast::types::Range;
 
 /// Return the amount of indentation, expanding tabs to the next multiple of 8.
 fn expand_indent(mut line: &str) -> usize {
@@ -225,8 +227,9 @@ mod tests {
     use rustpython_parser::lexer::LexResult;
     use rustpython_parser::{lexer, Mode};
 
-    use crate::checkers::logical_lines::iter_logical_lines;
     use ruff_python_ast::source_code::Locator;
+
+    use crate::checkers::logical_lines::iter_logical_lines;
 
     #[test]
     fn split_logical_lines() {

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -4,13 +4,13 @@ use log::warn;
 use nohash_hasher::IntMap;
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_python_ast::types::Range;
 
 use crate::codes::NoqaCode;
-use crate::fix::Fix;
 use crate::noqa;
 use crate::noqa::{extract_file_exemption, Directive, Exemption};
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rule_redirects::get_redirect_target;
 use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
 use crate::settings::{flags, Settings};

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -2,7 +2,10 @@
 
 use std::path::Path;
 
-use crate::registry::{Diagnostic, Rule};
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::source_code::Stylist;
+
+use crate::registry::Rule;
 use crate::rules::flake8_executable::helpers::{extract_shebang, ShebangDirective};
 use crate::rules::flake8_executable::rules::{
     shebang_missing, shebang_newline, shebang_not_executable, shebang_python, shebang_whitespace,
@@ -15,7 +18,6 @@ use crate::rules::pygrep_hooks::rules::{blanket_noqa, blanket_type_ignore};
 use crate::rules::pylint;
 use crate::rules::pyupgrade::rules::unnecessary_coding_comment;
 use crate::settings::{flags, Settings};
-use ruff_python_ast::source_code::Stylist;
 
 pub fn check_physical_lines(
     path: &Path,
@@ -179,13 +181,14 @@ pub fn check_physical_lines(
 
 #[cfg(test)]
 mod tests {
-
     use std::path::Path;
 
-    use super::check_physical_lines;
+    use ruff_python_ast::source_code::{Locator, Stylist};
+
     use crate::registry::Rule;
     use crate::settings::{flags, Settings};
-    use ruff_python_ast::source_code::{Locator, Stylist};
+
+    use super::check_physical_lines;
 
     #[test]
     fn e501_non_ascii_char() {

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -4,13 +4,14 @@ use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
 use crate::lex::docstring_detection::StateMachine;
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rules::ruff::rules::Context;
 use crate::rules::{
     eradicate, flake8_commas, flake8_implicit_str_concat, flake8_pyi, flake8_quotes, pycodestyle,
     pyupgrade, ruff,
 };
 use crate::settings::{flags, Settings};
+use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::source_code::Locator;
 
 pub fn check_tokens(

--- a/crates/ruff/src/fix.rs
+++ b/crates/ruff/src/fix.rs
@@ -1,6 +1,3 @@
-use rustpython_parser::ast::Location;
-use serde::{Deserialize, Serialize};
-
 #[derive(Debug, Copy, Clone, Hash)]
 pub enum FixMode {
     Generate,
@@ -15,43 +12,6 @@ impl From<bool> for FixMode {
             Self::Apply
         } else {
             Self::None
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Fix {
-    pub content: String,
-    pub location: Location,
-    pub end_location: Location,
-}
-
-impl Fix {
-    pub const fn deletion(start: Location, end: Location) -> Self {
-        Self {
-            content: String::new(),
-            location: start,
-            end_location: end,
-        }
-    }
-
-    pub fn replacement(content: String, start: Location, end: Location) -> Self {
-        debug_assert!(!content.is_empty(), "Prefer `Fix::deletion`");
-
-        Self {
-            content,
-            location: start,
-            end_location: end,
-        }
-    }
-
-    pub fn insertion(content: String, at: Location) -> Self {
-        debug_assert!(!content.is_empty(), "Insert content is empty");
-
-        Self {
-            content,
-            location: at,
-            end_location: at,
         }
     }
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -9,7 +9,6 @@ pub use ruff_python_ast::source_code::round_trip;
 pub use ruff_python_ast::types::Range;
 pub use rule_selector::RuleSelector;
 pub use rules::pycodestyle::rules::IOError;
-pub use violation::{AutofixKind, Availability as AutofixAvailability};
 
 mod autofix;
 mod checkers;
@@ -33,7 +32,6 @@ mod rule_redirects;
 mod rule_selector;
 pub mod rules;
 pub mod settings;
-mod violation;
 
 #[cfg(test)]
 mod test;

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -4,10 +4,13 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use log::error;
-use ruff_python_stdlib::path::is_python_stub_file;
 use rustc_hash::FxHashMap;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::ParseError;
+
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+use ruff_python_stdlib::path::is_python_stub_file;
 
 use crate::autofix::fix_file;
 use crate::checkers::ast::check_ast;
@@ -21,11 +24,10 @@ use crate::directives::Directives;
 use crate::doc_lines::{doc_lines_from_ast, doc_lines_from_tokens};
 use crate::message::{Message, Source};
 use crate::noqa::{add_noqa, rule_is_ignored};
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rules::pycodestyle;
 use crate::settings::{flags, Settings};
 use crate::{directives, fs};
-use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 
 const CARGO_PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const CARGO_PKG_REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");

--- a/crates/ruff/src/message.rs
+++ b/crates/ruff/src/message.rs
@@ -3,8 +3,7 @@ use std::cmp::Ordering;
 pub use rustpython_parser::ast::Location;
 use serde::{Deserialize, Serialize};
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, DiagnosticKind};
+use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -11,11 +11,12 @@ use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::source_code::{LineEnding, Locator};
 use ruff_python_ast::types::Range;
 
 use crate::codes::NoqaCode;
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rule_redirects::get_redirect_target;
 
 static NOQA_LINE_REGEX: Lazy<Regex> = Lazy::new(|| {
@@ -333,11 +334,11 @@ mod tests {
     use nohash_hasher::IntMap;
     use rustpython_parser::ast::Location;
 
+    use ruff_diagnostics::Diagnostic;
     use ruff_python_ast::source_code::LineEnding;
     use ruff_python_ast::types::Range;
 
     use crate::noqa::{add_noqa_inner, NOQA_LINE_REGEX};
-    use crate::registry::Diagnostic;
     use crate::rules::pycodestyle::rules::AmbiguousVariableName;
     use crate::rules::pyflakes;
 

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -1,16 +1,12 @@
-//! Registry of [`Rule`] to [`DiagnosticKind`] mappings.
+//! Registry of all [`Rule`] implementations.
 
-use rustpython_parser::ast::Location;
-use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, EnumIter};
 
+use ruff_diagnostics::Violation;
 use ruff_macros::RuleNamespace;
-use ruff_python_ast::types::Range;
 
 use crate::codes::{self, RuleCodePrefix};
-use crate::fix::Fix;
 use crate::rules;
-use crate::violation::Violation;
 
 ruff_macros::register_rules!(
     // pycodestyle errors
@@ -896,49 +892,6 @@ impl Rule {
             | Rule::WhitespaceBeforePunctuation => &LintSource::LogicalLines,
             _ => &LintSource::Ast,
         }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DiagnosticKind {
-    /// The identifier of the corresponding [`Rule`].
-    pub name: String,
-    /// The message body to display to the user, to explain the diagnostic.
-    pub body: String,
-    /// The message to display to the user, to explain the suggested fix.
-    pub suggestion: Option<String>,
-    /// Whether the diagnostic is automatically fixable.
-    pub fixable: bool,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Diagnostic {
-    pub kind: DiagnosticKind,
-    pub location: Location,
-    pub end_location: Location,
-    pub fix: Option<Fix>,
-    pub parent: Option<Location>,
-}
-
-impl Diagnostic {
-    pub fn new<K: Into<DiagnosticKind>>(kind: K, range: Range) -> Self {
-        Self {
-            kind: kind.into(),
-            location: range.location,
-            end_location: range.end_location,
-            fix: None,
-            parent: None,
-        }
-    }
-
-    pub fn amend(&mut self, fix: Fix) -> &mut Self {
-        self.fix = Some(fix);
-        self
-    }
-
-    pub fn parent(&mut self, parent: Location) -> &mut Self {
-        self.parent = Some(parent);
-        self
     }
 }
 

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::detection::comment_contains_code;
 

--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -1,12 +1,12 @@
 use num_bigint::BigInt;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Located};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct SysVersionSlice3Referenced;

--- a/crates/ruff/src/rules/flake8_annotations/fixes.rs
+++ b/crates/ruff/src/rules/flake8_annotations/fixes.rs
@@ -2,10 +2,9 @@ use anyhow::{bail, Result};
 use rustpython_parser::ast::Stmt;
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
-
-use crate::fix::Fix;
 
 /// ANN204
 pub fn add_return_none_annotation(locator: &Locator, stmt: &Stmt) -> Result<Fix> {

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -1,6 +1,7 @@
 use log::error;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::ReturnStatementVisitor;
 use ruff_python_ast::types::Range;
@@ -11,8 +12,7 @@ use ruff_python_ast::{cast, helpers};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{Definition, DefinitionKind};
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 use super::fixes;
 use super::helpers::match_function_def;

--- a/crates/ruff/src/rules/flake8_bandit/rules/assert_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/assert_used.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct Assert;

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -3,13 +3,12 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Operator};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{compose_call_path, SimpleCallArgs};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BadFilePermissions {

--- a/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/exec_used.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ExecBuiltin;

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -1,8 +1,6 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct HardcodedBindAllInterfaces;

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_default.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Arg, Arguments, Expr};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::super::helpers::{matches_password_name, string_literal};
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_func_arg.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Keyword;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::super::helpers::{matches_password_name, string_literal};
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::super::helpers::{matches_password_name, string_literal};
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -2,13 +2,12 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::{Expr, ExprKind, Operator};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{any_over_expr, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::super::helpers::string_literal;
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct HardcodedTempFile {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::super::helpers::string_literal;
 

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct Jinja2AutoescapeFalse {

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct LoggingConfigInsecureListen;

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RequestWithNoCertValidation {

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{unparse_constant, SimpleCallArgs};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RequestWithoutTimeout {

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -1,13 +1,12 @@
 use num_traits::{One, Zero};
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct SnmpInsecureVersion;

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct SnmpWeakCryptography;

--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_continue.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Excepthandler, Expr, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::flake8_bandit::helpers::is_untyped_exception;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TryExceptContinue;

--- a/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/try_except_pass.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Excepthandler, Expr, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::flake8_bandit::helpers::is_untyped_exception;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TryExceptPass;

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnsafeYAMLLoad {

--- a/crates/ruff/src/rules/flake8_blind_except/rules.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::{find_keyword, is_const_true};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BlindExcept {

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind};
 
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, DiagnosticKind};
-use crate::violation::Violation;
 
 #[violation]
 pub struct BooleanPositionalArgInFunctionDefinition;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visibility::{is_abstract, is_overload};
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct AbstractBaseClassWithoutAbstractMethod {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct AssertFalse;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{ExprKind, Stmt, Withitem};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `self.assertRaises(Exception)`.

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assignment_to_os_environ.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AssignmentToOsEnviron;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct CachedInstanceMethod;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cannot_raise_literal.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct CannotRaiseLiteral;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -4,15 +4,15 @@ use rustpython_parser::ast::{
     Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind, Location,
 };
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::{CallPath, Range};
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct DuplicateTryBlockException {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/except_with_empty_tuple.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Excepthandler;
 use rustpython_parser::ast::{ExcepthandlerKind, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ExceptWithEmptyTuple;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/except_with_non_exception_classes.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/except_with_non_exception_classes.rs
@@ -2,12 +2,11 @@ use std::collections::VecDeque;
 
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ExceptWithNonExceptionClasses;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/f_string_docstring.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct FStringDocstring;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -1,5 +1,7 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind};
 
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{compose_call_path, to_call_path};
 use ruff_python_ast::types::{CallPath, Range};
@@ -7,8 +9,6 @@ use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, DiagnosticKind};
-use crate::violation::Violation;
 
 use super::mutable_argument_default::is_mutable_func;
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Comprehension, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_arg_names;
 use ruff_python_ast::types::{Node, Range};
@@ -8,8 +9,6 @@ use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct FunctionUsesLoopVariable {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -1,5 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -7,9 +8,7 @@ use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
 use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct GetAttrWithConstant;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/jump_statement_in_finally.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct JumpStatementInFinally {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -1,14 +1,13 @@
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct LoopVariableOverridesIterator {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind, Operator};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MutableArgumentDefault;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::RaiseStatementVisitor;
 use ruff_python_ast::visitor;
 use ruff_python_stdlib::str::is_lower;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RaiseWithoutFromInsideExcept;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RedundantTupleInExceptionHandler {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,5 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::source_code::Stylist;
@@ -8,9 +9,7 @@ use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
 use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct SetAttrWithConstant;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/star_arg_unpacking_after_keyword_arg.rs
@@ -9,12 +9,11 @@
 
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct StarArgUnpackingAfterKeywordArg;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/strip_with_multi_characters.rs
@@ -1,12 +1,11 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct StripWithMultiCharacters;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unary_prefix_increment.rs
@@ -19,12 +19,11 @@
 
 use rustpython_parser::ast::{Expr, ExprKind, Unaryop};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnaryPrefixIncrement;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unintentional_type_annotation.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for the unintentional use of type annotations.

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unreliable_callable_check.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnreliableCallableCheck;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -22,15 +22,14 @@ use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{helpers, visitor};
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, result_like::BoolLike)]
 pub enum Certainty {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_comparison.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UselessComparison;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UselessContextlibSuppress;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Constant, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UselessExpression;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ZipWithoutExplicitStrict;

--- a/crates/ruff/src/rules/flake8_builtins/rules.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Located;
 
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::builtins::BUILTINS;
-
-use crate::registry::{Diagnostic, DiagnosticKind};
-use crate::violation::Violation;
 
 use super::types::ShadowingType;
 

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -2,14 +2,14 @@ use itertools::Itertools;
 use rustpython_parser::lexer::{LexResult, Spanned};
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
 
 /// Simplified token type.
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -7,10 +7,10 @@ use libcst_native::{
     RightParen, RightSquareBracket, Set, SetComp, SimpleString, SimpleWhitespace, Tuple,
 };
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 
 use crate::cst::matchers::{match_expr, match_module};
-use crate::fix::Fix;
 
 fn match_call<'a, 'b>(expr: &'a mut Expr<'b>) -> Result<&'a mut Call<'b>> {
     if let Expression::Call(call) = &mut expr.value {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -1,14 +1,14 @@
 use log::error;
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
 use crate::rules::flake8_comprehensions::settings::Settings;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Comprehension, Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_dict.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -1,13 +1,14 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::Diagnostic;
+use ruff_diagnostics::{AutofixKind, Availability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use crate::violation::{AutofixKind, Availability, Violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -1,12 +1,11 @@
 use num_bigint::BigInt;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Unaryop};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_datetimez/rules.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_non_none_keyword, is_const_none};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct CallDatetimeWithoutTzinfo;

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::format_call_path;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::types::DebuggerUsingType;
 

--- a/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -1,11 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
+use crate::checkers::ast::Checker;
 use crate::rules::flake8_django::rules::helpers::is_model_form;
-use crate::violation::Violation;
-use crate::{checkers::ast::Checker, registry::Diagnostic};
 
 /// ## What it does
 /// Checks for the use of `fields = "__all__"` in Django `ModelForm`

--- a/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -1,11 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
+use crate::checkers::ast::Checker;
 use crate::rules::flake8_django::rules::helpers::is_model_form;
-use crate::violation::Violation;
-use crate::{checkers::ast::Checker, registry::Diagnostic};
 
 /// ## What it does
 /// Checks for the use of `exclude` in Django `ModelForm` classes.

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -1,9 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::{checkers::ast::Checker, registry::Diagnostic, violation::Violation};
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for the use of `locals()` in `render` functions.

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, StmtKind};
 use rustpython_parser::ast::{ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/non_leading_receiver_decorator.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{CallPath, Range};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks that Django's `@receiver` decorator is listed first, prior to

--- a/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Constant::Bool;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -1,11 +1,11 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 /// ## What it does
 /// Checks for the use of string literals in exception constructors.

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -2,13 +2,13 @@
 
 use std::path::Path;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 #[cfg(target_family = "unix")]
 use crate::rules::flake8_executable::helpers::is_executable;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ShebangMissingExecutableFile;

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_newline.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ShebangNewline;

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -4,14 +4,14 @@ use std::path::Path;
 
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 #[cfg(target_family = "unix")]
 use crate::rules::flake8_executable::helpers::is_executable;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ShebangNotExecutable;

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_python.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ShebangPython;

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -1,12 +1,10 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::Diagnostic;
 use crate::rules::flake8_executable::helpers::ShebangDirective;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct ShebangWhitespace;

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/rules.rs
@@ -3,12 +3,11 @@ use rustpython_parser::ast::{Constant, Expr, ExprKind, Operator};
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::flake8_implicit_str_concat::settings::Settings;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for implicitly concatenated strings on a single line.

--- a/crates/ruff/src/rules/flake8_import_conventions/rules.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/rules.rs
@@ -1,11 +1,9 @@
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for imports that are typically imported using a common convention,

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Location, Operator};
 
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_python_ast::helpers::{find_keyword, is_logger_candidate, SimpleCallArgs};
 use ruff_python_ast::logging::LoggingLevel;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rules::flake8_logging_format::violations::{
     LoggingExcInfo, LoggingExtraAttrClash, LoggingFString, LoggingPercentFormat,
     LoggingRedundantExcInfo, LoggingStringConcat, LoggingStringFormat, LoggingWarn,

--- a/crates/ruff/src/rules/flake8_logging_format/violations.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/violations.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::{AlwaysAutofixableViolation, Violation};
 
 #[violation]
 pub struct LoggingStringFormat;

--- a/crates/ruff/src/rules/flake8_no_pep420/rules.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/rules.rs
@@ -1,11 +1,10 @@
 use std::path::{Path, PathBuf};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::fs;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for packages that are missing an `__init__.py` file.

--- a/crates/ruff/src/rules/flake8_pie/fixes.rs
+++ b/crates/ruff/src/rules/flake8_pie/fixes.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, Expression, GeneratorExp};
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 
 use crate::cst::matchers::{match_call, match_expression};
-use crate::fix::Fix;
 
 /// (PIE802) Convert `[i for i in a]` into `i for i in a`
 pub fn fix_unnecessary_comprehension_any_all(

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -2,6 +2,8 @@ use log::error;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Boolop, Constant, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{match_trailing_comment, unparse_expr};
@@ -11,10 +13,8 @@ use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::AsRule;
 
 use super::fixes;
 

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_const_none;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::Violation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct PrintFound;

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Cmpop, Expr};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for usages of comparators other than `<` and `>=` for

--- a/crates/ruff/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/docstring_in_stubs.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DocstringInStub;

--- a/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/non_empty_stub_body.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Constant, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct NonEmptyStubBody;

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_statement_stub_body.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct PassStatementStubBody;

--- a/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -3,12 +3,11 @@ use std::fmt;
 use rustpython_parser::ast::{Expr, ExprKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum VarKind {

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind, Operator, Unaryop};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TypedArgumentSimpleDefaults;

--- a/crates/ruff/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
@@ -3,11 +3,9 @@ use regex::Regex;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for the use of type comments (e.g., `x = 1  # type: int`) in stub

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -1,11 +1,11 @@
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 /// ## What it does
 /// Check for unrecognized `sys.platform` checks. Platform checks should be

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -10,6 +10,7 @@ use rustpython_parser::ast::{
     Unaryop,
 };
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments_in, unparse_stmt};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -19,9 +20,7 @@ use ruff_python_ast::{visitor, whitespace};
 
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::match_module;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 use super::helpers::is_falsy_constant;
 use super::unittest_assert::UnittestAssert;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::SimpleCallArgs;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::helpers::{is_empty_or_null_string, is_pytest_fail};
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use log::error;
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Keyword, Location, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{collect_arg_names, collect_call_path};
 use ruff_python_ast::source_code::Locator;
@@ -11,9 +13,7 @@ use ruff_python_ast::visitor::Visitor;
 
 use crate::autofix::helpers::remove_argument;
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 use super::helpers::{
     get_mark_decorators, get_mark_name, is_abstractmethod_decorator, is_pytest_fixture,

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/imports.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct IncorrectPytestImport;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind, Location};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 use super::helpers::{get_mark_decorators, get_mark_name};
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -1,13 +1,13 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 use super::super::types;
 use super::helpers::{is_pytest_parametrize, split_names};

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
@@ -1,14 +1,12 @@
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{collect_arg_names, compose_call_path, SimpleCallArgs};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct PatchWithLambda;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword, Stmt, StmtKind, Withitem};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{format_call_path, to_call_path};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 use super::helpers::is_empty_or_null_string;
 

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -2,15 +2,14 @@ use rustpython_parser::ast::Location;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
 use crate::lex::docstring_detection::StateMachine;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::settings::Quote;
 

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::match_parens;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UnnecessaryParenOnRaiseException;

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -1,6 +1,8 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{elif_else_range, end_of_statement};
 use ruff_python_ast::types::Range;
@@ -8,9 +10,7 @@ use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::whitespace::indentation;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 use super::branch::Branch;
 use super::helpers::result_exists;

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for accesses on "private" class members.

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -4,14 +4,13 @@ use std::iter;
 use itertools::Either::{Left, Right};
 use rustpython_parser::ast::{Boolop, Cmpop, Constant, Expr, ExprContext, ExprKind, Unaryop};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{contains_effect, create_expr, has_comments, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 /// ## What it does
 /// Checks for multiple `isinstance` calls on the same target.

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UseCapitalEnvironmentVariables {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -2,6 +2,7 @@ use log::error;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr, ComparableStmt};
 use ruff_python_ast::helpers::{
@@ -11,10 +12,8 @@ use ruff_python_ast::helpers::{
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::flake8_simplify::rules::fix_if;
-use crate::violation::{AutofixKind, Availability, Violation};
 
 fn compare_expr(expr1: &ComparableExpr, expr2: &ComparableExpr) -> bool {
     expr1.eq(expr2)

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Unaryop};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct IfExprWithTrueFalse {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Stmt, StmtKind, Unaryop};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct NegateEqualOp {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -1,13 +1,14 @@
 use log::error;
 use rustpython_parser::ast::{Located, Stmt, StmtKind, Withitem};
 
+use ruff_diagnostics::Diagnostic;
+use ruff_diagnostics::{AutofixKind, Availability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{first_colon_range, has_comments_in};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 use super::fix_with;
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -6,12 +6,12 @@ use libcst_native::{
 };
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
 
 use crate::cst::matchers::match_module;
-use crate::fix::Fix;
 
 fn parenthesize_and_operand(expr: Expression) -> Expression {
     match &expr {

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
@@ -2,12 +2,12 @@ use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, CompoundStatement, Statement, Suite, With};
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
 
 use crate::cst::matchers::match_module;
-use crate::fix::Fix;
 
 /// (SIM117) Convert `with a: with b:` to `with a, b:`.
 pub(crate) fn fix_multiple_with_statements(

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct KeyInDict {

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct OpenFileWithContextHandler;

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -2,15 +2,14 @@ use rustpython_parser::ast::{
     Cmpop, Comprehension, Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind, Unaryop,
 };
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct ReimplementedBuiltin {

--- a/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ReturnInTryExceptFinally;

--- a/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/use_contextlib_suppress.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Located, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::compose_call_path;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UseContextlibSuppress {

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use libcst_native::{Codegen, CodegenState, CompOp};
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -9,9 +10,7 @@ use ruff_python_stdlib::str::{self};
 
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_comparison, match_expression};
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct YodaConditions {

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -3,12 +3,11 @@ use rustpython_parser::ast::{Alias, Expr, Located};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
 use ruff_python_ast::types::{CallPath, Range};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 pub type Settings = FxHashMap<String, ApiBan>;
 

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{Stmt, StmtKind};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
 use ruff_python_ast::helpers::{create_stmt, from_relative_import, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -9,9 +10,7 @@ use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::is_module_name;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 pub type Settings = Strictness;
 

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct EmptyTypeCheckingBlock;

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -1,8 +1,6 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Binding, BindingKind, ExecutionContext};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RuntimeImportInTypeCheckingBlock {

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -1,12 +1,11 @@
 use std::path::Path;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Binding, BindingKind, ExecutionContext};
 
-use crate::registry::Diagnostic;
 use crate::rules::isort::{categorize, ImportType};
 use crate::settings::Settings;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TypingOnlyFirstPartyImport {

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Arg, Arguments};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::function_type;
 use ruff_python_ast::function_type::FunctionType;
@@ -11,8 +12,6 @@ use ruff_python_ast::types::{Binding, FunctionDef, Lambda, Scope, ScopeKind};
 use ruff_python_ast::visibility;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 use super::helpers;
 use super::types::Argumentable;

--- a/crates/ruff/src/rules/flake8_unused_arguments/types.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/types.rs
@@ -1,4 +1,6 @@
-use crate::registry::{DiagnosticKind, Rule};
+use ruff_diagnostics::DiagnosticKind;
+
+use crate::registry::Rule;
 
 use super::rules;
 

--- a/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
@@ -1,9 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic, DiagnosticKind};
+use crate::registry::AsRule;
 use crate::rules::flake8_use_pathlib::violations::{
     PathlibAbspath, PathlibBasename, PathlibChmod, PathlibDirname, PathlibExists,
     PathlibExpanduser, PathlibGetcwd, PathlibIsAbs, PathlibIsDir, PathlibIsFile, PathlibIsLink,

--- a/crates/ruff/src/rules/flake8_use_pathlib/violations.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/violations.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 // PTH100
 #[violation]

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -4,15 +4,14 @@ use log::error;
 use rustpython_parser as parser;
 use rustpython_parser::ast::{Location, StmtKind, Suite};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::super::helpers;
 use super::super::track::Block;

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -4,6 +4,7 @@ use itertools::{EitherOrBoth, Itertools};
 use rustpython_parser::ast::{Location, Stmt};
 use textwrap::indent;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{
     count_trailing_lines, followed_by_multi_statement_line, preceded_by_multi_statement_line,
@@ -12,10 +13,8 @@ use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::leading_space;
 
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 use super::super::track::Block;
 use super::super::{comments, format_imports};

--- a/crates/ruff/src/rules/mccabe/rules.rs
+++ b/crates/ruff/src/rules/mccabe/rules.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{ExcepthandlerKind, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for functions with a high `McCabe` complexity.

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 /// ## What it does
 /// Checks for deprecated NumPy type aliases.

--- a/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
+++ b/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for the use of legacy `np.random` function calls.

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword, Location};
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
 use crate::autofix::apply_fix;
 use crate::autofix::helpers::remove_argument;
-use crate::fix::Fix;
 
 fn match_name(expr: &Expr) -> Option<&str> {
     if let ExprKind::Call { func, .. } = &expr.node {

--- a/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/assignment_to_df.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DfIsABadVariableName;

--- a/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
@@ -1,12 +1,13 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{BindingKind, Range};
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, DiagnosticKind, Rule};
+use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::is_dataframe_candidate;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UseOfDotIx;

--- a/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
@@ -1,12 +1,13 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{BindingKind, Range};
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, DiagnosticKind, Rule};
+use crate::registry::Rule;
 use crate::rules::pandas_vet::helpers::is_dataframe_candidate;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UseOfDotIsNull;

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pandas_vet::fixes::fix_inplace_argument;
-use crate::violation::AlwaysAutofixableViolation;
 
 /// ## What it does
 /// Checks for `inplace=True` usages in `pandas` function and method

--- a/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/pd_merge.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UseOfPdMerge;

--- a/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::str::{self};
 
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `CamelCase` imports that are aliased as acronyms.

--- a/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_constant.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::str::{self};
 
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `CamelCase` imports that are aliased to constant-style names.

--- a/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::str;
 
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `CamelCase` imports that are aliased to lowercase names.

--- a/crates/ruff/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -1,12 +1,10 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::str;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for constant imports that are aliased to non-constant-style

--- a/crates/ruff/src/rules/pep8_naming/rules/dunder_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/dunder_function_name.rs
@@ -1,12 +1,10 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::{Scope, ScopeKind};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for functions with "dunder" names (that is, names with two

--- a/crates/ruff/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/error_suffix_on_exception_name.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for custom exception definitions that omit the `Error` suffix.

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_argument_name.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Arg;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct InvalidArgumentName {

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_class_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_class_name.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for class names that do not follow the `CamelCase` convention.

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Arguments, Expr};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::function_type;
 use ruff_python_ast::types::{Range, Scope};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for class methods that use a name other than `cls` for their

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Arguments, Expr};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::function_type;
 use ruff_python_ast::types::{Range, Scope};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for instance methods that use a name other than `self` for their

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for functions names that do not follow the `snake_case` naming

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
@@ -1,11 +1,9 @@
 use std::path::Path;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::is_module_name;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for module names that do not follow the `snake_case` naming

--- a/crates/ruff/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
@@ -1,12 +1,10 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_stdlib::str;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for lowercase imports that are aliased to non-lowercase names.

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MixedCaseVariableInClassScope {

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MixedCaseVariableInGlobalScope {

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::pep8_naming::helpers;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for the use of non-lowercase variable names in functions.

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
@@ -1,9 +1,8 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AmbiguousClassName(pub String);

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
@@ -1,9 +1,8 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AmbiguousFunctionName(pub String);

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
@@ -1,9 +1,8 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AmbiguousVariableName(pub String);

--- a/crates/ruff/src/rules/pycodestyle/rules/bare_except.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/bare_except.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{Excepthandler, Expr, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::except_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for bare `except` catches in `try`-`except` statements.

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -1,13 +1,13 @@
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
 
 #[violation]
 pub struct MultipleStatementsOnOneLineColon;

--- a/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/doc_line_too_long.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DocLineTooLong(pub usize, pub usize);

--- a/crates/ruff/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/errors.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ParseError;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct IOError {

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -3,10 +3,9 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::registry::DiagnosticKind;
-use crate::violation::Violation;
 
 #[violation]
 pub struct WhitespaceAfterOpenBracket;

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Alias, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MultipleImportsOnOneLine;

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -1,10 +1,10 @@
 #![allow(dead_code, unused_imports, unused_variables)]
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::registry::DiagnosticKind;
 use crate::rules::pycodestyle::logical_lines::LogicalLine;
-use crate::violation::Violation;
 
 #[violation]
 pub struct IndentationWithInvalidMultiple {

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation_contains_tabs.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation_contains_tabs.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::leading_space;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct IndentationContainsTabs;

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -2,13 +2,10 @@ use anyhow::{bail, Result};
 use log::error;
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
-
-use crate::fix::Fix;
-use crate::registry::Diagnostic;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct InvalidEscapeSequence(pub char);

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -1,5 +1,6 @@
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Location, Stmt, StmtKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{match_leading_content, match_trailing_content, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -7,9 +8,7 @@ use ruff_python_ast::types::{Range, ScopeKind};
 use ruff_python_ast::whitespace::leading_space;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct LambdaAssignment {

--- a/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::registry::Diagnostic;
 use crate::rules::pycodestyle::helpers::is_overlong;
 use crate::settings::Settings;
-use crate::violation::Violation;
 
 #[violation]
 pub struct LineTooLong(pub usize, pub usize);

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -3,15 +3,14 @@ use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::compare;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EqCmpop {

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
@@ -3,15 +3,15 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Fix;
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::DiagnosticKind;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::{is_keyword_token, is_singleton_token};
-use crate::violation::AlwaysAutofixableViolation;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MissingWhitespace {

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_after_keyword.rs
@@ -3,11 +3,11 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::registry::DiagnosticKind;
 use crate::rules::pycodestyle::helpers::{is_keyword_token, is_singleton_token};
-use crate::violation::Violation;
 
 #[violation]
 pub struct MissingWhitespaceAfterKeyword;

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_around_operator.rs
@@ -3,14 +3,14 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::registry::DiagnosticKind;
 use crate::rules::pycodestyle::helpers::{
     is_arithmetic_token, is_keyword_token, is_op_token, is_singleton_token, is_skip_comment_token,
     is_soft_keyword_token, is_unary_token, is_ws_needed_token, is_ws_optional_token,
 };
-use crate::violation::Violation;
 
 // E225
 #[violation]

--- a/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::leading_space;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MixedSpacesAndTabs;

--- a/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/no_newline_at_end_of_file.rs
@@ -1,12 +1,9 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
-
-use crate::fix::Fix;
-use crate::registry::Diagnostic;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct NoNewLineAtEndOfFile;

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::compare;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct NotInTest;

--- a/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
@@ -3,10 +3,9 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::registry::DiagnosticKind;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TabBeforeOperator;

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct TrailingWhitespace;

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -1,11 +1,9 @@
 use itertools::izip;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TypeComparison;

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
@@ -3,10 +3,9 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::registry::DiagnosticKind;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MultipleSpacesAfterKeyword;

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_named_parameter_equals.rs
@@ -5,12 +5,12 @@ use regex::Regex;
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::registry::DiagnosticKind;
 #[cfg(feature = "logical_lines")]
 use crate::rules::pycodestyle::helpers::is_op_token;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnexpectedSpacesAroundKeywordParameterEquals;

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -3,12 +3,11 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::DiagnosticKind;
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
-
-use crate::registry::DiagnosticKind;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TooFewSpacesBeforeInlineComment;

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
@@ -3,13 +3,12 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::{is_keyword_token, is_op_token, is_soft_keyword_token};
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct WhitespaceBeforeParameters {

--- a/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/backslashes.rs
@@ -1,13 +1,12 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct EscapeSequenceInDocstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -1,12 +1,11 @@
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct BlankLineAfterSummary {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -1,12 +1,11 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct OneBlankLineBeforeClass {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -1,15 +1,14 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct NoBlankLineBeforeFunction {

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -1,10 +1,9 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct FirstLineCapitalized;

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -1,5 +1,6 @@
 use strum::IntoEnumIterator;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::leading_quote;
 use ruff_python_ast::types::Range;
@@ -7,11 +8,9 @@ use ruff_python_ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
 use crate::docstrings::sections::SectionKind;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pydocstyle::helpers::logical_line;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct EndsInPeriod;

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -1,5 +1,6 @@
 use strum::IntoEnumIterator;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::leading_quote;
 use ruff_python_ast::types::Range;
@@ -7,11 +8,9 @@ use ruff_python_ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
 use crate::docstrings::sections::SectionKind;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pydocstyle::helpers::logical_line;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct EndsInPunctuation;

--- a/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::identifier_range;
@@ -5,8 +6,6 @@ use ruff_python_ast::visibility::is_overload;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct OverloadWithDocstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -1,3 +1,5 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
@@ -5,10 +7,8 @@ use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct IndentWithSpaces;

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{is_triple_quote, leading_quote};
 use ruff_python_ast::types::Range;
@@ -5,10 +6,8 @@ use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct MultiLineSummaryFirstLine;

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
@@ -5,10 +6,8 @@ use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct NewLineAfterLastParagraph;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_signature.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::StmtKind;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct NoSignature;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::leading_quote;
 use ruff_python_ast::types::Range;
@@ -5,10 +6,8 @@ use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct NoSurroundingWhitespace;

--- a/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use imperative::Mood;
 use once_cell::sync::Lazy;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::to_call_path;
@@ -11,9 +12,7 @@ use ruff_python_ast::visibility::{is_property, is_test};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
-use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::normalize_word;
-use crate::violation::Violation;
 
 static MOOD: Lazy<Mood> = Lazy::new(Mood::new);
 

--- a/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
@@ -1,10 +1,10 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct EmptyDocstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::identifier_range;
@@ -9,8 +10,7 @@ use ruff_python_ast::visibility::{
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{Definition, DefinitionKind};
 use crate::message::Location;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::Violation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct PublicModule;

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,3 +1,4 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
@@ -5,9 +6,7 @@ use ruff_python_ast::whitespace::LinesWithTrailingNewline;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct FitsOnOneLine;

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -4,6 +4,8 @@ use regex::Regex;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::StmtKind;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
+use ruff_diagnostics::{Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::types::Range;
@@ -15,11 +17,9 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{DefinitionKind, Docstring};
 use crate::docstrings::sections::{section_contexts, SectionContext, SectionKind};
 use crate::docstrings::styles::SectionStyle;
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, Rule};
+use crate::registry::{AsRule, Rule};
 use crate::rules::pydocstyle::settings::Convention;
-use crate::violation::{AlwaysAutofixableViolation, Violation};
 
 #[violation]
 pub struct SectionNotOverIndented {

--- a/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/starts_with_this.rs
@@ -1,11 +1,10 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::registry::Diagnostic;
 use crate::rules::pydocstyle::helpers::normalize_word;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DocstringStartsWithThis;

--- a/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/triple_quotes.rs
@@ -1,10 +1,9 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::Docstring;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TripleSingleQuotes;

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -3,12 +3,12 @@ use libcst_native::{Call, Codegen, CodegenState, Dict, DictElement, Expression};
 use rustpython_parser::ast::{Excepthandler, Expr};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::str::raw_contents;
 use ruff_python_ast::types::Range;
 
 use crate::cst::matchers::{match_expr, match_module};
-use crate::fix::Fix;
 
 /// Generate a [`Fix`] to remove unused keys from format dict.
 pub fn remove_unused_format_arguments_from_dict(

--- a/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AssertTuple;

--- a/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/break_outside_loop.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BreakOutsideLoop;

--- a/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/continue_outside_loop.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ContinueOutsideLoop;

--- a/crates/ruff/src/rules/pyflakes/rules/default_except_not_last.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/default_except_not_last.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::except_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DefaultExceptNotLast;

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_useless_f_strings;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 /// ## What it does
 /// Checks for f-strings that do not contain any placeholder expressions.

--- a/crates/ruff/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/forward_annotation_syntax_error.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 #[violation]
 pub struct ForwardAnnotationSyntaxError {

--- a/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct IfTuple;

--- a/crates/ruff/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/imports.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools;
 use rustpython_parser::ast::Alias;
 
+use ruff_diagnostics::Diagnostic;
+use ruff_diagnostics::{AutofixKind, Availability, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::future::ALL_FEATURE_NAMES;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::{AutofixKind, Availability, Violation};
 
 #[violation]
 pub struct UnusedImport {

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -4,15 +4,14 @@ use once_cell::unsync::Lazy;
 use rustpython_parser::ast::{Cmpop, Expr};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::operations::locate_cmpops;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IsCmpop {

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct InvalidPrintSyntax;

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RaiseNotImplemented;

--- a/crates/ruff/src/rules/pyflakes/rules/redefined_while_unused.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/redefined_while_unused.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 #[violation]
 pub struct RedefinedWhileUnused {

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -3,15 +3,14 @@ use std::hash::{BuildHasherDefault, Hash};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::{AsRule, Rule};
 
 #[violation]
 pub struct MultiValueRepeatedKeyLiteral {

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ReturnOutsideFunction;

--- a/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ExpressionsInStarAssignment;

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -4,12 +4,12 @@ use log::error;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, KeywordData};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AlwaysAutofixableViolation, Violation};
+use crate::registry::AsRule;
 
 use super::super::cformat::CFormatSummary;
 use super::super::fixes::{

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, Scope};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UndefinedExport {

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -1,10 +1,8 @@
 use std::string::ToString;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Binding, Scope, ScopeKind};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UndefinedLocal {

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_name.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_name.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 #[violation]
 pub struct UndefinedName {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -1,8 +1,7 @@
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnusedAnnotation {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -3,6 +3,7 @@ use log::error;
 use rustpython_parser::ast::{ExprKind, Located, Stmt, StmtKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::source_code::Locator;
@@ -10,9 +11,7 @@ use ruff_python_ast::types::{Range, RefEquality, ScopeKind};
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 /// ## What it does
 /// Checks for the presence of unused variables in function scopes.

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -3,12 +3,11 @@ use std::fmt;
 use rustpython_parser::ast::{Expr, ExprKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeferralKeyword {

--- a/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/blanket_noqa.rs
@@ -2,11 +2,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BlanketNOQA;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/blanket_type_ignore.rs
@@ -2,11 +2,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BlanketTypeIgnore;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct DeprecatedLogWarn;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct NoEval;

--- a/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{FunctionDef, Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct AwaitOutsideAsync;

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -4,13 +4,12 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::settings::types::PythonVersion;
-use crate::violation::Violation;
 
 #[violation]
 pub struct BadStrStripCall {

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
@@ -5,13 +5,12 @@ use rustpython_common::cformat::{CFormatPart, CFormatSpec, CFormatStrOrBytes, CF
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Operator};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for mismatched argument types in "old-style" format strings.

--- a/crates/ruff/src/rules/pylint/rules/bidirectional_unicode.rs
+++ b/crates/ruff/src/rules/pylint/rules/bidirectional_unicode.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 const BIDI_UNICODE: [char; 10] = [
     '\u{202A}', //{LEFT-TO-RIGHT EMBEDDING}

--- a/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
+++ b/crates/ruff/src/rules/pylint/rules/collapsible_else_if.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct CollapsibleElseIf;

--- a/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
@@ -4,13 +4,12 @@ use itertools::Itertools;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Located};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_constant;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ViolationsCmpop {

--- a/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
+++ b/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{BindingKind, Range};
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ConsiderUsingSysExit {

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -1,10 +1,10 @@
-use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::types::Range;
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
+use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::types::Range;
+
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for the use of `global` statements to update identifiers.

--- a/crates/ruff/src/rules/pylint/rules/global_variable_not_assigned.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_variable_not_assigned.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 #[violation]
 pub struct GlobalVariableNotAssigned {

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_format.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct InvalidAllFormat;

--- a/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_all_object.rs
@@ -1,10 +1,8 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct InvalidAllObject;

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -1,14 +1,14 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{is_logger_candidate, SimpleCallArgs};
 use ruff_python_ast::logging::LoggingLevel;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::rules::pyflakes::cformat::CFormatSummary;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for too few positional arguments for a `logging` format string.

--- a/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
@@ -1,14 +1,13 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Unaryop};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::pylint::settings::ConstantType;
-use crate::violation::Violation;
 
 #[violation]
 pub struct MagicValueComparison {

--- a/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
+++ b/crates/ruff/src/rules/pylint/rules/merge_isinstance.rs
@@ -2,14 +2,13 @@ use itertools::Itertools;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Boolop, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::hashable::HashableExpr;
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ConsiderMergingIsinstance {

--- a/crates/ruff/src/rules/pylint/rules/nonlocal_without_binding.rs
+++ b/crates/ruff/src/rules/pylint/rules/nonlocal_without_binding.rs
@@ -1,6 +1,5 @@
+use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::Violation;
 
 #[violation]
 pub struct NonlocalWithoutBinding {

--- a/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct PropertyWithParameters;

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind, Withitem};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::unparse_expr;
@@ -12,8 +13,6 @@ use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 pub enum OuterBindingKind {

--- a/crates/ruff/src/rules/pylint/rules/return_in_init.rs
+++ b/crates/ruff/src/rules/pylint/rules/return_in_init.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Constant, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::pylint::helpers::in_dunder_init;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `__init__` methods that return values.

--- a/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Arguments, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TooManyArguments {

--- a/crates/ruff/src/rules/pylint/rules/too_many_branches.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_branches.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{ExcepthandlerKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TooManyBranches {

--- a/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
@@ -1,12 +1,10 @@
 use rustpython_parser::ast::Stmt;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{identifier_range, ReturnStatementVisitor};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::visitor::Visitor;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TooManyReturnStatements {

--- a/crates/ruff/src/rules/pylint/rules/too_many_statements.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_statements.rs
@@ -1,11 +1,9 @@
 use rustpython_parser::ast::{ExcepthandlerKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TooManyStatements {

--- a/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/unnecessary_direct_lambda_call.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UnnecessaryDirectLambdaCall;

--- a/crates/ruff/src/rules/pylint/rules/use_from_import.rs
+++ b/crates/ruff/src/rules/pylint/rules/use_from_import.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt, StmtKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_stmt, unparse_stmt};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ConsiderUsingFromImport {

--- a/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UsedPriorGlobalDeclaration {

--- a/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_else_on_loop.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{ExcepthandlerKind, MatchCase, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct UselessElseOnLoop;

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Alias;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UselessImportAlias;

--- a/crates/ruff/src/rules/pylint/rules/yield_in_init.rs
+++ b/crates/ruff/src/rules/pylint/rules/yield_in_init.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
+use crate::checkers::ast::Checker;
 use crate::rules::pylint::helpers::in_dunder_init;
-use crate::{checkers::ast::Checker, registry::Diagnostic, violation::Violation};
 
 /// ## What it does
 /// Checks for `__init__` methods that are turned into generators by the

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -6,12 +6,12 @@ use libcst_native::{
 use rustpython_parser::ast::{Expr, Keyword, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::Fix;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 
 use crate::autofix::helpers::remove_argument;
 use crate::cst::matchers::match_module;
-use crate::fix::Fix;
 
 /// Safely adjust the indentation of the indented block at [`Range`].
 pub fn adjust_indentation(

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -10,10 +11,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{Availability, Violation};
-use crate::AutofixKind;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ConvertNamedTupleFunctionalToClass {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -10,10 +11,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{Availability, Violation};
-use crate::AutofixKind;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ConvertTypedDictFunctionalToClass {

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct DatetimeTimezoneUTC {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -2,13 +2,12 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct DeprecatedUnittestAlias {

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -1,14 +1,13 @@
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct ExtraneousParentheses;

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -5,16 +5,15 @@ use rustpython_common::format::{
 use rustpython_parser::ast::{Constant, Expr, ExprKind, KeywordData};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pyflakes::format::FormatSummary;
 use crate::rules::pyupgrade::helpers::curly_escape;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct FString;

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -4,16 +4,15 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_call, match_expression};
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pyflakes::format::FormatSummary;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct FormatLiterals;

--- a/crates/ruff/src/rules/pyupgrade/rules/functools_cache.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/functools_cache.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, KeywordData};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct FunctoolsCache;

--- a/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/import_replacements.rs
@@ -1,17 +1,16 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, AliasData, Stmt};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::indentation;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
+use crate::registry::Rule;
 use crate::rules::pyupgrade::fixes;
 use crate::settings::types::PythonVersion;
-use crate::violation::{AutofixKind, Availability, Violation};
 
 #[violation]
 pub struct ImportReplacements {

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct LRUCacheWithoutParameters;

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -4,13 +4,12 @@ use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::{lexer, Mode, Tok};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LiteralType {

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct OpenAlias;

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -1,14 +1,13 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::compose_call_path;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct OSErrorAlias {

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -5,6 +5,7 @@ use num_bigint::{BigInt, Sign};
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Located, Location, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::{Range, RefEquality};
@@ -12,11 +13,9 @@ use ruff_python_ast::whitespace::indentation;
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pyupgrade::fixes::adjust_indentation;
 use crate::settings::types::PythonVersion;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct OutdatedVersionBlock;

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -6,6 +6,7 @@ use rustpython_common::cformat::{
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
@@ -14,10 +15,8 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pyupgrade::helpers::curly_escape;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct PrintfStringFormatting;

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -1,10 +1,9 @@
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct QuotedAnnotation;

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -5,15 +5,14 @@ use log::error;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct RedundantOpenModes {

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -1,5 +1,6 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -7,9 +8,7 @@ use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::indentation;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ReplaceStdoutStderr;

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, Keyword, Location};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct ReplaceUniversalNewlines;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_c_element_tree.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Located, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RewriteCElementTree;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -7,6 +7,7 @@ use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -15,9 +16,7 @@ use ruff_python_ast::whitespace::indentation;
 
 use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_import, match_import_from, match_module};
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::{AsRule, Rule};
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MockReference {

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_unicode_literal.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, Location};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RewriteUnicodeLiteral;

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_yield_from.rs
@@ -1,15 +1,14 @@
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RewriteYieldFrom;

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -1,12 +1,12 @@
 use rustpython_parser::ast::{ArgData, Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
+use crate::registry::AsRule;
 use crate::rules::pyupgrade::fixes;
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct SuperCallWithParameters;

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 use super::super::types::Primitive;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct TypingTextStrAlias;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -2,13 +2,13 @@ use itertools::Itertools;
 use log::error;
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::autofix;
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UnnecessaryBuiltinImport {

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -2,12 +2,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Location;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
-
-use crate::fix::Fix;
-use crate::registry::Diagnostic;
-use crate::violation::AlwaysAutofixableViolation;
 
 // TODO: document referencing [PEP 3120]: https://peps.python.org/pep-3120/
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,14 +1,13 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{Diagnostic, Rule};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::Rule;
 
 #[violation]
 pub struct UnnecessaryEncodeUTF8;

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -2,13 +2,13 @@ use itertools::Itertools;
 use log::error;
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::autofix;
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UnnecessaryFutureImport {

--- a/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpack_list_comprehension.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct RewriteListComprehension;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::Expr;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 // TODO: document referencing [PEP 585]: https://peps.python.org/pep-0585/
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Operator};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 // TODO: document referencing [PEP 604]: https://peps.python.org/pep-0604/
 #[violation]

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -3,14 +3,13 @@ use std::fmt;
 use rustpython_parser::ast::{Expr, ExprKind, Location, Operator};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CallKind {

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -1,13 +1,13 @@
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::autofix::helpers;
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UselessMetaclassType;

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -1,11 +1,11 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword, Stmt};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Binding, BindingKind, Range, Scope};
 
 use crate::checkers::ast::Checker;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::AlwaysAutofixableViolation;
+use crate::registry::AsRule;
 
 use super::super::fixes;
 

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1,16 +1,15 @@
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
 use crate::message::Location;
-use crate::registry::{AsRule, Diagnostic, DiagnosticKind};
+use crate::registry::AsRule;
 use crate::rules::ruff::rules::Context;
 use crate::settings::{flags, Settings};
-use crate::violation::AlwaysAutofixableViolation;
 
 #[violation]
 pub struct AmbiguousUnicodeCharacterString {

--- a/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -3,11 +3,9 @@ use std::fmt;
 use rustpython_parser::ast::{Expr, ExprKind};
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{CallPath, Range};
-
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for `asyncio.create_task` and `asyncio.ensure_future` calls

--- a/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
+++ b/crates/ruff/src/rules/ruff/rules/unpack_instead_of_concatenating_to_collection_literal.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Operator};
 
+use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, has_comments, unparse_expr};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::fix::Fix;
-use crate::registry::{AsRule, Diagnostic};
-use crate::violation::{AutofixKind, Availability, Violation};
+use crate::registry::AsRule;
 
 #[violation]
 pub struct UnpackInsteadOfConcatenatingToCollectionLiteral {

--- a/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
@@ -1,9 +1,8 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+use ruff_diagnostics::AlwaysAutofixableViolation;
 use ruff_macros::{derive_message_formats, violation};
-
-use crate::violation::AlwaysAutofixableViolation;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnusedCodes {

--- a/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::tryceratops::helpers::LoggerCandidateVisitor;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ErrorInsteadOfException;

--- a/crates/ruff/src/rules/tryceratops/rules/prefer_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/prefer_type_error.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct PreferTypeError;

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RaiseVanillaArgs;

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for code that raises `Exception` directly.

--- a/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor::{self, Visitor};
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct RaiseWithinTry;

--- a/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -1,12 +1,11 @@
 use rustpython_parser::ast::{ExprKind, Stmt};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::RaiseStatementVisitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct ReraiseNoCause;

--- a/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
@@ -1,11 +1,10 @@
 use rustpython_parser::ast::{Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct TryConsiderElse;

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
@@ -1,14 +1,13 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
 use crate::rules::tryceratops::helpers::LoggerCandidateVisitor;
-use crate::violation::Violation;
 
 /// ## What it does
 /// Checks for excessive logging of exception objects.

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_raise.rs
@@ -1,13 +1,12 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprKind, Stmt, StmtKind};
 
+use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
-use crate::registry::Diagnostic;
-use crate::violation::Violation;
 
 #[violation]
 pub struct VerboseRaise;

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -6,13 +6,14 @@ use std::path::Path;
 use anyhow::Result;
 use rustpython_parser::lexer::LexResult;
 
+use ruff_diagnostics::Diagnostic;
+use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+
 use crate::autofix::fix_file;
 use crate::directives;
 use crate::linter::{check_path, LinterResult};
 use crate::packaging::detect_package_root;
-use crate::registry::Diagnostic;
 use crate::settings::{flags, Settings};
-use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 
 pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
     Path::new("./resources/test/").join(path)

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -24,6 +24,7 @@ doc = false
 [dependencies]
 ruff = { path = "../ruff" }
 ruff_cache = { path = "../ruff_cache" }
+ruff_diagnostics = { path = "../ruff_diagnostics" }
 
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 anyhow = { workspace = true }

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use ruff::registry::{Linter, Rule, RuleNamespace};
-use ruff::AutofixAvailability;
+use ruff_diagnostics::Availability;
 
 use crate::args::HelpFormat;
 
@@ -34,8 +34,8 @@ pub fn rule(rule: &Rule, format: HelpFormat) -> Result<()> {
 
             if let Some(autofix) = rule.autofixable() {
                 output.push_str(match autofix.available {
-                    AutofixAvailability::Sometimes => "Autofix is sometimes available.",
-                    AutofixAvailability::Always => "Autofix is always available.",
+                    Availability::Sometimes => "Autofix is sometimes available.",
+                    Availability::Always => "Autofix is always available.",
                 });
                 output.push('\n');
                 output.push('\n');

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -1,4 +1,4 @@
-use std::io::{self};
+use std::io;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -10,10 +10,11 @@ use log::{debug, error};
 use rayon::prelude::*;
 
 use ruff::message::{Location, Message};
-use ruff::registry::{Diagnostic, Rule};
+use ruff::registry::Rule;
 use ruff::resolver::PyprojectDiscovery;
 use ruff::settings::flags;
 use ruff::{fix, fs, packaging, resolver, warn_user_once, IOError, Range};
+use ruff_diagnostics::Diagnostic;
 
 use crate::args::Overrides;
 use crate::cache;

--- a/crates/ruff_dev/Cargo.toml
+++ b/crates/ruff_dev/Cargo.toml
@@ -6,6 +6,10 @@ edition = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+ruff = { path = "../ruff" }
+ruff_cli = { path = "../ruff_cli" }
+ruff_diagnostics = { path = "../ruff_diagnostics" }
+
 anyhow = { workspace = true }
 clap = { workspace = true }
 itertools = { workspace = true }
@@ -13,8 +17,6 @@ libcst = { workspace = true }
 once_cell = { workspace = true }
 pretty_assertions = { version = "1.3.0" }
 regex = { workspace = true }
-ruff = { path = "../ruff" }
-ruff_cli = { path = "../ruff_cli" }
 rustpython-common = { workspace = true }
 rustpython-parser = { workspace = true }
 schemars = { workspace = true }

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -11,7 +11,7 @@ use strum::IntoEnumIterator;
 use ruff::registry::{Linter, Rule, RuleNamespace};
 use ruff::settings::options::Options;
 use ruff::settings::options_base::ConfigurationOptions;
-use ruff::AutofixAvailability;
+use ruff_diagnostics::Availability;
 
 use crate::ROOT_DIR;
 
@@ -39,8 +39,8 @@ pub fn main(args: &Args) -> Result<()> {
 
             if let Some(autofix) = rule.autofixable() {
                 output.push_str(match autofix.available {
-                    AutofixAvailability::Sometimes => "Autofix is sometimes available.",
-                    AutofixAvailability::Always => "Autofix is always available.",
+                    Availability::Sometimes => "Autofix is sometimes available.",
+                    Availability::Always => "Autofix is always available.",
                 });
                 output.push('\n');
                 output.push('\n');

--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ruff_diagnostics"
+version = "0.0.0"
+publish = false
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+
+[dependencies]
+ruff_python_ast = { path = "../ruff_python_ast" }
+
+rustpython-parser = { workspace = true }
+serde = { workspace = true, optional = true, default_features = false, features = [] }

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -1,0 +1,52 @@
+use rustpython_parser::ast::Location;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use ruff_python_ast::types::Range;
+
+use crate::fix::Fix;
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DiagnosticKind {
+    /// The identifier of the diagnostic, used to align the diagnostic with a rule.
+    pub name: String,
+    /// The message body to display to the user, to explain the diagnostic.
+    pub body: String,
+    /// The message to display to the user, to explain the suggested fix.
+    pub suggestion: Option<String>,
+    /// Whether the diagnostic is automatically fixable.
+    pub fixable: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Diagnostic {
+    pub kind: DiagnosticKind,
+    pub location: Location,
+    pub end_location: Location,
+    pub fix: Option<Fix>,
+    pub parent: Option<Location>,
+}
+
+impl Diagnostic {
+    pub fn new<K: Into<DiagnosticKind>>(kind: K, range: Range) -> Self {
+        Self {
+            kind: kind.into(),
+            location: range.location,
+            end_location: range.end_location,
+            fix: None,
+            parent: None,
+        }
+    }
+
+    pub fn amend(&mut self, fix: Fix) -> &mut Self {
+        self.fix = Some(fix);
+        self
+    }
+
+    pub fn parent(&mut self, parent: Location) -> &mut Self {
+        self.parent = Some(parent);
+        self
+    }
+}

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -1,0 +1,41 @@
+use rustpython_parser::ast::Location;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Fix {
+    pub content: String,
+    pub location: Location,
+    pub end_location: Location,
+}
+
+impl Fix {
+    pub const fn deletion(start: Location, end: Location) -> Self {
+        Self {
+            content: String::new(),
+            location: start,
+            end_location: end,
+        }
+    }
+
+    pub fn replacement(content: String, start: Location, end: Location) -> Self {
+        debug_assert!(!content.is_empty(), "Prefer `Fix::deletion`");
+
+        Self {
+            content,
+            location: start,
+            end_location: end,
+        }
+    }
+
+    pub fn insertion(content: String, at: Location) -> Self {
+        debug_assert!(!content.is_empty(), "Insert content is empty");
+
+        Self {
+            content,
+            location: at,
+            end_location: at,
+        }
+    }
+}

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,0 +1,7 @@
+pub use diagnostic::{Diagnostic, DiagnosticKind};
+pub use fix::Fix;
+pub use violation::{AlwaysAutofixableViolation, AutofixKind, Availability, Violation};
+
+mod diagnostic;
+mod fix;
+mod violation;

--- a/crates/ruff_diagnostics/src/violation.rs
+++ b/crates/ruff_diagnostics/src/violation.rs
@@ -1,9 +1,21 @@
 use std::fmt::Debug;
 
-use serde::de::DeserializeOwned;
-use serde::Serialize;
+pub enum Availability {
+    Sometimes,
+    Always,
+}
 
-pub trait Violation: Debug + PartialEq + Eq + Serialize + DeserializeOwned {
+pub struct AutofixKind {
+    pub available: Availability,
+}
+
+impl AutofixKind {
+    pub const fn new(available: Availability) -> Self {
+        Self { available }
+    }
+}
+
+pub trait Violation: Debug + PartialEq + Eq {
     /// `None` in the case an autofix is never available or otherwise Some
     /// [`AutofixKind`] describing the available autofix.
     const AUTOFIX: Option<AutofixKind> = None;
@@ -27,26 +39,9 @@ pub trait Violation: Debug + PartialEq + Eq + Serialize + DeserializeOwned {
     fn message_formats() -> &'static [&'static str];
 }
 
-pub struct AutofixKind {
-    pub available: Availability,
-}
-
-pub enum Availability {
-    Sometimes,
-    Always,
-}
-
-impl AutofixKind {
-    pub const fn new(available: Availability) -> Self {
-        Self { available }
-    }
-}
-
 /// This trait exists just to make implementing the [`Violation`] trait more
 /// convenient for violations that can always be autofixed.
-pub trait AlwaysAutofixableViolation:
-    Debug + PartialEq + Eq + Serialize + DeserializeOwned
-{
+pub trait AlwaysAutofixableViolation: Debug + PartialEq + Eq {
     /// The message used to describe the violation.
     fn message(&self) -> String;
 

--- a/crates/ruff_macros/src/register_rules.rs
+++ b/crates/ruff_macros/src/register_rules.rs
@@ -17,9 +17,10 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
         });
         // Apply the `attrs` to each arm, like `[cfg(feature = "foo")]`.
         rule_message_formats_match_arms
-            .extend(quote! {#(#attr)* Self::#name => <#path as Violation>::message_formats(),});
-        rule_autofixable_match_arms
-            .extend(quote! {#(#attr)* Self::#name => <#path as Violation>::AUTOFIX,});
+            .extend(quote! {#(#attr)* Self::#name => <#path as ruff_diagnostics::Violation>::message_formats(),});
+        rule_autofixable_match_arms.extend(
+            quote! {#(#attr)* Self::#name => <#path as ruff_diagnostics::Violation>::AUTOFIX,},
+        );
         rule_explanation_match_arms.extend(quote! {#(#attr)* Self::#name => #path::explanation(),});
 
         // Enable conversion from `DiagnosticKind` to `Rule`.
@@ -56,7 +57,7 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
             }
 
             /// Returns the autofix status of this rule.
-            pub fn autofixable(&self) -> Option<crate::violation::AutofixKind> {
+            pub fn autofixable(&self) -> Option<ruff_diagnostics::AutofixKind> {
                 match self { #rule_autofixable_match_arms }
             }
         }
@@ -65,7 +66,7 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
             fn rule(&self) -> &'static Rule;
         }
 
-        impl AsRule for DiagnosticKind {
+        impl AsRule for ruff_diagnostics::DiagnosticKind {
             fn rule(&self) -> &'static Rule {
                 match self.name.as_str() {
                     #from_impls_for_diagnostic_kind

--- a/crates/ruff_macros/src/violation.rs
+++ b/crates/ruff_macros/src/violation.rs
@@ -44,12 +44,12 @@ pub fn violation(violation: &ItemStruct) -> Result<TokenStream> {
     let explanation = get_docs(&violation.attrs)?;
     let violation = if explanation.trim().is_empty() {
         quote! {
-            #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, PartialEq, Eq)]
             #violation
 
-            impl From<#ident> for crate::registry::DiagnosticKind {
+            impl From<#ident> for ruff_diagnostics::DiagnosticKind {
                 fn from(value: #ident) -> Self {
-                    use crate::violation::Violation;
+                    use ruff_diagnostics::Violation;
 
                     Self {
                         body: Violation::message(&value),
@@ -62,7 +62,7 @@ pub fn violation(violation: &ItemStruct) -> Result<TokenStream> {
         }
     } else {
         quote! {
-            #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+            #[derive(Debug, PartialEq, Eq)]
             #violation
 
             impl #ident {
@@ -71,9 +71,9 @@ pub fn violation(violation: &ItemStruct) -> Result<TokenStream> {
                 }
             }
 
-            impl From<#ident> for crate::registry::DiagnosticKind {
+            impl From<#ident> for ruff_diagnostics::DiagnosticKind {
                 fn from(value: #ident) -> Self {
-                    use crate::violation::Violation;
+                    use ruff_diagnostics::Violation;
 
                     Self {
                         body: Violation::message(&value),

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -79,10 +79,9 @@ def main(*, name: str, code: str, linter: str) -> None:
     # Add the relevant rule function.
     with (rules_dir / f"{rule_name_snake}.rs").open("w") as fp:
         fp.write(
-            """use ruff_macros::derive_message_formats;
+            """use ruff_macros::{derive_message_formats, violation};
+use ruff_diagnostics::Violation;
 
-use ruff_macros::violation;
-use crate::violation::Violation;
 use crate::checkers::ast::Checker;
 
 #[violation]


### PR DESCRIPTION
## Summary

This PR moves `Diagnostic`, `DiagnosticKind`, and `Fix` into their own crate, which will enable us to further split up Ruff, since sub-linter crates (which need to implement functions that return `Diagnostic`) can now depend on `ruff_diagnostics` rather than Ruff.
