### PR TITLE
refactor(ruff_python_ast): Split `get_argument`

### DIFF
--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -108,7 +108,7 @@ pub fn bad_file_permissions(
         .map_or(false, |call_path| call_path.as_slice() == ["os", "chmod"])
     {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(mode_arg) = call_args.get_argument("mode", Some(1)) {
+        if let Some(mode_arg) = call_args.argument("mode", 1) {
             if let Some(int_value) = get_int_value(mode_arg) {
                 if (int_value & WRITE_WORLD > 0) || (int_value & EXECUTE_GROUP > 0) {
                     checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -25,7 +25,7 @@ impl Violation for HashlibInsecureHashFunction {
 const WEAK_HASHES: [&str; 4] = ["md4", "md5", "sha", "sha1"];
 
 fn is_used_for_security(call_args: &SimpleCallArgs) -> bool {
-    match call_args.get_argument("usedforsecurity", None) {
+    match call_args.keyword_argument("usedforsecurity") {
         Some(expr) => !matches!(
             &expr.node,
             ExprKind::Constant {
@@ -67,7 +67,7 @@ pub fn hashlib_insecure_hash_functions(
                     return;
                 }
 
-                if let Some(name_arg) = call_args.get_argument("name", Some(0)) {
+                if let Some(name_arg) = call_args.argument("name", 0) {
                     if let Some(hash_func_name) = string_literal(name_arg) {
                         if WEAK_HASHES.contains(&hash_func_name.to_lowercase().as_str()) {
                             checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -46,7 +46,7 @@ pub fn jinja2_autoescape_false(
     {
         let call_args = SimpleCallArgs::new(args, keywords);
 
-        if let Some(autoescape_arg) = call_args.get_argument("autoescape", None) {
+        if let Some(autoescape_arg) = call_args.keyword_argument("autoescape") {
             match &autoescape_arg.node {
                 ExprKind::Constant {
                     value: Constant::Bool(true),

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -33,7 +33,7 @@ pub fn logging_config_insecure_listen(
     {
         let call_args = SimpleCallArgs::new(args, keywords);
 
-        if call_args.get_argument("verify", None).is_none() {
+        if call_args.keyword_argument("verify").is_none() {
             checker.diagnostics.push(Diagnostic::new(
                 LoggingConfigInsecureListen,
                 Range::from(func),

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -56,7 +56,7 @@ pub fn request_with_no_cert_validation(
         None
     }) {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(verify_arg) = call_args.get_argument("verify", None) {
+        if let Some(verify_arg) = call_args.keyword_argument("verify") {
             if let ExprKind::Constant {
                 value: Constant::Bool(false),
                 ..

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -44,7 +44,7 @@ pub fn request_without_timeout(
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(timeout_arg) = call_args.get_argument("timeout", None) {
+        if let Some(timeout_arg) = call_args.keyword_argument("timeout") {
             if let Some(timeout) = match &timeout_arg.node {
                 ExprKind::Constant {
                     value: value @ Constant::None,

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -33,7 +33,7 @@ pub fn snmp_insecure_version(
         })
     {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(mp_model_arg) = call_args.get_argument("mpModel", None) {
+        if let Some(mp_model_arg) = call_args.keyword_argument("mpModel") {
             if let ExprKind::Constant {
                 value: Constant::Int(value),
                 ..

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -39,7 +39,7 @@ pub fn unsafe_yaml_load(checker: &mut Checker, func: &Expr, args: &[Expr], keywo
         .map_or(false, |call_path| call_path.as_slice() == ["yaml", "load"])
     {
         let call_args = SimpleCallArgs::new(args, keywords);
-        if let Some(loader_arg) = call_args.get_argument("Loader", Some(1)) {
+        if let Some(loader_arg) = call_args.argument("Loader", 1) {
             if !checker
                 .ctx
                 .resolve_call_path(loader_arg)

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -146,7 +146,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             );
 
             // G001 - G004
-            if let Some(format_arg) = call_args.get_argument("msg", Some(0)) {
+            if let Some(format_arg) = call_args.argument("msg", 0) {
                 check_msg(checker, format_arg);
             }
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -22,7 +22,7 @@ impl Violation for FailWithoutMessage {
 pub fn fail_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_fail(func, checker) {
         let call_args = SimpleCallArgs::new(args, keywords);
-        let msg = call_args.get_argument("msg", Some(0));
+        let msg = call_args.argument("msg", 0);
 
         if let Some(msg) = msg {
             if is_empty_or_null_string(msg) {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/patch.rs
@@ -68,11 +68,11 @@ fn check_patch_call(
     new_arg_number: usize,
 ) -> Option<Diagnostic> {
     let simple_args = SimpleCallArgs::new(args, keywords);
-    if simple_args.get_argument("return_value", None).is_some() {
+    if simple_args.keyword_argument("return_value").is_some() {
         return None;
     }
 
-    if let Some(new_arg) = simple_args.get_argument("new", Some(new_arg_number)) {
+    if let Some(new_arg) = simple_args.argument("new", new_arg_number) {
         if let ExprKind::Lambda { args, body } = &new_arg.node {
             // Walk the lambda body.
             let mut visitor = LambdaBodyVisitor {

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -107,7 +107,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
     if let ExprKind::Attribute { attr, .. } = &func.node {
         if LoggingLevel::from_attribute(attr.as_str()).is_some() {
             let call_args = SimpleCallArgs::new(args, keywords);
-            if let Some(msg) = call_args.get_argument("msg", Some(0)) {
+            if let Some(msg) = call_args.argument("msg", 0) {
                 if let ExprKind::Constant {
                     value: Constant::Str(value),
                     ..


### PR DESCRIPTION
This PR splits `SimpleCallArguments::get_arguments` into two methods:

* `keyword_argument`: Retrieves an argument by name only
* `argument`: Retrieves an argument by name or position

Splitting the methods has the advantage that:

* It's no longer necessary to pass `None` (or wrap the position in `Some`) when retrieving a keyword argument that has no position
* We hint to the compiler that checking if `position` is `Some` is never necessary for keyword arguments.
* The method names use the python semantics of keyword arguments vs "regular arguments"