### PR TITLE
Remove unnecessary Serde derives

### DIFF
--- a/crates/ruff/src/rules/flake8_debugger/types.rs
+++ b/crates/ruff/src/rules/flake8_debugger/types.rs
@@ -1,6 +1,4 @@
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DebuggerUsingType {
     Call(String),
     Import(String),

--- a/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -9,7 +8,7 @@ use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum VarKind {
     TypeVar,
     ParamSpec,

--- a/crates/ruff/src/rules/flake8_return/branch.rs
+++ b/crates/ruff/src/rules/flake8_return/branch.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Branch {
     Elif,
     Else,

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -1,7 +1,6 @@
 use itertools::izip;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -12,7 +11,7 @@ use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::pycodestyle::helpers::compare;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum EqCmpop {
     Eq,
     NotEq,

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -2,7 +2,6 @@ use itertools::izip;
 use log::error;
 use once_cell::unsync::Lazy;
 use rustpython_parser::ast::{Cmpop, Expr};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -13,7 +12,7 @@ use ruff_python_ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum IsCmpop {
     Is,
     IsNot,

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -9,7 +8,7 @@ use ruff_python_ast::types::{Range, ScopeKind};
 
 use crate::checkers::ast::Checker;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DeferralKeyword {
     Yield,
     YieldFrom,

--- a/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_str_strip_call.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -31,7 +30,7 @@ impl Violation for BadStrStripCall {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum StripKind {
     Strip,
     LStrip,
@@ -60,7 +59,7 @@ impl fmt::Display for StripKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RemovalKind {
     RemovePrefix,
     RemoveSuffix,

--- a/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use itertools::Itertools;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Located};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -11,7 +10,7 @@ use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ViolationsCmpop {
     Eq,
     NotEq,

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -2,7 +2,6 @@ use std::{fmt, iter};
 
 use regex::Regex;
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind, Withitem};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -14,7 +13,7 @@ use ruff_python_ast::visitor::Visitor;
 
 use crate::checkers::ast::Checker;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum OuterBindingKind {
     For,
     With,
@@ -29,7 +28,7 @@ impl fmt::Display for OuterBindingKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum InnerBindingKind {
     For,
     With,

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -2,7 +2,6 @@ use std::fmt;
 
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::{lexer, Mode, Tok};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -11,7 +10,7 @@ use ruff_python_ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum LiteralType {
     Str,
     Bytes,

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -5,7 +5,6 @@ use libcst_native::{
 };
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -18,7 +17,7 @@ use crate::checkers::ast::Checker;
 use crate::cst::matchers::{match_import, match_import_from, match_module};
 use crate::registry::{AsRule, Rule};
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum MockReference {
     Import,
     Attribute,

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind, Location, Operator};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -11,7 +10,7 @@ use ruff_python_ast::types::Range;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CallKind {
     Isinstance,
     Issubclass,

--- a/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
+++ b/crates/ruff/src/rules/ruff/rules/asyncio_dangling_task.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind};
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -63,7 +62,7 @@ impl Violation for AsyncioDanglingTask {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Method {
     CreateTask,
     EnsureFuture,

--- a/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
+++ b/crates/ruff/src/rules/ruff/rules/unused_noqa.rs
@@ -1,10 +1,9 @@
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::AlwaysAutofixableViolation;
 use ruff_macros::{derive_message_formats, violation};
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct UnusedCodes {
     pub unknown: Vec<String>,
     pub disabled: Vec<String>,


### PR DESCRIPTION
These became unnecessary when we started serializing the materialized `Diagnostic`, rather than the underlying struct.