### PR TITLE
Gracefully handle lint panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ textwrap = { version = "0.16.0" }
 toml = { version = "0.7.2" }
 
 [profile.release]
-panic = "abort"
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 opt-level = 3
 

--- a/crates/ruff_cli/src/commands/linter.rs
+++ b/crates/ruff_cli/src/commands/linter.rs
@@ -1,6 +1,6 @@
+use std::fmt::Write;
 use std::io;
 use std::io::BufWriter;
-use std::io::Write;
 
 use anyhow::Result;
 use itertools::Itertools;
@@ -41,7 +41,7 @@ pub fn linter(format: HelpFormat) -> Result<()> {
                         .join("/"),
                     prefix => prefix.to_string(),
                 };
-                output.push_str(&format!("{:>4} {}\n", prefix, linter.name()));
+                writeln!(output, "{:>4} {}", prefix, linter.name()).unwrap();
             }
         }
 
@@ -65,7 +65,7 @@ pub fn linter(format: HelpFormat) -> Result<()> {
         }
     }
 
-    write!(stdout, "{output}")?;
+    io::Write::write_fmt(&mut stdout, format_args!("{output}"))?;
 
     Ok(())
 }

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod args;
 mod cache;
 mod commands;
 mod diagnostics;
+mod panic;
 mod printer;
 mod resolve;
 
@@ -46,7 +47,6 @@ pub fn run(
         log_level_args,
     }: Args,
 ) -> Result<ExitStatus> {
-    #[cfg(not(debug_assertions))]
     {
         use colored::Colorize;
 

--- a/crates/ruff_cli/src/panic.rs
+++ b/crates/ruff_cli/src/panic.rs
@@ -1,0 +1,46 @@
+#[derive(Default, Debug)]
+pub(crate) struct PanicError {
+    pub info: String,
+    pub backtrace: Option<std::backtrace::Backtrace>,
+}
+
+impl std::fmt::Display for PanicError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self.info)?;
+        if let Some(backtrace) = &self.backtrace {
+            writeln!(f, "Backtrace: {backtrace}")
+        } else {
+            Ok(())
+        }
+    }
+}
+
+thread_local! {
+    static LAST_PANIC: std::cell::Cell<Option<PanicError>> = std::cell::Cell::new(None);
+}
+
+/// [`catch_unwind`](std::panic::catch_unwind) wrapper that sets a custom [`set_hook`](std::panic::set_hook)
+/// to extract the backtrace. The original panic-hook gets restored before returning.
+pub(crate) fn catch_unwind<F, R>(f: F) -> Result<R, PanicError>
+where
+    F: FnOnce() -> R + std::panic::UnwindSafe,
+{
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|info| {
+        let info = info.to_string();
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        LAST_PANIC.with(|cell| {
+            cell.set(Some(PanicError {
+                info,
+                backtrace: Some(backtrace),
+            }));
+        });
+    }));
+
+    let result = std::panic::catch_unwind(f)
+        .map_err(|_| LAST_PANIC.with(std::cell::Cell::take).unwrap_or_default());
+
+    std::panic::set_hook(prev);
+
+    result
+}


