### PR TITLE
refactor: Add Copy implementation to Rule

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -118,12 +118,12 @@ impl<'a> Checker<'a> {
 impl<'a> Checker<'a> {
     /// Return `true` if a patch should be generated under the given autofix
     /// `Mode`.
-    pub fn patch(&self, code: &Rule) -> bool {
+    pub fn patch(&self, code: Rule) -> bool {
         self.autofix.into() && self.settings.rules.should_fix(code)
     }
 
     /// Return `true` if a `Rule` is disabled by a `noqa` directive.
-    pub fn rule_is_ignored(&self, code: &Rule, lineno: usize) -> bool {
+    pub fn rule_is_ignored(&self, code: Rule, lineno: usize) -> bool {
         // TODO(charlie): `noqa` directives are mostly enforced in `check_lines.rs`.
         // However, in rare cases, we need to check them here. For example, when
         // removing unused imports, we create a single fix that's applied to all
@@ -215,7 +215,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
+                if self.settings.rules.enabled(Rule::AmbiguousVariableName) {
                     self.diagnostics
                         .extend(names.iter().zip(ranges.iter()).filter_map(|(name, range)| {
                             pycodestyle::rules::ambiguous_variable_name(name, *range)
@@ -259,7 +259,7 @@ where
 
                         // Ensure that every nonlocal has an existing binding from a parent scope.
                         if !exists {
-                            if self.settings.rules.enabled(&Rule::NonlocalWithoutBinding) {
+                            if self.settings.rules.enabled(Rule::NonlocalWithoutBinding) {
                                 self.diagnostics.push(Diagnostic::new(
                                     pylint::rules::NonlocalWithoutBinding {
                                         name: name.to_string(),
@@ -271,7 +271,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
+                if self.settings.rules.enabled(Rule::AmbiguousVariableName) {
                     self.diagnostics
                         .extend(names.iter().zip(ranges.iter()).filter_map(|(name, range)| {
                             pycodestyle::rules::ambiguous_variable_name(name, *range)
@@ -279,7 +279,7 @@ where
                 }
             }
             StmtKind::Break => {
-                if self.settings.rules.enabled(&Rule::BreakOutsideLoop) {
+                if self.settings.rules.enabled(Rule::BreakOutsideLoop) {
                     if let Some(diagnostic) = pyflakes::rules::break_outside_loop(
                         stmt,
                         &mut self.ctx.parents.iter().rev().map(Into::into).skip(1),
@@ -289,7 +289,7 @@ where
                 }
             }
             StmtKind::Continue => {
-                if self.settings.rules.enabled(&Rule::ContinueOutsideLoop) {
+                if self.settings.rules.enabled(Rule::ContinueOutsideLoop) {
                     if let Some(diagnostic) = pyflakes::rules::continue_outside_loop(
                         stmt,
                         &mut self.ctx.parents.iter().rev().map(Into::into).skip(1),
@@ -317,7 +317,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::NonLeadingReceiverDecorator)
+                    .enabled(Rule::NonLeadingReceiverDecorator)
                 {
                     self.diagnostics
                         .extend(flake8_django::rules::non_leading_receiver_decorator(
@@ -325,7 +325,7 @@ where
                             |expr| self.ctx.resolve_call_path(expr),
                         ));
                 }
-                if self.settings.rules.enabled(&Rule::AmbiguousFunctionName) {
+                if self.settings.rules.enabled(Rule::AmbiguousFunctionName) {
                     if let Some(diagnostic) =
                         pycodestyle::rules::ambiguous_function_name(name, || {
                             helpers::identifier_range(stmt, self.locator)
@@ -335,7 +335,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::InvalidFunctionName) {
+                if self.settings.rules.enabled(Rule::InvalidFunctionName) {
                     if let Some(diagnostic) = pep8_naming::rules::invalid_function_name(
                         stmt,
                         name,
@@ -349,7 +349,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::InvalidFirstArgumentNameForClassMethod)
+                    .enabled(Rule::InvalidFirstArgumentNameForClassMethod)
                 {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_first_argument_name_for_class_method(
@@ -367,7 +367,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::InvalidFirstArgumentNameForMethod)
+                    .enabled(Rule::InvalidFirstArgumentNameForMethod)
                 {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_first_argument_name_for_method(
@@ -383,15 +383,15 @@ where
                 }
 
                 if self.is_stub {
-                    if self.settings.rules.enabled(&Rule::PassStatementStubBody) {
+                    if self.settings.rules.enabled(Rule::PassStatementStubBody) {
                         flake8_pyi::rules::pass_statement_stub_body(self, body);
                     }
-                    if self.settings.rules.enabled(&Rule::NonEmptyStubBody) {
+                    if self.settings.rules.enabled(Rule::NonEmptyStubBody) {
                         flake8_pyi::rules::non_empty_stub_body(self, body);
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::DunderFunctionName) {
+                if self.settings.rules.enabled(Rule::DunderFunctionName) {
                     if let Some(diagnostic) = pep8_naming::rules::dunder_function_name(
                         self.ctx.current_scope(),
                         stmt,
@@ -402,45 +402,42 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     pylint::rules::global_statement(self, name);
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::LRUCacheWithoutParameters)
+                if self.settings.rules.enabled(Rule::LRUCacheWithoutParameters)
                     && self.settings.target_version >= PythonVersion::Py38
                 {
                     pyupgrade::rules::lru_cache_without_parameters(self, decorator_list);
                 }
-                if self.settings.rules.enabled(&Rule::FunctoolsCache)
+                if self.settings.rules.enabled(Rule::FunctoolsCache)
                     && self.settings.target_version >= PythonVersion::Py39
                 {
                     pyupgrade::rules::functools_cache(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&Rule::UselessExpression) {
+                if self.settings.rules.enabled(Rule::UselessExpression) {
                     flake8_bugbear::rules::useless_expression(self, body);
                 }
 
-                if self.settings.rules.enabled(&Rule::CachedInstanceMethod) {
+                if self.settings.rules.enabled(Rule::CachedInstanceMethod) {
                     flake8_bugbear::rules::cached_instance_method(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(&Rule::UnnecessaryReturnNone)
-                    || self.settings.rules.enabled(&Rule::ImplicitReturnValue)
-                    || self.settings.rules.enabled(&Rule::ImplicitReturn)
-                    || self.settings.rules.enabled(&Rule::UnnecessaryAssign)
-                    || self.settings.rules.enabled(&Rule::SuperfluousElseReturn)
-                    || self.settings.rules.enabled(&Rule::SuperfluousElseRaise)
-                    || self.settings.rules.enabled(&Rule::SuperfluousElseContinue)
-                    || self.settings.rules.enabled(&Rule::SuperfluousElseBreak)
+                if self.settings.rules.enabled(Rule::UnnecessaryReturnNone)
+                    || self.settings.rules.enabled(Rule::ImplicitReturnValue)
+                    || self.settings.rules.enabled(Rule::ImplicitReturn)
+                    || self.settings.rules.enabled(Rule::UnnecessaryAssign)
+                    || self.settings.rules.enabled(Rule::SuperfluousElseReturn)
+                    || self.settings.rules.enabled(Rule::SuperfluousElseRaise)
+                    || self.settings.rules.enabled(Rule::SuperfluousElseContinue)
+                    || self.settings.rules.enabled(Rule::SuperfluousElseBreak)
                 {
                     flake8_return::rules::function(self, body);
                 }
 
-                if self.settings.rules.enabled(&Rule::ComplexStructure) {
+                if self.settings.rules.enabled(Rule::ComplexStructure) {
                     if let Some(diagnostic) = mccabe::rules::function_is_too_complex(
                         stmt,
                         name,
@@ -452,20 +449,20 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::HardcodedPasswordDefault) {
+                if self.settings.rules.enabled(Rule::HardcodedPasswordDefault) {
                     self.diagnostics
                         .extend(flake8_bandit::rules::hardcoded_password_default(args));
                 }
 
-                if self.settings.rules.enabled(&Rule::PropertyWithParameters) {
+                if self.settings.rules.enabled(Rule::PropertyWithParameters) {
                     pylint::rules::property_with_parameters(self, stmt, decorator_list, args);
                 }
 
-                if self.settings.rules.enabled(&Rule::TooManyArguments) {
+                if self.settings.rules.enabled(Rule::TooManyArguments) {
                     pylint::rules::too_many_arguments(self, args, stmt);
                 }
 
-                if self.settings.rules.enabled(&Rule::TooManyReturnStatements) {
+                if self.settings.rules.enabled(Rule::TooManyReturnStatements) {
                     if let Some(diagnostic) = pylint::rules::too_many_return_statements(
                         stmt,
                         body,
@@ -476,7 +473,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::TooManyBranches) {
+                if self.settings.rules.enabled(Rule::TooManyBranches) {
                     if let Some(diagnostic) = pylint::rules::too_many_branches(
                         stmt,
                         body,
@@ -487,7 +484,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::TooManyStatements) {
+                if self.settings.rules.enabled(Rule::TooManyStatements) {
                     if let Some(diagnostic) = pylint::rules::too_many_statements(
                         stmt,
                         body,
@@ -501,29 +498,29 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::IncorrectFixtureParenthesesStyle)
-                    || self.settings.rules.enabled(&Rule::FixturePositionalArgs)
-                    || self.settings.rules.enabled(&Rule::ExtraneousScopeFunction)
+                    .enabled(Rule::IncorrectFixtureParenthesesStyle)
+                    || self.settings.rules.enabled(Rule::FixturePositionalArgs)
+                    || self.settings.rules.enabled(Rule::ExtraneousScopeFunction)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::MissingFixtureNameUnderscore)
+                        .enabled(Rule::MissingFixtureNameUnderscore)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::IncorrectFixtureNameUnderscore)
-                    || self.settings.rules.enabled(&Rule::FixtureParamWithoutValue)
-                    || self.settings.rules.enabled(&Rule::DeprecatedYieldFixture)
-                    || self.settings.rules.enabled(&Rule::FixtureFinalizerCallback)
-                    || self.settings.rules.enabled(&Rule::UselessYieldFixture)
+                        .enabled(Rule::IncorrectFixtureNameUnderscore)
+                    || self.settings.rules.enabled(Rule::FixtureParamWithoutValue)
+                    || self.settings.rules.enabled(Rule::DeprecatedYieldFixture)
+                    || self.settings.rules.enabled(Rule::FixtureFinalizerCallback)
+                    || self.settings.rules.enabled(Rule::UselessYieldFixture)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+                        .enabled(Rule::UnnecessaryAsyncioMarkOnFixture)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::ErroneousUseFixturesOnFixture)
+                        .enabled(Rule::ErroneousUseFixturesOnFixture)
                 {
                     flake8_pytest_style::rules::fixture(
                         self,
@@ -535,14 +532,11 @@ where
                     );
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::ParametrizeNamesWrongType)
+                if self.settings.rules.enabled(Rule::ParametrizeNamesWrongType)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::ParametrizeValuesWrongType)
+                        .enabled(Rule::ParametrizeValuesWrongType)
                 {
                     flake8_pytest_style::rules::parametrize(self, decorator_list);
                 }
@@ -550,11 +544,11 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::IncorrectMarkParenthesesStyle)
+                    .enabled(Rule::IncorrectMarkParenthesesStyle)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::UseFixturesWithoutParameters)
+                        .enabled(Rule::UseFixturesWithoutParameters)
                 {
                     flake8_pytest_style::rules::marks(self, decorator_list);
                 }
@@ -562,7 +556,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::BooleanPositionalArgInFunctionDefinition)
+                    .enabled(Rule::BooleanPositionalArgInFunctionDefinition)
                 {
                     flake8_boolean_trap::rules::check_positional_boolean_in_def(
                         self,
@@ -575,7 +569,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::BooleanDefaultValueInFunctionDefinition)
+                    .enabled(Rule::BooleanDefaultValueInFunctionDefinition)
                 {
                     flake8_boolean_trap::rules::check_boolean_default_value_in_function_definition(
                         self,
@@ -676,10 +670,10 @@ where
                 );
             }
             StmtKind::Return { .. } => {
-                if self.settings.rules.enabled(&Rule::ReturnOutsideFunction) {
+                if self.settings.rules.enabled(Rule::ReturnOutsideFunction) {
                     pyflakes::rules::return_outside_function(self, stmt);
                 }
-                if self.settings.rules.enabled(&Rule::ReturnInInit) {
+                if self.settings.rules.enabled(Rule::ReturnInInit) {
                     pylint::rules::return_in_init(self, stmt);
                 }
             }
@@ -690,42 +684,42 @@ where
                 decorator_list,
                 body,
             } => {
-                if self.settings.rules.enabled(&Rule::NullableModelStringField) {
+                if self.settings.rules.enabled(Rule::NullableModelStringField) {
                     self.diagnostics
                         .extend(flake8_django::rules::nullable_model_string_field(
                             self, body,
                         ));
                 }
 
-                if self.settings.rules.enabled(&Rule::ExcludeWithModelForm) {
+                if self.settings.rules.enabled(Rule::ExcludeWithModelForm) {
                     if let Some(diagnostic) =
                         flake8_django::rules::exclude_with_model_form(self, bases, body)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::AllWithModelForm) {
+                if self.settings.rules.enabled(Rule::AllWithModelForm) {
                     if let Some(diagnostic) =
                         flake8_django::rules::all_with_model_form(self, bases, body)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::ModelWithoutDunderStr) {
+                if self.settings.rules.enabled(Rule::ModelWithoutDunderStr) {
                     if let Some(diagnostic) =
                         flake8_django::rules::model_without_dunder_str(self, bases, body, stmt)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     pylint::rules::global_statement(self, name);
                 }
-                if self.settings.rules.enabled(&Rule::UselessObjectInheritance) {
+                if self.settings.rules.enabled(Rule::UselessObjectInheritance) {
                     pyupgrade::rules::useless_object_inheritance(self, stmt, name, bases, keywords);
                 }
 
-                if self.settings.rules.enabled(&Rule::AmbiguousClassName) {
+                if self.settings.rules.enabled(Rule::AmbiguousClassName) {
                     if let Some(diagnostic) = pycodestyle::rules::ambiguous_class_name(name, || {
                         helpers::identifier_range(stmt, self.locator)
                     }) {
@@ -733,7 +727,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::InvalidClassName) {
+                if self.settings.rules.enabled(Rule::InvalidClassName) {
                     if let Some(diagnostic) =
                         pep8_naming::rules::invalid_class_name(stmt, name, self.locator)
                     {
@@ -744,7 +738,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ErrorSuffixOnExceptionName)
+                    .enabled(Rule::ErrorSuffixOnExceptionName)
                 {
                     if let Some(diagnostic) = pep8_naming::rules::error_suffix_on_exception_name(
                         stmt,
@@ -756,7 +750,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::UselessExpression) {
+                if self.settings.rules.enabled(Rule::UselessExpression) {
                     flake8_bugbear::rules::useless_expression(self, body);
                 }
 
@@ -764,11 +758,11 @@ where
                     if self
                         .settings
                         .rules
-                        .enabled(&Rule::AbstractBaseClassWithoutAbstractMethod)
+                        .enabled(Rule::AbstractBaseClassWithoutAbstractMethod)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::EmptyMethodWithoutAbstractDecorator)
+                            .enabled(Rule::EmptyMethodWithoutAbstractDecorator)
                     {
                         flake8_bugbear::rules::abstract_base_class(
                             self, stmt, name, bases, keywords, body,
@@ -776,7 +770,7 @@ where
                     }
                 }
                 if self.is_stub {
-                    if self.settings.rules.enabled(&Rule::PassStatementStubBody) {
+                    if self.settings.rules.enabled(Rule::PassStatementStubBody) {
                         flake8_pyi::rules::pass_statement_stub_body(self, body);
                     }
                 }
@@ -784,20 +778,16 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::IncorrectMarkParenthesesStyle)
+                    .enabled(Rule::IncorrectMarkParenthesesStyle)
                 {
                     flake8_pytest_style::rules::marks(self, decorator_list);
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::DupeClassFieldDefinitions)
-                {
+                if self.settings.rules.enabled(Rule::DupeClassFieldDefinitions) {
                     flake8_pie::rules::dupe_class_field_definitions(self, stmt, body);
                 }
 
-                if self.settings.rules.enabled(&Rule::PreferUniqueEnums) {
+                if self.settings.rules.enabled(Rule::PreferUniqueEnums) {
                     flake8_pie::rules::prefer_unique_enums(self, stmt, body);
                 }
 
@@ -814,18 +804,18 @@ where
                 }
             }
             StmtKind::Import { names } => {
-                if self.settings.rules.enabled(&Rule::MultipleImportsOnOneLine) {
+                if self.settings.rules.enabled(Rule::MultipleImportsOnOneLine) {
                     pycodestyle::rules::multiple_imports_on_one_line(self, stmt, names);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ModuleImportNotAtTopOfFile)
+                    .enabled(Rule::ModuleImportNotAtTopOfFile)
                 {
                     pycodestyle::rules::module_import_not_at_top_of_file(self, stmt);
                 }
 
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     for name in names.iter() {
                         if let Some(asname) = name.node.asname.as_ref() {
                             pylint::rules::global_statement(self, asname);
@@ -835,10 +825,10 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::RewriteCElementTree) {
+                if self.settings.rules.enabled(Rule::RewriteCElementTree) {
                     pyupgrade::rules::replace_c_element_tree(self, stmt);
                 }
-                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
+                if self.settings.rules.enabled(Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_import(self, stmt);
                 }
 
@@ -875,7 +865,7 @@ where
                             },
                         );
 
-                        if self.settings.rules.enabled(&Rule::LateFutureImport)
+                        if self.settings.rules.enabled(Rule::LateFutureImport)
                             && !self.ctx.futures_allowed
                         {
                             self.diagnostics.push(Diagnostic::new(
@@ -957,7 +947,7 @@ where
                     }
 
                     // flake8-debugger
-                    if self.settings.rules.enabled(&Rule::Debugger) {
+                    if self.settings.rules.enabled(Rule::Debugger) {
                         if let Some(diagnostic) =
                             flake8_debugger::rules::debugger_import(stmt, None, &alias.node.name)
                         {
@@ -966,7 +956,7 @@ where
                     }
 
                     // flake8_tidy_imports
-                    if self.settings.rules.enabled(&Rule::BannedApi) {
+                    if self.settings.rules.enabled(Rule::BannedApi) {
                         if let Some(diagnostic) =
                             flake8_tidy_imports::banned_api::name_or_parent_is_banned(
                                 alias,
@@ -979,10 +969,10 @@ where
                     }
 
                     // pylint
-                    if self.settings.rules.enabled(&Rule::UselessImportAlias) {
+                    if self.settings.rules.enabled(Rule::UselessImportAlias) {
                         pylint::rules::useless_import_alias(self, alias);
                     }
-                    if self.settings.rules.enabled(&Rule::ConsiderUsingFromImport) {
+                    if self.settings.rules.enabled(Rule::ConsiderUsingFromImport) {
                         pylint::rules::use_from_import(self, stmt, alias, names);
                     }
 
@@ -991,7 +981,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::ConstantImportedAsNonConstant)
+                            .enabled(Rule::ConstantImportedAsNonConstant)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
@@ -1008,7 +998,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::LowercaseImportedAsNonLowercase)
+                            .enabled(Rule::LowercaseImportedAsNonLowercase)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
@@ -1025,7 +1015,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsLowercase)
+                            .enabled(Rule::CamelcaseImportedAsLowercase)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
@@ -1042,7 +1032,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsConstant)
+                            .enabled(Rule::CamelcaseImportedAsConstant)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
@@ -1059,7 +1049,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsAcronym)
+                            .enabled(Rule::CamelcaseImportedAsAcronym)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
@@ -1074,11 +1064,7 @@ where
                         }
                     }
 
-                    if self
-                        .settings
-                        .rules
-                        .enabled(&Rule::UnconventionalImportAlias)
-                    {
+                    if self.settings.rules.enabled(Rule::UnconventionalImportAlias) {
                         if let Some(diagnostic) =
                             flake8_import_conventions::rules::check_conventional_import(
                                 stmt,
@@ -1091,7 +1077,7 @@ where
                         }
                     }
 
-                    if self.settings.rules.enabled(&Rule::IncorrectPytestImport) {
+                    if self.settings.rules.enabled(Rule::IncorrectPytestImport) {
                         if let Some(diagnostic) = flake8_pytest_style::rules::import(
                             stmt,
                             &alias.node.name,
@@ -1110,12 +1096,12 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ModuleImportNotAtTopOfFile)
+                    .enabled(Rule::ModuleImportNotAtTopOfFile)
                 {
                     pycodestyle::rules::module_import_not_at_top_of_file(self, stmt);
                 }
 
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     for name in names.iter() {
                         if let Some(asname) = name.node.asname.as_ref() {
                             pylint::rules::global_statement(self, asname);
@@ -1125,20 +1111,20 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::UnnecessaryFutureImport)
+                if self.settings.rules.enabled(Rule::UnnecessaryFutureImport)
                     && self.settings.target_version >= PythonVersion::Py37
                 {
                     if let Some("__future__") = module.as_deref() {
                         pyupgrade::rules::unnecessary_future_import(self, stmt, names);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
+                if self.settings.rules.enabled(Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_import(self, stmt);
                 }
-                if self.settings.rules.enabled(&Rule::RewriteCElementTree) {
+                if self.settings.rules.enabled(Rule::RewriteCElementTree) {
                     pyupgrade::rules::replace_c_element_tree(self, stmt);
                 }
-                if self.settings.rules.enabled(&Rule::DeprecatedImport) {
+                if self.settings.rules.enabled(Rule::DeprecatedImport) {
                     pyupgrade::rules::deprecated_import(
                         self,
                         stmt,
@@ -1147,13 +1133,13 @@ where
                         level.as_ref(),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryBuiltinImport) {
+                if self.settings.rules.enabled(Rule::UnnecessaryBuiltinImport) {
                     if let Some(module) = module.as_deref() {
                         pyupgrade::rules::unnecessary_builtin_import(self, stmt, module, names);
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::BannedApi) {
+                if self.settings.rules.enabled(Rule::BannedApi) {
                     if let Some(module) = module {
                         for name in names {
                             if let Some(diagnostic) =
@@ -1178,7 +1164,7 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::IncorrectPytestImport) {
+                if self.settings.rules.enabled(Rule::IncorrectPytestImport) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::import_from(
                         stmt,
                         module.as_deref(),
@@ -1225,11 +1211,11 @@ where
                             self.ctx.annotations_future_enabled = true;
                         }
 
-                        if self.settings.rules.enabled(&Rule::FutureFeatureNotDefined) {
+                        if self.settings.rules.enabled(Rule::FutureFeatureNotDefined) {
                             pyflakes::rules::future_feature_not_defined(self, alias);
                         }
 
-                        if self.settings.rules.enabled(&Rule::LateFutureImport)
+                        if self.settings.rules.enabled(Rule::LateFutureImport)
                             && !self.ctx.futures_allowed
                         {
                             self.diagnostics.push(Diagnostic::new(
@@ -1263,7 +1249,7 @@ where
                             },
                         );
 
-                        if self.settings.rules.enabled(&Rule::ImportStarNotPermitted) {
+                        if self.settings.rules.enabled(Rule::ImportStarNotPermitted) {
                             let scope = &self.ctx.scopes
                                 [*(self.ctx.scope_stack.last().expect("No current scope found"))];
                             if !matches!(scope.kind, ScopeKind::Module) {
@@ -1279,7 +1265,7 @@ where
                             }
                         }
 
-                        if self.settings.rules.enabled(&Rule::ImportStar) {
+                        if self.settings.rules.enabled(Rule::ImportStar) {
                             self.diagnostics.push(Diagnostic::new(
                                 pyflakes::rules::ImportStar {
                                     name: helpers::format_import_from(
@@ -1343,7 +1329,7 @@ where
                         );
                     }
 
-                    if self.settings.rules.enabled(&Rule::RelativeImports) {
+                    if self.settings.rules.enabled(Rule::RelativeImports) {
                         if let Some(diagnostic) =
                             flake8_tidy_imports::relative_imports::banned_relative_import(
                                 self,
@@ -1359,7 +1345,7 @@ where
                     }
 
                     // flake8-debugger
-                    if self.settings.rules.enabled(&Rule::Debugger) {
+                    if self.settings.rules.enabled(Rule::Debugger) {
                         if let Some(diagnostic) = flake8_debugger::rules::debugger_import(
                             stmt,
                             module.as_deref(),
@@ -1369,11 +1355,7 @@ where
                         }
                     }
 
-                    if self
-                        .settings
-                        .rules
-                        .enabled(&Rule::UnconventionalImportAlias)
-                    {
+                    if self.settings.rules.enabled(Rule::UnconventionalImportAlias) {
                         let full_name = helpers::format_import_from_member(
                             level.as_ref(),
                             module.as_deref(),
@@ -1395,7 +1377,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::ConstantImportedAsNonConstant)
+                            .enabled(Rule::ConstantImportedAsNonConstant)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
@@ -1412,7 +1394,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::LowercaseImportedAsNonLowercase)
+                            .enabled(Rule::LowercaseImportedAsNonLowercase)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
@@ -1429,7 +1411,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsLowercase)
+                            .enabled(Rule::CamelcaseImportedAsLowercase)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
@@ -1446,7 +1428,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsConstant)
+                            .enabled(Rule::CamelcaseImportedAsConstant)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
@@ -1463,7 +1445,7 @@ where
                         if self
                             .settings
                             .rules
-                            .enabled(&Rule::CamelcaseImportedAsAcronym)
+                            .enabled(Rule::CamelcaseImportedAsAcronym)
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
@@ -1478,42 +1460,42 @@ where
                         }
 
                         // pylint
-                        if self.settings.rules.enabled(&Rule::UselessImportAlias) {
+                        if self.settings.rules.enabled(Rule::UselessImportAlias) {
                             pylint::rules::useless_import_alias(self, alias);
                         }
                     }
                 }
             }
             StmtKind::Raise { exc, .. } => {
-                if self.settings.rules.enabled(&Rule::RaiseNotImplemented) {
+                if self.settings.rules.enabled(Rule::RaiseNotImplemented) {
                     if let Some(expr) = exc {
                         pyflakes::rules::raise_not_implemented(self, expr);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::CannotRaiseLiteral) {
+                if self.settings.rules.enabled(Rule::CannotRaiseLiteral) {
                     if let Some(exc) = exc {
                         flake8_bugbear::rules::cannot_raise_literal(self, exc);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::RawStringInException)
-                    || self.settings.rules.enabled(&Rule::FStringInException)
-                    || self.settings.rules.enabled(&Rule::DotFormatInException)
+                if self.settings.rules.enabled(Rule::RawStringInException)
+                    || self.settings.rules.enabled(Rule::FStringInException)
+                    || self.settings.rules.enabled(Rule::DotFormatInException)
                 {
                     if let Some(exc) = exc {
                         flake8_errmsg::rules::string_in_exception(self, exc);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
+                if self.settings.rules.enabled(Rule::OSErrorAlias) {
                     if let Some(item) = exc {
                         pyupgrade::rules::os_error_alias_raise(self, item);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::RaiseVanillaClass) {
+                if self.settings.rules.enabled(Rule::RaiseVanillaClass) {
                     if let Some(expr) = exc {
                         tryceratops::rules::raise_vanilla_class(self, expr);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::RaiseVanillaArgs) {
+                if self.settings.rules.enabled(Rule::RaiseVanillaArgs) {
                     if let Some(expr) = exc {
                         tryceratops::rules::raise_vanilla_args(self, expr);
                     }
@@ -1521,7 +1503,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryParenOnRaiseException)
+                    .enabled(Rule::UnnecessaryParenOnRaiseException)
                 {
                     if let Some(expr) = exc {
                         flake8_raise::rules::unnecessary_paren_on_raise_exception(self, expr);
@@ -1531,17 +1513,17 @@ where
             StmtKind::AugAssign { target, .. } => {
                 self.handle_node_load(target);
 
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     if let ExprKind::Name { id, .. } = &target.node {
                         pylint::rules::global_statement(self, id);
                     }
                 }
             }
             StmtKind::If { test, body, orelse } => {
-                if self.settings.rules.enabled(&Rule::IfTuple) {
+                if self.settings.rules.enabled(Rule::IfTuple) {
                     pyflakes::rules::if_tuple(self, stmt, test);
                 }
-                if self.settings.rules.enabled(&Rule::CollapsibleIf) {
+                if self.settings.rules.enabled(Rule::CollapsibleIf) {
                     flake8_simplify::rules::nested_if_statements(
                         self,
                         stmt,
@@ -1551,17 +1533,17 @@ where
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::IfWithSameArms) {
+                if self.settings.rules.enabled(Rule::IfWithSameArms) {
                     flake8_simplify::rules::if_with_same_arms(
                         self,
                         stmt,
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::NeedlessBool) {
+                if self.settings.rules.enabled(Rule::NeedlessBool) {
                     flake8_simplify::rules::needless_bool(self, stmt);
                 }
-                if self.settings.rules.enabled(&Rule::ManualDictLookup) {
+                if self.settings.rules.enabled(Rule::ManualDictLookup) {
                     flake8_simplify::rules::manual_dict_lookup(
                         self,
                         stmt,
@@ -1571,14 +1553,14 @@ where
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UseTernaryOperator) {
+                if self.settings.rules.enabled(Rule::UseTernaryOperator) {
                     flake8_simplify::rules::use_ternary_operator(
                         self,
                         stmt,
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::DictGetWithDefault) {
+                if self.settings.rules.enabled(Rule::DictGetWithDefault) {
                     flake8_simplify::rules::use_dict_get_with_default(
                         self,
                         stmt,
@@ -1588,7 +1570,7 @@ where
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::PreferTypeError) {
+                if self.settings.rules.enabled(Rule::PreferTypeError) {
                     tryceratops::rules::prefer_type_error(
                         self,
                         body,
@@ -1597,10 +1579,10 @@ where
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::OutdatedVersionBlock) {
+                if self.settings.rules.enabled(Rule::OutdatedVersionBlock) {
                     pyupgrade::rules::outdated_version_block(self, stmt, test, body, orelse);
                 }
-                if self.settings.rules.enabled(&Rule::CollapsibleElseIf) {
+                if self.settings.rules.enabled(Rule::CollapsibleElseIf) {
                     if let Some(diagnostic) =
                         pylint::rules::collapsible_else_if(orelse, self.locator)
                     {
@@ -1609,22 +1591,22 @@ where
                 }
             }
             StmtKind::Assert { test, msg } => {
-                if self.settings.rules.enabled(&Rule::AssertTuple) {
+                if self.settings.rules.enabled(Rule::AssertTuple) {
                     pyflakes::rules::assert_tuple(self, stmt, test);
                 }
-                if self.settings.rules.enabled(&Rule::AssertFalse) {
+                if self.settings.rules.enabled(Rule::AssertFalse) {
                     flake8_bugbear::rules::assert_false(self, stmt, test, msg.as_deref());
                 }
-                if self.settings.rules.enabled(&Rule::Assert) {
+                if self.settings.rules.enabled(Rule::Assert) {
                     self.diagnostics
                         .push(flake8_bandit::rules::assert_used(stmt));
                 }
-                if self.settings.rules.enabled(&Rule::AssertAlwaysFalse) {
+                if self.settings.rules.enabled(Rule::AssertAlwaysFalse) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::assert_falsy(stmt, test) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::CompositeAssertion) {
+                if self.settings.rules.enabled(Rule::CompositeAssertion) {
                     flake8_pytest_style::rules::composite_condition(
                         self,
                         stmt,
@@ -1634,17 +1616,17 @@ where
                 }
             }
             StmtKind::With { items, body, .. } => {
-                if self.settings.rules.enabled(&Rule::AssertRaisesException) {
+                if self.settings.rules.enabled(Rule::AssertRaisesException) {
                     flake8_bugbear::rules::assert_raises_exception(self, stmt, items);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::RaisesWithMultipleStatements)
+                    .enabled(Rule::RaisesWithMultipleStatements)
                 {
                     flake8_pytest_style::rules::complex_raises(self, stmt, items, body);
                 }
-                if self.settings.rules.enabled(&Rule::MultipleWithStatements) {
+                if self.settings.rules.enabled(Rule::MultipleWithStatements) {
                     flake8_simplify::rules::multiple_with_statements(
                         self,
                         stmt,
@@ -1652,15 +1634,15 @@ where
                         self.ctx.current_stmt_parent().map(Into::into),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::RedefinedLoopName) {
+                if self.settings.rules.enabled(Rule::RedefinedLoopName) {
                     pylint::rules::redefined_loop_name(self, &Node::Stmt(stmt));
                 }
             }
             StmtKind::While { body, orelse, .. } => {
-                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
+                if self.settings.rules.enabled(Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Stmt(stmt));
                 }
-                if self.settings.rules.enabled(&Rule::UselessElseOnLoop) {
+                if self.settings.rules.enabled(Rule::UselessElseOnLoop) {
                     pylint::rules::useless_else_on_loop(self, stmt, body, orelse);
                 }
             }
@@ -1678,11 +1660,7 @@ where
                 orelse,
                 ..
             } => {
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::UnusedLoopControlVariable)
-                {
+                if self.settings.rules.enabled(Rule::UnusedLoopControlVariable) {
                     self.deferred.for_loops.push((
                         stmt,
                         (self.ctx.scope_stack.clone(), self.ctx.parents.clone()),
@@ -1691,28 +1669,28 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::LoopVariableOverridesIterator)
+                    .enabled(Rule::LoopVariableOverridesIterator)
                 {
                     flake8_bugbear::rules::loop_variable_overrides_iterator(self, target, iter);
                 }
-                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
+                if self.settings.rules.enabled(Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Stmt(stmt));
                 }
-                if self.settings.rules.enabled(&Rule::UselessElseOnLoop) {
+                if self.settings.rules.enabled(Rule::UselessElseOnLoop) {
                     pylint::rules::useless_else_on_loop(self, stmt, body, orelse);
                 }
-                if self.settings.rules.enabled(&Rule::RedefinedLoopName) {
+                if self.settings.rules.enabled(Rule::RedefinedLoopName) {
                     pylint::rules::redefined_loop_name(self, &Node::Stmt(stmt));
                 }
                 if matches!(stmt.node, StmtKind::For { .. }) {
-                    if self.settings.rules.enabled(&Rule::ReimplementedBuiltin) {
+                    if self.settings.rules.enabled(Rule::ReimplementedBuiltin) {
                         flake8_simplify::rules::convert_for_loop_to_any_all(
                             self,
                             stmt,
                             self.ctx.current_sibling_stmt(),
                         );
                     }
-                    if self.settings.rules.enabled(&Rule::KeyInDict) {
+                    if self.settings.rules.enabled(Rule::KeyInDict) {
                         flake8_simplify::rules::key_in_dict_for(self, target, iter);
                     }
                 }
@@ -1731,77 +1709,74 @@ where
                 finalbody,
                 ..
             } => {
-                if self.settings.rules.enabled(&Rule::DefaultExceptNotLast) {
+                if self.settings.rules.enabled(Rule::DefaultExceptNotLast) {
                     if let Some(diagnostic) =
                         pyflakes::rules::default_except_not_last(handlers, self.locator)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::DuplicateHandlerException)
+                if self.settings.rules.enabled(Rule::DuplicateHandlerException)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::DuplicateTryBlockException)
+                        .enabled(Rule::DuplicateTryBlockException)
                 {
                     flake8_bugbear::rules::duplicate_exceptions(self, handlers);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::RedundantTupleInExceptionHandler)
+                    .enabled(Rule::RedundantTupleInExceptionHandler)
                 {
                     flake8_bugbear::rules::redundant_tuple_in_exception_handler(self, handlers);
                 }
-                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
+                if self.settings.rules.enabled(Rule::OSErrorAlias) {
                     pyupgrade::rules::os_error_alias_handlers(self, handlers);
                 }
-                if self.settings.rules.enabled(&Rule::AssertInExcept) {
+                if self.settings.rules.enabled(Rule::AssertInExcept) {
                     self.diagnostics.extend(
                         flake8_pytest_style::rules::assert_in_exception_handler(handlers),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UseContextlibSuppress) {
+                if self.settings.rules.enabled(Rule::UseContextlibSuppress) {
                     flake8_simplify::rules::use_contextlib_suppress(
                         self, stmt, body, handlers, orelse, finalbody,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::ReturnInTryExceptFinally) {
+                if self.settings.rules.enabled(Rule::ReturnInTryExceptFinally) {
                     flake8_simplify::rules::return_in_try_except_finally(
                         self, body, handlers, finalbody,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::TryConsiderElse) {
+                if self.settings.rules.enabled(Rule::TryConsiderElse) {
                     tryceratops::rules::try_consider_else(self, body, orelse);
                 }
-                if self.settings.rules.enabled(&Rule::VerboseRaise) {
+                if self.settings.rules.enabled(Rule::VerboseRaise) {
                     tryceratops::rules::verbose_raise(self, handlers);
                 }
-                if self.settings.rules.enabled(&Rule::VerboseLogMessage) {
+                if self.settings.rules.enabled(Rule::VerboseLogMessage) {
                     tryceratops::rules::verbose_log_message(self, handlers);
                 }
-                if self.settings.rules.enabled(&Rule::RaiseWithinTry) {
+                if self.settings.rules.enabled(Rule::RaiseWithinTry) {
                     tryceratops::rules::raise_within_try(self, body);
                 }
-                if self.settings.rules.enabled(&Rule::ErrorInsteadOfException) {
+                if self.settings.rules.enabled(Rule::ErrorInsteadOfException) {
                     tryceratops::rules::error_instead_of_exception(self, handlers);
                 }
             }
             StmtKind::Assign { targets, value, .. } => {
-                if self.settings.rules.enabled(&Rule::LambdaAssignment) {
+                if self.settings.rules.enabled(Rule::LambdaAssignment) {
                     if let [target] = &targets[..] {
                         pycodestyle::rules::lambda_assignment(self, target, value, stmt);
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::AssignmentToOsEnviron) {
+                if self.settings.rules.enabled(Rule::AssignmentToOsEnviron) {
                     flake8_bugbear::rules::assignment_to_os_environ(self, targets);
                 }
 
-                if self.settings.rules.enabled(&Rule::HardcodedPasswordString) {
+                if self.settings.rules.enabled(Rule::HardcodedPasswordString) {
                     if let Some(diagnostic) =
                         flake8_bandit::rules::assign_hardcoded_password_string(value, targets)
                     {
@@ -1810,12 +1785,12 @@ where
                 }
 
                 if self.is_stub {
-                    if self.settings.rules.enabled(&Rule::PrefixTypeParams) {
+                    if self.settings.rules.enabled(Rule::PrefixTypeParams) {
                         flake8_pyi::rules::prefix_type_params(self, value, targets);
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     for target in targets.iter() {
                         if let ExprKind::Name { id, .. } = &target.node {
                             pylint::rules::global_statement(self, id);
@@ -1823,13 +1798,13 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::UselessMetaclassType) {
+                if self.settings.rules.enabled(Rule::UselessMetaclassType) {
                     pyupgrade::rules::useless_metaclass_type(self, stmt, value, targets);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ConvertTypedDictFunctionalToClass)
+                    .enabled(Rule::ConvertTypedDictFunctionalToClass)
                 {
                     pyupgrade::rules::convert_typed_dict_functional_to_class(
                         self, stmt, targets, value,
@@ -1838,24 +1813,24 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ConvertNamedTupleFunctionalToClass)
+                    .enabled(Rule::ConvertNamedTupleFunctionalToClass)
                 {
                     pyupgrade::rules::convert_named_tuple_functional_to_class(
                         self, stmt, targets, value,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::RewriteListComprehension) {
+                if self.settings.rules.enabled(Rule::RewriteListComprehension) {
                     pyupgrade::rules::unpack_list_comprehension(self, targets, value);
                 }
 
-                if self.settings.rules.enabled(&Rule::DfIsABadVariableName) {
+                if self.settings.rules.enabled(Rule::DfIsABadVariableName) {
                     if let Some(diagnostic) = pandas_vet::rules::assignment_to_df(targets) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
             }
             StmtKind::AnnAssign { target, value, .. } => {
-                if self.settings.rules.enabled(&Rule::LambdaAssignment) {
+                if self.settings.rules.enabled(Rule::LambdaAssignment) {
                     if let Some(value) = value {
                         pycodestyle::rules::lambda_assignment(self, target, value, stmt);
                     }
@@ -1863,7 +1838,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnintentionalTypeAnnotation)
+                    .enabled(Rule::UnintentionalTypeAnnotation)
                 {
                     flake8_bugbear::rules::unintentional_type_annotation(
                         self,
@@ -1874,7 +1849,7 @@ where
                 }
             }
             StmtKind::Delete { targets } => {
-                if self.settings.rules.enabled(&Rule::GlobalStatement) {
+                if self.settings.rules.enabled(Rule::GlobalStatement) {
                     for target in targets.iter() {
                         if let ExprKind::Name { id, .. } = &target.node {
                             pylint::rules::global_statement(self, id);
@@ -1883,17 +1858,17 @@ where
                 }
             }
             StmtKind::Expr { value, .. } => {
-                if self.settings.rules.enabled(&Rule::UselessComparison) {
+                if self.settings.rules.enabled(Rule::UselessComparison) {
                     flake8_bugbear::rules::useless_comparison(self, value);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UseCapitalEnvironmentVariables)
+                    .enabled(Rule::UseCapitalEnvironmentVariables)
                 {
                     flake8_simplify::rules::use_capital_environment_variables(self, value);
                 }
-                if self.settings.rules.enabled(&Rule::AsyncioDanglingTask) {
+                if self.settings.rules.enabled(Rule::AsyncioDanglingTask) {
                     if let Some(diagnostic) = ruff::rules::asyncio_dangling_task(value, |expr| {
                         self.ctx.resolve_call_path(expr)
                     }) {
@@ -1922,7 +1897,7 @@ where
                 decorator_list,
                 ..
             } => {
-                if self.settings.rules.enabled(&Rule::FStringDocstring) {
+                if self.settings.rules.enabled(Rule::FStringDocstring) {
                     flake8_bugbear::rules::f_string_docstring(self, body);
                 }
                 let definition = docstrings::extraction::extract(
@@ -1931,7 +1906,7 @@ where
                     body,
                     &Documentable::Function,
                 );
-                if self.settings.rules.enabled(&Rule::RewriteYieldFrom) {
+                if self.settings.rules.enabled(Rule::RewriteYieldFrom) {
                     pyupgrade::rules::rewrite_yield_from(self, stmt);
                 }
                 let scope =
@@ -1991,7 +1966,7 @@ where
                 decorator_list,
                 ..
             } => {
-                if self.settings.rules.enabled(&Rule::FStringDocstring) {
+                if self.settings.rules.enabled(Rule::FStringDocstring) {
                     flake8_bugbear::rules::f_string_docstring(self, body);
                 }
                 let definition = docstrings::extraction::extract(
@@ -2066,7 +2041,7 @@ where
                 }
 
                 self.ctx.handled_exceptions.push(handled_exceptions);
-                if self.settings.rules.enabled(&Rule::JumpStatementInFinally) {
+                if self.settings.rules.enabled(Rule::JumpStatementInFinally) {
                     flake8_bugbear::rules::jump_statement_in_finally(self, finalbody);
                 }
                 self.visit_body(body);
@@ -2133,7 +2108,7 @@ where
                 self.visit_expr(test);
 
                 if flake8_type_checking::helpers::is_type_checking_block(&self.ctx, test) {
-                    if self.settings.rules.enabled(&Rule::EmptyTypeCheckingBlock) {
+                    if self.settings.rules.enabled(Rule::EmptyTypeCheckingBlock) {
                         flake8_type_checking::rules::empty_type_checking_block(self, stmt, body);
                     }
 
@@ -2222,7 +2197,7 @@ where
                 if self.ctx.in_type_definition
                     && !self.ctx.in_deferred_string_type_definition
                     && !self.settings.pyupgrade.keep_runtime_typing
-                    && self.settings.rules.enabled(&Rule::TypingUnion)
+                    && self.settings.rules.enabled(Rule::TypingUnion)
                     && (self.settings.target_version >= PythonVersion::Py310
                         || (self.settings.target_version >= PythonVersion::Py37
                             && self.ctx.annotations_future_enabled
@@ -2238,13 +2213,13 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::SysVersionSlice3Referenced)
-                    || self.settings.rules.enabled(&Rule::SysVersion2Referenced)
-                    || self.settings.rules.enabled(&Rule::SysVersion0Referenced)
+                    .enabled(Rule::SysVersionSlice3Referenced)
+                    || self.settings.rules.enabled(Rule::SysVersion2Referenced)
+                    || self.settings.rules.enabled(Rule::SysVersion0Referenced)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::SysVersionSlice1Referenced)
+                        .enabled(Rule::SysVersionSlice1Referenced)
                 {
                     flake8_2020::rules::subscript(self, value, slice);
                 }
@@ -2254,9 +2229,9 @@ where
                     let check_too_many_expressions = self
                         .settings
                         .rules
-                        .enabled(&Rule::ExpressionsInStarAssignment);
+                        .enabled(Rule::ExpressionsInStarAssignment);
                     let check_two_starred_expressions =
-                        self.settings.rules.enabled(&Rule::TwoStarredExpressions);
+                        self.settings.rules.enabled(Rule::TwoStarredExpressions);
                     if let Some(diagnostic) = pyflakes::rules::starred_expressions(
                         elts,
                         check_too_many_expressions,
@@ -2270,17 +2245,17 @@ where
             ExprKind::Name { id, ctx } => {
                 match ctx {
                     ExprContext::Load => {
-                        if self.settings.rules.enabled(&Rule::TypingTextStrAlias) {
+                        if self.settings.rules.enabled(Rule::TypingTextStrAlias) {
                             pyupgrade::rules::typing_text_str_alias(self, expr);
                         }
-                        if self.settings.rules.enabled(&Rule::NumpyDeprecatedTypeAlias) {
+                        if self.settings.rules.enabled(Rule::NumpyDeprecatedTypeAlias) {
                             numpy::rules::deprecated_type_alias(self, expr);
                         }
 
                         // Ex) List[...]
                         if !self.ctx.in_deferred_string_type_definition
                             && !self.settings.pyupgrade.keep_runtime_typing
-                            && self.settings.rules.enabled(&Rule::DeprecatedCollectionType)
+                            && self.settings.rules.enabled(Rule::DeprecatedCollectionType)
                             && (self.settings.target_version >= PythonVersion::Py39
                                 || (self.settings.target_version >= PythonVersion::Py37
                                     && self.ctx.annotations_future_enabled
@@ -2295,7 +2270,7 @@ where
                         self.handle_node_load(expr);
                     }
                     ExprContext::Store => {
-                        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
+                        if self.settings.rules.enabled(Rule::AmbiguousVariableName) {
                             if let Some(diagnostic) =
                                 pycodestyle::rules::ambiguous_variable_name(id, Range::from(expr))
                             {
@@ -2310,14 +2285,14 @@ where
                     ExprContext::Del => self.handle_node_delete(expr),
                 }
 
-                if self.settings.rules.enabled(&Rule::SixPY3Referenced) {
+                if self.settings.rules.enabled(Rule::SixPY3Referenced) {
                     flake8_2020::rules::name_or_attribute(self, expr);
                 }
 
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UsedPriorGlobalDeclaration)
+                    .enabled(Rule::UsedPriorGlobalDeclaration)
                 {
                     pylint::rules::used_prior_global_declaration(self, id, expr);
                 }
@@ -2326,7 +2301,7 @@ where
                 // Ex) typing.List[...]
                 if !self.ctx.in_deferred_string_type_definition
                     && !self.settings.pyupgrade.keep_runtime_typing
-                    && self.settings.rules.enabled(&Rule::DeprecatedCollectionType)
+                    && self.settings.rules.enabled(Rule::DeprecatedCollectionType)
                     && (self.settings.target_version >= PythonVersion::Py39
                         || (self.settings.target_version >= PythonVersion::Py37
                             && self.ctx.annotations_future_enabled
@@ -2335,27 +2310,27 @@ where
                 {
                     pyupgrade::rules::use_pep585_annotation(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::DatetimeTimezoneUTC)
+                if self.settings.rules.enabled(Rule::DatetimeTimezoneUTC)
                     && self.settings.target_version >= PythonVersion::Py311
                 {
                     pyupgrade::rules::datetime_utc_alias(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::TypingTextStrAlias) {
+                if self.settings.rules.enabled(Rule::TypingTextStrAlias) {
                     pyupgrade::rules::typing_text_str_alias(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::NumpyDeprecatedTypeAlias) {
+                if self.settings.rules.enabled(Rule::NumpyDeprecatedTypeAlias) {
                     numpy::rules::deprecated_type_alias(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::RewriteMockImport) {
+                if self.settings.rules.enabled(Rule::RewriteMockImport) {
                     pyupgrade::rules::rewrite_mock_attribute(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::SixPY3Referenced) {
+                if self.settings.rules.enabled(Rule::SixPY3Referenced) {
                     flake8_2020::rules::name_or_attribute(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::BannedApi) {
+                if self.settings.rules.enabled(Rule::BannedApi) {
                     flake8_tidy_imports::banned_api::banned_attribute_access(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::PrivateMemberAccess) {
+                if self.settings.rules.enabled(Rule::PrivateMemberAccess) {
                     flake8_self::rules::private_member_access(self, expr);
                 }
                 pandas_vet::rules::check_attr(self, attr, value, expr);
@@ -2366,14 +2341,14 @@ where
                 keywords,
             } => {
                 // pyflakes
-                if self.settings.rules.enabled(&Rule::StringDotFormatInvalidFormat)
-                    || self.settings.rules.enabled(&Rule::StringDotFormatExtraNamedArguments)
-                    || self.settings.rules.enabled(&Rule::StringDotFormatExtraPositionalArguments)
-                    || self.settings.rules.enabled(&Rule::StringDotFormatMissingArguments)
-                    || self.settings.rules.enabled(&Rule::StringDotFormatMixingAutomatic)
+                if self.settings.rules.enabled(Rule::StringDotFormatInvalidFormat)
+                    || self.settings.rules.enabled(Rule::StringDotFormatExtraNamedArguments)
+                    || self.settings.rules.enabled(Rule::StringDotFormatExtraPositionalArguments)
+                    || self.settings.rules.enabled(Rule::StringDotFormatMissingArguments)
+                    || self.settings.rules.enabled(Rule::StringDotFormatMixingAutomatic)
                     // pyupgrade
-                    || self.settings.rules.enabled(&Rule::FormatLiterals)
-                    || self.settings.rules.enabled(&Rule::FString)
+                    || self.settings.rules.enabled(Rule::FormatLiterals)
+                    || self.settings.rules.enabled(Rule::FString)
                 {
                     if let ExprKind::Attribute { value, attr, .. } = &func.node {
                         if let ExprKind::Constant {
@@ -2389,7 +2364,7 @@ where
                                         if self
                                             .settings
                                             .rules
-                                            .enabled(&Rule::StringDotFormatInvalidFormat)
+                                            .enabled(Rule::StringDotFormatInvalidFormat)
                                         {
                                             self.diagnostics.push(Diagnostic::new(
                                                 pyflakes::rules::StringDotFormatInvalidFormat {
@@ -2403,7 +2378,7 @@ where
                                         if self
                                             .settings
                                             .rules
-                                            .enabled(&Rule::StringDotFormatExtraNamedArguments)
+                                            .enabled(Rule::StringDotFormatExtraNamedArguments)
                                         {
                                             pyflakes::rules::string_dot_format_extra_named_arguments(
                                                 self, &summary, keywords, location,
@@ -2413,7 +2388,7 @@ where
                                         if self
                                             .settings
                                             .rules
-                                            .enabled(&Rule::StringDotFormatExtraPositionalArguments)
+                                            .enabled(Rule::StringDotFormatExtraPositionalArguments)
                                         {
                                             pyflakes::rules::string_dot_format_extra_positional_arguments(
                                                 self,
@@ -2424,7 +2399,7 @@ where
                                         if self
                                             .settings
                                             .rules
-                                            .enabled(&Rule::StringDotFormatMissingArguments)
+                                            .enabled(Rule::StringDotFormatMissingArguments)
                                         {
                                             pyflakes::rules::string_dot_format_missing_argument(
                                                 self, &summary, args, keywords, location,
@@ -2434,18 +2409,18 @@ where
                                         if self
                                             .settings
                                             .rules
-                                            .enabled(&Rule::StringDotFormatMixingAutomatic)
+                                            .enabled(Rule::StringDotFormatMixingAutomatic)
                                         {
                                             pyflakes::rules::string_dot_format_mixing_automatic(
                                                 self, &summary, location,
                                             );
                                         }
 
-                                        if self.settings.rules.enabled(&Rule::FormatLiterals) {
+                                        if self.settings.rules.enabled(Rule::FormatLiterals) {
                                             pyupgrade::rules::format_literals(self, &summary, expr);
                                         }
 
-                                        if self.settings.rules.enabled(&Rule::FString) {
+                                        if self.settings.rules.enabled(Rule::FString) {
                                             pyupgrade::rules::f_strings(self, &summary, expr);
                                         }
                                     }
@@ -2456,149 +2431,145 @@ where
                 }
 
                 // pyupgrade
-                if self.settings.rules.enabled(&Rule::TypeOfPrimitive) {
+                if self.settings.rules.enabled(Rule::TypeOfPrimitive) {
                     pyupgrade::rules::type_of_primitive(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::DeprecatedUnittestAlias) {
+                if self.settings.rules.enabled(Rule::DeprecatedUnittestAlias) {
                     pyupgrade::rules::deprecated_unittest_alias(self, func);
                 }
-                if self.settings.rules.enabled(&Rule::SuperCallWithParameters) {
+                if self.settings.rules.enabled(Rule::SuperCallWithParameters) {
                     pyupgrade::rules::super_call_with_parameters(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryEncodeUTF8) {
+                if self.settings.rules.enabled(Rule::UnnecessaryEncodeUTF8) {
                     pyupgrade::rules::unnecessary_encode_utf8(self, expr, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::RedundantOpenModes) {
+                if self.settings.rules.enabled(Rule::RedundantOpenModes) {
                     pyupgrade::rules::redundant_open_modes(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::NativeLiterals) {
+                if self.settings.rules.enabled(Rule::NativeLiterals) {
                     pyupgrade::rules::native_literals(self, expr, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::OpenAlias) {
+                if self.settings.rules.enabled(Rule::OpenAlias) {
                     pyupgrade::rules::open_alias(self, expr, func);
                 }
-                if self.settings.rules.enabled(&Rule::ReplaceUniversalNewlines) {
+                if self.settings.rules.enabled(Rule::ReplaceUniversalNewlines) {
                     pyupgrade::rules::replace_universal_newlines(self, func, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::ReplaceStdoutStderr) {
+                if self.settings.rules.enabled(Rule::ReplaceStdoutStderr) {
                     pyupgrade::rules::replace_stdout_stderr(self, expr, func, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::OSErrorAlias) {
+                if self.settings.rules.enabled(Rule::OSErrorAlias) {
                     pyupgrade::rules::os_error_alias_call(self, func);
                 }
-                if self.settings.rules.enabled(&Rule::IsinstanceWithTuple)
+                if self.settings.rules.enabled(Rule::IsinstanceWithTuple)
                     && self.settings.target_version >= PythonVersion::Py310
                 {
                     pyupgrade::rules::use_pep604_isinstance(self, expr, func, args);
                 }
 
                 // flake8-print
-                if self.settings.rules.enabled(&Rule::PrintFound)
-                    || self.settings.rules.enabled(&Rule::PPrintFound)
+                if self.settings.rules.enabled(Rule::PrintFound)
+                    || self.settings.rules.enabled(Rule::PPrintFound)
                 {
                     flake8_print::rules::print_call(self, func, keywords);
                 }
 
                 // flake8-bugbear
-                if self.settings.rules.enabled(&Rule::UnreliableCallableCheck) {
+                if self.settings.rules.enabled(Rule::UnreliableCallableCheck) {
                     flake8_bugbear::rules::unreliable_callable_check(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::StripWithMultiCharacters) {
+                if self.settings.rules.enabled(Rule::StripWithMultiCharacters) {
                     flake8_bugbear::rules::strip_with_multi_characters(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::GetAttrWithConstant) {
+                if self.settings.rules.enabled(Rule::GetAttrWithConstant) {
                     flake8_bugbear::rules::getattr_with_constant(self, expr, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::SetAttrWithConstant) {
+                if self.settings.rules.enabled(Rule::SetAttrWithConstant) {
                     flake8_bugbear::rules::setattr_with_constant(self, expr, func, args);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::UselessContextlibSuppress)
-                {
+                if self.settings.rules.enabled(Rule::UselessContextlibSuppress) {
                     flake8_bugbear::rules::useless_contextlib_suppress(self, expr, func, args);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::StarArgUnpackingAfterKeywordArg)
+                    .enabled(Rule::StarArgUnpackingAfterKeywordArg)
                 {
                     flake8_bugbear::rules::star_arg_unpacking_after_keyword_arg(
                         self, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::ZipWithoutExplicitStrict)
+                if self.settings.rules.enabled(Rule::ZipWithoutExplicitStrict)
                     && self.settings.target_version >= PythonVersion::Py310
                 {
                     flake8_bugbear::rules::zip_without_explicit_strict(self, expr, func, keywords);
                 }
 
                 // flake8-pie
-                if self.settings.rules.enabled(&Rule::UnnecessaryDictKwargs) {
+                if self.settings.rules.enabled(Rule::UnnecessaryDictKwargs) {
                     flake8_pie::rules::no_unnecessary_dict_kwargs(self, expr, keywords);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryComprehensionAnyAll)
+                    .enabled(Rule::UnnecessaryComprehensionAnyAll)
                 {
                     flake8_pie::rules::unnecessary_comprehension_any_all(self, expr, func, args);
                 }
 
                 // flake8-bandit
-                if self.settings.rules.enabled(&Rule::ExecBuiltin) {
+                if self.settings.rules.enabled(Rule::ExecBuiltin) {
                     if let Some(diagnostic) = flake8_bandit::rules::exec_used(expr, func) {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::BadFilePermissions) {
+                if self.settings.rules.enabled(Rule::BadFilePermissions) {
                     flake8_bandit::rules::bad_file_permissions(self, func, args, keywords);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::RequestWithNoCertValidation)
+                    .enabled(Rule::RequestWithNoCertValidation)
                 {
                     flake8_bandit::rules::request_with_no_cert_validation(
                         self, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnsafeYAMLLoad) {
+                if self.settings.rules.enabled(Rule::UnsafeYAMLLoad) {
                     flake8_bandit::rules::unsafe_yaml_load(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::SnmpInsecureVersion) {
+                if self.settings.rules.enabled(Rule::SnmpInsecureVersion) {
                     flake8_bandit::rules::snmp_insecure_version(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::SnmpWeakCryptography) {
+                if self.settings.rules.enabled(Rule::SnmpWeakCryptography) {
                     flake8_bandit::rules::snmp_weak_cryptography(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::Jinja2AutoescapeFalse) {
+                if self.settings.rules.enabled(Rule::Jinja2AutoescapeFalse) {
                     flake8_bandit::rules::jinja2_autoescape_false(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::HardcodedPasswordFuncArg) {
+                if self.settings.rules.enabled(Rule::HardcodedPasswordFuncArg) {
                     self.diagnostics
                         .extend(flake8_bandit::rules::hardcoded_password_func_arg(keywords));
                 }
-                if self.settings.rules.enabled(&Rule::HardcodedSQLExpression) {
+                if self.settings.rules.enabled(Rule::HardcodedSQLExpression) {
                     flake8_bandit::rules::hardcoded_sql_expression(self, expr);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::HashlibInsecureHashFunction)
+                    .enabled(Rule::HashlibInsecureHashFunction)
                 {
                     flake8_bandit::rules::hashlib_insecure_hash_functions(
                         self, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::RequestWithoutTimeout) {
+                if self.settings.rules.enabled(Rule::RequestWithoutTimeout) {
                     flake8_bandit::rules::request_without_timeout(self, func, args, keywords);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::LoggingConfigInsecureListen)
+                    .enabled(Rule::LoggingConfigInsecureListen)
                 {
                     flake8_bandit::rules::logging_config_insecure_listen(
                         self, func, args, keywords,
@@ -2606,12 +2577,12 @@ where
                 }
 
                 // flake8-comprehensions
-                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorList) {
+                if self.settings.rules.enabled(Rule::UnnecessaryGeneratorList) {
                     flake8_comprehensions::rules::unnecessary_generator_list(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorSet) {
+                if self.settings.rules.enabled(Rule::UnnecessaryGeneratorSet) {
                     flake8_comprehensions::rules::unnecessary_generator_set(
                         self,
                         expr,
@@ -2621,7 +2592,7 @@ where
                         keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryGeneratorDict) {
+                if self.settings.rules.enabled(Rule::UnnecessaryGeneratorDict) {
                     flake8_comprehensions::rules::unnecessary_generator_dict(
                         self,
                         expr,
@@ -2634,7 +2605,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryListComprehensionSet)
+                    .enabled(Rule::UnnecessaryListComprehensionSet)
                 {
                     flake8_comprehensions::rules::unnecessary_list_comprehension_set(
                         self, expr, func, args, keywords,
@@ -2643,27 +2614,23 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryListComprehensionDict)
+                    .enabled(Rule::UnnecessaryListComprehensionDict)
                 {
                     flake8_comprehensions::rules::unnecessary_list_comprehension_dict(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryLiteralSet) {
+                if self.settings.rules.enabled(Rule::UnnecessaryLiteralSet) {
                     flake8_comprehensions::rules::unnecessary_literal_set(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryLiteralDict) {
+                if self.settings.rules.enabled(Rule::UnnecessaryLiteralDict) {
                     flake8_comprehensions::rules::unnecessary_literal_dict(
                         self, expr, func, args, keywords,
                     );
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::UnnecessaryCollectionCall)
-                {
+                if self.settings.rules.enabled(Rule::UnnecessaryCollectionCall) {
                     flake8_comprehensions::rules::unnecessary_collection_call(
                         self,
                         expr,
@@ -2676,7 +2643,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryLiteralWithinTupleCall)
+                    .enabled(Rule::UnnecessaryLiteralWithinTupleCall)
                 {
                     flake8_comprehensions::rules::unnecessary_literal_within_tuple_call(
                         self, expr, func, args,
@@ -2685,19 +2652,19 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryLiteralWithinListCall)
+                    .enabled(Rule::UnnecessaryLiteralWithinListCall)
                 {
                     flake8_comprehensions::rules::unnecessary_literal_within_list_call(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryListCall) {
+                if self.settings.rules.enabled(Rule::UnnecessaryListCall) {
                     flake8_comprehensions::rules::unnecessary_list_call(self, expr, func, args);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryCallAroundSorted)
+                    .enabled(Rule::UnnecessaryCallAroundSorted)
                 {
                     flake8_comprehensions::rules::unnecessary_call_around_sorted(
                         self, expr, func, args,
@@ -2706,7 +2673,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryDoubleCastOrProcess)
+                    .enabled(Rule::UnnecessaryDoubleCastOrProcess)
                 {
                     flake8_comprehensions::rules::unnecessary_double_cast_or_process(
                         self, expr, func, args,
@@ -2715,13 +2682,13 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessarySubscriptReversal)
+                    .enabled(Rule::UnnecessarySubscriptReversal)
                 {
                     flake8_comprehensions::rules::unnecessary_subscript_reversal(
                         self, expr, func, args,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::UnnecessaryMap) {
+                if self.settings.rules.enabled(Rule::UnnecessaryMap) {
                     flake8_comprehensions::rules::unnecessary_map(
                         self,
                         expr,
@@ -2735,7 +2702,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::BooleanPositionalValueInFunctionCall)
+                    .enabled(Rule::BooleanPositionalValueInFunctionCall)
                 {
                     flake8_boolean_trap::rules::check_boolean_positional_value_in_function_call(
                         self, args, func,
@@ -2750,30 +2717,26 @@ where
                 }
 
                 // flake8-debugger
-                if self.settings.rules.enabled(&Rule::Debugger) {
+                if self.settings.rules.enabled(Rule::Debugger) {
                     flake8_debugger::rules::debugger_call(self, expr, func);
                 }
 
                 // pandas-vet
-                if self.settings.rules.enabled(&Rule::UseOfInplaceArgument) {
+                if self.settings.rules.enabled(Rule::UseOfInplaceArgument) {
                     self.diagnostics.extend(
                         pandas_vet::rules::inplace_argument(self, expr, args, keywords).into_iter(),
                     );
                 }
                 pandas_vet::rules::check_call(self, func);
 
-                if self.settings.rules.enabled(&Rule::UseOfPdMerge) {
+                if self.settings.rules.enabled(Rule::UseOfPdMerge) {
                     if let Some(diagnostic) = pandas_vet::rules::use_of_pd_merge(func) {
                         self.diagnostics.push(diagnostic);
                     };
                 }
 
                 // flake8-datetimez
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::CallDatetimeWithoutTzinfo)
-                {
+                if self.settings.rules.enabled(Rule::CallDatetimeWithoutTzinfo) {
                     flake8_datetimez::rules::call_datetime_without_tzinfo(
                         self,
                         func,
@@ -2782,16 +2745,16 @@ where
                         Range::from(expr),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::CallDatetimeToday) {
+                if self.settings.rules.enabled(Rule::CallDatetimeToday) {
                     flake8_datetimez::rules::call_datetime_today(self, func, Range::from(expr));
                 }
-                if self.settings.rules.enabled(&Rule::CallDatetimeUtcnow) {
+                if self.settings.rules.enabled(Rule::CallDatetimeUtcnow) {
                     flake8_datetimez::rules::call_datetime_utcnow(self, func, Range::from(expr));
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::CallDatetimeUtcfromtimestamp)
+                    .enabled(Rule::CallDatetimeUtcfromtimestamp)
                 {
                     flake8_datetimez::rules::call_datetime_utcfromtimestamp(
                         self,
@@ -2802,7 +2765,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::CallDatetimeNowWithoutTzinfo)
+                    .enabled(Rule::CallDatetimeNowWithoutTzinfo)
                 {
                     flake8_datetimez::rules::call_datetime_now_without_tzinfo(
                         self,
@@ -2812,11 +2775,7 @@ where
                         Range::from(expr),
                     );
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::CallDatetimeFromtimestamp)
-                {
+                if self.settings.rules.enabled(Rule::CallDatetimeFromtimestamp) {
                     flake8_datetimez::rules::call_datetime_fromtimestamp(
                         self,
                         func,
@@ -2828,7 +2787,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::CallDatetimeStrptimeWithoutZone)
+                    .enabled(Rule::CallDatetimeStrptimeWithoutZone)
                 {
                     flake8_datetimez::rules::call_datetime_strptime_without_zone(
                         self,
@@ -2837,18 +2796,18 @@ where
                         Range::from(expr),
                     );
                 }
-                if self.settings.rules.enabled(&Rule::CallDateToday) {
+                if self.settings.rules.enabled(Rule::CallDateToday) {
                     flake8_datetimez::rules::call_date_today(self, func, Range::from(expr));
                 }
-                if self.settings.rules.enabled(&Rule::CallDateFromtimestamp) {
+                if self.settings.rules.enabled(Rule::CallDateFromtimestamp) {
                     flake8_datetimez::rules::call_date_fromtimestamp(self, func, Range::from(expr));
                 }
 
                 // pygrep-hooks
-                if self.settings.rules.enabled(&Rule::NoEval) {
+                if self.settings.rules.enabled(Rule::NoEval) {
                     pygrep_hooks::rules::no_eval(self, func);
                 }
-                if self.settings.rules.enabled(&Rule::DeprecatedLogWarn) {
+                if self.settings.rules.enabled(Rule::DeprecatedLogWarn) {
                     pygrep_hooks::rules::deprecated_log_warn(self, func);
                 }
 
@@ -2856,32 +2815,32 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnnecessaryDirectLambdaCall)
+                    .enabled(Rule::UnnecessaryDirectLambdaCall)
                 {
                     pylint::rules::unnecessary_direct_lambda_call(self, expr, func);
                 }
-                if self.settings.rules.enabled(&Rule::ConsiderUsingSysExit) {
+                if self.settings.rules.enabled(Rule::ConsiderUsingSysExit) {
                     pylint::rules::consider_using_sys_exit(self, func);
                 }
-                if self.settings.rules.enabled(&Rule::BadStrStripCall) {
+                if self.settings.rules.enabled(Rule::BadStrStripCall) {
                     pylint::rules::bad_str_strip_call(self, func, args);
                 }
-                if self.settings.rules.enabled(&Rule::InvalidEnvvarDefault) {
+                if self.settings.rules.enabled(Rule::InvalidEnvvarDefault) {
                     pylint::rules::invalid_envvar_default(self, func, args, keywords);
                 }
-                if self.settings.rules.enabled(&Rule::InvalidEnvvarValue) {
+                if self.settings.rules.enabled(Rule::InvalidEnvvarValue) {
                     pylint::rules::invalid_envvar_value(self, func, args, keywords);
                 }
 
                 // flake8-pytest-style
-                if self.settings.rules.enabled(&Rule::PatchWithLambda) {
+                if self.settings.rules.enabled(Rule::PatchWithLambda) {
                     if let Some(diagnostic) =
                         flake8_pytest_style::rules::patch_with_lambda(func, args, keywords)
                     {
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::UnittestAssertion) {
+                if self.settings.rules.enabled(Rule::UnittestAssertion) {
                     if let Some(diagnostic) = flake8_pytest_style::rules::unittest_assertion(
                         self, expr, func, args, keywords,
                     ) {
@@ -2889,13 +2848,13 @@ where
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::RaisesWithoutException)
-                    || self.settings.rules.enabled(&Rule::RaisesTooBroad)
+                if self.settings.rules.enabled(Rule::RaisesWithoutException)
+                    || self.settings.rules.enabled(Rule::RaisesTooBroad)
                 {
                     flake8_pytest_style::rules::raises_call(self, func, args, keywords);
                 }
 
-                if self.settings.rules.enabled(&Rule::FailWithoutMessage) {
+                if self.settings.rules.enabled(Rule::FailWithoutMessage) {
                     flake8_pytest_style::rules::fail_call(self, func, args, keywords);
                 }
 
@@ -2903,67 +2862,67 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::OpenFileWithContextHandler)
+                    .enabled(Rule::OpenFileWithContextHandler)
                 {
                     flake8_simplify::rules::open_file_with_context_handler(self, func);
                 }
 
                 // flake8-use-pathlib
-                if self.settings.rules.enabled(&Rule::PathlibAbspath)
-                    || self.settings.rules.enabled(&Rule::PathlibChmod)
-                    || self.settings.rules.enabled(&Rule::PathlibMkdir)
-                    || self.settings.rules.enabled(&Rule::PathlibMakedirs)
-                    || self.settings.rules.enabled(&Rule::PathlibRename)
-                    || self.settings.rules.enabled(&Rule::PathlibReplace)
-                    || self.settings.rules.enabled(&Rule::PathlibRmdir)
-                    || self.settings.rules.enabled(&Rule::PathlibRemove)
-                    || self.settings.rules.enabled(&Rule::PathlibUnlink)
-                    || self.settings.rules.enabled(&Rule::PathlibGetcwd)
-                    || self.settings.rules.enabled(&Rule::PathlibExists)
-                    || self.settings.rules.enabled(&Rule::PathlibExpanduser)
-                    || self.settings.rules.enabled(&Rule::PathlibIsDir)
-                    || self.settings.rules.enabled(&Rule::PathlibIsFile)
-                    || self.settings.rules.enabled(&Rule::PathlibIsLink)
-                    || self.settings.rules.enabled(&Rule::PathlibReadlink)
-                    || self.settings.rules.enabled(&Rule::PathlibStat)
-                    || self.settings.rules.enabled(&Rule::PathlibIsAbs)
-                    || self.settings.rules.enabled(&Rule::PathlibJoin)
-                    || self.settings.rules.enabled(&Rule::PathlibBasename)
-                    || self.settings.rules.enabled(&Rule::PathlibSamefile)
-                    || self.settings.rules.enabled(&Rule::PathlibSplitext)
-                    || self.settings.rules.enabled(&Rule::PathlibOpen)
-                    || self.settings.rules.enabled(&Rule::PathlibPyPath)
+                if self.settings.rules.enabled(Rule::PathlibAbspath)
+                    || self.settings.rules.enabled(Rule::PathlibChmod)
+                    || self.settings.rules.enabled(Rule::PathlibMkdir)
+                    || self.settings.rules.enabled(Rule::PathlibMakedirs)
+                    || self.settings.rules.enabled(Rule::PathlibRename)
+                    || self.settings.rules.enabled(Rule::PathlibReplace)
+                    || self.settings.rules.enabled(Rule::PathlibRmdir)
+                    || self.settings.rules.enabled(Rule::PathlibRemove)
+                    || self.settings.rules.enabled(Rule::PathlibUnlink)
+                    || self.settings.rules.enabled(Rule::PathlibGetcwd)
+                    || self.settings.rules.enabled(Rule::PathlibExists)
+                    || self.settings.rules.enabled(Rule::PathlibExpanduser)
+                    || self.settings.rules.enabled(Rule::PathlibIsDir)
+                    || self.settings.rules.enabled(Rule::PathlibIsFile)
+                    || self.settings.rules.enabled(Rule::PathlibIsLink)
+                    || self.settings.rules.enabled(Rule::PathlibReadlink)
+                    || self.settings.rules.enabled(Rule::PathlibStat)
+                    || self.settings.rules.enabled(Rule::PathlibIsAbs)
+                    || self.settings.rules.enabled(Rule::PathlibJoin)
+                    || self.settings.rules.enabled(Rule::PathlibBasename)
+                    || self.settings.rules.enabled(Rule::PathlibSamefile)
+                    || self.settings.rules.enabled(Rule::PathlibSplitext)
+                    || self.settings.rules.enabled(Rule::PathlibOpen)
+                    || self.settings.rules.enabled(Rule::PathlibPyPath)
                 {
                     flake8_use_pathlib::helpers::replaceable_by_pathlib(self, func);
                 }
 
                 // numpy
-                if self.settings.rules.enabled(&Rule::NumpyLegacyRandom) {
+                if self.settings.rules.enabled(Rule::NumpyLegacyRandom) {
                     numpy::rules::numpy_legacy_random(self, func);
                 }
 
                 // flake8-logging-format
-                if self.settings.rules.enabled(&Rule::LoggingStringFormat)
-                    || self.settings.rules.enabled(&Rule::LoggingPercentFormat)
-                    || self.settings.rules.enabled(&Rule::LoggingStringConcat)
-                    || self.settings.rules.enabled(&Rule::LoggingFString)
-                    || self.settings.rules.enabled(&Rule::LoggingWarn)
-                    || self.settings.rules.enabled(&Rule::LoggingExtraAttrClash)
-                    || self.settings.rules.enabled(&Rule::LoggingExcInfo)
-                    || self.settings.rules.enabled(&Rule::LoggingRedundantExcInfo)
+                if self.settings.rules.enabled(Rule::LoggingStringFormat)
+                    || self.settings.rules.enabled(Rule::LoggingPercentFormat)
+                    || self.settings.rules.enabled(Rule::LoggingStringConcat)
+                    || self.settings.rules.enabled(Rule::LoggingFString)
+                    || self.settings.rules.enabled(Rule::LoggingWarn)
+                    || self.settings.rules.enabled(Rule::LoggingExtraAttrClash)
+                    || self.settings.rules.enabled(Rule::LoggingExcInfo)
+                    || self.settings.rules.enabled(Rule::LoggingRedundantExcInfo)
                 {
                     flake8_logging_format::rules::logging_call(self, func, args, keywords);
                 }
 
                 // pylint logging checker
-                if self.settings.rules.enabled(&Rule::LoggingTooFewArgs)
-                    || self.settings.rules.enabled(&Rule::LoggingTooManyArgs)
+                if self.settings.rules.enabled(Rule::LoggingTooFewArgs)
+                    || self.settings.rules.enabled(Rule::LoggingTooManyArgs)
                 {
                     pylint::rules::logging_call(self, func, args, keywords);
                 }
 
                 // flake8-django
-                if self.settings.rules.enabled(&Rule::LocalsInRenderFunction) {
+                if self.settings.rules.enabled(Rule::LocalsInRenderFunction) {
                     flake8_django::rules::locals_in_render_function(self, func, args, keywords);
                 }
             }
@@ -2971,40 +2930,40 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::MultiValueRepeatedKeyLiteral)
+                    .enabled(Rule::MultiValueRepeatedKeyLiteral)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::MultiValueRepeatedKeyVariable)
+                        .enabled(Rule::MultiValueRepeatedKeyVariable)
                 {
                     pyflakes::rules::repeated_keys(self, keys, values);
                 }
 
-                if self.settings.rules.enabled(&Rule::UnnecessarySpread) {
+                if self.settings.rules.enabled(Rule::UnnecessarySpread) {
                     flake8_pie::rules::no_unnecessary_spread(self, keys, values);
                 }
             }
             ExprKind::Yield { .. } => {
-                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
+                if self.settings.rules.enabled(Rule::YieldOutsideFunction) {
                     pyflakes::rules::yield_outside_function(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::YieldInInit) {
+                if self.settings.rules.enabled(Rule::YieldInInit) {
                     pylint::rules::yield_in_init(self, expr);
                 }
             }
             ExprKind::YieldFrom { .. } => {
-                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
+                if self.settings.rules.enabled(Rule::YieldOutsideFunction) {
                     pyflakes::rules::yield_outside_function(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::YieldInInit) {
+                if self.settings.rules.enabled(Rule::YieldInInit) {
                     pylint::rules::yield_in_init(self, expr);
                 }
             }
             ExprKind::Await { .. } => {
-                if self.settings.rules.enabled(&Rule::YieldOutsideFunction) {
+                if self.settings.rules.enabled(Rule::YieldOutsideFunction) {
                     pyflakes::rules::yield_outside_function(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::AwaitOutsideAsync) {
+                if self.settings.rules.enabled(Rule::AwaitOutsideAsync) {
                     pylint::rules::await_outside_async(self, expr);
                 }
             }
@@ -3012,11 +2971,11 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::FStringMissingPlaceholders)
+                    .enabled(Rule::FStringMissingPlaceholders)
                 {
                     pyflakes::rules::f_string_missing_placeholders(expr, values, self);
                 }
-                if self.settings.rules.enabled(&Rule::HardcodedSQLExpression) {
+                if self.settings.rules.enabled(Rule::HardcodedSQLExpression) {
                     flake8_bandit::rules::hardcoded_sql_expression(self, expr);
                 }
             }
@@ -3025,7 +2984,7 @@ where
                 op: Operator::RShift,
                 ..
             } => {
-                if self.settings.rules.enabled(&Rule::InvalidPrintSyntax) {
+                if self.settings.rules.enabled(Rule::InvalidPrintSyntax) {
                     pyflakes::rules::invalid_print_syntax(self, left);
                 }
             }
@@ -3042,39 +3001,39 @@ where
                     if self
                         .settings
                         .rules
-                        .enabled(&Rule::PercentFormatInvalidFormat)
+                        .enabled(Rule::PercentFormatInvalidFormat)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatExpectedMapping)
+                            .enabled(Rule::PercentFormatExpectedMapping)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatExpectedSequence)
+                            .enabled(Rule::PercentFormatExpectedSequence)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatExtraNamedArguments)
+                            .enabled(Rule::PercentFormatExtraNamedArguments)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatMissingArgument)
+                            .enabled(Rule::PercentFormatMissingArgument)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatMixedPositionalAndNamed)
+                            .enabled(Rule::PercentFormatMixedPositionalAndNamed)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatPositionalCountMismatch)
+                            .enabled(Rule::PercentFormatPositionalCountMismatch)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatStarRequiresSequence)
+                            .enabled(Rule::PercentFormatStarRequiresSequence)
                         || self
                             .settings
                             .rules
-                            .enabled(&Rule::PercentFormatUnsupportedFormatCharacter)
+                            .enabled(Rule::PercentFormatUnsupportedFormatCharacter)
                     {
                         let location = Range::from(expr);
                         match pyflakes::cformat::CFormatSummary::try_from(value.as_str()) {
@@ -3085,7 +3044,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatUnsupportedFormatCharacter)
+                                    .enabled(Rule::PercentFormatUnsupportedFormatCharacter)
                                 {
                                     self.diagnostics.push(Diagnostic::new(
                                         pyflakes::rules::PercentFormatUnsupportedFormatCharacter {
@@ -3099,7 +3058,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatInvalidFormat)
+                                    .enabled(Rule::PercentFormatInvalidFormat)
                                 {
                                     self.diagnostics.push(Diagnostic::new(
                                         pyflakes::rules::PercentFormatInvalidFormat {
@@ -3113,7 +3072,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatExpectedMapping)
+                                    .enabled(Rule::PercentFormatExpectedMapping)
                                 {
                                     pyflakes::rules::percent_format_expected_mapping(
                                         self, &summary, right, location,
@@ -3122,7 +3081,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatExpectedSequence)
+                                    .enabled(Rule::PercentFormatExpectedSequence)
                                 {
                                     pyflakes::rules::percent_format_expected_sequence(
                                         self, &summary, right, location,
@@ -3131,7 +3090,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatExtraNamedArguments)
+                                    .enabled(Rule::PercentFormatExtraNamedArguments)
                                 {
                                     pyflakes::rules::percent_format_extra_named_arguments(
                                         self, &summary, right, location,
@@ -3140,7 +3099,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatMissingArgument)
+                                    .enabled(Rule::PercentFormatMissingArgument)
                                 {
                                     pyflakes::rules::percent_format_missing_arguments(
                                         self, &summary, right, location,
@@ -3149,7 +3108,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatMixedPositionalAndNamed)
+                                    .enabled(Rule::PercentFormatMixedPositionalAndNamed)
                                 {
                                     pyflakes::rules::percent_format_mixed_positional_and_named(
                                         self, &summary, location,
@@ -3158,7 +3117,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatPositionalCountMismatch)
+                                    .enabled(Rule::PercentFormatPositionalCountMismatch)
                                 {
                                     pyflakes::rules::percent_format_positional_count_mismatch(
                                         self, &summary, right, location,
@@ -3167,7 +3126,7 @@ where
                                 if self
                                     .settings
                                     .rules
-                                    .enabled(&Rule::PercentFormatStarRequiresSequence)
+                                    .enabled(Rule::PercentFormatStarRequiresSequence)
                                 {
                                     pyflakes::rules::percent_format_star_requires_sequence(
                                         self, &summary, right, location,
@@ -3177,13 +3136,13 @@ where
                         }
                     }
 
-                    if self.settings.rules.enabled(&Rule::PrintfStringFormatting) {
+                    if self.settings.rules.enabled(Rule::PrintfStringFormatting) {
                         pyupgrade::rules::printf_string_formatting(self, expr, left, right);
                     }
-                    if self.settings.rules.enabled(&Rule::BadStringFormatType) {
+                    if self.settings.rules.enabled(Rule::BadStringFormatType) {
                         pylint::rules::bad_string_format_type(self, expr, right);
                     }
-                    if self.settings.rules.enabled(&Rule::HardcodedSQLExpression) {
+                    if self.settings.rules.enabled(Rule::HardcodedSQLExpression) {
                         flake8_bandit::rules::hardcoded_sql_expression(self, expr);
                     }
                 }
@@ -3194,7 +3153,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ExplicitStringConcatenation)
+                    .enabled(Rule::ExplicitStringConcatenation)
                 {
                     if let Some(diagnostic) = flake8_implicit_str_concat::rules::explicit(expr) {
                         self.diagnostics.push(diagnostic);
@@ -3203,17 +3162,17 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::UnpackInsteadOfConcatenatingToCollectionLiteral)
+                    .enabled(Rule::UnpackInsteadOfConcatenatingToCollectionLiteral)
                 {
                     ruff::rules::unpack_instead_of_concatenating_to_collection_literal(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::HardcodedSQLExpression) {
+                if self.settings.rules.enabled(Rule::HardcodedSQLExpression) {
                     flake8_bandit::rules::hardcoded_sql_expression(self, expr);
                 }
             }
             ExprKind::UnaryOp { op, operand } => {
-                let check_not_in = self.settings.rules.enabled(&Rule::NotInTest);
-                let check_not_is = self.settings.rules.enabled(&Rule::NotIsTest);
+                let check_not_in = self.settings.rules.enabled(Rule::NotInTest);
+                let check_not_is = self.settings.rules.enabled(Rule::NotIsTest);
                 if check_not_in || check_not_is {
                     pycodestyle::rules::not_tests(
                         self,
@@ -3225,17 +3184,17 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&Rule::UnaryPrefixIncrement) {
+                if self.settings.rules.enabled(Rule::UnaryPrefixIncrement) {
                     flake8_bugbear::rules::unary_prefix_increment(self, expr, op, operand);
                 }
 
-                if self.settings.rules.enabled(&Rule::NegateEqualOp) {
+                if self.settings.rules.enabled(Rule::NegateEqualOp) {
                     flake8_simplify::rules::negation_with_equal_op(self, expr, op, operand);
                 }
-                if self.settings.rules.enabled(&Rule::NegateNotEqualOp) {
+                if self.settings.rules.enabled(Rule::NegateNotEqualOp) {
                     flake8_simplify::rules::negation_with_not_equal_op(self, expr, op, operand);
                 }
-                if self.settings.rules.enabled(&Rule::DoubleNegation) {
+                if self.settings.rules.enabled(Rule::DoubleNegation) {
                     flake8_simplify::rules::double_negation(self, expr, op, operand);
                 }
             }
@@ -3244,9 +3203,9 @@ where
                 ops,
                 comparators,
             } => {
-                let check_none_comparisons = self.settings.rules.enabled(&Rule::NoneComparison);
+                let check_none_comparisons = self.settings.rules.enabled(Rule::NoneComparison);
                 let check_true_false_comparisons =
-                    self.settings.rules.enabled(&Rule::TrueFalseComparison);
+                    self.settings.rules.enabled(Rule::TrueFalseComparison);
                 if check_none_comparisons || check_true_false_comparisons {
                     pycodestyle::rules::literal_comparisons(
                         self,
@@ -3259,7 +3218,7 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&Rule::IsLiteral) {
+                if self.settings.rules.enabled(Rule::IsLiteral) {
                     pyflakes::rules::invalid_literal_comparison(
                         self,
                         left,
@@ -3269,7 +3228,7 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&Rule::TypeComparison) {
+                if self.settings.rules.enabled(Rule::TypeComparison) {
                     self.diagnostics.extend(pycodestyle::rules::type_comparison(
                         ops,
                         comparators,
@@ -3277,22 +3236,19 @@ where
                     ));
                 }
 
-                if self.settings.rules.enabled(&Rule::SysVersionCmpStr3)
+                if self.settings.rules.enabled(Rule::SysVersionCmpStr3)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::SysVersionInfo0Eq3Referenced)
-                    || self.settings.rules.enabled(&Rule::SysVersionInfo1CmpInt)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(&Rule::SysVersionInfoMinorCmpInt)
-                    || self.settings.rules.enabled(&Rule::SysVersionCmpStr10)
+                        .enabled(Rule::SysVersionInfo0Eq3Referenced)
+                    || self.settings.rules.enabled(Rule::SysVersionInfo1CmpInt)
+                    || self.settings.rules.enabled(Rule::SysVersionInfoMinorCmpInt)
+                    || self.settings.rules.enabled(Rule::SysVersionCmpStr10)
                 {
                     flake8_2020::rules::compare(self, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&Rule::HardcodedPasswordString) {
+                if self.settings.rules.enabled(Rule::HardcodedPasswordString) {
                     self.diagnostics.extend(
                         flake8_bandit::rules::compare_to_hardcoded_password_string(
                             left,
@@ -3301,32 +3257,29 @@ where
                     );
                 }
 
-                if self.settings.rules.enabled(&Rule::ComparisonOfConstant) {
+                if self.settings.rules.enabled(Rule::ComparisonOfConstant) {
                     pylint::rules::comparison_of_constant(self, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&Rule::CompareToEmptyString) {
+                if self.settings.rules.enabled(Rule::CompareToEmptyString) {
                     pylint::rules::compare_to_empty_string(self, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&Rule::MagicValueComparison) {
+                if self.settings.rules.enabled(Rule::MagicValueComparison) {
                     pylint::rules::magic_value_comparison(self, left, comparators);
                 }
 
-                if self.settings.rules.enabled(&Rule::KeyInDict) {
+                if self.settings.rules.enabled(Rule::KeyInDict) {
                     flake8_simplify::rules::key_in_dict_compare(self, expr, left, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(&Rule::YodaConditions) {
+                if self.settings.rules.enabled(Rule::YodaConditions) {
                     flake8_simplify::rules::yoda_conditions(self, expr, left, ops, comparators);
                 }
 
                 if self.is_stub {
-                    if self
-                        .settings
-                        .rules
-                        .enabled(&Rule::UnrecognizedPlatformCheck)
-                        || self.settings.rules.enabled(&Rule::UnrecognizedPlatformName)
+                    if self.settings.rules.enabled(Rule::UnrecognizedPlatformCheck)
+                        || self.settings.rules.enabled(Rule::UnrecognizedPlatformName)
                     {
                         flake8_pyi::rules::unrecognized_platform(
                             self,
@@ -3337,7 +3290,7 @@ where
                         );
                     }
 
-                    if self.settings.rules.enabled(&Rule::BadVersionInfoComparison) {
+                    if self.settings.rules.enabled(Rule::BadVersionInfoComparison) {
                         flake8_pyi::rules::bad_version_info_comparison(
                             self,
                             expr,
@@ -3363,7 +3316,7 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::HardcodedBindAllInterfaces)
+                    .enabled(Rule::HardcodedBindAllInterfaces)
                 {
                     if let Some(diagnostic) = flake8_bandit::rules::hardcoded_bind_all_interfaces(
                         value,
@@ -3372,7 +3325,7 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::HardcodedTempFile) {
+                if self.settings.rules.enabled(Rule::HardcodedTempFile) {
                     if let Some(diagnostic) = flake8_bandit::rules::hardcoded_tmp_directory(
                         expr,
                         value,
@@ -3381,12 +3334,12 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(&Rule::RewriteUnicodeLiteral) {
+                if self.settings.rules.enabled(Rule::RewriteUnicodeLiteral) {
                     pyupgrade::rules::rewrite_unicode_literal(self, expr, kind.as_deref());
                 }
             }
             ExprKind::Lambda { args, body, .. } => {
-                if self.settings.rules.enabled(&Rule::PreferListBuiltin) {
+                if self.settings.rules.enabled(Rule::PreferListBuiltin) {
                     flake8_pie::rules::prefer_list_builtin(self, expr);
                 }
 
@@ -3401,64 +3354,60 @@ where
                     .push_scope(Scope::new(ScopeKind::Lambda(Lambda { args, body })));
             }
             ExprKind::IfExp { test, body, orelse } => {
-                if self.settings.rules.enabled(&Rule::IfExprWithTrueFalse) {
+                if self.settings.rules.enabled(Rule::IfExprWithTrueFalse) {
                     flake8_simplify::rules::explicit_true_false_in_ifexpr(
                         self, expr, test, body, orelse,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::IfExprWithFalseTrue) {
+                if self.settings.rules.enabled(Rule::IfExprWithFalseTrue) {
                     flake8_simplify::rules::explicit_false_true_in_ifexpr(
                         self, expr, test, body, orelse,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::IfExprWithTwistedArms) {
+                if self.settings.rules.enabled(Rule::IfExprWithTwistedArms) {
                     flake8_simplify::rules::twisted_arms_in_ifexpr(self, expr, test, body, orelse);
                 }
             }
             ExprKind::ListComp { elt, generators } | ExprKind::SetComp { elt, generators } => {
-                if self.settings.rules.enabled(&Rule::UnnecessaryComprehension) {
+                if self.settings.rules.enabled(Rule::UnnecessaryComprehension) {
                     flake8_comprehensions::rules::unnecessary_comprehension(
                         self, expr, elt, generators,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
+                if self.settings.rules.enabled(Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Expr(expr));
                 }
                 self.ctx.push_scope(Scope::new(ScopeKind::Generator));
             }
             ExprKind::GeneratorExp { .. } | ExprKind::DictComp { .. } => {
-                if self.settings.rules.enabled(&Rule::FunctionUsesLoopVariable) {
+                if self.settings.rules.enabled(Rule::FunctionUsesLoopVariable) {
                     flake8_bugbear::rules::function_uses_loop_variable(self, &Node::Expr(expr));
                 }
                 self.ctx.push_scope(Scope::new(ScopeKind::Generator));
             }
             ExprKind::BoolOp { op, values } => {
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::ConsiderMergingIsinstance)
-                {
+                if self.settings.rules.enabled(Rule::ConsiderMergingIsinstance) {
                     pylint::rules::merge_isinstance(self, expr, op, values);
                 }
-                if self.settings.rules.enabled(&Rule::SingleStartsEndsWith) {
+                if self.settings.rules.enabled(Rule::SingleStartsEndsWith) {
                     flake8_pie::rules::single_starts_ends_with(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::DuplicateIsinstanceCall) {
+                if self.settings.rules.enabled(Rule::DuplicateIsinstanceCall) {
                     flake8_simplify::rules::duplicate_isinstance_call(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::CompareWithTuple) {
+                if self.settings.rules.enabled(Rule::CompareWithTuple) {
                     flake8_simplify::rules::compare_with_tuple(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::ExprAndNotExpr) {
+                if self.settings.rules.enabled(Rule::ExprAndNotExpr) {
                     flake8_simplify::rules::expr_and_not_expr(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::ExprOrNotExpr) {
+                if self.settings.rules.enabled(Rule::ExprOrNotExpr) {
                     flake8_simplify::rules::expr_or_not_expr(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::ExprOrTrue) {
+                if self.settings.rules.enabled(Rule::ExprOrTrue) {
                     flake8_simplify::rules::expr_or_true(self, expr);
                 }
-                if self.settings.rules.enabled(&Rule::ExprAndFalse) {
+                if self.settings.rules.enabled(Rule::ExprAndFalse) {
                     flake8_simplify::rules::expr_and_false(self, expr);
                 }
             }
@@ -3714,7 +3663,7 @@ where
     }
 
     fn visit_comprehension(&mut self, comprehension: &'b Comprehension) {
-        if self.settings.rules.enabled(&Rule::KeyInDict) {
+        if self.settings.rules.enabled(Rule::KeyInDict) {
             flake8_simplify::rules::key_in_dict_for(
                 self,
                 &comprehension.target,
@@ -3729,7 +3678,7 @@ where
             ExcepthandlerKind::ExceptHandler {
                 type_, name, body, ..
             } => {
-                if self.settings.rules.enabled(&Rule::BareExcept) {
+                if self.settings.rules.enabled(Rule::BareExcept) {
                     if let Some(diagnostic) = pycodestyle::rules::bare_except(
                         type_.as_deref(),
                         body,
@@ -3742,11 +3691,11 @@ where
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::RaiseWithoutFromInsideExcept)
+                    .enabled(Rule::RaiseWithoutFromInsideExcept)
                 {
                     flake8_bugbear::rules::raise_without_from_inside_except(self, body);
                 }
-                if self.settings.rules.enabled(&Rule::BlindExcept) {
+                if self.settings.rules.enabled(Rule::BlindExcept) {
                     flake8_blind_except::rules::blind_except(
                         self,
                         type_.as_deref(),
@@ -3754,7 +3703,7 @@ where
                         body,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::TryExceptPass) {
+                if self.settings.rules.enabled(Rule::TryExceptPass) {
                     flake8_bandit::rules::try_except_pass(
                         self,
                         excepthandler,
@@ -3764,7 +3713,7 @@ where
                         self.settings.flake8_bandit.check_typed_exception,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::TryExceptContinue) {
+                if self.settings.rules.enabled(Rule::TryExceptContinue) {
                     flake8_bandit::rules::try_except_continue(
                         self,
                         excepthandler,
@@ -3774,22 +3723,22 @@ where
                         self.settings.flake8_bandit.check_typed_exception,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::ExceptWithEmptyTuple) {
+                if self.settings.rules.enabled(Rule::ExceptWithEmptyTuple) {
                     flake8_bugbear::rules::except_with_empty_tuple(self, excepthandler);
                 }
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ExceptWithNonExceptionClasses)
+                    .enabled(Rule::ExceptWithNonExceptionClasses)
                 {
                     flake8_bugbear::rules::except_with_non_exception_classes(self, excepthandler);
                 }
-                if self.settings.rules.enabled(&Rule::ReraiseNoCause) {
+                if self.settings.rules.enabled(Rule::ReraiseNoCause) {
                     tryceratops::rules::reraise_no_cause(self, body);
                 }
                 match name {
                     Some(name) => {
-                        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
+                        if self.settings.rules.enabled(Rule::AmbiguousVariableName) {
                             if let Some(diagnostic) = pycodestyle::rules::ambiguous_variable_name(
                                 name,
                                 helpers::excepthandler_name_range(excepthandler, self.locator)
@@ -3849,14 +3798,14 @@ where
                             &scope.bindings.remove(&name.as_str())
                         } {
                             if !self.ctx.bindings[*index].used() {
-                                if self.settings.rules.enabled(&Rule::UnusedVariable) {
+                                if self.settings.rules.enabled(Rule::UnusedVariable) {
                                     let mut diagnostic = Diagnostic::new(
                                         pyflakes::rules::UnusedVariable {
                                             name: name.to_string(),
                                         },
                                         name_range,
                                     );
-                                    if self.patch(&Rule::UnusedVariable) {
+                                    if self.patch(Rule::UnusedVariable) {
                                         match pyflakes::fixes::remove_exception_handler_assignment(
                                             excepthandler,
                                             self.locator,
@@ -3902,13 +3851,13 @@ where
     }
 
     fn visit_arguments(&mut self, arguments: &'b Arguments) {
-        if self.settings.rules.enabled(&Rule::MutableArgumentDefault) {
+        if self.settings.rules.enabled(Rule::MutableArgumentDefault) {
             flake8_bugbear::rules::mutable_argument_default(self, arguments);
         }
         if self
             .settings
             .rules
-            .enabled(&Rule::FunctionCallArgumentDefault)
+            .enabled(Rule::FunctionCallArgumentDefault)
         {
             flake8_bugbear::rules::function_call_argument_default(self, arguments);
         }
@@ -3917,13 +3866,13 @@ where
             if self
                 .settings
                 .rules
-                .enabled(&Rule::TypedArgumentSimpleDefaults)
+                .enabled(Rule::TypedArgumentSimpleDefaults)
             {
                 flake8_pyi::rules::typed_argument_simple_defaults(self, arguments);
             }
         }
         if self.is_stub {
-            if self.settings.rules.enabled(&Rule::ArgumentSimpleDefaults) {
+            if self.settings.rules.enabled(Rule::ArgumentSimpleDefaults) {
                 flake8_pyi::rules::argument_simple_defaults(self, arguments);
             }
         }
@@ -3963,7 +3912,7 @@ where
             },
         );
 
-        if self.settings.rules.enabled(&Rule::AmbiguousVariableName) {
+        if self.settings.rules.enabled(Rule::AmbiguousVariableName) {
             if let Some(diagnostic) =
                 pycodestyle::rules::ambiguous_variable_name(&arg.node.arg, Range::from(arg))
             {
@@ -3971,7 +3920,7 @@ where
             }
         }
 
-        if self.settings.rules.enabled(&Rule::InvalidArgumentName) {
+        if self.settings.rules.enabled(Rule::InvalidArgumentName) {
             if let Some(diagnostic) = pep8_naming::rules::invalid_argument_name(
                 &arg.node.arg,
                 arg,
@@ -4011,7 +3960,7 @@ where
     }
 
     fn visit_body(&mut self, body: &'b [Stmt]) {
-        if self.settings.rules.enabled(&Rule::UnnecessaryPass) {
+        if self.settings.rules.enabled(Rule::UnnecessaryPass) {
             flake8_pie::rules::no_unnecessary_pass(self, body);
         }
 
@@ -4069,7 +4018,7 @@ impl<'a> Checker<'a> {
                         | BindingKind::FutureImportation
                 );
                 if binding.kind.is_loop_var() && existing_is_import {
-                    if self.settings.rules.enabled(&Rule::ImportShadowedByLoopVar) {
+                    if self.settings.rules.enabled(Rule::ImportShadowedByLoopVar) {
                         self.diagnostics.push(Diagnostic::new(
                             pyflakes::rules::ImportShadowedByLoopVar {
                                 name: name.to_string(),
@@ -4088,7 +4037,7 @@ impl<'a> Checker<'a> {
                                 cast::decorator_list(existing.source.as_ref().unwrap()),
                             ))
                     {
-                        if self.settings.rules.enabled(&Rule::RedefinedWhileUnused) {
+                        if self.settings.rules.enabled(Rule::RedefinedWhileUnused) {
                             let mut diagnostic = Diagnostic::new(
                                 pyflakes::rules::RedefinedWhileUnused {
                                     name: name.to_string(),
@@ -4276,7 +4225,7 @@ impl<'a> Checker<'a> {
         }
 
         if import_starred {
-            if self.settings.rules.enabled(&Rule::ImportStarUsage) {
+            if self.settings.rules.enabled(Rule::ImportStarUsage) {
                 let mut from_list = vec![];
                 for scope_index in self.ctx.scope_stack.iter().rev() {
                     let scope = &self.ctx.scopes[*scope_index];
@@ -4306,7 +4255,7 @@ impl<'a> Checker<'a> {
             return;
         }
 
-        if self.settings.rules.enabled(&Rule::UndefinedName) {
+        if self.settings.rules.enabled(Rule::UndefinedName) {
             // Allow __path__.
             if self.path.ends_with("__init__.py") && id == "__path__" {
                 return;
@@ -4342,7 +4291,7 @@ impl<'a> Checker<'a> {
     {
         let parent = self.ctx.current_stmt().0;
 
-        if self.settings.rules.enabled(&Rule::UndefinedLocal) {
+        if self.settings.rules.enabled(Rule::UndefinedLocal) {
             let scopes: Vec<&Scope> = self
                 .ctx
                 .scope_stack
@@ -4359,7 +4308,7 @@ impl<'a> Checker<'a> {
         if self
             .settings
             .rules
-            .enabled(&Rule::NonLowercaseVariableInFunction)
+            .enabled(Rule::NonLowercaseVariableInFunction)
         {
             if matches!(self.ctx.current_scope().kind, ScopeKind::Function(..)) {
                 // Ignore globals.
@@ -4378,7 +4327,7 @@ impl<'a> Checker<'a> {
         if self
             .settings
             .rules
-            .enabled(&Rule::MixedCaseVariableInClassScope)
+            .enabled(Rule::MixedCaseVariableInClassScope)
         {
             if matches!(self.ctx.current_scope().kind, ScopeKind::Class(..)) {
                 pep8_naming::rules::mixed_case_variable_in_class_scope(self, expr, parent, id);
@@ -4388,7 +4337,7 @@ impl<'a> Checker<'a> {
         if self
             .settings
             .rules
-            .enabled(&Rule::MixedCaseVariableInGlobalScope)
+            .enabled(Rule::MixedCaseVariableInGlobalScope)
         {
             if matches!(self.ctx.current_scope().kind, ScopeKind::Module) {
                 pep8_naming::rules::mixed_case_variable_in_global_scope(self, expr, parent, id);
@@ -4483,14 +4432,14 @@ impl<'a> Checker<'a> {
             } {
                 let (all_names, all_names_flags) = extract_all_names(&self.ctx, parent, current);
 
-                if self.settings.rules.enabled(&Rule::InvalidAllFormat) {
+                if self.settings.rules.enabled(Rule::InvalidAllFormat) {
                     if matches!(all_names_flags, AllNamesFlags::INVALID_FORMAT) {
                         self.diagnostics
                             .push(pylint::rules::invalid_all_format(expr));
                     }
                 }
 
-                if self.settings.rules.enabled(&Rule::InvalidAllObject) {
+                if self.settings.rules.enabled(Rule::InvalidAllObject) {
                     if matches!(all_names_flags, AllNamesFlags::INVALID_OBJECT) {
                         self.diagnostics
                             .push(pylint::rules::invalid_all_object(expr));
@@ -4543,7 +4492,7 @@ impl<'a> Checker<'a> {
         if scope.bindings.remove(&id.as_str()).is_some() {
             return;
         }
-        if !self.settings.rules.enabled(&Rule::UndefinedName) {
+        if !self.settings.rules.enabled(Rule::UndefinedName) {
             return;
         }
 
@@ -4559,7 +4508,7 @@ impl<'a> Checker<'a> {
     where
         'b: 'a,
     {
-        if self.settings.rules.enabled(&Rule::FStringDocstring) {
+        if self.settings.rules.enabled(Rule::FStringDocstring) {
             flake8_bugbear::rules::f_string_docstring(self, python_ast);
         }
         let docstring = docstrings::extraction::docstring_from(python_ast);
@@ -4606,7 +4555,7 @@ impl<'a> Checker<'a> {
         {
             if let Ok(mut expr) = parser::parse_expression(expression, "<filename>") {
                 if in_annotation && self.ctx.annotations_future_enabled {
-                    if self.settings.rules.enabled(&Rule::QuotedAnnotation) {
+                    if self.settings.rules.enabled(Rule::QuotedAnnotation) {
                         pyupgrade::rules::quoted_annotation(self, expression, range);
                     }
                 }
@@ -4617,7 +4566,7 @@ impl<'a> Checker<'a> {
                 if self
                     .settings
                     .rules
-                    .enabled(&Rule::ForwardAnnotationSyntaxError)
+                    .enabled(Rule::ForwardAnnotationSyntaxError)
                 {
                     self.diagnostics.push(Diagnostic::new(
                         pyflakes::rules::ForwardAnnotationSyntaxError {
@@ -4687,26 +4636,23 @@ impl<'a> Checker<'a> {
             let parent_scope_index = scopes[scopes.len() - 2];
 
             // pyflakes
-            if self.settings.rules.enabled(&Rule::UnusedVariable) {
+            if self.settings.rules.enabled(Rule::UnusedVariable) {
                 pyflakes::rules::unused_variable(self, scope_index);
             }
-            if self.settings.rules.enabled(&Rule::UnusedAnnotation) {
+            if self.settings.rules.enabled(Rule::UnusedAnnotation) {
                 pyflakes::rules::unused_annotation(self, scope_index);
             }
 
             if !self.is_stub {
                 // flake8-unused-arguments
-                if self.settings.rules.enabled(&Rule::UnusedFunctionArgument)
-                    || self.settings.rules.enabled(&Rule::UnusedMethodArgument)
+                if self.settings.rules.enabled(Rule::UnusedFunctionArgument)
+                    || self.settings.rules.enabled(Rule::UnusedMethodArgument)
+                    || self.settings.rules.enabled(Rule::UnusedClassMethodArgument)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::UnusedClassMethodArgument)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(&Rule::UnusedStaticMethodArgument)
-                    || self.settings.rules.enabled(&Rule::UnusedLambdaArgument)
+                        .enabled(Rule::UnusedStaticMethodArgument)
+                    || self.settings.rules.enabled(Rule::UnusedLambdaArgument)
                 {
                     self.diagnostics
                         .extend(flake8_unused_arguments::rules::unused_arguments(
@@ -4729,11 +4675,7 @@ impl<'a> Checker<'a> {
             if let StmtKind::For { target, body, .. } | StmtKind::AsyncFor { target, body, .. } =
                 &stmt.node
             {
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::UnusedLoopControlVariable)
-                {
+                if self.settings.rules.enabled(Rule::UnusedLoopControlVariable) {
                     flake8_bugbear::rules::unused_loop_control_variable(self, stmt, target, body);
                 }
             } else {
@@ -4744,31 +4686,28 @@ impl<'a> Checker<'a> {
 
     fn check_dead_scopes(&mut self) {
         let enforce_typing_imports = !self.is_stub
-            && (self
-                .settings
-                .rules
-                .enabled(&Rule::GlobalVariableNotAssigned)
+            && (self.settings.rules.enabled(Rule::GlobalVariableNotAssigned)
                 || self
                     .settings
                     .rules
-                    .enabled(&Rule::RuntimeImportInTypeCheckingBlock)
+                    .enabled(Rule::RuntimeImportInTypeCheckingBlock)
                 || self
                     .settings
                     .rules
-                    .enabled(&Rule::TypingOnlyFirstPartyImport)
+                    .enabled(Rule::TypingOnlyFirstPartyImport)
                 || self
                     .settings
                     .rules
-                    .enabled(&Rule::TypingOnlyThirdPartyImport)
+                    .enabled(Rule::TypingOnlyThirdPartyImport)
                 || self
                     .settings
                     .rules
-                    .enabled(&Rule::TypingOnlyStandardLibraryImport));
+                    .enabled(Rule::TypingOnlyStandardLibraryImport));
 
-        if !(self.settings.rules.enabled(&Rule::UnusedImport)
-            || self.settings.rules.enabled(&Rule::ImportStarUsage)
-            || self.settings.rules.enabled(&Rule::RedefinedWhileUnused)
-            || self.settings.rules.enabled(&Rule::UndefinedExport)
+        if !(self.settings.rules.enabled(Rule::UnusedImport)
+            || self.settings.rules.enabled(Rule::ImportStarUsage)
+            || self.settings.rules.enabled(Rule::RedefinedWhileUnused)
+            || self.settings.rules.enabled(Rule::UndefinedExport)
             || enforce_typing_imports)
         {
             return;
@@ -4847,7 +4786,7 @@ impl<'a> Checker<'a> {
 
             // F822
             if *index == GLOBAL_SCOPE_INDEX {
-                if self.settings.rules.enabled(&Rule::UndefinedExport) {
+                if self.settings.rules.enabled(Rule::UndefinedExport) {
                     if let Some((names, range)) = &all_names {
                         diagnostics.extend(pyflakes::rules::undefined_export(
                             names, range, self.path, scope,
@@ -4857,11 +4796,7 @@ impl<'a> Checker<'a> {
             }
 
             // PLW0602
-            if self
-                .settings
-                .rules
-                .enabled(&Rule::GlobalVariableNotAssigned)
-            {
+            if self.settings.rules.enabled(Rule::GlobalVariableNotAssigned) {
                 for (name, index) in &scope.bindings {
                     let binding = &self.ctx.bindings[*index];
                     if binding.kind.is_global() {
@@ -4887,7 +4822,7 @@ impl<'a> Checker<'a> {
             // Look for any bindings that were redefined in another scope, and remain
             // unused. Note that we only store references in `redefinitions` if
             // the bindings are in different scopes.
-            if self.settings.rules.enabled(&Rule::RedefinedWhileUnused) {
+            if self.settings.rules.enabled(Rule::RedefinedWhileUnused) {
                 for (name, index) in &scope.bindings {
                     let binding = &self.ctx.bindings[*index];
 
@@ -4927,7 +4862,7 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            if self.settings.rules.enabled(&Rule::ImportStarUsage) {
+            if self.settings.rules.enabled(Rule::ImportStarUsage) {
                 if scope.import_starred {
                     if let Some((names, range)) = &all_names {
                         let mut from_list = vec![];
@@ -4996,7 +4931,7 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            if self.settings.rules.enabled(&Rule::UnusedImport) {
+            if self.settings.rules.enabled(Rule::UnusedImport) {
                 // Collect all unused imports by location. (Multiple unused imports at the same
                 // location indicates an `import from`.)
                 type UnusedImport<'a> = (&'a str, &'a Range);
@@ -5034,9 +4969,9 @@ impl<'a> Checker<'a> {
                         None
                     };
 
-                    if self.rule_is_ignored(&Rule::UnusedImport, diagnostic_lineno)
+                    if self.rule_is_ignored(Rule::UnusedImport, diagnostic_lineno)
                         || parent_lineno.map_or(false, |parent_lineno| {
-                            self.rule_is_ignored(&Rule::UnusedImport, parent_lineno)
+                            self.rule_is_ignored(Rule::UnusedImport, parent_lineno)
                         })
                     {
                         ignored
@@ -5060,7 +4995,7 @@ impl<'a> Checker<'a> {
                     let child: &Stmt = defined_by.into();
                     let parent: Option<&Stmt> = defined_in.map(Into::into);
 
-                    let fix = if !ignore_init && self.patch(&Rule::UnusedImport) {
+                    let fix = if !ignore_init && self.patch(Rule::UnusedImport) {
                         let deleted: Vec<&Stmt> = self.deletions.iter().map(Into::into).collect();
                         match autofix::helpers::remove_unused_imports(
                             unused_imports.iter().map(|(full_name, _)| *full_name),
@@ -5139,111 +5074,93 @@ impl<'a> Checker<'a> {
         let enforce_annotations = self
             .settings
             .rules
-            .enabled(&Rule::MissingTypeFunctionArgument)
-            || self.settings.rules.enabled(&Rule::MissingTypeArgs)
-            || self.settings.rules.enabled(&Rule::MissingTypeKwargs)
-            || self.settings.rules.enabled(&Rule::MissingTypeSelf)
-            || self.settings.rules.enabled(&Rule::MissingTypeCls)
+            .enabled(Rule::MissingTypeFunctionArgument)
+            || self.settings.rules.enabled(Rule::MissingTypeArgs)
+            || self.settings.rules.enabled(Rule::MissingTypeKwargs)
+            || self.settings.rules.enabled(Rule::MissingTypeSelf)
+            || self.settings.rules.enabled(Rule::MissingTypeCls)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MissingReturnTypePublicFunction)
+                .enabled(Rule::MissingReturnTypePublicFunction)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MissingReturnTypePrivateFunction)
+                .enabled(Rule::MissingReturnTypePrivateFunction)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MissingReturnTypeSpecialMethod)
+                .enabled(Rule::MissingReturnTypeSpecialMethod)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MissingReturnTypeStaticMethod)
+                .enabled(Rule::MissingReturnTypeStaticMethod)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MissingReturnTypeClassMethod)
-            || self.settings.rules.enabled(&Rule::AnyType);
-        let enforce_docstrings = self.settings.rules.enabled(&Rule::PublicModule)
-            || self.settings.rules.enabled(&Rule::PublicClass)
-            || self.settings.rules.enabled(&Rule::PublicMethod)
-            || self.settings.rules.enabled(&Rule::PublicFunction)
-            || self.settings.rules.enabled(&Rule::PublicPackage)
-            || self.settings.rules.enabled(&Rule::MagicMethod)
-            || self.settings.rules.enabled(&Rule::PublicNestedClass)
-            || self.settings.rules.enabled(&Rule::PublicInit)
-            || self.settings.rules.enabled(&Rule::FitsOnOneLine)
+                .enabled(Rule::MissingReturnTypeClassMethod)
+            || self.settings.rules.enabled(Rule::AnyType);
+        let enforce_docstrings = self.settings.rules.enabled(Rule::PublicModule)
+            || self.settings.rules.enabled(Rule::PublicClass)
+            || self.settings.rules.enabled(Rule::PublicMethod)
+            || self.settings.rules.enabled(Rule::PublicFunction)
+            || self.settings.rules.enabled(Rule::PublicPackage)
+            || self.settings.rules.enabled(Rule::MagicMethod)
+            || self.settings.rules.enabled(Rule::PublicNestedClass)
+            || self.settings.rules.enabled(Rule::PublicInit)
+            || self.settings.rules.enabled(Rule::FitsOnOneLine)
+            || self.settings.rules.enabled(Rule::NoBlankLineBeforeFunction)
+            || self.settings.rules.enabled(Rule::NoBlankLineAfterFunction)
+            || self.settings.rules.enabled(Rule::OneBlankLineBeforeClass)
+            || self.settings.rules.enabled(Rule::OneBlankLineAfterClass)
+            || self.settings.rules.enabled(Rule::BlankLineAfterSummary)
+            || self.settings.rules.enabled(Rule::IndentWithSpaces)
+            || self.settings.rules.enabled(Rule::NoUnderIndentation)
+            || self.settings.rules.enabled(Rule::NoOverIndentation)
+            || self.settings.rules.enabled(Rule::NewLineAfterLastParagraph)
+            || self.settings.rules.enabled(Rule::NoSurroundingWhitespace)
+            || self.settings.rules.enabled(Rule::NoBlankLineBeforeClass)
+            || self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::NoBlankLineBeforeFunction)
-            || self.settings.rules.enabled(&Rule::NoBlankLineAfterFunction)
-            || self.settings.rules.enabled(&Rule::OneBlankLineBeforeClass)
-            || self.settings.rules.enabled(&Rule::OneBlankLineAfterClass)
-            || self.settings.rules.enabled(&Rule::BlankLineAfterSummary)
-            || self.settings.rules.enabled(&Rule::IndentWithSpaces)
-            || self.settings.rules.enabled(&Rule::NoUnderIndentation)
-            || self.settings.rules.enabled(&Rule::NoOverIndentation)
+                .enabled(Rule::MultiLineSummarySecondLine)
+            || self.settings.rules.enabled(Rule::SectionNotOverIndented)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::NewLineAfterLastParagraph)
-            || self.settings.rules.enabled(&Rule::NoSurroundingWhitespace)
-            || self.settings.rules.enabled(&Rule::NoBlankLineBeforeClass)
+                .enabled(Rule::SectionUnderlineNotOverIndented)
+            || self.settings.rules.enabled(Rule::TripleSingleQuotes)
+            || self.settings.rules.enabled(Rule::EscapeSequenceInDocstring)
+            || self.settings.rules.enabled(Rule::EndsInPeriod)
+            || self.settings.rules.enabled(Rule::NonImperativeMood)
+            || self.settings.rules.enabled(Rule::NoSignature)
+            || self.settings.rules.enabled(Rule::FirstLineCapitalized)
+            || self.settings.rules.enabled(Rule::DocstringStartsWithThis)
+            || self.settings.rules.enabled(Rule::CapitalizeSectionName)
+            || self.settings.rules.enabled(Rule::NewLineAfterSectionName)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MultiLineSummaryFirstLine)
+                .enabled(Rule::DashedUnderlineAfterSection)
+            || self.settings.rules.enabled(Rule::SectionUnderlineAfterName)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::MultiLineSummarySecondLine)
-            || self.settings.rules.enabled(&Rule::SectionNotOverIndented)
+                .enabled(Rule::SectionUnderlineMatchesSectionLength)
+            || self.settings.rules.enabled(Rule::BlankLineAfterSection)
+            || self.settings.rules.enabled(Rule::BlankLineBeforeSection)
             || self
                 .settings
                 .rules
-                .enabled(&Rule::SectionUnderlineNotOverIndented)
-            || self.settings.rules.enabled(&Rule::TripleSingleQuotes)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::EscapeSequenceInDocstring)
-            || self.settings.rules.enabled(&Rule::EndsInPeriod)
-            || self.settings.rules.enabled(&Rule::NonImperativeMood)
-            || self.settings.rules.enabled(&Rule::NoSignature)
-            || self.settings.rules.enabled(&Rule::FirstLineCapitalized)
-            || self.settings.rules.enabled(&Rule::DocstringStartsWithThis)
-            || self.settings.rules.enabled(&Rule::CapitalizeSectionName)
-            || self.settings.rules.enabled(&Rule::NewLineAfterSectionName)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::DashedUnderlineAfterSection)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::SectionUnderlineAfterName)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::SectionUnderlineMatchesSectionLength)
-            || self.settings.rules.enabled(&Rule::BlankLineAfterSection)
-            || self.settings.rules.enabled(&Rule::BlankLineBeforeSection)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
-            || self
-                .settings
-                .rules
-                .enabled(&Rule::BlankLineAfterLastSection)
-            || self.settings.rules.enabled(&Rule::EmptyDocstringSection)
-            || self.settings.rules.enabled(&Rule::EndsInPunctuation)
-            || self.settings.rules.enabled(&Rule::SectionNameEndsInColon)
-            || self.settings.rules.enabled(&Rule::UndocumentedParam)
-            || self.settings.rules.enabled(&Rule::OverloadWithDocstring)
-            || self.settings.rules.enabled(&Rule::EmptyDocstring);
+                .enabled(Rule::NoBlankLinesBetweenHeaderAndContent)
+            || self.settings.rules.enabled(Rule::BlankLineAfterLastSection)
+            || self.settings.rules.enabled(Rule::EmptyDocstringSection)
+            || self.settings.rules.enabled(Rule::EndsInPunctuation)
+            || self.settings.rules.enabled(Rule::SectionNameEndsInColon)
+            || self.settings.rules.enabled(Rule::UndocumentedParam)
+            || self.settings.rules.enabled(Rule::OverloadWithDocstring)
+            || self.settings.rules.enabled(Rule::EmptyDocstring);
 
         let mut overloaded_name: Option<String> = None;
         self.deferred.definitions.reverse();
@@ -5277,7 +5194,7 @@ impl<'a> Checker<'a> {
                 overloaded_name = flake8_annotations::helpers::overloaded_name(self, &definition);
             }
             if self.is_stub {
-                if self.settings.rules.enabled(&Rule::DocstringInStub) {
+                if self.settings.rules.enabled(Rule::DocstringInStub) {
                     flake8_pyi::rules::docstring_in_stubs(self, definition.docstring);
                 }
             }
@@ -5318,124 +5235,101 @@ impl<'a> Checker<'a> {
                     continue;
                 }
 
-                if self.settings.rules.enabled(&Rule::FitsOnOneLine) {
+                if self.settings.rules.enabled(Rule::FitsOnOneLine) {
                     pydocstyle::rules::one_liner(self, &docstring);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::NoBlankLineBeforeFunction)
-                    || self.settings.rules.enabled(&Rule::NoBlankLineAfterFunction)
+                if self.settings.rules.enabled(Rule::NoBlankLineBeforeFunction)
+                    || self.settings.rules.enabled(Rule::NoBlankLineAfterFunction)
                 {
                     pydocstyle::rules::blank_before_after_function(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::OneBlankLineBeforeClass)
-                    || self.settings.rules.enabled(&Rule::OneBlankLineAfterClass)
-                    || self.settings.rules.enabled(&Rule::NoBlankLineBeforeClass)
+                if self.settings.rules.enabled(Rule::OneBlankLineBeforeClass)
+                    || self.settings.rules.enabled(Rule::OneBlankLineAfterClass)
+                    || self.settings.rules.enabled(Rule::NoBlankLineBeforeClass)
                 {
                     pydocstyle::rules::blank_before_after_class(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::BlankLineAfterSummary) {
+                if self.settings.rules.enabled(Rule::BlankLineAfterSummary) {
                     pydocstyle::rules::blank_after_summary(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::IndentWithSpaces)
-                    || self.settings.rules.enabled(&Rule::NoUnderIndentation)
-                    || self.settings.rules.enabled(&Rule::NoOverIndentation)
+                if self.settings.rules.enabled(Rule::IndentWithSpaces)
+                    || self.settings.rules.enabled(Rule::NoUnderIndentation)
+                    || self.settings.rules.enabled(Rule::NoOverIndentation)
                 {
                     pydocstyle::rules::indent(self, &docstring);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::NewLineAfterLastParagraph)
-                {
+                if self.settings.rules.enabled(Rule::NewLineAfterLastParagraph) {
                     pydocstyle::rules::newline_after_last_paragraph(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::NoSurroundingWhitespace) {
+                if self.settings.rules.enabled(Rule::NoSurroundingWhitespace) {
                     pydocstyle::rules::no_surrounding_whitespace(self, &docstring);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::MultiLineSummaryFirstLine)
+                if self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::MultiLineSummarySecondLine)
+                        .enabled(Rule::MultiLineSummarySecondLine)
                 {
                     pydocstyle::rules::multi_line_summary_start(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::TripleSingleQuotes) {
+                if self.settings.rules.enabled(Rule::TripleSingleQuotes) {
                     pydocstyle::rules::triple_quotes(self, &docstring);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::EscapeSequenceInDocstring)
-                {
+                if self.settings.rules.enabled(Rule::EscapeSequenceInDocstring) {
                     pydocstyle::rules::backslashes(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::EndsInPeriod) {
+                if self.settings.rules.enabled(Rule::EndsInPeriod) {
                     pydocstyle::rules::ends_with_period(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::NonImperativeMood) {
+                if self.settings.rules.enabled(Rule::NonImperativeMood) {
                     pydocstyle::rules::non_imperative_mood(
                         self,
                         &docstring,
                         &self.settings.pydocstyle.property_decorators,
                     );
                 }
-                if self.settings.rules.enabled(&Rule::NoSignature) {
+                if self.settings.rules.enabled(Rule::NoSignature) {
                     pydocstyle::rules::no_signature(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::FirstLineCapitalized) {
+                if self.settings.rules.enabled(Rule::FirstLineCapitalized) {
                     pydocstyle::rules::capitalized(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::DocstringStartsWithThis) {
+                if self.settings.rules.enabled(Rule::DocstringStartsWithThis) {
                     pydocstyle::rules::starts_with_this(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::EndsInPunctuation) {
+                if self.settings.rules.enabled(Rule::EndsInPunctuation) {
                     pydocstyle::rules::ends_with_punctuation(self, &docstring);
                 }
-                if self.settings.rules.enabled(&Rule::OverloadWithDocstring) {
+                if self.settings.rules.enabled(Rule::OverloadWithDocstring) {
                     pydocstyle::rules::if_needed(self, &docstring);
                 }
-                if self
-                    .settings
-                    .rules
-                    .enabled(&Rule::MultiLineSummaryFirstLine)
-                    || self.settings.rules.enabled(&Rule::SectionNotOverIndented)
+                if self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
+                    || self.settings.rules.enabled(Rule::SectionNotOverIndented)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::SectionUnderlineNotOverIndented)
-                    || self.settings.rules.enabled(&Rule::CapitalizeSectionName)
-                    || self.settings.rules.enabled(&Rule::NewLineAfterSectionName)
+                        .enabled(Rule::SectionUnderlineNotOverIndented)
+                    || self.settings.rules.enabled(Rule::CapitalizeSectionName)
+                    || self.settings.rules.enabled(Rule::NewLineAfterSectionName)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::DashedUnderlineAfterSection)
+                        .enabled(Rule::DashedUnderlineAfterSection)
+                    || self.settings.rules.enabled(Rule::SectionUnderlineAfterName)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::SectionUnderlineAfterName)
+                        .enabled(Rule::SectionUnderlineMatchesSectionLength)
+                    || self.settings.rules.enabled(Rule::BlankLineAfterSection)
+                    || self.settings.rules.enabled(Rule::BlankLineBeforeSection)
                     || self
                         .settings
                         .rules
-                        .enabled(&Rule::SectionUnderlineMatchesSectionLength)
-                    || self.settings.rules.enabled(&Rule::BlankLineAfterSection)
-                    || self.settings.rules.enabled(&Rule::BlankLineBeforeSection)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(&Rule::BlankLineAfterLastSection)
-                    || self.settings.rules.enabled(&Rule::EmptyDocstringSection)
-                    || self.settings.rules.enabled(&Rule::SectionNameEndsInColon)
-                    || self.settings.rules.enabled(&Rule::UndocumentedParam)
+                        .enabled(Rule::NoBlankLinesBetweenHeaderAndContent)
+                    || self.settings.rules.enabled(Rule::BlankLineAfterLastSection)
+                    || self.settings.rules.enabled(Rule::EmptyDocstringSection)
+                    || self.settings.rules.enabled(Rule::SectionNameEndsInColon)
+                    || self.settings.rules.enabled(Rule::UndocumentedParam)
                 {
                     pydocstyle::rules::sections(
                         self,
@@ -5449,11 +5343,7 @@ impl<'a> Checker<'a> {
 
     fn check_builtin_shadowing<T>(&mut self, name: &str, located: &Located<T>, is_attribute: bool) {
         if is_attribute && matches!(self.ctx.current_scope().kind, ScopeKind::Class(_)) {
-            if self
-                .settings
-                .rules
-                .enabled(&Rule::BuiltinAttributeShadowing)
-            {
+            if self.settings.rules.enabled(Rule::BuiltinAttributeShadowing) {
                 if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                     name,
                     located,
@@ -5464,7 +5354,7 @@ impl<'a> Checker<'a> {
                 }
             }
         } else {
-            if self.settings.rules.enabled(&Rule::BuiltinVariableShadowing) {
+            if self.settings.rules.enabled(Rule::BuiltinVariableShadowing) {
                 if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                     name,
                     located,
@@ -5478,7 +5368,7 @@ impl<'a> Checker<'a> {
     }
 
     fn check_builtin_arg_shadowing(&mut self, name: &str, arg: &Arg) {
-        if self.settings.rules.enabled(&Rule::BuiltinArgumentShadowing) {
+        if self.settings.rules.enabled(Rule::BuiltinArgumentShadowing) {
             if let Some(diagnostic) = flake8_builtins::rules::builtin_shadowing(
                 name,
                 arg,

--- a/crates/ruff/src/checkers/filesystem.rs
+++ b/crates/ruff/src/checkers/filesystem.rs
@@ -15,7 +15,7 @@ pub fn check_file_path(
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
     // flake8-no-pep420
-    if settings.rules.enabled(&Rule::ImplicitNamespacePackage) {
+    if settings.rules.enabled(Rule::ImplicitNamespacePackage) {
         if let Some(diagnostic) =
             implicit_namespace_package(path, package, &settings.project_root, &settings.src)
         {
@@ -24,7 +24,7 @@ pub fn check_file_path(
     }
 
     // pep8-naming
-    if settings.rules.enabled(&Rule::InvalidModuleName) {
+    if settings.rules.enabled(Rule::InvalidModuleName) {
         if let Some(diagnostic) = invalid_module_name(path, package) {
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -38,7 +38,7 @@ pub fn check_imports(
 
     // Enforce import rules.
     let mut diagnostics = vec![];
-    if settings.rules.enabled(&Rule::UnsortedImports) {
+    if settings.rules.enabled(Rule::UnsortedImports) {
         for block in &blocks {
             if !block.imports.is_empty() {
                 if let Some(diagnostic) = isort::rules::organize_imports(
@@ -49,7 +49,7 @@ pub fn check_imports(
             }
         }
     }
-    if settings.rules.enabled(&Rule::MissingRequiredImport) {
+    if settings.rules.enabled(Rule::MissingRequiredImport) {
         diagnostics.extend(isort::rules::add_required_imports(
             &blocks, python_ast, locator, stylist, settings, autofix,
         ));

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -166,7 +166,7 @@ pub fn check_logical_lines(
             }
 
             #[cfg(feature = "logical_lines")]
-            let should_fix = autofix.into() && settings.rules.should_fix(&Rule::MissingWhitespace);
+            let should_fix = autofix.into() && settings.rules.should_fix(Rule::MissingWhitespace);
 
             #[cfg(not(feature = "logical_lines"))]
             let should_fix = false;
@@ -181,7 +181,7 @@ pub fn check_logical_lines(
         if line.flags.contains(TokenFlags::BRACKET) {
             #[cfg(feature = "logical_lines")]
             let should_fix =
-                autofix.into() && settings.rules.should_fix(&Rule::WhitespaceBeforeParameters);
+                autofix.into() && settings.rules.should_fix(Rule::WhitespaceBeforeParameters);
 
             #[cfg(not(feature = "logical_lines"))]
             let should_fix = false;

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -24,7 +24,7 @@ pub fn check_noqa(
     settings: &Settings,
     autofix: flags::Autofix,
 ) -> Vec<usize> {
-    let enforce_noqa = settings.rules.enabled(&Rule::UnusedNOQA);
+    let enforce_noqa = settings.rules.enabled(Rule::UnusedNOQA);
 
     // Whether the file is exempted from all checks.
     let mut file_exempted = false;
@@ -188,7 +188,7 @@ pub fn check_noqa(
                             valid_codes.push(code);
                         } else {
                             if let Ok(rule) = Rule::from_code(code) {
-                                if settings.rules.enabled(&rule) {
+                                if settings.rules.enabled(rule) {
                                     unmatched_codes.push(code);
                                 } else {
                                     disabled_codes.push(code);

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -32,28 +32,28 @@ pub fn check_physical_lines(
     let mut diagnostics: Vec<Diagnostic> = vec![];
     let mut has_any_shebang = false;
 
-    let enforce_blanket_noqa = settings.rules.enabled(&Rule::BlanketNOQA);
-    let enforce_shebang_not_executable = settings.rules.enabled(&Rule::ShebangNotExecutable);
-    let enforce_shebang_missing = settings.rules.enabled(&Rule::ShebangMissingExecutableFile);
-    let enforce_shebang_whitespace = settings.rules.enabled(&Rule::ShebangWhitespace);
-    let enforce_shebang_newline = settings.rules.enabled(&Rule::ShebangNewline);
-    let enforce_shebang_python = settings.rules.enabled(&Rule::ShebangPython);
-    let enforce_blanket_type_ignore = settings.rules.enabled(&Rule::BlanketTypeIgnore);
-    let enforce_doc_line_too_long = settings.rules.enabled(&Rule::DocLineTooLong);
-    let enforce_line_too_long = settings.rules.enabled(&Rule::LineTooLong);
-    let enforce_no_newline_at_end_of_file = settings.rules.enabled(&Rule::NoNewLineAtEndOfFile);
-    let enforce_unnecessary_coding_comment = settings.rules.enabled(&Rule::UTF8EncodingDeclaration);
-    let enforce_mixed_spaces_and_tabs = settings.rules.enabled(&Rule::MixedSpacesAndTabs);
-    let enforce_bidirectional_unicode = settings.rules.enabled(&Rule::BidirectionalUnicode);
-    let enforce_trailing_whitespace = settings.rules.enabled(&Rule::TrailingWhitespace);
+    let enforce_blanket_noqa = settings.rules.enabled(Rule::BlanketNOQA);
+    let enforce_shebang_not_executable = settings.rules.enabled(Rule::ShebangNotExecutable);
+    let enforce_shebang_missing = settings.rules.enabled(Rule::ShebangMissingExecutableFile);
+    let enforce_shebang_whitespace = settings.rules.enabled(Rule::ShebangWhitespace);
+    let enforce_shebang_newline = settings.rules.enabled(Rule::ShebangNewline);
+    let enforce_shebang_python = settings.rules.enabled(Rule::ShebangPython);
+    let enforce_blanket_type_ignore = settings.rules.enabled(Rule::BlanketTypeIgnore);
+    let enforce_doc_line_too_long = settings.rules.enabled(Rule::DocLineTooLong);
+    let enforce_line_too_long = settings.rules.enabled(Rule::LineTooLong);
+    let enforce_no_newline_at_end_of_file = settings.rules.enabled(Rule::NoNewLineAtEndOfFile);
+    let enforce_unnecessary_coding_comment = settings.rules.enabled(Rule::UTF8EncodingDeclaration);
+    let enforce_mixed_spaces_and_tabs = settings.rules.enabled(Rule::MixedSpacesAndTabs);
+    let enforce_bidirectional_unicode = settings.rules.enabled(Rule::BidirectionalUnicode);
+    let enforce_trailing_whitespace = settings.rules.enabled(Rule::TrailingWhitespace);
     let enforce_blank_line_contains_whitespace =
-        settings.rules.enabled(&Rule::BlankLineContainsWhitespace);
-    let enforce_indentation_contains_tabs = settings.rules.enabled(&Rule::IndentationContainsTabs);
+        settings.rules.enabled(Rule::BlankLineContainsWhitespace);
+    let enforce_indentation_contains_tabs = settings.rules.enabled(Rule::IndentationContainsTabs);
 
     let fix_unnecessary_coding_comment =
-        autofix.into() && settings.rules.should_fix(&Rule::UTF8EncodingDeclaration);
+        autofix.into() && settings.rules.should_fix(Rule::UTF8EncodingDeclaration);
     let fix_shebang_whitespace =
-        autofix.into() && settings.rules.should_fix(&Rule::ShebangWhitespace);
+        autofix.into() && settings.rules.should_fix(Rule::ShebangWhitespace);
 
     let mut commented_lines_iter = commented_lines.iter().peekable();
     let mut doc_lines_iter = doc_lines.iter().peekable();
@@ -165,7 +165,7 @@ pub fn check_physical_lines(
         if let Some(diagnostic) = no_newline_at_end_of_file(
             locator,
             stylist,
-            autofix.into() && settings.rules.should_fix(&Rule::NoNewLineAtEndOfFile),
+            autofix.into() && settings.rules.should_fix(Rule::NoNewLineAtEndOfFile),
         ) {
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -25,39 +25,39 @@ pub fn check_tokens(
 
     let enforce_ambiguous_unicode_character = settings
         .rules
-        .enabled(&Rule::AmbiguousUnicodeCharacterString)
+        .enabled(Rule::AmbiguousUnicodeCharacterString)
         || settings
             .rules
-            .enabled(&Rule::AmbiguousUnicodeCharacterDocstring)
+            .enabled(Rule::AmbiguousUnicodeCharacterDocstring)
         || settings
             .rules
-            .enabled(&Rule::AmbiguousUnicodeCharacterComment);
-    let enforce_quotes = settings.rules.enabled(&Rule::BadQuotesInlineString)
-        || settings.rules.enabled(&Rule::BadQuotesMultilineString)
-        || settings.rules.enabled(&Rule::BadQuotesDocstring)
-        || settings.rules.enabled(&Rule::AvoidableEscapedQuote);
-    let enforce_commented_out_code = settings.rules.enabled(&Rule::CommentedOutCode);
+            .enabled(Rule::AmbiguousUnicodeCharacterComment);
+    let enforce_quotes = settings.rules.enabled(Rule::BadQuotesInlineString)
+        || settings.rules.enabled(Rule::BadQuotesMultilineString)
+        || settings.rules.enabled(Rule::BadQuotesDocstring)
+        || settings.rules.enabled(Rule::AvoidableEscapedQuote);
+    let enforce_commented_out_code = settings.rules.enabled(Rule::CommentedOutCode);
     let enforce_compound_statements = settings
         .rules
-        .enabled(&Rule::MultipleStatementsOnOneLineColon)
+        .enabled(Rule::MultipleStatementsOnOneLineColon)
         || settings
             .rules
-            .enabled(&Rule::MultipleStatementsOnOneLineSemicolon)
-        || settings.rules.enabled(&Rule::UselessSemicolon);
-    let enforce_invalid_escape_sequence = settings.rules.enabled(&Rule::InvalidEscapeSequence);
+            .enabled(Rule::MultipleStatementsOnOneLineSemicolon)
+        || settings.rules.enabled(Rule::UselessSemicolon);
+    let enforce_invalid_escape_sequence = settings.rules.enabled(Rule::InvalidEscapeSequence);
     let enforce_implicit_string_concatenation = settings
         .rules
-        .enabled(&Rule::SingleLineImplicitStringConcatenation)
+        .enabled(Rule::SingleLineImplicitStringConcatenation)
         || settings
             .rules
-            .enabled(&Rule::MultiLineImplicitStringConcatenation);
-    let enforce_trailing_comma = settings.rules.enabled(&Rule::TrailingCommaMissing)
+            .enabled(Rule::MultiLineImplicitStringConcatenation);
+    let enforce_trailing_comma = settings.rules.enabled(Rule::TrailingCommaMissing)
         || settings
             .rules
-            .enabled(&Rule::TrailingCommaOnBareTupleProhibited)
-        || settings.rules.enabled(&Rule::TrailingCommaProhibited);
-    let enforce_extraneous_parenthesis = settings.rules.enabled(&Rule::ExtraneousParentheses);
-    let enforce_type_comment_in_stub = settings.rules.enabled(&Rule::TypeCommentInStub);
+            .enabled(Rule::TrailingCommaOnBareTupleProhibited)
+        || settings.rules.enabled(Rule::TrailingCommaProhibited);
+    let enforce_extraneous_parenthesis = settings.rules.enabled(Rule::ExtraneousParentheses);
+    let enforce_type_comment_in_stub = settings.rules.enabled(Rule::TypeCommentInStub);
 
     // RUF001, RUF002, RUF003
     if enforce_ambiguous_unicode_character {
@@ -111,7 +111,7 @@ pub fn check_tokens(
                     locator,
                     *start,
                     *end,
-                    autofix.into() && settings.rules.should_fix(&Rule::InvalidEscapeSequence),
+                    autofix.into() && settings.rules.should_fix(Rule::InvalidEscapeSequence),
                 ));
             }
         }

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -50,7 +50,7 @@ impl<T> LinterResult<T> {
     }
 }
 
-pub type FixTable = FxHashMap<&'static Rule, usize>;
+pub type FixTable = FxHashMap<Rule, usize>;
 
 /// Generate `Diagnostic`s from the source code contents at the
 /// given `Path`.
@@ -74,7 +74,7 @@ pub fn check_path(
 
     // Collect doc lines. This requires a rare mix of tokens (for comments) and AST
     // (for docstrings), which demands special-casing at this level.
-    let use_doc_lines = settings.rules.enabled(&Rule::DocLineTooLong);
+    let use_doc_lines = settings.rules.enabled(Rule::DocLineTooLong);
     let mut doc_lines = vec![];
     if use_doc_lines {
         doc_lines.extend(doc_lines_from_tokens(&tokens));
@@ -159,14 +159,14 @@ pub fn check_path(
                 }
             }
             Err(parse_error) => {
-                if settings.rules.enabled(&Rule::SyntaxError) {
+                if settings.rules.enabled(Rule::SyntaxError) {
                     pycodestyle::rules::syntax_error(&mut diagnostics, &parse_error);
                 }
 
                 // If the syntax error is ignored, suppress it (regardless of whether
                 // `Rule::SyntaxError` is enabled).
                 if !rule_is_ignored(
-                    &Rule::SyntaxError,
+                    Rule::SyntaxError,
                     parse_error.location.row(),
                     &directives.noqa_line_for,
                     locator,
@@ -204,7 +204,7 @@ pub fn check_path(
     if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
         let ignores = fs::ignores_from_path(path, &settings.per_file_ignores);
         if !ignores.is_empty() {
-            diagnostics.retain(|diagnostic| !ignores.contains(diagnostic.kind.rule()));
+            diagnostics.retain(|diagnostic| !ignores.contains(&diagnostic.kind.rule()));
         }
     };
 

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -121,7 +121,7 @@ pub fn extract_noqa_directive(line: &str) -> Directive {
 
 /// Returns `true` if the string list of `codes` includes `code` (or an alias
 /// thereof).
-pub fn includes(needle: &Rule, haystack: &[&str]) -> bool {
+pub fn includes(needle: Rule, haystack: &[&str]) -> bool {
     let needle = needle.noqa_code();
     haystack
         .iter()
@@ -130,7 +130,7 @@ pub fn includes(needle: &Rule, haystack: &[&str]) -> bool {
 
 /// Returns `true` if the given [`Rule`] is ignored at the specified `lineno`.
 pub fn rule_is_ignored(
-    code: &Rule,
+    code: Rule,
     lineno: usize,
     noqa_line_for: &IntMap<usize, usize>,
     locator: &Locator,
@@ -174,7 +174,7 @@ fn add_noqa_inner(
     line_ending: &LineEnding,
 ) -> (usize, String) {
     // Map of line number to set of (non-ignored) diagnostic codes that are triggered on that line.
-    let mut matches_by_line: FxHashMap<usize, FxHashSet<&Rule>> = FxHashMap::default();
+    let mut matches_by_line: FxHashMap<usize, FxHashSet<Rule>> = FxHashMap::default();
 
     // Whether the file is exempted from all checks.
     let mut file_exempted = false;
@@ -280,7 +280,7 @@ fn add_noqa_inner(
                         output.push_str("  # noqa: ");
 
                         // Add codes.
-                        push_codes(&mut output, rules.iter().map(|r| r.noqa_code()));
+                        push_codes(&mut output, rules.iter().map(Rule::noqa_code));
                         output.push_str(line_ending);
                         count += 1;
                     }

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -610,6 +610,10 @@ ruff_macros::register_rules!(
     rules::flake8_django::rules::NonLeadingReceiverDecorator,
 );
 
+pub trait AsRule {
+    fn rule(&self) -> Rule;
+}
+
 impl Rule {
     pub fn from_code(code: &str) -> Result<Self, FromCodeError> {
         let (linter, code) = Linter::parse_code(code).ok_or(FromCodeError::Unknown)?;
@@ -916,6 +920,7 @@ pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 2] = &[
 
 #[cfg(test)]
 mod tests {
+    use std::mem::size_of;
     use strum::IntoEnumIterator;
 
     use super::{Linter, Rule, RuleNamespace};
@@ -960,5 +965,10 @@ mod tests {
                 Linter::parse_code(&code).unwrap_or_else(|| panic!("couldn't parse {code:?}"));
             assert_eq!(code, format!("{}{rest}", linter.common_prefix()));
         }
+    }
+
+    #[test]
+    fn rule_size() {
+        assert_eq!(2, size_of::<Rule>());
     }
 }

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -61,7 +61,7 @@ pub fn commented_out_code(
     // Verify that the comment is on its own line, and that it contains code.
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, Range::new(start, end));
-        if autofix.into() && settings.rules.should_fix(&Rule::CommentedOutCode) {
+        if autofix.into() && settings.rules.should_fix(Rule::CommentedOutCode) {
             diagnostic.amend(Fix::deletion(location, end_location));
         }
         Some(diagnostic)

--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -140,7 +140,7 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                         && checker
                             .settings
                             .rules
-                            .enabled(&Rule::SysVersionSlice1Referenced)
+                            .enabled(Rule::SysVersionSlice1Referenced)
                     {
                         checker.diagnostics.push(Diagnostic::new(
                             SysVersionSlice1Referenced,
@@ -150,7 +150,7 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                         && checker
                             .settings
                             .rules
-                            .enabled(&Rule::SysVersionSlice3Referenced)
+                            .enabled(Rule::SysVersionSlice3Referenced)
                     {
                         checker.diagnostics.push(Diagnostic::new(
                             SysVersionSlice3Referenced,
@@ -165,13 +165,13 @@ pub fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                 ..
             } => {
                 if *i == BigInt::from(2)
-                    && checker.settings.rules.enabled(&Rule::SysVersion2Referenced)
+                    && checker.settings.rules.enabled(Rule::SysVersion2Referenced)
                 {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersion2Referenced, Range::from(value)));
                 } else if *i == BigInt::from(0)
-                    && checker.settings.rules.enabled(&Rule::SysVersion0Referenced)
+                    && checker.settings.rules.enabled(Rule::SysVersion0Referenced)
                 {
                     checker
                         .diagnostics
@@ -210,7 +210,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                             && checker
                                 .settings
                                 .rules
-                                .enabled(&Rule::SysVersionInfo0Eq3Referenced)
+                                .enabled(Rule::SysVersionInfo0Eq3Referenced)
                         {
                             checker.diagnostics.push(Diagnostic::new(
                                 SysVersionInfo0Eq3Referenced,
@@ -231,7 +231,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                         }],
                     ) = (ops, comparators)
                     {
-                        if checker.settings.rules.enabled(&Rule::SysVersionInfo1CmpInt) {
+                        if checker.settings.rules.enabled(Rule::SysVersionInfo1CmpInt) {
                             checker
                                 .diagnostics
                                 .push(Diagnostic::new(SysVersionInfo1CmpInt, Range::from(left)));
@@ -259,7 +259,7 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::SysVersionInfoMinorCmpInt)
+                    .enabled(Rule::SysVersionInfoMinorCmpInt)
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         SysVersionInfoMinorCmpInt,
@@ -286,12 +286,12 @@ pub fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], comparators: &
         ) = (ops, comparators)
         {
             if s.len() == 1 {
-                if checker.settings.rules.enabled(&Rule::SysVersionCmpStr10) {
+                if checker.settings.rules.enabled(Rule::SysVersionCmpStr10) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersionCmpStr10, Range::from(left)));
                 }
-            } else if checker.settings.rules.enabled(&Rule::SysVersionCmpStr3) {
+            } else if checker.settings.rules.enabled(Rule::SysVersionCmpStr3) {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(SysVersionCmpStr3, Range::from(left)));

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -492,7 +492,7 @@ pub fn definition(
             // ANN401 for dynamically typed arguments
             if let Some(annotation) = &arg.node.annotation {
                 has_any_typed_arg = true;
-                if checker.settings.rules.enabled(&Rule::AnyType) {
+                if checker.settings.rules.enabled(Rule::AnyType) {
                     check_dynamically_typed(
                         checker,
                         annotation,
@@ -507,7 +507,7 @@ pub fn definition(
                     if checker
                         .settings
                         .rules
-                        .enabled(&Rule::MissingTypeFunctionArgument)
+                        .enabled(Rule::MissingTypeFunctionArgument)
                     {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeFunctionArgument {
@@ -525,7 +525,7 @@ pub fn definition(
             if let Some(expr) = &arg.node.annotation {
                 has_any_typed_arg = true;
                 if !checker.settings.flake8_annotations.allow_star_arg_any {
-                    if checker.settings.rules.enabled(&Rule::AnyType) {
+                    if checker.settings.rules.enabled(Rule::AnyType) {
                         let name = &arg.node.arg;
                         check_dynamically_typed(
                             checker,
@@ -539,7 +539,7 @@ pub fn definition(
                 if !(checker.settings.flake8_annotations.suppress_dummy_args
                     && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                 {
-                    if checker.settings.rules.enabled(&Rule::MissingTypeArgs) {
+                    if checker.settings.rules.enabled(Rule::MissingTypeArgs) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeArgs {
                                 name: arg.node.arg.to_string(),
@@ -556,7 +556,7 @@ pub fn definition(
             if let Some(expr) = &arg.node.annotation {
                 has_any_typed_arg = true;
                 if !checker.settings.flake8_annotations.allow_star_arg_any {
-                    if checker.settings.rules.enabled(&Rule::AnyType) {
+                    if checker.settings.rules.enabled(Rule::AnyType) {
                         let name = &arg.node.arg;
                         check_dynamically_typed(
                             checker,
@@ -570,7 +570,7 @@ pub fn definition(
                 if !(checker.settings.flake8_annotations.suppress_dummy_args
                     && checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
                 {
-                    if checker.settings.rules.enabled(&Rule::MissingTypeKwargs) {
+                    if checker.settings.rules.enabled(Rule::MissingTypeKwargs) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeKwargs {
                                 name: arg.node.arg.to_string(),
@@ -587,7 +587,7 @@ pub fn definition(
             if let Some(arg) = args.posonlyargs.first().or_else(|| args.args.first()) {
                 if arg.node.annotation.is_none() {
                     if visibility::is_classmethod(&checker.ctx, cast::decorator_list(stmt)) {
-                        if checker.settings.rules.enabled(&Rule::MissingTypeCls) {
+                        if checker.settings.rules.enabled(Rule::MissingTypeCls) {
                             diagnostics.push(Diagnostic::new(
                                 MissingTypeCls {
                                     name: arg.node.arg.to_string(),
@@ -596,7 +596,7 @@ pub fn definition(
                             ));
                         }
                     } else {
-                        if checker.settings.rules.enabled(&Rule::MissingTypeSelf) {
+                        if checker.settings.rules.enabled(Rule::MissingTypeSelf) {
                             diagnostics.push(Diagnostic::new(
                                 MissingTypeSelf {
                                     name: arg.node.arg.to_string(),
@@ -614,7 +614,7 @@ pub fn definition(
         // ANN201, ANN202, ANN401
         if let Some(expr) = &returns {
             has_typed_return = true;
-            if checker.settings.rules.enabled(&Rule::AnyType) {
+            if checker.settings.rules.enabled(Rule::AnyType) {
                 check_dynamically_typed(checker, expr, || name.to_string(), &mut diagnostics);
             }
         } else if !(
@@ -626,7 +626,7 @@ pub fn definition(
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::MissingReturnTypeClassMethod)
+                    .enabled(Rule::MissingReturnTypeClassMethod)
                 {
                     diagnostics.push(Diagnostic::new(
                         MissingReturnTypeClassMethod {
@@ -641,7 +641,7 @@ pub fn definition(
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::MissingReturnTypeStaticMethod)
+                    .enabled(Rule::MissingReturnTypeStaticMethod)
                 {
                     diagnostics.push(Diagnostic::new(
                         MissingReturnTypeStaticMethod {
@@ -656,7 +656,7 @@ pub fn definition(
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::MissingReturnTypeSpecialMethod)
+                    .enabled(Rule::MissingReturnTypeSpecialMethod)
                 {
                     if !(checker.settings.flake8_annotations.mypy_init_return && has_any_typed_arg)
                     {
@@ -681,7 +681,7 @@ pub fn definition(
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::MissingReturnTypeSpecialMethod)
+                    .enabled(Rule::MissingReturnTypeSpecialMethod)
                 {
                     diagnostics.push(Diagnostic::new(
                         MissingReturnTypeSpecialMethod {
@@ -696,7 +696,7 @@ pub fn definition(
                         if checker
                             .settings
                             .rules
-                            .enabled(&Rule::MissingReturnTypePublicFunction)
+                            .enabled(Rule::MissingReturnTypePublicFunction)
                         {
                             diagnostics.push(Diagnostic::new(
                                 MissingReturnTypePublicFunction {
@@ -710,7 +710,7 @@ pub fn definition(
                         if checker
                             .settings
                             .rules
-                            .enabled(&Rule::MissingReturnTypePrivateFunction)
+                            .enabled(Rule::MissingReturnTypePrivateFunction)
                         {
                             diagnostics.push(Diagnostic::new(
                                 MissingReturnTypePrivateFunction {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -115,7 +115,7 @@ pub fn abstract_base_class(
         if !checker
             .settings
             .rules
-            .enabled(&Rule::EmptyMethodWithoutAbstractDecorator)
+            .enabled(Rule::EmptyMethodWithoutAbstractDecorator)
         {
             continue;
         }
@@ -135,7 +135,7 @@ pub fn abstract_base_class(
     if checker
         .settings
         .rules
-        .enabled(&Rule::AbstractBaseClassWithoutAbstractMethod)
+        .enabled(Rule::AbstractBaseClassWithoutAbstractMethod)
     {
         if !has_abstract_method {
             checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -83,7 +83,7 @@ fn duplicate_handler_exceptions<'a>(
     if checker
         .settings
         .rules
-        .enabled(&Rule::DuplicateHandlerException)
+        .enabled(Rule::DuplicateHandlerException)
     {
         // TODO(charlie): Handle "BaseException" and redundant exception aliases.
         if !duplicates.is_empty() {
@@ -149,7 +149,7 @@ pub fn duplicate_exceptions(checker: &mut Checker, handlers: &[Excepthandler]) {
     if checker
         .settings
         .rules
-        .enabled(&Rule::DuplicateTryBlockException)
+        .enabled(Rule::DuplicateTryBlockException)
     {
         for (name, exprs) in duplicates {
             for expr in exprs {

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -260,7 +260,7 @@ pub fn trailing_commas(
                     end_location: comma.2,
                 },
             );
-            if autofix.into() && settings.rules.should_fix(&Rule::TrailingCommaProhibited) {
+            if autofix.into() && settings.rules.should_fix(Rule::TrailingCommaProhibited) {
                 diagnostic.amend(Fix::deletion(comma.0, comma.2));
             }
             diagnostics.push(diagnostic);
@@ -304,7 +304,7 @@ pub fn trailing_commas(
                     end_location: missing_comma.2,
                 },
             );
-            if autofix.into() && settings.rules.should_fix(&Rule::TrailingCommaMissing) {
+            if autofix.into() && settings.rules.should_fix(Rule::TrailingCommaMissing) {
                 // Create a replacement that includes the final bracket (or other token),
                 // rather than just inserting a comma at the end. This prevents the UP034 autofix
                 // removing any brackets in the same linter pass - doing both at the same time could

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -162,7 +162,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                     value: Constant::Str(string),
                     ..
                 } => {
-                    if checker.settings.rules.enabled(&Rule::RawStringInException) {
+                    if checker.settings.rules.enabled(Rule::RawStringInException) {
                         if string.len() > checker.settings.flake8_errmsg.max_string_length {
                             checker
                                 .diagnostics
@@ -172,7 +172,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                 }
                 // Check for f-strings
                 ExprKind::JoinedStr { .. } => {
-                    if checker.settings.rules.enabled(&Rule::FStringInException) {
+                    if checker.settings.rules.enabled(Rule::FStringInException) {
                         checker
                             .diagnostics
                             .push(Diagnostic::new(FStringInException, Range::from(first)));
@@ -180,7 +180,7 @@ pub fn string_in_exception(checker: &mut Checker, exc: &Expr) {
                 }
                 // Check for .format() calls
                 ExprKind::Call { func, .. } => {
-                    if checker.settings.rules.enabled(&Rule::DotFormatInException) {
+                    if checker.settings.rules.enabled(Rule::DotFormatInException) {
                         if let ExprKind::Attribute { value, attr, .. } = &func.node {
                             if attr == "format" && matches!(value.node, ExprKind::Constant { .. }) {
                                 checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -43,14 +43,14 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         // Check for string concatenation and percent format.
         ExprKind::BinOp { op, .. } => match op {
             Operator::Add => {
-                if checker.settings.rules.enabled(&Rule::LoggingStringConcat) {
+                if checker.settings.rules.enabled(Rule::LoggingStringConcat) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(LoggingStringConcat, Range::from(msg)));
                 }
             }
             Operator::Mod => {
-                if checker.settings.rules.enabled(&Rule::LoggingPercentFormat) {
+                if checker.settings.rules.enabled(Rule::LoggingPercentFormat) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(LoggingPercentFormat, Range::from(msg)));
@@ -60,7 +60,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         },
         // Check for f-strings.
         ExprKind::JoinedStr { .. } => {
-            if checker.settings.rules.enabled(&Rule::LoggingFString) {
+            if checker.settings.rules.enabled(Rule::LoggingFString) {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(LoggingFString, Range::from(msg)));
@@ -68,7 +68,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         }
         // Check for .format() calls.
         ExprKind::Call { func, .. } => {
-            if checker.settings.rules.enabled(&Rule::LoggingStringFormat) {
+            if checker.settings.rules.enabled(Rule::LoggingStringFormat) {
                 if let ExprKind::Attribute { value, attr, .. } = &func.node {
                     if attr == "format" && matches!(value.node, ExprKind::Constant { .. }) {
                         checker
@@ -151,7 +151,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             }
 
             // G010
-            if checker.settings.rules.enabled(&Rule::LoggingWarn)
+            if checker.settings.rules.enabled(Rule::LoggingWarn)
                 && matches!(logging_level, LoggingLevel::Warn)
             {
                 let mut diagnostic = Diagnostic::new(LoggingWarn, level_call_range);
@@ -166,18 +166,18 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             }
 
             // G101
-            if checker.settings.rules.enabled(&Rule::LoggingExtraAttrClash) {
+            if checker.settings.rules.enabled(Rule::LoggingExtraAttrClash) {
                 if let Some(extra) = find_keyword(keywords, "extra") {
                     check_log_record_attr_clash(checker, extra);
                 }
             }
 
             // G201, G202
-            if checker.settings.rules.enabled(&Rule::LoggingExcInfo)
+            if checker.settings.rules.enabled(Rule::LoggingExcInfo)
                 || checker
                     .settings
                     .rules
-                    .enabled(&Rule::LoggingRedundantExcInfo)
+                    .enabled(Rule::LoggingRedundantExcInfo)
             {
                 if !checker.ctx.in_exception_handler() {
                     return;
@@ -206,7 +206,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
 
                     match logging_level {
                         LoggingLevel::Error => {
-                            if checker.settings.rules.enabled(&Rule::LoggingExcInfo) {
+                            if checker.settings.rules.enabled(Rule::LoggingExcInfo) {
                                 checker
                                     .diagnostics
                                     .push(Diagnostic::new(LoggingExcInfo, level_call_range));
@@ -216,7 +216,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
                             if checker
                                 .settings
                                 .rules
-                                .enabled(&Rule::LoggingRedundantExcInfo)
+                                .enabled(Rule::LoggingRedundantExcInfo)
                             {
                                 checker.diagnostics.push(Diagnostic::new(
                                     LoggingRedundantExcInfo,

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -118,7 +118,7 @@ pub fn unrecognized_platform(
         && checker
             .settings
             .rules
-            .enabled(&Rule::UnrecognizedPlatformCheck)
+            .enabled(Rule::UnrecognizedPlatformCheck)
     {
         checker
             .diagnostics
@@ -137,7 +137,7 @@ pub fn unrecognized_platform(
                 && checker
                     .settings
                     .rules
-                    .enabled(&Rule::UnrecognizedPlatformName)
+                    .enabled(Rule::UnrecognizedPlatformName)
             {
                 checker.diagnostics.push(Diagnostic::new(
                     UnrecognizedPlatformName {
@@ -151,7 +151,7 @@ pub fn unrecognized_platform(
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::UnrecognizedPlatformCheck)
+                .enabled(Rule::UnrecognizedPlatformCheck)
             {
                 checker
                     .diagnostics

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -277,7 +277,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::IncorrectFixtureParenthesesStyle)
+                .enabled(Rule::IncorrectFixtureParenthesesStyle)
                 && !checker.settings.flake8_pytest_style.fixture_parentheses
                 && args.is_empty()
                 && keywords.is_empty()
@@ -287,7 +287,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 pytest_fixture_parentheses(checker, decorator, fix, "", "()");
             }
 
-            if checker.settings.rules.enabled(&Rule::FixturePositionalArgs) && !args.is_empty() {
+            if checker.settings.rules.enabled(Rule::FixturePositionalArgs) && !args.is_empty() {
                 checker.diagnostics.push(Diagnostic::new(
                     FixturePositionalArgs {
                         function: func_name.to_string(),
@@ -299,7 +299,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::ExtraneousScopeFunction)
+                .enabled(Rule::ExtraneousScopeFunction)
             {
                 let scope_keyword = keywords
                     .iter()
@@ -333,7 +333,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::IncorrectFixtureParenthesesStyle)
+                .enabled(Rule::IncorrectFixtureParenthesesStyle)
                 && checker.settings.flake8_pytest_style.fixture_parentheses
             {
                 let fix = Fix::insertion("()".to_string(), decorator.end_location.unwrap());
@@ -354,7 +354,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
     if checker
         .settings
         .rules
-        .enabled(&Rule::IncorrectFixtureNameUnderscore)
+        .enabled(Rule::IncorrectFixtureNameUnderscore)
         && visitor.has_return_with_value
         && func_name.starts_with('_')
     {
@@ -367,7 +367,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
     } else if checker
         .settings
         .rules
-        .enabled(&Rule::MissingFixtureNameUnderscore)
+        .enabled(Rule::MissingFixtureNameUnderscore)
         && !visitor.has_return_with_value
         && !visitor.has_yield_from
         && !func_name.starts_with('_')
@@ -380,7 +380,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
         ));
     }
 
-    if checker.settings.rules.enabled(&Rule::UselessYieldFixture) {
+    if checker.settings.rules.enabled(Rule::UselessYieldFixture) {
         if let Some(stmt) = body.last() {
             if let StmtKind::Expr { value, .. } = &stmt.node {
                 if let ExprKind::Yield { .. } = value.node {
@@ -462,7 +462,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
         if checker
             .settings
             .rules
-            .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+            .enabled(Rule::UnnecessaryAsyncioMarkOnFixture)
         {
             if name == "asyncio" {
                 let mut diagnostic =
@@ -479,7 +479,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
         if checker
             .settings
             .rules
-            .enabled(&Rule::ErroneousUseFixturesOnFixture)
+            .enabled(Rule::ErroneousUseFixturesOnFixture)
         {
             if name == "usefixtures" {
                 let mut diagnostic =
@@ -508,20 +508,17 @@ pub fn fixture(
         if checker
             .settings
             .rules
-            .enabled(&Rule::IncorrectFixtureParenthesesStyle)
-            || checker.settings.rules.enabled(&Rule::FixturePositionalArgs)
+            .enabled(Rule::IncorrectFixtureParenthesesStyle)
+            || checker.settings.rules.enabled(Rule::FixturePositionalArgs)
             || checker
                 .settings
                 .rules
-                .enabled(&Rule::ExtraneousScopeFunction)
+                .enabled(Rule::ExtraneousScopeFunction)
         {
             check_fixture_decorator(checker, func_name, decorator);
         }
 
-        if checker
-            .settings
-            .rules
-            .enabled(&Rule::DeprecatedYieldFixture)
+        if checker.settings.rules.enabled(Rule::DeprecatedYieldFixture)
             && checker.settings.flake8_pytest_style.fixture_parentheses
         {
             check_fixture_decorator_name(checker, decorator);
@@ -530,12 +527,12 @@ pub fn fixture(
         if (checker
             .settings
             .rules
-            .enabled(&Rule::MissingFixtureNameUnderscore)
+            .enabled(Rule::MissingFixtureNameUnderscore)
             || checker
                 .settings
                 .rules
-                .enabled(&Rule::IncorrectFixtureNameUnderscore)
-            || checker.settings.rules.enabled(&Rule::UselessYieldFixture))
+                .enabled(Rule::IncorrectFixtureNameUnderscore)
+            || checker.settings.rules.enabled(Rule::UselessYieldFixture))
             && !has_abstractmethod_decorator(decorators, checker)
         {
             check_fixture_returns(checker, func, func_name, body);
@@ -544,7 +541,7 @@ pub fn fixture(
         if checker
             .settings
             .rules
-            .enabled(&Rule::FixtureFinalizerCallback)
+            .enabled(Rule::FixtureFinalizerCallback)
         {
             check_fixture_addfinalizer(checker, args, body);
         }
@@ -552,11 +549,11 @@ pub fn fixture(
         if checker
             .settings
             .rules
-            .enabled(&Rule::UnnecessaryAsyncioMarkOnFixture)
+            .enabled(Rule::UnnecessaryAsyncioMarkOnFixture)
             || checker
                 .settings
                 .rules
-                .enabled(&Rule::ErroneousUseFixturesOnFixture)
+                .enabled(Rule::ErroneousUseFixturesOnFixture)
         {
             check_fixture_marks(checker, decorators);
         }
@@ -565,7 +562,7 @@ pub fn fixture(
     if checker
         .settings
         .rules
-        .enabled(&Rule::FixtureParamWithoutValue)
+        .enabled(Rule::FixtureParamWithoutValue)
         && func_name.starts_with("test_")
     {
         check_test_function_args(checker, args);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -123,11 +123,11 @@ pub fn marks(checker: &mut Checker, decorators: &[Expr]) {
     let enforce_parentheses = checker
         .settings
         .rules
-        .enabled(&Rule::IncorrectMarkParenthesesStyle);
+        .enabled(Rule::IncorrectMarkParenthesesStyle);
     let enforce_useless_usefixtures = checker
         .settings
         .rules
-        .enabled(&Rule::UseFixturesWithoutParameters);
+        .enabled(Rule::UseFixturesWithoutParameters);
 
     for mark in get_mark_decorators(decorators) {
         if enforce_parentheses {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -380,7 +380,7 @@ pub fn parametrize(checker: &mut Checker, decorators: &[Expr]) {
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::ParametrizeNamesWrongType)
+                    .enabled(Rule::ParametrizeNamesWrongType)
                 {
                     if let Some(names) = args.get(0) {
                         check_names(checker, names);
@@ -389,7 +389,7 @@ pub fn parametrize(checker: &mut Checker, decorators: &[Expr]) {
                 if checker
                     .settings
                     .rules
-                    .enabled(&Rule::ParametrizeValuesWrongType)
+                    .enabled(Rule::ParametrizeValuesWrongType)
                 {
                     if let Some(names) = args.get(0) {
                         if let Some(values) = args.get(1) {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -67,11 +67,7 @@ const fn is_non_trivial_with_body(body: &[Stmt]) -> bool {
 
 pub fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_raises(checker, func) {
-        if checker
-            .settings
-            .rules
-            .enabled(&Rule::RaisesWithoutException)
-        {
+        if checker.settings.rules.enabled(Rule::RaisesWithoutException) {
             if args.is_empty() && keywords.is_empty() {
                 checker
                     .diagnostics
@@ -79,7 +75,7 @@ pub fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: 
             }
         }
 
-        if checker.settings.rules.enabled(&Rule::RaisesTooBroad) {
+        if checker.settings.rules.enabled(Rule::RaisesTooBroad) {
             let match_keyword = keywords
                 .iter()
                 .find(|kw| kw.node.arg == Some("match".to_string()));

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -281,7 +281,7 @@ fn docstring(
         },
         Range::new(start, end),
     );
-    if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesDocstring) {
+    if autofix.into() && settings.rules.should_fix(Rule::BadQuotesDocstring) {
         let quote_count = if trivia.is_multiline { 3 } else { 1 };
         let string_contents = &trivia.raw_text[quote_count..trivia.raw_text.len() - quote_count];
         let quote = good_docstring(&quotes_settings.docstring_quotes).repeat(quote_count);
@@ -356,7 +356,7 @@ fn strings(
                 Range::new(*start, *end),
             );
 
-            if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesMultilineString) {
+            if autofix.into() && settings.rules.should_fix(Rule::BadQuotesMultilineString) {
                 let string_contents = &trivia.raw_text[3..trivia.raw_text.len() - 3];
                 let quote = good_multiline(&quotes_settings.multiline_quotes);
                 let mut fixed_contents = String::with_capacity(
@@ -386,7 +386,7 @@ fn strings(
                 {
                     let mut diagnostic =
                         Diagnostic::new(AvoidableEscapedQuote, Range::new(*start, *end));
-                    if autofix.into() && settings.rules.should_fix(&Rule::AvoidableEscapedQuote) {
+                    if autofix.into() && settings.rules.should_fix(Rule::AvoidableEscapedQuote) {
                         let quote = bad_single(&quotes_settings.inline_quotes);
 
                         let mut fixed_contents =
@@ -445,7 +445,7 @@ fn strings(
                     },
                     Range::new(*start, *end),
                 );
-                if autofix.into() && settings.rules.should_fix(&Rule::BadQuotesInlineString) {
+                if autofix.into() && settings.rules.should_fix(Rule::BadQuotesInlineString) {
                     let quote = good_single(&quotes_settings.inline_quotes);
                     let mut fixed_contents =
                         String::with_capacity(trivia.prefix.len() + string_contents.len() + 2);

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -514,13 +514,13 @@ pub fn function(checker: &mut Checker, body: &[Stmt]) {
         return;
     }
 
-    if checker.settings.rules.enabled(&Rule::SuperfluousElseReturn)
-        || checker.settings.rules.enabled(&Rule::SuperfluousElseRaise)
+    if checker.settings.rules.enabled(Rule::SuperfluousElseReturn)
+        || checker.settings.rules.enabled(Rule::SuperfluousElseRaise)
         || checker
             .settings
             .rules
-            .enabled(&Rule::SuperfluousElseContinue)
-        || checker.settings.rules.enabled(&Rule::SuperfluousElseBreak)
+            .enabled(Rule::SuperfluousElseContinue)
+        || checker.settings.rules.enabled(Rule::SuperfluousElseBreak)
     {
         if superfluous_elif(checker, &stack) {
             return;
@@ -536,20 +536,20 @@ pub fn function(checker: &mut Checker, body: &[Stmt]) {
     }
 
     if !result_exists(&stack.returns) {
-        if checker.settings.rules.enabled(&Rule::UnnecessaryReturnNone) {
+        if checker.settings.rules.enabled(Rule::UnnecessaryReturnNone) {
             unnecessary_return_none(checker, &stack);
         }
         return;
     }
 
-    if checker.settings.rules.enabled(&Rule::ImplicitReturnValue) {
+    if checker.settings.rules.enabled(Rule::ImplicitReturnValue) {
         implicit_return_value(checker, &stack);
     }
-    if checker.settings.rules.enabled(&Rule::ImplicitReturn) {
+    if checker.settings.rules.enabled(Rule::ImplicitReturn) {
         implicit_return(checker, last_stmt);
     }
 
-    if checker.settings.rules.enabled(&Rule::UnnecessaryAssign) {
+    if checker.settings.rules.enabled(Rule::UnnecessaryAssign) {
         for (_, expr) in &stack.returns {
             if let Some(expr) = expr {
                 unnecessary_assign(checker, &stack, expr);

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -201,7 +201,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
         .or_else(|| sibling.and_then(|sibling| return_values_for_siblings(stmt, sibling)))
     {
         if loop_info.return_value && !loop_info.next_return_value {
-            if checker.settings.rules.enabled(&Rule::ReimplementedBuiltin) {
+            if checker.settings.rules.enabled(Rule::ReimplementedBuiltin) {
                 let contents = return_stmt(
                     "any",
                     loop_info.test,
@@ -233,7 +233,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
         }
 
         if !loop_info.return_value && loop_info.next_return_value {
-            if checker.settings.rules.enabled(&Rule::ReimplementedBuiltin) {
+            if checker.settings.rules.enabled(Rule::ReimplementedBuiltin) {
                 // Invert the condition.
                 let test = {
                     if let ExprKind::UnaryOp {

--- a/crates/ruff/src/rules/flake8_unused_arguments/types.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/types.rs
@@ -24,13 +24,13 @@ impl Argumentable {
         }
     }
 
-    pub const fn rule_code(&self) -> &Rule {
+    pub const fn rule_code(&self) -> Rule {
         match self {
-            Self::Function => &Rule::UnusedFunctionArgument,
-            Self::Method => &Rule::UnusedMethodArgument,
-            Self::ClassMethod => &Rule::UnusedClassMethodArgument,
-            Self::StaticMethod => &Rule::UnusedStaticMethodArgument,
-            Self::Lambda => &Rule::UnusedLambdaArgument,
+            Self::Function => Rule::UnusedFunctionArgument,
+            Self::Method => Rule::UnusedMethodArgument,
+            Self::ClassMethod => Rule::UnusedClassMethodArgument,
+            Self::StaticMethod => Rule::UnusedStaticMethodArgument,
+            Self::Lambda => Rule::UnusedLambdaArgument,
         }
     }
 }

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -168,7 +168,7 @@ fn add_required_import(
         MissingRequiredImport(required_import.clone()),
         Range::new(Location::default(), Location::default()),
     );
-    if autofix.into() && settings.rules.should_fix(&Rule::MissingRequiredImport) {
+    if autofix.into() && settings.rules.should_fix(Rule::MissingRequiredImport) {
         // Determine the location at which the import should be inserted.
         let splice = helpers::find_splice_location(python_ast, locator);
 

--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -47,7 +47,7 @@ mod tests {
         );
         let actual: Vec<Rule> = diagnostics
             .into_iter()
-            .map(|diagnostic| diagnostic.kind.rule().clone())
+            .map(|diagnostic| diagnostic.kind.rule())
             .collect();
         assert_eq!(actual, expected);
     }

--- a/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
@@ -52,10 +52,10 @@ impl Violation for UseOfDotValues {
 pub fn check_attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &Expr) {
     let rules = &checker.settings.rules;
     let violation: DiagnosticKind = match attr {
-        "ix" if rules.enabled(&Rule::UseOfDotIx) => UseOfDotIx.into(),
-        "at" if rules.enabled(&Rule::UseOfDotAt) => UseOfDotAt.into(),
-        "iat" if rules.enabled(&Rule::UseOfDotIat) => UseOfDotIat.into(),
-        "values" if rules.enabled(&Rule::UseOfDotValues) => UseOfDotValues.into(),
+        "ix" if rules.enabled(Rule::UseOfDotIx) => UseOfDotIx.into(),
+        "at" if rules.enabled(Rule::UseOfDotAt) => UseOfDotAt.into(),
+        "iat" if rules.enabled(Rule::UseOfDotIat) => UseOfDotIat.into(),
+        "values" if rules.enabled(Rule::UseOfDotValues) => UseOfDotValues.into(),
         _ => return,
     };
 

--- a/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
@@ -65,13 +65,13 @@ pub fn check_call(checker: &mut Checker, func: &Expr) {
     let rules = &checker.settings.rules;
     let ExprKind::Attribute { value, attr, .. } = &func.node else {return};
     let violation: DiagnosticKind = match attr.as_str() {
-        "isnull" if rules.enabled(&Rule::UseOfDotIsNull) => UseOfDotIsNull.into(),
-        "notnull" if rules.enabled(&Rule::UseOfDotNotNull) => UseOfDotNotNull.into(),
-        "pivot" | "unstack" if rules.enabled(&Rule::UseOfDotPivotOrUnstack) => {
+        "isnull" if rules.enabled(Rule::UseOfDotIsNull) => UseOfDotIsNull.into(),
+        "notnull" if rules.enabled(Rule::UseOfDotNotNull) => UseOfDotNotNull.into(),
+        "pivot" | "unstack" if rules.enabled(Rule::UseOfDotPivotOrUnstack) => {
             UseOfDotPivotOrUnstack.into()
         }
-        "read_table" if rules.enabled(&Rule::UseOfDotReadTable) => UseOfDotReadTable.into(),
-        "stack" if rules.enabled(&Rule::UseOfDotStack) => UseOfDotStack.into(),
+        "read_table" if rules.enabled(Rule::UseOfDotReadTable) => UseOfDotReadTable.into(),
+        "stack" if rules.enabled(Rule::UseOfDotStack) => UseOfDotStack.into(),
         _ => return,
     };
 

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -162,7 +162,7 @@ pub fn compound_statements(
             Tok::Newline => {
                 if let Some((start, end)) = semi {
                     let mut diagnostic = Diagnostic::new(UselessSemicolon, Range::new(start, end));
-                    if autofix.into() && settings.rules.should_fix(&Rule::UselessSemicolon) {
+                    if autofix.into() && settings.rules.should_fix(Rule::UselessSemicolon) {
                         diagnostic.amend(Fix::deletion(start, end));
                     };
                     diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -88,22 +88,20 @@ pub fn trailing_whitespace(
         let end = Location::new(lineno + 1, line_char_count);
 
         if whitespace_count == line_char_count {
-            if settings.rules.enabled(&Rule::BlankLineContainsWhitespace) {
+            if settings.rules.enabled(Rule::BlankLineContainsWhitespace) {
                 let mut diagnostic =
                     Diagnostic::new(BlankLineContainsWhitespace, Range::new(start, end));
                 if matches!(autofix, flags::Autofix::Enabled)
-                    && settings
-                        .rules
-                        .should_fix(&Rule::BlankLineContainsWhitespace)
+                    && settings.rules.should_fix(Rule::BlankLineContainsWhitespace)
                 {
                     diagnostic.amend(Fix::deletion(start, end));
                 }
                 return Some(diagnostic);
             }
-        } else if settings.rules.enabled(&Rule::TrailingWhitespace) {
+        } else if settings.rules.enabled(Rule::TrailingWhitespace) {
             let mut diagnostic = Diagnostic::new(TrailingWhitespace, Range::new(start, end));
             if matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(&Rule::TrailingWhitespace)
+                && settings.rules.should_fix(Rule::TrailingWhitespace)
             {
                 diagnostic.amend(Fix::deletion(start, end));
             }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -65,11 +65,8 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
     if checker
         .settings
         .rules
-        .enabled(&Rule::OneBlankLineBeforeClass)
-        || checker
-            .settings
-            .rules
-            .enabled(&Rule::NoBlankLineBeforeClass)
+        .enabled(Rule::OneBlankLineBeforeClass)
+        || checker.settings.rules.enabled(Rule::NoBlankLineBeforeClass)
     {
         let before = checker
             .locator
@@ -81,11 +78,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
             .skip(1)
             .take_while(|line| line.trim().is_empty())
             .count();
-        if checker
-            .settings
-            .rules
-            .enabled(&Rule::NoBlankLineBeforeClass)
-        {
+        if checker.settings.rules.enabled(Rule::NoBlankLineBeforeClass) {
             if blank_lines_before != 0 {
                 let mut diagnostic = Diagnostic::new(
                     NoBlankLineBeforeClass {
@@ -106,7 +99,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
         if checker
             .settings
             .rules
-            .enabled(&Rule::OneBlankLineBeforeClass)
+            .enabled(Rule::OneBlankLineBeforeClass)
         {
             if blank_lines_before != 1 {
                 let mut diagnostic = Diagnostic::new(
@@ -128,11 +121,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(&Rule::OneBlankLineAfterClass)
-    {
+    if checker.settings.rules.enabled(Rule::OneBlankLineAfterClass) {
         let after = checker.locator.slice(Range::new(
             docstring.expr.end_location.unwrap(),
             parent.end_location.unwrap(),

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -61,7 +61,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
     if checker
         .settings
         .rules
-        .enabled(&Rule::NoBlankLineBeforeFunction)
+        .enabled(Rule::NoBlankLineBeforeFunction)
     {
         let before = checker
             .locator
@@ -94,7 +94,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
     if checker
         .settings
         .rules
-        .enabled(&Rule::NoBlankLineAfterFunction)
+        .enabled(Rule::NoBlankLineAfterFunction)
     {
         let after = checker.locator.slice(Range::new(
             docstring.expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -80,7 +80,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
         // yet.
         has_seen_tab = has_seen_tab || line_indent.contains('\t');
 
-        if checker.settings.rules.enabled(&Rule::NoUnderIndentation) {
+        if checker.settings.rules.enabled(Rule::NoUnderIndentation) {
             // We report under-indentation on every line. This isn't great, but enables
             // autofix.
             if (i == lines.len() - 1 || !is_blank)
@@ -119,7 +119,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
         }
     }
 
-    if checker.settings.rules.enabled(&Rule::IndentWithSpaces) {
+    if checker.settings.rules.enabled(Rule::IndentWithSpaces) {
         if has_seen_tab {
             checker.diagnostics.push(Diagnostic::new(
                 IndentWithSpaces,
@@ -128,7 +128,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
         }
     }
 
-    if checker.settings.rules.enabled(&Rule::NoOverIndentation) {
+    if checker.settings.rules.enabled(Rule::NoOverIndentation) {
         // If every line (except the last) is over-indented...
         if is_over_indented {
             for i in over_indented_lines {

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -56,7 +56,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
         if checker
             .settings
             .rules
-            .enabled(&Rule::MultiLineSummaryFirstLine)
+            .enabled(Rule::MultiLineSummaryFirstLine)
         {
             let mut diagnostic =
                 Diagnostic::new(MultiLineSummaryFirstLine, Range::from(docstring.expr));
@@ -81,7 +81,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
         if checker
             .settings
             .rules
-            .enabled(&Rule::MultiLineSummarySecondLine)
+            .enabled(Rule::MultiLineSummarySecondLine)
         {
             let mut diagnostic =
                 Diagnostic::new(MultiLineSummarySecondLine, Range::from(docstring.expr));

--- a/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
@@ -22,7 +22,7 @@ pub fn not_empty(checker: &mut Checker, docstring: &Docstring) -> bool {
         return true;
     }
 
-    if checker.settings.rules.enabled(&Rule::EmptyDocstring) {
+    if checker.settings.rules.enabled(Rule::EmptyDocstring) {
         checker
             .diagnostics
             .push(Diagnostic::new(EmptyDocstring, Range::from(docstring.expr)));

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -104,7 +104,7 @@ pub fn not_missing(
 
     match definition.kind {
         DefinitionKind::Module => {
-            if checker.settings.rules.enabled(&Rule::PublicModule) {
+            if checker.settings.rules.enabled(Rule::PublicModule) {
                 checker.diagnostics.push(Diagnostic::new(
                     PublicModule,
                     Range::new(Location::new(1, 0), Location::new(1, 0)),
@@ -113,7 +113,7 @@ pub fn not_missing(
             false
         }
         DefinitionKind::Package => {
-            if checker.settings.rules.enabled(&Rule::PublicPackage) {
+            if checker.settings.rules.enabled(Rule::PublicPackage) {
                 checker.diagnostics.push(Diagnostic::new(
                     PublicPackage,
                     Range::new(Location::new(1, 0), Location::new(1, 0)),
@@ -122,7 +122,7 @@ pub fn not_missing(
             false
         }
         DefinitionKind::Class(stmt) => {
-            if checker.settings.rules.enabled(&Rule::PublicClass) {
+            if checker.settings.rules.enabled(Rule::PublicClass) {
                 checker.diagnostics.push(Diagnostic::new(
                     PublicClass,
                     identifier_range(stmt, checker.locator),
@@ -131,7 +131,7 @@ pub fn not_missing(
             false
         }
         DefinitionKind::NestedClass(stmt) => {
-            if checker.settings.rules.enabled(&Rule::PublicNestedClass) {
+            if checker.settings.rules.enabled(Rule::PublicNestedClass) {
                 checker.diagnostics.push(Diagnostic::new(
                     PublicNestedClass,
                     identifier_range(stmt, checker.locator),
@@ -143,7 +143,7 @@ pub fn not_missing(
             if is_overload(&checker.ctx, cast::decorator_list(stmt)) {
                 true
             } else {
-                if checker.settings.rules.enabled(&Rule::PublicFunction) {
+                if checker.settings.rules.enabled(Rule::PublicFunction) {
                     checker.diagnostics.push(Diagnostic::new(
                         PublicFunction,
                         identifier_range(stmt, checker.locator),
@@ -158,7 +158,7 @@ pub fn not_missing(
             {
                 true
             } else if is_init(cast::name(stmt)) {
-                if checker.settings.rules.enabled(&Rule::PublicInit) {
+                if checker.settings.rules.enabled(Rule::PublicInit) {
                     checker.diagnostics.push(Diagnostic::new(
                         PublicInit,
                         identifier_range(stmt, checker.locator),
@@ -166,7 +166,7 @@ pub fn not_missing(
                 }
                 true
             } else if is_new(cast::name(stmt)) || is_call(cast::name(stmt)) {
-                if checker.settings.rules.enabled(&Rule::PublicMethod) {
+                if checker.settings.rules.enabled(Rule::PublicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         PublicMethod,
                         identifier_range(stmt, checker.locator),
@@ -174,7 +174,7 @@ pub fn not_missing(
                 }
                 true
             } else if is_magic(cast::name(stmt)) {
-                if checker.settings.rules.enabled(&Rule::MagicMethod) {
+                if checker.settings.rules.enabled(Rule::MagicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         MagicMethod,
                         identifier_range(stmt, checker.locator),
@@ -182,7 +182,7 @@ pub fn not_missing(
                 }
                 true
             } else {
-                if checker.settings.rules.enabled(&Rule::PublicMethod) {
+                if checker.settings.rules.enabled(Rule::PublicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         PublicMethod,
                         identifier_range(stmt, checker.locator),

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -353,7 +353,7 @@ fn blanks_and_section_underline(
         if checker
             .settings
             .rules
-            .enabled(&Rule::DashedUnderlineAfterSection)
+            .enabled(Rule::DashedUnderlineAfterSection)
         {
             let mut diagnostic = Diagnostic::new(
                 DashedUnderlineAfterSection {
@@ -379,7 +379,7 @@ fn blanks_and_section_underline(
             }
             checker.diagnostics.push(diagnostic);
         }
-        if checker.settings.rules.enabled(&Rule::EmptyDocstringSection) {
+        if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
             checker.diagnostics.push(Diagnostic::new(
                 EmptyDocstringSection {
                     name: context.section_name.to_string(),
@@ -400,7 +400,7 @@ fn blanks_and_section_underline(
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::SectionUnderlineAfterName)
+                .enabled(Rule::SectionUnderlineAfterName)
             {
                 let mut diagnostic = Diagnostic::new(
                     SectionUnderlineAfterName {
@@ -438,7 +438,7 @@ fn blanks_and_section_underline(
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::SectionUnderlineMatchesSectionLength)
+                .enabled(Rule::SectionUnderlineMatchesSectionLength)
             {
                 let mut diagnostic = Diagnostic::new(
                     SectionUnderlineMatchesSectionLength {
@@ -480,7 +480,7 @@ fn blanks_and_section_underline(
         if checker
             .settings
             .rules
-            .enabled(&Rule::SectionUnderlineNotOverIndented)
+            .enabled(Rule::SectionUnderlineNotOverIndented)
         {
             let leading_space = whitespace::leading_space(non_empty_line);
             if leading_space.len() > docstring.indentation.len() {
@@ -525,7 +525,7 @@ fn blanks_and_section_underline(
                     .take_while(|line| line.trim().is_empty())
                     .count();
                 if blank_lines_after_dashes == rest_of_lines.len() {
-                    if checker.settings.rules.enabled(&Rule::EmptyDocstringSection) {
+                    if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
                         checker.diagnostics.push(Diagnostic::new(
                             EmptyDocstringSection {
                                 name: context.section_name.to_string(),
@@ -537,7 +537,7 @@ fn blanks_and_section_underline(
                     if checker
                         .settings
                         .rules
-                        .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
+                        .enabled(Rule::NoBlankLinesBetweenHeaderAndContent)
                     {
                         let mut diagnostic = Diagnostic::new(
                             NoBlankLinesBetweenHeaderAndContent {
@@ -570,7 +570,7 @@ fn blanks_and_section_underline(
                 }
             }
         } else {
-            if checker.settings.rules.enabled(&Rule::EmptyDocstringSection) {
+            if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
                 checker.diagnostics.push(Diagnostic::new(
                     EmptyDocstringSection {
                         name: context.section_name.to_string(),
@@ -583,7 +583,7 @@ fn blanks_and_section_underline(
         if checker
             .settings
             .rules
-            .enabled(&Rule::DashedUnderlineAfterSection)
+            .enabled(Rule::DashedUnderlineAfterSection)
         {
             let mut diagnostic = Diagnostic::new(
                 DashedUnderlineAfterSection {
@@ -613,7 +613,7 @@ fn blanks_and_section_underline(
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::NoBlankLinesBetweenHeaderAndContent)
+                .enabled(Rule::NoBlankLinesBetweenHeaderAndContent)
             {
                 let mut diagnostic = Diagnostic::new(
                     NoBlankLinesBetweenHeaderAndContent {
@@ -644,7 +644,7 @@ fn blanks_and_section_underline(
 }
 
 fn common_section(checker: &mut Checker, docstring: &Docstring, context: &SectionContext) {
-    if checker.settings.rules.enabled(&Rule::CapitalizeSectionName) {
+    if checker.settings.rules.enabled(Rule::CapitalizeSectionName) {
         let capitalized_section_name = context.kind.as_str();
         if context.section_name != capitalized_section_name {
             let mut diagnostic = Diagnostic::new(
@@ -677,11 +677,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(&Rule::SectionNotOverIndented)
-    {
+    if checker.settings.rules.enabled(Rule::SectionNotOverIndented) {
         let leading_space = whitespace::leading_space(context.line);
         if leading_space.len() > docstring.indentation.len() {
             let mut diagnostic = Diagnostic::new(
@@ -715,7 +711,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
             if checker
                 .settings
                 .rules
-                .enabled(&Rule::BlankLineAfterLastSection)
+                .enabled(Rule::BlankLineAfterLastSection)
             {
                 let mut diagnostic = Diagnostic::new(
                     BlankLineAfterLastSection {
@@ -739,7 +735,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 checker.diagnostics.push(diagnostic);
             }
         } else {
-            if checker.settings.rules.enabled(&Rule::BlankLineAfterSection) {
+            if checker.settings.rules.enabled(Rule::BlankLineAfterSection) {
                 let mut diagnostic = Diagnostic::new(
                     BlankLineAfterSection {
                         name: context.section_name.to_string(),
@@ -764,11 +760,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(&Rule::BlankLineBeforeSection)
-    {
+    if checker.settings.rules.enabled(Rule::BlankLineBeforeSection) {
         if !context.previous_line.is_empty() {
             let mut diagnostic = Diagnostic::new(
                 BlankLineBeforeSection {
@@ -959,7 +951,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
     if checker
         .settings
         .rules
-        .enabled(&Rule::NewLineAfterSectionName)
+        .enabled(Rule::NewLineAfterSectionName)
     {
         let suffix = context
             .line
@@ -997,7 +989,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
         }
     }
 
-    if checker.settings.rules.enabled(&Rule::UndocumentedParam) {
+    if checker.settings.rules.enabled(Rule::UndocumentedParam) {
         if matches!(context.kind, SectionKind::Parameters) {
             parameters_section(checker, docstring, context);
         }
@@ -1007,11 +999,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
 fn google_section(checker: &mut Checker, docstring: &Docstring, context: &SectionContext) {
     common_section(checker, docstring, context);
 
-    if checker
-        .settings
-        .rules
-        .enabled(&Rule::SectionNameEndsInColon)
-    {
+    if checker.settings.rules.enabled(Rule::SectionNameEndsInColon) {
         let suffix = context
             .line
             .trim()
@@ -1049,7 +1037,7 @@ fn google_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
         }
     }
 
-    if checker.settings.rules.enabled(&Rule::UndocumentedParam) {
+    if checker.settings.rules.enabled(Rule::UndocumentedParam) {
         if matches!(context.kind, SectionKind::Args | SectionKind::Arguments) {
             args_section(checker, docstring, context);
         }

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -272,7 +272,7 @@ mod tests {
         diagnostics.sort_by_key(|diagnostic| diagnostic.location);
         let actual = diagnostics
             .iter()
-            .map(|diagnostic| diagnostic.kind.rule().clone())
+            .map(|diagnostic| diagnostic.kind.rule())
             .collect::<Vec<_>>();
         assert_eq!(actual, expected);
     }

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -97,7 +97,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                         if checker
                             .settings
                             .rules
-                            .enabled(&Rule::MultiValueRepeatedKeyLiteral)
+                            .enabled(Rule::MultiValueRepeatedKeyLiteral)
                         {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);
@@ -125,7 +125,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                         if checker
                             .settings
                             .rules
-                            .enabled(&Rule::MultiValueRepeatedKeyVariable)
+                            .enabled(Rule::MultiValueRepeatedKeyVariable)
                         {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -123,7 +123,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
 
                         let message_args = call_args.args.len() - 1;
 
-                        if checker.settings.rules.enabled(&Rule::LoggingTooManyArgs) {
+                        if checker.settings.rules.enabled(Rule::LoggingTooManyArgs) {
                             if summary.num_positional < message_args {
                                 checker
                                     .diagnostics
@@ -131,7 +131,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
                             }
                         }
 
-                        if checker.settings.rules.enabled(&Rule::LoggingTooFewArgs) {
+                        if checker.settings.rules.enabled(Rule::LoggingTooFewArgs) {
                             if message_args > 0
                                 && call_args.kwargs.is_empty()
                                 && summary.num_positional > message_args

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -550,7 +550,7 @@ pub fn deprecated_import(
             },
             Range::from(stmt),
         );
-        if checker.patch(&Rule::DeprecatedImport) {
+        if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
                 diagnostic.amend(Fix::replacement(
                     content,

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -137,7 +137,7 @@ pub fn extraneous_parentheses(
                 };
                 let mut diagnostic =
                     Diagnostic::new(ExtraneousParentheses, Range::new(*start, *end));
-                if autofix.into() && settings.rules.should_fix(&Rule::ExtraneousParentheses) {
+                if autofix.into() && settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents = locator.slice(Range::new(*start, *end));
                     diagnostic.amend(Fix::replacement(
                         contents[1..contents.len() - 1].to_string(),

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -22,7 +22,7 @@ impl AlwaysAutofixableViolation for QuotedAnnotation {
 /// UP037
 pub fn quoted_annotation(checker: &mut Checker, annotation: &str, range: Range) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
-    if checker.patch(&Rule::QuotedAnnotation) {
+    if checker.patch(Rule::QuotedAnnotation) {
         diagnostic.amend(Fix::replacement(
             annotation.to_string(),
             range.location,

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -193,7 +193,7 @@ pub fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                         &keyword.node.value,
                         mode.replacement_value(),
                         checker.locator,
-                        checker.patch(&Rule::RedundantOpenModes),
+                        checker.patch(Rule::RedundantOpenModes),
                     ));
                 }
             }
@@ -210,7 +210,7 @@ pub fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
                     mode_param,
                     mode.replacement_value(),
                     checker.locator,
-                    checker.patch(&Rule::RedundantOpenModes),
+                    checker.patch(Rule::RedundantOpenModes),
                 ));
             }
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/rewrite_mock_import.rs
@@ -262,7 +262,7 @@ pub fn rewrite_mock_import(checker: &mut Checker, stmt: &Stmt) {
                 .any(|name| name.node.name == "mock" || name.node.name == "mock.mock")
             {
                 // Generate the fix, if needed, which is shared between all `mock` imports.
-                let content = if checker.patch(&Rule::RewriteMockImport) {
+                let content = if checker.patch(Rule::RewriteMockImport) {
                     if let Some(indent) = indentation(checker.locator, stmt) {
                         match format_import(stmt, indent, checker.locator, checker.stylist) {
                             Ok(content) => Some(content),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -161,7 +161,7 @@ pub fn unnecessary_encode_utf8(
                         expr,
                         variable,
                         checker.locator,
-                        checker.patch(&Rule::UnnecessaryEncodeUTF8),
+                        checker.patch(Rule::UnnecessaryEncodeUTF8),
                     ));
                 } else {
                     // "unicode text©".encode("utf-8")
@@ -169,7 +169,7 @@ pub fn unnecessary_encode_utf8(
                         expr,
                         args,
                         kwargs,
-                        checker.patch(&Rule::UnnecessaryEncodeUTF8),
+                        checker.patch(Rule::UnnecessaryEncodeUTF8),
                     ) {
                         checker.diagnostics.push(diagnostic);
                     }
@@ -183,7 +183,7 @@ pub fn unnecessary_encode_utf8(
                     expr,
                     args,
                     kwargs,
-                    checker.patch(&Rule::UnnecessaryEncodeUTF8),
+                    checker.patch(Rule::UnnecessaryEncodeUTF8),
                 ) {
                     checker.diagnostics.push(diagnostic);
                 }

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -386,16 +386,16 @@ impl From<&Configuration> for RuleTable {
             .and_then(|pydocstyle| pydocstyle.convention)
         {
             for rule in convention.rules_to_be_ignored() {
-                rules.disable(rule);
+                rules.disable(*rule);
             }
         }
 
         // Validate that we didn't enable any incompatible rules. Use this awkward
         // approach to give each pair it's own `warn_user_once`.
         for (preferred, expendable, message) in INCOMPATIBLE_CODES {
-            if rules.enabled(preferred) && rules.enabled(expendable) {
+            if rules.enabled(*preferred) && rules.enabled(*expendable) {
                 warn_user_once_by_id!(expendable.as_ref(), "{}", message);
-                rules.disable(expendable);
+                rules.disable(*expendable);
             }
         }
 
@@ -440,7 +440,7 @@ mod tests {
             ..Configuration::default()
         })
         .iter_enabled()
-        .cloned()
+        .copied()
         .collect()
     }
 

--- a/crates/ruff/src/settings/rule_table.rs
+++ b/crates/ruff/src/settings/rule_table.rs
@@ -22,13 +22,15 @@ impl RuleTable {
     }
 
     /// Returns whether the given rule should be checked.
-    pub fn enabled(&self, code: &Rule) -> bool {
-        self.enabled.contains_key(code)
+    #[inline]
+    pub fn enabled(&self, code: Rule) -> bool {
+        self.enabled.contains_key(&code)
     }
 
     /// Returns whether violations of the given rule should be autofixed.
-    pub fn should_fix(&self, code: &Rule) -> bool {
-        *self.enabled.get(code).unwrap_or(&false)
+    #[inline]
+    pub fn should_fix(&self, code: Rule) -> bool {
+        *self.enabled.get(&code).unwrap_or(&false)
     }
 
     /// Returns an iterator over all enabled rules.
@@ -37,13 +39,15 @@ impl RuleTable {
     }
 
     /// Enables the given rule.
+    #[inline]
     pub fn enable(&mut self, code: Rule, should_fix: bool) {
         self.enabled.insert(code, should_fix);
     }
 
     /// Disables the given rule.
-    pub fn disable(&mut self, rule: &Rule) {
-        self.enabled.remove(rule);
+    #[inline]
+    pub fn disable(&mut self, rule: Rule) {
+        self.enabled.remove(&rule);
     }
 }
 

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -16,7 +16,7 @@ struct Explanation<'a> {
 }
 
 /// Explain a `Rule` to the user.
-pub fn rule(rule: &Rule, format: HelpFormat) -> Result<()> {
+pub fn rule(rule: Rule, format: HelpFormat) -> Result<()> {
     let (linter, _) = Linter::parse_code(&rule.noqa_code().to_string()).unwrap();
     let mut stdout = BufWriter::new(io::stdout().lock());
     let mut output = String::new();

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -105,7 +105,7 @@ pub fn run(
                         ":".bold()
                     );
                     let settings = resolver.resolve(path, pyproject_strategy);
-                    if settings.rules.enabled(&Rule::IOError) {
+                    if settings.rules.enabled(Rule::IOError) {
                         Diagnostics::new(vec![Message::from_diagnostic(
                             Diagnostic::new(
                                 IOError { message },

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -73,7 +73,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
     set_up_logging(&log_level)?;
 
     match command {
-        Command::Rule { rule, format } => commands::rule::rule(&rule, format)?,
+        Command::Rule { rule, format } => commands::rule::rule(rule, format)?,
         Command::Config { option } => return Ok(commands::config::config(option.as_deref())),
         Command::Linter { format } => commands::linter::linter(format)?,
         Command::Clean => commands::clean::clean(log_level)?,

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -46,7 +46,7 @@ struct ExpandedFix<'a> {
 
 #[derive(Serialize)]
 struct ExpandedMessage<'a> {
-    code: SerializeRuleAsCode<'a>,
+    code: SerializeRuleAsCode,
     message: String,
     fix: Option<ExpandedFix<'a>>,
     location: Location,
@@ -63,9 +63,9 @@ struct ExpandedStatistics {
     fixable: bool,
 }
 
-struct SerializeRuleAsCode<'a>(&'a Rule);
+struct SerializeRuleAsCode(Rule);
 
-impl Serialize for SerializeRuleAsCode<'_> {
+impl Serialize for SerializeRuleAsCode {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -74,8 +74,8 @@ impl Serialize for SerializeRuleAsCode<'_> {
     }
 }
 
-impl<'a> From<&'a Rule> for SerializeRuleAsCode<'a> {
-    fn from(rule: &'a Rule) -> Self {
+impl From<Rule> for SerializeRuleAsCode {
+    fn from(rule: Rule) -> Self {
         Self(rule)
     }
 }
@@ -405,13 +405,13 @@ impl Printer {
     }
 
     pub fn write_statistics(&self, diagnostics: &Diagnostics) -> Result<()> {
-        let violations: Vec<&Rule> = diagnostics
+        let violations: Vec<Rule> = diagnostics
             .messages
             .iter()
             .map(|message| message.kind.rule())
             .sorted()
             .dedup()
-            .collect::<Vec<_>>();
+            .collect();
         if violations.is_empty() {
             return Ok(());
         }
@@ -537,11 +537,11 @@ impl Printer {
     }
 }
 
-fn group_messages_by_filename(messages: &[Message]) -> BTreeMap<&String, Vec<&Message>> {
+fn group_messages_by_filename(messages: &[Message]) -> BTreeMap<&str, Vec<&Message>> {
     let mut grouped_messages = BTreeMap::default();
     for message in messages {
         grouped_messages
-            .entry(&message.filename)
+            .entry(message.filename.as_str())
             .or_insert_with(Vec::new)
             .push(message);
     }

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -23,7 +23,7 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
         table_out.push_str(&format!(
             "| {}{} | {} | {} | {} |",
             linter.common_prefix(),
-            linter.code_for_rule(&rule).unwrap(),
+            linter.code_for_rule(rule).unwrap(),
             rule.explanation()
                 .is_some()
                 .then_some(format_args!("[{rule_name}](rules/{rule_name}.md)"))

--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -167,7 +167,7 @@ pub fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
     });
 
     #[allow(clippy::type_complexity)]
-    let mut rule_to_codes: HashMap<&Path, Vec<(&Ident, &String, &Vec<Attribute>)>> = HashMap::new();
+    let mut rule_to_codes: HashMap<&Path, Vec<(&Ident, &str, &Vec<Attribute>)>> = HashMap::new();
     let mut linter_code_for_rule_match_arms = quote!();
 
     for (linter, map) in &linters {
@@ -227,7 +227,7 @@ pub fn map_codes(func: &ItemFn) -> syn::Result<TokenStream> {
         }
 
         impl crate::registry::Linter {
-            pub fn code_for_rule(&self, rule: &Rule) -> Option<&'static str> {
+            pub fn code_for_rule(&self, rule: Rule) -> Option<&'static str> {
                 match (self, rule) {
                     #linter_code_for_rule_match_arms
                     _ => None,


### PR DESCRIPTION
This PR adds a `Copy` implementation to `Rule` because `Rule` is only two bytes large (less than a poiner). 

I don't expect this to improve performance, but it allows us to remove some lifetime annotations.
