### PR TITLE
perf: Optimize UTF8/ASCII byte offset index

### DIFF
--- a/crates/ruff_python_ast/src/source_code/locator.rs
+++ b/crates/ruff_python_ast/src/source_code/locator.rs
@@ -248,10 +248,6 @@ mod tests {
         let index = index_ascii(contents);
         assert_eq!(index, AsciiIndex::new(vec![0, 6]));
 
-        let contents = "x = 1\r\n";
-        let index = index_ascii(contents);
-        assert_eq!(index, AsciiIndex::new(vec![0, 7]));
-
         let contents = "x = 1\ny = 2\nz = x + y\n";
         let index = index_ascii(contents);
         assert_eq!(index, AsciiIndex::new(vec![0, 6, 12, 22]));
@@ -286,6 +282,17 @@ mod tests {
         assert_eq!(index.byte_offset(Location::new(2, 1), contents), 7);
     }
 
+    #[test]
+    fn ascii_carriage_return_newline() {
+        let contents = "x = 4\r\ny = 3";
+        let index = index_ascii(contents);
+        assert_eq!(index, AsciiIndex::new(vec![0, 7]));
+
+        assert_eq!(index.byte_offset(Location::new(1, 4), contents), 4);
+        assert_eq!(index.byte_offset(Location::new(2, 0), contents), 7);
+        assert_eq!(index.byte_offset(Location::new(2, 1), contents), 8);
+    }
+
     impl Utf8Index {
         fn line_count(&self) -> usize {
             self.line_start_byte_offsets.len()
@@ -303,11 +310,6 @@ mod tests {
         let index = index_utf8(contents);
         assert_eq!(index.line_count(), 2);
         assert_eq!(index, Utf8Index::new(vec![0, 11]));
-
-        let contents = "x = '🫣'\r\n";
-        let index = index_utf8(contents);
-        assert_eq!(index.line_count(), 2);
-        assert_eq!(index, Utf8Index::new(vec![0, 12]));
 
         let contents = "x = '🫣'\ny = 2\nz = x + y\n";
         let index = index_utf8(contents);
@@ -331,6 +333,19 @@ mod tests {
         assert_eq!(index.byte_offset(Location::new(1, 6), contents), 9);
         assert_eq!(index.byte_offset(Location::new(2, 0), contents), 11);
         assert_eq!(index.byte_offset(Location::new(2, 1), contents), 12);
+    }
+
+    #[test]
+    fn utf8_carriage_return_newline() {
+        let contents = "x = '🫣'\r\ny = 3";
+        let index = index_utf8(contents);
+        assert_eq!(index.line_count(), 2);
+        assert_eq!(index, Utf8Index::new(vec![0, 12]));
+
+        // Second '
+        assert_eq!(index.byte_offset(Location::new(1, 6), contents), 9);
+        assert_eq!(index.byte_offset(Location::new(2, 0), contents), 12);
+        assert_eq!(index.byte_offset(Location::new(2, 1), contents), 13);
     }
 
     #[test]


### PR DESCRIPTION
This PR improves the memory consumption and performance of our line/column based `Location`s to byte offsets. The PR also introduces two new zero-cost wrappers so that the functionality can be implemented as methods rather than free floating functions. 

The first improvement is that the implementation no longer performs two passes over the string:

1. To determine if its ASCII
2. To build up the index

The implementation now assumes ASCII and falls back (and converts the intermediate state) to UTF8 when it sees the first non-ascii character while building the index. 

The second optimization is to use `u32` to store the offsets (has anyone ever tried running a 4GB+ source document with Python?)

The last optimization avoids the nested `Vec<Vec<usize>>` for the `Utf8Index`. I tried two different approaches

## Line -> Char and Char -> Byte Index

The idea is to use two vectors instead of a nested vector:

* The first vector stores the *character* offset at which a new line starts
* The second vector stores the *byte* offsets for each character

You can then compute the [Location] offset by:

```rust
// retrieving the start character on that line and add the column (character offset)
let char_offset = lines[location.row() - 1] + location.column();
let byte_offset = char_to_byte_offsets[char_offset]
```
0b39da539059d87301f7319a2575114d87363e49

## Lazy column computation

This implementation makes the assumption that we're only querying a few locations and that computing the column offset for a single line is cheap (no minified documents where everything is on a single line). 

Based on this assumption, it is sufficient to only store the byte offsets for every line and then lazily compute the column offset. 

Computing the index lazily has the added benefit of reducing the memory footprint. 

7527612fcd254a14fcba1fa6d34a7d15883802e9

## Benchmark

```
❯ hyperfine --ignore-failure --warmup 10 \
        "./ruff_two ./crates/ruff/resources/test/cpython/ --no-cache" \
        "./ruff_main ./crates/ruff/resources/test/cpython/ --no-cache" \
        "./ruff_lazy ./crates/ruff/resources/test/cpython/ --no-cache"
Benchmark 1: ./ruff_two ./crates/ruff/resources/test/cpython/ --no-cache
  Time (mean ± σ):     186.3 ms ±   3.5 ms    [User: 3177.1 ms, System: 91.2 ms]
  Range (min … max):   180.5 ms … 192.1 ms    15 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 2: ./ruff_main ./crates/ruff/resources/test/cpython/ --no-cache
  Time (mean ± σ):     187.8 ms ±   3.5 ms    [User: 3215.8 ms, System: 99.4 ms]
  Range (min … max):   183.9 ms … 195.6 ms    15 runs
 
  Warning: Ignoring non-zero exit code.
 
Benchmark 3: ./ruff_lazy ./crates/ruff/resources/test/cpython/ --no-cache
  Time (mean ± σ):     184.7 ms ±   4.1 ms    [User: 3188.5 ms, System: 97.6 ms]
  Range (min … max):   179.5 ms … 195.8 ms    16 runs
 
  Warning: Ignoring non-zero exit code.
 
Summary
  './ruff_lazy ./crates/ruff/resources/test/cpython/ --no-cache' ran
    1.01 ± 0.03 times faster than './ruff_two ./crates/ruff/resources/test/cpython/ --no-cache'
    1.02 ± 0.03 times faster than './ruff_main ./crates/ruff/resources/test/cpython/ --no-cache'

```

## Memory usage

I used `/usr/bin/time` to get the max resident memory when linting cpython

* `main`:  ~324MB
* `two`: ~298MB
* `lazy`: ~287MB

## Verdict

This PR implements the `lazy` computation as it has a similar performance as storing all character positions but requires significantly less memory (only stores line mappings, not also mappings for every line)