### PR TITLE
[FIX] PYI011: recognize `Bool` / `Float` / `Complex` numbers as simple defaults

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI014.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI014.pyi
@@ -43,3 +43,6 @@ def f21(
 def f22(
     x=-42.5j + 4.3j,  # Error PYI014
 ) -> None: ...
+def f23(
+  x=True,  # OK
+) -> None: ...

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -61,18 +61,16 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
             value: Constant::Bytes(..),
             ..
         } => return checker.locator.slice(default).len() <= 50,
-        // 123
-        // True / False
-        // 3.14
+        // Ex) `123`, `True`, `False`, `3.14`
         ExprKind::Constant {
             value: Constant::Int(..) | Constant::Bool(..) | Constant::Float(..),
             ..
         } => {
             return checker.locator.slice(default).len() <= 10;
         }
-        // 2j
+        // Ex) `2j`
         ExprKind::Constant {
-            value: Constant::Complex { real, imag: _ },
+            value: Constant::Complex { real, .. },
             ..
         } => {
             if *real == 0.0 {
@@ -83,8 +81,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
             op: Unaryop::USub,
             operand,
         } => {
-            // - 1
-            // - 3.14
+            // Ex) `-1`, `-3.14`
             if let ExprKind::Constant {
                 value: Constant::Int(..) | Constant::Float(..),
                 ..
@@ -92,9 +89,9 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
             {
                 return checker.locator.slice(operand).len() <= 10;
             }
-            // - 2j
+            // Ex) `-2j`
             if let ExprKind::Constant {
-                value: Constant::Complex { real, imag: _ },
+                value: Constant::Complex { real, .. },
                 ..
             } = &operand.node
             {
@@ -108,17 +105,13 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
             op: Operator::Add | Operator::Sub,
             right,
         } => {
-            // 1 + 2j
-            // 1 - 2j
-            // -1 - 2j
-            // -1 + 2j
+            // Ex) `1 + 2j`, `1 - 2j`, `-1 - 2j`, `-1 + 2j`
             if let ExprKind::Constant {
                 value: Constant::Complex { .. },
                 ..
             } = right.node
             {
-                // 1 + 2j
-                // 1 - 2j
+                // Ex) `1 + 2j`, `1 - 2j`
                 if let ExprKind::Constant {
                     value: Constant::Int(..) | Constant::Float(..),
                     ..
@@ -130,8 +123,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                     operand,
                 } = &left.node
                 {
-                    // -1 + 2j
-                    // -1 - 2j
+                    // Ex) `-1 + 2j`, `-1 - 2j`
                     if let ExprKind::Constant {
                         value: Constant::Int(..) | Constant::Float(..),
                         ..
@@ -142,7 +134,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                 }
             }
         }
-        // `sys.stdin`, etc.
+        // Ex) `sys.stdin`, etc.
         ExprKind::Attribute { .. } => {
             if checker
                 .ctx

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -61,22 +61,46 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
             value: Constant::Bytes(..),
             ..
         } => return checker.locator.slice(default).len() <= 50,
+        // 123
+        // True / False
+        // 3.14
         ExprKind::Constant {
-            value: Constant::Int(..),
+            value: Constant::Int(..) | Constant::Bool(..) | Constant::Float(..),
             ..
         } => {
             return checker.locator.slice(default).len() <= 10;
+        }
+        // 2j
+        ExprKind::Constant {
+            value: Constant::Complex { real, imag: _ },
+            ..
+        } => {
+            if *real == 0.0 {
+                return checker.locator.slice(default).len() <= 10;
+            }
         }
         ExprKind::UnaryOp {
             op: Unaryop::USub,
             operand,
         } => {
+            // - 1
+            // - 3.14
             if let ExprKind::Constant {
-                value: Constant::Int(..),
+                value: Constant::Int(..) | Constant::Float(..),
                 ..
             } = &operand.node
             {
                 return checker.locator.slice(operand).len() <= 10;
+            }
+            // - 2j
+            if let ExprKind::Constant {
+                value: Constant::Complex { real, imag: _ },
+                ..
+            } = &operand.node
+            {
+                if *real == 0.0 {
+                    return checker.locator.slice(operand).len() <= 10;
+                }
             }
         }
         ExprKind::BinOp {
@@ -96,7 +120,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                 // 1 + 2j
                 // 1 - 2j
                 if let ExprKind::Constant {
-                    value: Constant::Int(..),
+                    value: Constant::Int(..) | Constant::Float(..),
                     ..
                 } = &left.node
                 {
@@ -109,7 +133,7 @@ fn is_valid_default_value_with_annotation(default: &Expr, checker: &Checker) -> 
                     // -1 + 2j
                     // -1 - 2j
                     if let ExprKind::Constant {
-                        value: Constant::Int(..),
+                        value: Constant::Int(..) | Constant::Float(..),
                         ..
                     } = &operand.node
                     {


### PR DESCRIPTION
In https://github.com/PyCQA/flake8-pyi/blob/40d547e9624a50f06f0a8369cb2787addabf9ce8/pyi.py#L733-L738

```python
    def _is_valid_Num(node: ast.expr) -> TypeGuard[ast.Num]:
        # The maximum character limit is arbitrary, but here's what it's based on:
        # Hex representation of 32-bit integers tend to be 10 chars.
        # So is the decimal representation of the maximum positive signed 32-bit integer.
        # 0xFFFFFFFF --> 4294967295
        return isinstance(node, ast.Num) and len(str(node.n)) <= 10
```

constant numbers its representation of fewer than 10 characters are considered simple defaults. The definition of `ast.Num` is:

```python
class Num(Constant, metaclass=...):
    value: int | float | complex
```

Currently, `ruff` only considers `int`s are simple defaults. Constant numbers of:

- `bool`: `True` / `False`
- `float`: `3.14`, `2.0`, `0.5`
- `complex`: `2j`, `-3.14j`

are not.

Ref:

- #3238

------

In Python, `bool` is a subclass of `int`, which has only two instances `True` and `False`.

`True` and `False` should be considered simple defaults and should be allowed in `.pyi`.

```python
# test.pyi
def func(flag: bool = False) -> None: ...
```

Output:

```console
$ ruff --version
ruff 0.0.254

$ ruff check --select=PYI test.pyi
test.pyi:2:23: PYI011 Only simple default values allowed for typed arguments
Found 1 error.
```

```console
$ pip3 install -U flake8 flake8-pyi

$ flake8 --select=Y test.pyi
.. # empty output and no violation
```

I think this should be considered a bug in `rustpython_parser::ast::Constant`. It does not recognize `True` / `False` also to be a `Constain::Int(..)` (note that `bool` is a subclass of `int`).

```python
>>> bool.mro()
[bool, int, object]

>>> isinstance(True, int)
True

>>> isinstance(False, int)
True

>>> True == 1
True
>>> hash(True) == hash(1)
True
>>> len({True, 1})
1
>>> False == 0
True
>>> hash(False) == hash(0)
True
>>> len({False, 0})
1
```