### PR TITLE
Refine complexity rules for try-except-else-finally

### DIFF
--- a/crates/ruff/src/rules/mccabe/snapshots/ruff__rules__mccabe__tests__max_complexity_0.snap
+++ b/crates/ruff/src/rules/mccabe/snapshots/ruff__rules__mccabe__tests__max_complexity_0.snap
@@ -160,7 +160,7 @@ expression: diagnostics
   parent: ~
 - kind:
     name: ComplexStructure
-    body: "`nested_try_finally` is too complex (3)"
+    body: "`nested_try_finally` is too complex (1)"
     suggestion: ~
     fixable: false
   location:


### PR DESCRIPTION
## Summary

`try-finally` shouldn't increase the complexity score, but `try-except-else` should.

Closes #3347.
