### PR TITLE
Respect ignores for runtime-import-in-type-checking-block (TCH004)

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4968,7 +4968,9 @@ impl<'a> Checker<'a> {
                     if let Some(diagnostic) =
                         flake8_type_checking::rules::runtime_import_in_type_checking_block(binding)
                     {
-                        diagnostics.push(diagnostic);
+                        if self.settings.rules.enabled(diagnostic.kind.rule()) {
+                            diagnostics.push(diagnostic);
+                        }
                     }
                     if let Some(diagnostic) =
                         flake8_type_checking::rules::typing_only_runtime_import(


### PR DESCRIPTION
Closes #3472.