### PR TITLE
Fix base ref determination for artifact download in ecosystem CI check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
       - uses: dawidd6/action-download-artifact@v2
         with:
           name: ruff
-          branch: ${{ github.event.pull_request.base_ref }}
+          branch: ${{ github.event.pull_request.base.ref }}
           check_artifacts: true
       - name: Run ecosystem check
         run: |


### PR DESCRIPTION
Not sure how I missed this. Fixes charliermarsh/ruff#3458