### PR TITLE
fix: method `red` not found in release builds

### DIFF
--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -49,6 +49,8 @@ pub fn run(
 ) -> Result<ExitStatus> {
     #[cfg(not(debug_assertions))]
     {
+        use colored::Colorize;
+
         let default_panic_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
             #[allow(clippy::print_stderr)]


### PR DESCRIPTION
Release builds are currently failing with

```
   Compiling ruff_cli v0.0.254 (/home/rafal/test/ruff/crates/ruff_cli)
error[E0599]: no method named `red` found for reference `&'static str` in the current scope
  --> crates/ruff_cli/src/lib.rs:64:29
   |
64 |                     "error".red().bold(),
   |                             ^^^ method not found in `&'static str`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
1  | use colored::Colorize;
   |

For more information about this error, try `rustc --explain E0599`.
error: could not compile `ruff_cli` due to previous error
```

This PR adds the missing `colored::Colorize` import to the release build only panic hook handler in the CLI.

Fixes #3432