### PR TITLE
Avoid tracking as-imports separately with force-single-line

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/force_single_line.py
+++ b/crates/ruff/resources/test/fixtures/isort/force_single_line.py
@@ -1,5 +1,10 @@
 import sys, math
 from os import path, uname
+from json import detect_encoding
+from json import dump
+from json import dumps as json_dumps
+from json import load
+from json import loads as json_loads
 from logging.handlers import StreamHandler, FileHandler
 
 # comment 1

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -143,7 +143,7 @@ pub fn format_imports(
     let block = annotate_imports(&block.imports, comments, locator, split_on_trailing_comma);
 
     // Normalize imports (i.e., deduplicate, aggregate `from` imports).
-    let block = normalize_imports(block, combine_as_imports);
+    let block = normalize_imports(block, combine_as_imports, force_single_line);
 
     let mut output = String::new();
 

--- a/crates/ruff/src/rules/isort/normalize.rs
+++ b/crates/ruff/src/rules/isort/normalize.rs
@@ -3,7 +3,11 @@ use crate::rules::isort::types::TrailingComma;
 use super::types::{AliasData, ImportBlock, ImportFromData};
 use super::AnnotatedImport;
 
-pub fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool) -> ImportBlock {
+pub fn normalize_imports(
+    imports: Vec<AnnotatedImport>,
+    combine_as_imports: bool,
+    force_single_line: bool,
+) -> ImportBlock {
     let mut block = ImportBlock::default();
     for import in imports {
         match import {
@@ -55,7 +59,7 @@ pub fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool
                             .import_from_star
                             .entry(ImportFromData { module, level })
                             .or_default()
-                    } else if alias.asname.is_none() || combine_as_imports {
+                    } else if alias.asname.is_none() || combine_as_imports || force_single_line {
                         block
                             .import_from
                             .entry(ImportFromData { module, level })
@@ -89,7 +93,7 @@ pub fn normalize_imports(imports: Vec<AnnotatedImport>, combine_as_imports: bool
                             .import_from_star
                             .entry(ImportFromData { module, level })
                             .or_default()
-                    } else if alias.asname.is_none() || combine_as_imports {
+                    } else if alias.asname.is_none() || combine_as_imports || force_single_line {
                         block
                             .import_from
                             .entry(ImportFromData { module, level })

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_single_line_force_single_line.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_single_line_force_single_line.py.snap
@@ -11,15 +11,15 @@ expression: diagnostics
     row: 1
     column: 0
   end_location:
-    row: 20
+    row: 25
     column: 0
   fix:
-    content: "import math\nimport sys\nfrom logging.handlers import FileHandler, StreamHandler\nfrom os import path, uname\n\n# comment 6\nfrom bar import a  # comment 7\nfrom bar import b  # comment 8\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\nfrom foo3 import bar3  # comment 5\nfrom foo3 import baz3  # comment 5\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
+    content: "import math\nimport sys\nfrom json import detect_encoding\nfrom json import dump\nfrom json import dumps as json_dumps\nfrom json import load\nfrom json import loads as json_loads\nfrom logging.handlers import FileHandler, StreamHandler\nfrom os import path, uname\n\n# comment 6\nfrom bar import a  # comment 7\nfrom bar import b  # comment 8\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\nfrom foo3 import bar3  # comment 5\nfrom foo3 import baz3  # comment 5\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
     location:
       row: 1
       column: 0
     end_location:
-      row: 20
+      row: 25
       column: 0
   parent: ~
 


### PR DESCRIPTION
## Summary

This fixes a subtle bug in `force-single-line`.

With default settings (`force-single-line = false` and `combine-as-imports = false`), we track the `as` imports in a separate struct, and place those after all of the non-`as` imports. When `combine-as-imports = true`, we track them all together, which works fine too.

Now, if `force-single-line = true` but `combine-as-imports = false`, we still track the `as` imports separately, but then split them out later, which causes them to all appear at the end, after the non-`as` imports. Thus, the `as` imports actually appear out-of-order.

The fix here is to track the `as` imports alongside all the rest when `force-single-line` is enabled.

Closes #3528.
