### PR TITLE
add PaddlePaddle to `Who's Using Ruff?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Ruff is used in a number of major open-source projects, including:
 - [Starlite](https://github.com/starlite-api/starlite)
 - [telemetry-airflow (Mozilla)](https://github.com/mozilla/telemetry-airflow)
 - [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3)
+- [PaddlePaddle](https://github.com/PaddlePaddle/Paddle)
 
 ## License
 


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/blob/d1e2c61b22b9675adc3c4a52227d2220babaa001/pyproject.toml#L21-L60