### PR DESCRIPTION
This PR wraps the linting of every file in a [`catch_unwind`](https://blog.rust-lang.org/2016/05/26/Rust-1.9.html#controlled-unwinding) to catch potential panics (due to a bug in ruff) and prints a warning instead of crashing ruff. Catching panics on a per-file basis has the advantage that it doesn't prevent users from adopting or continuing using Ruff because of a bug triggered by a specific code snipped. The catch handler also includes the name of the problematic file to ease identifying the bug. 

The main downside of this approach is that we now need to compile ruff with `panic=unwind` instead of `panic=abort`. Changing the panic type results in a ~15% performance regression on my machine:

```
Panic 'unwind': ./target/release/ruff ./crates/ruff/resources/test/cpython/ --no-cache
  Time (mean ± σ):     215.3 ms ±   6.2 ms    [User: 3753.3 ms, System: 98.0 ms]
  Range (min … max):   203.8 ms … 226.1 ms    13 runs
 
Panic 'abort': ./target/release/ruff ./crates/ruff/resources/test/cpython/ --no-cache
  Time (mean ± σ):     188.9 ms ±   3.6 ms    [User: 3216.8 ms, System: 116.1 ms]
  Range (min … max):   181.5 ms … 194.0 ms    15 runs
```

It also slightly increases the binary from ~19MB to ~20MB due to the additional metadata required to enable unwinding (stack walking etc).

## Test Plan

I changed a linter and added an intentional index out of bounds. Ruff linted all files but printed the following warning everytime the out of bounds index paniced

```
warning: Linting panicked /home/micha/.config/JetBrains/CLion2022.3/scratches/scratch_3.py: This indicates a bug in `ruff`. If you could open an issue at:

https://github.com/charliermarsh/ruff/issues/new?title=%5BLinter%20panic%5D

with the relevant file contents, the `pyproject.toml` settings, and the following stack trace, we'd be very appreciative!

panicked at 'index out of bounds: the len is 0 but the index is 1', crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs:108:14
Backtrace:    0: ruff_cli::panic::catch_unwind::{{closure}}
             at ./crates/ruff_cli/src/panic.rs:35:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/alloc/src/boxed.rs:2032:9
   2: std::panicking::rust_panic_with_hook
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:692:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:579:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/sys_common/backtrace.rs:137:18
   5: rust_begin_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:575:5
   6: core::panicking::panic_fmt
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:64:14
   7: core::panicking::panic_bounds_check
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/panicking.rs:147:5
   8: <usize as core::slice::index::SliceIndex<[T]>>::index
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/slice/index.rs:260:10
   9: core::slice::index::<impl core::ops::index::Index<I> for [T]>::index
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/slice/index.rs:18:9
  10: <alloc::vec::Vec<T,A> as core::ops::index::Index<I>>::index
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/alloc/src/vec/mod.rs:2727:9
  11: ruff::rules::pycodestyle::rules::compound_statements::compound_statements
             at ./crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs:108:14
  12: ruff::checkers::tokens::check_tokens
             at ./crates/ruff/src/checkers/tokens.rs:123:13
  13: ruff::linter::check_path
             at ./crates/ruff/src/linter.rs:90:28
  14: ruff::linter::lint_only
             at ./crates/ruff/src/linter.rs:325:18
  15: ruff_cli::diagnostics::lint_path
             at ./crates/ruff_cli/src/diagnostics.rs:129:22
  16: ruff_cli::commands::run::lint_path::{{closure}}
             at ./crates/ruff_cli/src/commands/run.rs:146:9
  17: std::panicking::try::do_call
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:483:40
  18: __rust_try
  19: std::panicking::try
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:447:19
  20: std::panic::catch_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panic.rs:137:14
  21: ruff_cli::panic::catch_unwind
             at ./crates/ruff_cli/src/panic.rs:44:18
  22: ruff_cli::commands::run::lint_path
             at ./crates/ruff_cli/src/commands/run.rs:145:18
  23: ruff_cli::commands::run::run::{{closure}}
             at ./crates/ruff_cli/src/commands/run.rs:88:21
  24: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &F>::call_mut
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs:593:13
  25: core::iter::adapters::map::map_fold::{{closure}}
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/iter/adapters/map.rs:84:28
  26: core::iter::traits::iterator::Iterator::fold
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/iter/traits/iterator.rs:2414:21
  27: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::fold
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/iter/adapters/map.rs:124:9
  28: <rayon::iter::reduce::ReduceFolder<R,T> as rayon::iter::plumbing::Folder<T>>::consume_iter
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/reduce.rs:105:19
  29: <rayon::iter::map::MapFolder<C,F> as rayon::iter::plumbing::Folder<T>>::consume_iter
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/map.rs:248:21
  30: rayon::iter::plumbing::Producer::fold_with
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/plumbing/mod.rs:110:9
  31: rayon::iter::plumbing::bridge_producer_consumer::helper
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/plumbing/mod.rs:438:13
  32: rayon::iter::plumbing::bridge_producer_consumer
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/plumbing/mod.rs:397:12
  33: <rayon::iter::plumbing::bridge::Callback<C> as rayon::iter::plumbing::ProducerCallback<I>>::callback
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/plumbing/mod.rs:373:13
  34: <rayon::slice::Iter<T> as rayon::iter::IndexedParallelIterator>::with_producer
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/slice/mod.rs:732:9
  35: rayon::iter::plumbing::bridge
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/plumbing/mod.rs:357:12
  36: <rayon::slice::Iter<T> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/slice/mod.rs:708:9
  37: <rayon::iter::map::Map<I,F> as rayon::iter::ParallelIterator>::drive_unindexed
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/map.rs:49:9
  38: rayon::iter::reduce::reduce
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/reduce.rs:15:5
  39: rayon::iter::ParallelIterator::reduce
             at /home/micha/.cargo/registry/src/github.com-1ecc6299db9ec823/rayon-1.7.0/src/iter/mod.rs:991:9
  40: ruff_cli::commands::run::run
             at ./crates/ruff_cli/src/commands/run.rs:76:40
  41: ruff_cli::check
             at ./crates/ruff_cli/src/lib.rs:244:13
  42: ruff_cli::run
             at ./crates/ruff_cli/src/lib.rs:83:40
  43: ruff::main
             at ./crates/ruff_cli/src/bin/ruff.rs:45:11
  44: core::ops::function::FnOnce::call_once
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs:507:5
  45: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/sys_common/backtrace.rs:121:18
  46: std::rt::lang_start::{{closure}}
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/rt.rs:166:18
  47: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/core/src/ops/function.rs:606:13
  48: std::panicking::try::do_call
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:483:40
  49: std::panicking::try
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:447:19
  50: std::panic::catch_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panic.rs:137:14
  51: std::rt::lang_start_internal::{{closure}}
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/rt.rs:148:48
  52: std::panicking::try::do_call
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:483:40
  53: std::panicking::try
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panicking.rs:447:19
  54: std::panic::catch_unwind
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/panic.rs:137:14
  55: std::rt::lang_start_internal
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/rt.rs:148:20
  56: std::rt::lang_start
             at /rustc/d5a82bbd26e1ad8b7401f6a718a9c57c96905483/library/std/src/rt.rs:165:17
  57: main
  58: <unknown>
  59: __libc_start_main
  60: _start
```

The top frames are related to Rust's unwind handling but frame 11 points to the problematic line. 


## Alternatives

* We could set a panic handler (`set_handler`) per processed file. This would allow us to print the file name before crashing ruff, but it doesn't solve the problem that the bug now prevents users from using ruff. 
* Keep as is
* Ship two binaries and fallback to the binary with `catch_unwind` enabled if we run into a panic :rofl: 