### PR TITLE
When "Args" and "Parameters" are present, prefer NumPy style

### DIFF
--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -294,18 +294,6 @@ pub fn sections(checker: &mut Checker, docstring: &Docstring, convention: Option
             // (e.g., "Returns", "Raises"). Break ties by checking for the presence of some of the
             // section names that are unique to each convention.
 
-            // If the docstring contains `Args:` or `Arguments:`, use the Google convention.
-            let google_sections = section_contexts(&lines, &SectionStyle::Google);
-            if google_sections
-                .iter()
-                .any(|context| matches!(context.kind, SectionKind::Arguments | SectionKind::Args))
-            {
-                for context in &google_sections {
-                    google_section(checker, docstring, context);
-                }
-                return;
-            }
-
             // If the docstring contains `Parameters:` or `Other Parameters:`, use the NumPy
             // convention.
             let numpy_sections = section_contexts(&lines, &SectionStyle::Numpy);
@@ -317,6 +305,18 @@ pub fn sections(checker: &mut Checker, docstring: &Docstring, convention: Option
             }) {
                 for context in &numpy_sections {
                     numpy_section(checker, docstring, context);
+                }
+                return;
+            }
+
+            // If the docstring contains `Args:` or `Arguments:`, use the Google convention.
+            let google_sections = section_contexts(&lines, &SectionStyle::Google);
+            if google_sections
+                .iter()
+                .any(|context| matches!(context.kind, SectionKind::Arguments | SectionKind::Args))
+            {
+                for context in &google_sections {
+                    google_section(checker, docstring, context);
                 }
                 return;
             }


### PR DESCRIPTION
We're much more likely to have an argument called "args" than an argument called "parameters", so in the presence of both, this seems like a better default.

Closes #3427.
