### PR TITLE
Fix autofix conflict between `D209` and `D400`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D209_D400.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D209_D400.py
@@ -1,0 +1,3 @@
+def lorem():
+    """lorem ipsum dolor sit amet consectetur adipiscing elit
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"""

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -153,4 +153,14 @@ mod tests {
         assert_yaml_snapshot!(diagnostics);
         Ok(())
     }
+
+    #[test]
+    fn d209_d400() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pydocstyle/D209_D400.py"),
+            &settings::Settings::for_rules([Rule::NewLineAfterLastParagraph, Rule::EndsInPeriod]),
+        )?;
+        assert_yaml_snapshot!(diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
@@ -42,24 +42,4 @@ expression: diagnostics
       row: 3
       column: 69
   parent: ~
-- kind:
-    name: NewLineAfterLastParagraph
-    body: Multi-line docstring closing quotes should be on a separate line
-    suggestion: Move closing quotes to new line
-    fixable: true
-  location:
-    row: 2
-    column: 4
-  end_location:
-    row: 4
-    column: 8
-  fix:
-    content: "\n    "
-    location:
-      row: 4
-      column: 5
-    end_location:
-      row: 4
-      column: 5
-  parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
@@ -1,0 +1,65 @@
+---
+source: crates/ruff/src/rules/pydocstyle/mod.rs
+expression: diagnostics
+---
+- kind:
+    name: NewLineAfterLastParagraph
+    body: Multi-line docstring closing quotes should be on a separate line
+    suggestion: Move closing quotes to new line
+    fixable: true
+  location:
+    row: 2
+    column: 4
+  end_location:
+    row: 3
+    column: 72
+  fix:
+    content: "\n    "
+    location:
+      row: 3
+      column: 69
+    end_location:
+      row: 3
+      column: 69
+  parent: ~
+- kind:
+    name: EndsInPeriod
+    body: First line should end with a period
+    suggestion: Add period
+    fixable: true
+  location:
+    row: 2
+    column: 4
+  end_location:
+    row: 3
+    column: 72
+  fix:
+    content: "."
+    location:
+      row: 3
+      column: 69
+    end_location:
+      row: 3
+      column: 69
+  parent: ~
+- kind:
+    name: NewLineAfterLastParagraph
+    body: Multi-line docstring closing quotes should be on a separate line
+    suggestion: Move closing quotes to new line
+    fixable: true
+  location:
+    row: 2
+    column: 4
+  end_location:
+    row: 4
+    column: 8
+  fix:
+    content: "\n    "
+    location:
+      row: 4
+      column: 5
+    end_location:
+      row: 4
+      column: 5
+  parent: ~
+


### PR DESCRIPTION
- Closes #3538
- The snapshot of the first commit was generated with #3557. Without #3557, there is no change to the snapshot, so I opened a PR for this.