### PR TITLE
fix: Emit a more useful error if an `extend` points at a non-existent ruff.toml file.

### DIFF
--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -127,7 +127,8 @@ pub fn resolve_configuration(
         }
 
         // Resolve the current path.
-        let options = pyproject::load_options(&path)?;
+        let options = pyproject::load_options(&path)
+            .map_err(|err| anyhow!("Failed to parse `{}`: {}", path.to_string_lossy(), err))?;
         let project_root = relativity.resolve(&path);
         let configuration = Configuration::from_options(options, &project_root)?;
 

--- a/crates/ruff/src/settings/pyproject.rs
+++ b/crates/ruff/src/settings/pyproject.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::settings::options::Options;
@@ -113,13 +113,7 @@ pub fn find_user_settings_toml() -> Option<PathBuf> {
 /// Load `Options` from a `pyproject.toml` or `ruff.toml` file.
 pub fn load_options<P: AsRef<Path>>(path: P) -> Result<Options> {
     if path.as_ref().ends_with("pyproject.toml") {
-        let pyproject = parse_pyproject_toml(&path).map_err(|err| {
-            anyhow!(
-                "Failed to parse `{}`: {}",
-                path.as_ref().to_string_lossy(),
-                err
-            )
-        })?;
+        let pyproject = parse_pyproject_toml(&path)?;
         Ok(pyproject
             .tool
             .and_then(|tool| tool.ruff)


### PR DESCRIPTION
Today some `extend` usage pointing at a ruff.toml (which does not exist):

```
[tool.ruff]
extend = '../ruff.toml'
```

For some ruff invocation, say, `ruff src tests`, you just get `No such file or directory (os error 2)`. When reading this, i initially thought it was telling me that for `ruff src tests`, src or tests didn't exist.

It seems like pyproject.toml handling already has an existing error map which prettifies the error and includes the offending file path, but ruff.toml doesnt benefit from being handled in the same place. I basically just moved that logic up a level in order to ensure it applied to either option.

---
I was originally trying to add (what i think is nicer behavior) to show the whole path. Something to the end result like:

```
error: Following `extends` through pyproject.toml -> ../ruff.toml -> ../ruff.toml, failed to parse: No such file or directory (os error 2)
```

but given the required changes i wasn't sure that it would be accepted, since it's much more involved for a marginal benefit.