### PR TITLE
Include individual path checks in --verbose logging

### DIFF
--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -128,7 +128,7 @@ pub fn resolve_configuration(
 
         // Resolve the current path.
         let options = pyproject::load_options(&path)
-            .map_err(|err| anyhow!("Failed to parse `{}`: {}", path.to_string_lossy(), err))?;
+            .map_err(|err| anyhow!("Failed to parse `{}`: {}", path.display(), err))?;
         let project_root = relativity.resolve(&path);
         let configuration = Configuration::from_options(options, &project_root)?;
 

--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -54,7 +54,7 @@ pub fn add_noqa(
             match add_noqa_to_path(path, package, settings) {
                 Ok(count) => Some(count),
                 Err(e) => {
-                    error!("Failed to add noqa to {}: {e}", path.to_string_lossy());
+                    error!("Failed to add noqa to {}: {e}", path.display());
                     None
                 }
             }

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -45,10 +45,7 @@ pub fn run(
     if cache.into() {
         fn init_cache(path: &std::path::Path) {
             if let Err(e) = cache::init(path) {
-                error!(
-                    "Failed to initialize cache at {}: {e:?}",
-                    path.to_string_lossy()
-                );
+                error!("Failed to initialize cache at {}: {e:?}", path.display());
             }
         }
 

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -74,13 +74,15 @@ pub fn lint_path(
         if let Some(messages) =
             cache::get(path, package.as_ref(), &metadata, settings, autofix.into())
         {
-            debug!("Cache hit for: {}", path.to_string_lossy());
+            debug!("Cache hit for: {}", path.display());
             return Ok(Diagnostics::new(messages));
         }
         Some(metadata)
     } else {
         None
     };
+
+    debug!("Checking: {}", path.display());
 
     // Read the file from disk.
     let contents = std::fs::read_to_string(path)?;


### PR DESCRIPTION
This modifies `ruff /path/to/file.py --verbose` to include a message for each file that's checked. `--verbose` is, in truth, more like `--debug`, but this generally fits with what we include in verbose logging.

Closes #3423.