### PR TITLE
Avoid C1901 violations within subscripts

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/compare_to_empty_string.py
+++ b/crates/ruff/resources/test/fixtures/pylint/compare_to_empty_string.py
@@ -17,3 +17,7 @@ def errors():
 def ok():
     if x and not y:
         print("x is not an empty string, but y is an empty string")
+
+
+data.loc[data["a"] != ""]
+data.loc[data["a"] != "", :]

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -74,6 +74,14 @@ pub fn compare_to_empty_string(
     ops: &[Cmpop],
     comparators: &[Expr],
 ) {
+    // Omit string comparison rules within subscripts. This is mostly commonly used within
+    // DataFrame and np.ndarray indexing.
+    for parent in checker.ctx.expr_ancestors() {
+        if matches!(parent.node, ExprKind::Subscript { .. }) {
+            return;
+        }
+    }
+
     let mut first = true;
     for ((lhs, rhs), op) in std::iter::once(left)
         .chain(comparators.iter())

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -251,6 +251,11 @@ impl<'a> Context<'a> {
         self.exprs.iter().rev().nth(2)
     }
 
+    /// Return an [`Iterator`] over the current `Expr` parents.
+    pub fn expr_ancestors(&self) -> impl Iterator<Item = &RefEquality<'a, Expr>> {
+        self.exprs.iter().rev().skip(1)
+    }
+
     /// Return the `Stmt` that immediately follows the current `Stmt`, if any.
     pub fn current_sibling_stmt(&self) -> Option<&'a Stmt> {
         self.body.get(self.body_index + 1)


### PR DESCRIPTION
## Summary

I'm not sold on merging this, but... this PR turns off "compare-to-empty-string" violations when such comparisons are used within a subscript, like `df[x == ""]`. This is a common idiom in Pandas especially, where `x == ""` is an elementwise comparison, and can't be replaced with `x` or `bool(x)` or whatever.

The downside here is that we trade off some false positives for false negatives.

Closes #3494.
