### PR TITLE
ci: fix missing short tag for cloudflare/wrangler-action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
           mkdocs build --strict
       - name: "Deploy to Cloudflare Pages"
         if: ${{ env.CF_API_TOKEN_EXISTS == 'true' }}
-        uses: cloudflare/wrangler-action@2
+        uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -40,7 +40,7 @@ jobs:
         working-directory: playground
       - name: "Deploy to Cloudflare Pages"
         if: ${{ env.CF_API_TOKEN_EXISTS == 'true' }}
-        uses: cloudflare/wrangler-action@2
+        uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
Sorry for adding noise here without a deep investigation in #3504. [cloudflare/wrangler-action](https://github.com/cloudflare/wrangler-action) does not have a short tag like `2` or `v2`. Use the full tag in GitHub Actions for cloudflare/wrangler-action.