### PR TITLE
Run ecosystem CI checks without --isolated

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -75,7 +75,6 @@ async def check(*, ruff: Path, path: Path) -> "Sequence[str]":
         "check",
         "--no-cache",
         "--exit-zero",
-        "--isolated",
         "--select",
         "ALL",
         ".",


### PR DESCRIPTION
Using `--isolated` runs the risk that we _avoid_ respecting certain code paths. For example, if a project (like Airflow) uses namespace packages, we'll no longer respect those settings, and we run the risk of introducing regressions for namespace packages.
