### PR TITLE
ci: Use rust toolchain actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup component add rustfmt
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          components: rustfmt
       - run: cargo fmt --all --check
 
   cargo-clippy:
@@ -32,9 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: |
-          rustup component add clippy
-      - uses: Swatinem/rust-cache@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   cargo-clippy-wasm:
@@ -43,10 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: |
-          rustup component add clippy
-          rustup target add wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          components: clippy
       - run: cargo clippy -p ruff_wasm --target wasm32-unknown-unknown --all-features -- -D warnings
 
   cargo-test:
@@ -58,8 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup show
-      - uses: Swatinem/rust-cache@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: cargo install cargo-insta
       - run: pip install black[d]==22.12.0
       - name: "Run tests (Ubuntu)"
@@ -80,6 +82,7 @@ jobs:
           # Setting RUSTDOCFLAGS because `cargo doc --check` isn't yet implemented (https://github.com/rust-lang/cargo/issues/10025).
           RUSTDOCFLAGS: "-D warnings"
       - uses: actions/upload-artifact@v3
+        if: ${{ !env.ACT }} # skip during local actions testing
         with:
           name: ruff
           path: target/debug/ruff
@@ -91,14 +94,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup target add wasm32-unknown-unknown
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           cache: "npm"
           cache-dependency-path: playground/package-lock.json
       - uses: jetli/wasm-pack-action@v0.4.0
-      - uses: Swatinem/rust-cache@v1
       - name: "Run wasm-pack"
         run: |
           cd crates/ruff_wasm
@@ -110,8 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup show
-      - uses: Swatinem/rust-cache@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: ./scripts/add_rule.py --name DoTheThing --code PLC999 --linter pylint
       - run: cargo check
       - run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,8 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
       - name: "Install Rust toolchain"
-        run: rustup show
-      - uses: Swatinem/rust-cache@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: "Install dependencies"
         run: |
           pip install -r docs/requirements.txt

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup target add wasm32-unknown-unknown
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          cache: false
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
Use the `actions-rs/toolchain` action to install Rust, `actions-rs/cargo` to run cargo commands, and `action-rs/clippy-check` to run clippy.

* Using `actinos-rs/toolchain` ensures that our workflows work with [act](https://github.com/nektos/act), allowing to test locally
* Using `actions-rs/cargo`: It gives nice warnings and errors in the GitHub UI
* Using `actions/clippy-check`: Posts lint annotations

## Test Plan

Sample output after I added clippy errors

https://github.com/charliermarsh/ruff/actions/runs/4404224020/jobs/7713601234