### PR TITLE
fix lack of `not`  in error message

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -34,8 +34,8 @@ impl TryFrom<&Cmpop> for EmptyStringCmpop {
 impl EmptyStringCmpop {
     pub fn into_unary(self) -> &'static str {
         match self {
-            Self::Is | Self::Eq => "",
-            Self::IsNot | Self::NotEq => "not ",
+            Self::Is | Self::Eq => "not ",
+            Self::IsNot | Self::NotEq => "",
         }
     }
 }
@@ -62,7 +62,7 @@ impl Violation for CompareToEmptyString {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!(
-            "`{}` can be simplified to `not {}` as an empty string is falsey",
+            "`{}` can be simplified to `{}` as an empty string is falsey",
             self.existing, self.replacement,
         )
     }

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -62,7 +62,7 @@ impl Violation for CompareToEmptyString {
     #[derive_message_formats]
     fn message(&self) -> String {
         format!(
-            "`{}` can be simplified to `{}` as an empty string is falsey",
+            "`{}` can be simplified to `not {}` as an empty string is falsey",
             self.existing, self.replacement,
         )
     }

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLC1901_compare_to_empty_string.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLC1901_compare_to_empty_string.py.snap
@@ -4,7 +4,7 @@ expression: diagnostics
 ---
 - kind:
     name: CompareToEmptyString
-    body: "`x is \"\"` can be simplified to `x` as an empty string is falsey"
+    body: "`x is \"\"` can be simplified to `not x` as an empty string is falsey"
     suggestion: ~
     fixable: false
   location:
@@ -17,7 +17,7 @@ expression: diagnostics
   parent: ~
 - kind:
     name: CompareToEmptyString
-    body: "`x == \"\"` can be simplified to `x` as an empty string is falsey"
+    body: "`x == \"\"` can be simplified to `not x` as an empty string is falsey"
     suggestion: ~
     fixable: false
   location:
@@ -30,7 +30,7 @@ expression: diagnostics
   parent: ~
 - kind:
     name: CompareToEmptyString
-    body: "`y is not \"\"` can be simplified to `not y` as an empty string is falsey"
+    body: "`y is not \"\"` can be simplified to `y` as an empty string is falsey"
     suggestion: ~
     fixable: false
   location:
@@ -43,7 +43,7 @@ expression: diagnostics
   parent: ~
 - kind:
     name: CompareToEmptyString
-    body: "`y != \"\"` can be simplified to `not y` as an empty string is falsey"
+    body: "`y != \"\"` can be simplified to `y` as an empty string is falsey"
     suggestion: ~
     fixable: false
   location:
@@ -56,7 +56,7 @@ expression: diagnostics
   parent: ~
 - kind:
     name: CompareToEmptyString
-    body: "`\"\" != z` can be simplified to `not z` as an empty string is falsey"
+    body: "`\"\" != z` can be simplified to `z` as an empty string is falsey"
     suggestion: ~
     fixable: false
   location:


### PR DESCRIPTION
In the implementation of PLC1901, an improper error message is emitted. 

Example of current error message:

```
unit_test/wheel_print_test.py:15:28: PLC1901 `captured.err == ""` can be simplified to `captured.err` as an empty string is falsey
```

where should be 


```
unit_test/wheel_print_test.py:15:28: PLC1901 `captured.err == ""` can be simplified to `not captured.err` as an empty string is falsey
```
