### PR TITLE
Make Clap an optional feature for ruff crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,13 +313,14 @@ dependencies = [
 
 [[package]]
 name = "clap_complete_command"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4160b4a4f72ef58bd766bad27c09e6ef1cc9d82a22f6a0f55d152985a4a48e31"
+checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
 dependencies = [
  "clap 4.1.8",
  "clap_complete",
  "clap_complete_fig",
+ "clap_complete_nushell",
 ]
 
 [[package]]
@@ -327,6 +328,16 @@ name = "clap_complete_fig"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63a06158a72dbb088f864887b4409fd22600ba379f3cee3040f842234cc5c2d0"
+dependencies = [
+ "clap 4.1.8",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fa41f5e6aa83bd151b70fd0ceaee703d68cd669522795dc812df9edad1252c"
 dependencies = [
  "clap 4.1.8",
  "clap_complete",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -25,7 +25,7 @@ anyhow = { workspace = true }
 bisection = { version = "0.1.0" }
 bitflags = { workspace = true }
 chrono = { workspace = true }
-clap = { workspace = true, features = ["derive", "env", "string"] }
+clap = { workspace = true, features = ["derive", "string"], optional = true }
 colored = { workspace = true }
 dirs = { version = "4.0.0" }
 fern = { version = "0.6.1" }
@@ -71,7 +71,6 @@ criterion = { version = "0.4.0" }
 insta = { workspace = true, features = ["yaml", "redactions"] }
 pretty_assertions = "1.3.0"
 test-case = { workspace = true }
-
 
 [features]
 default = []

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -277,6 +277,7 @@ pub(crate) enum Specificity {
     Code5Chars,
 }
 
+#[cfg(feature = "clap")]
 mod clap_completion {
     use clap::builder::{PossibleValue, TypedValueParser, ValueParserFactory};
     use strum::IntoEnumIterator;
@@ -316,9 +317,7 @@ mod clap_completion {
                 .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, e))
         }
 
-        fn possible_values(
-            &self,
-        ) -> Option<Box<dyn Iterator<Item = clap::builder::PossibleValue> + '_>> {
+        fn possible_values(&self) -> Option<Box<dyn Iterator<Item = PossibleValue> + '_>> {
             Some(Box::new(
                 std::iter::once(PossibleValue::new("ALL").help("all rules")).chain(
                     Linter::iter()

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -22,7 +22,7 @@ name = "ruff"
 doc = false
 
 [dependencies]
-ruff = { path = "../ruff" }
+ruff = { path = "../ruff", features = ["clap"] }
 ruff_cache = { path = "../ruff_cache" }
 ruff_diagnostics = { path = "../ruff_diagnostics" }
 
@@ -34,7 +34,7 @@ bitflags = { workspace = true }
 cachedir = { version = "0.3.0" }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-clap_complete_command = { version = "0.4.0" }
+clap_complete_command = { version = "0.5.1" }
 clearscreen = { version = "2.0.0" }
 colored = { workspace = true }
 filetime = { workspace = true }

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -99,7 +99,7 @@ pub struct CheckArgs {
     #[arg(long, value_enum, env = "RUFF_FORMAT")]
     pub format: Option<SerializationFormat>,
     /// The minimum Python version that should be supported.
-    #[arg(long)]
+    #[arg(long, value_enum)]
     pub target_version: Option<PythonVersion>,
     /// Path to the `pyproject.toml` or `ruff.toml` file to use for
     /// configuration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,7 +211,7 @@ Options:
       --format <FORMAT>
           Output serialization format for violations [env: RUFF_FORMAT=] [possible values: text, json, junit, grouped, github, gitlab, pylint, azure]
       --target-version <TARGET_VERSION>
-          The minimum Python version that should be supported
+          The minimum Python version that should be supported [possible values: py37, py38, py39, py310, py311]
       --config <CONFIG>
           Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
       --statistics


### PR DESCRIPTION
## Summary

It's hard to remove the `clap` dependency entirely due to orphan rules. Open to ideas -- we could create wrapper structs in `ruff-cli`? But this at least removes `clap` for isolated testing, etc.
