### PR TITLE
Remove erroneous C4-to-C40 redirect

### DIFF
--- a/crates/ruff/src/rule_redirects.rs
+++ b/crates/ruff/src/rule_redirects.rs
@@ -18,7 +18,6 @@ static REDIRECTS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
         // The following are here because we don't yet have the many-to-one mapping enabled.
         ("SIM111", "SIM110"),
         // The following are deprecated.
-        ("C4", "C40"),
         ("C9", "C90"),
         ("T1", "T10"),
         ("T2", "T20"),


### PR DESCRIPTION
This is my mistake. Redirecting `C4` to `C40` means that `C4` ends up omitting any of the `C41` rules. We don't need to redirect `C4` at all!

Closes #3486.