### PR TITLE
ci(check_ecosystem): add cibuildwheel

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -62,6 +62,7 @@ REPOSITORIES = {
     "bokeh": Repository("bokeh", "bokeh", "branch-3.2"),
     "scikit-build": Repository("scikit-build", "scikit-build", "main"),
     "scikit-build-core": Repository("scikit-build", "scikit-build-core", "main"),
+    "cibuildwheel": Repository("pypa", "cibuildwheel", "main"),
     "airflow": Repository("apache", "airflow", "main"),
     "typeshed": Repository("python", "typeshed", "main", select="PYI"),
 }


### PR DESCRIPTION
Adding cibuildwheel to the ecosystem check. Referenced in https://github.com/charliermarsh/ruff/pull/3390#issuecomment-1472791231
