### PR TITLE
Benchmark all rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,10 @@ version = "0.0.0"
 dependencies = [
  "criterion",
  "mimalloc",
+ "once_cell",
  "ruff",
+ "serde",
+ "serde_json",
  "tikv-jemallocator",
  "ureq",
  "url",

--- a/crates/ruff_benchmark/Cargo.toml
+++ b/crates/ruff_benchmark/Cargo.toml
@@ -17,7 +17,10 @@ name = "linter"
 harness = false
 
 [dependencies]
+once_cell.workspace = true
 ruff.path = "../ruff"
+serde.workspace = true
+serde_json.workspace = true
 url = "2.3.1"
 ureq = "2.6.2"
 

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -26,12 +26,12 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn create_test_cases() -> Result<Vec<TestCase>, TestFileDownloadError> {
     Ok(vec![
-        TestCase::fast(TestFile::try_download("numpy/globals.py", "https://github.com/numpy/numpy/blob/89d64415e349ca75a25250f22b874aa16e5c0973/numpy/_globals.py")?),
+        TestCase::fast(TestFile::try_download("numpy/globals.py", "https://raw.githubusercontent.com/numpy/numpy/89d64415e349ca75a25250f22b874aa16e5c0973/numpy/_globals.py")?),
         TestCase::normal(TestFile::try_download(
             "pydantic/types.py",
-            "https://raw.githubusercontent.com/pydantic/pydantic/main/pydantic/types.py",
+            "https://raw.githubusercontent.com/pydantic/pydantic/83b3c49e99ceb4599d9286a3d793cea44ac36d4b/pydantic/types.py",
         )?),
-        TestCase::normal(TestFile::try_download("numpy/ctypeslib.py", "https://github.com/numpy/numpy/blob/main/numpy/ctypeslib.py")?),
+        TestCase::normal(TestFile::try_download("numpy/ctypeslib.py", "https://raw.githubusercontent.com/numpy/numpy/e42c9503a14d66adfd41356ef5640c6975c45218/numpy/ctypeslib.py")?),
         TestCase::slow(TestFile::try_download(
             "large/dataset.py",
             "https://raw.githubusercontent.com/DHI/mikeio/b7d26418f4db2909b0aa965253dbe83194d7bb5b/tests/test_dataset.py",
@@ -55,14 +55,17 @@ fn benchmark_linter(mut group: BenchmarkGroup<WallTime>, settings: &Settings) {
             &case,
             |b, case| {
                 b.iter(|| {
-                    lint_only(
+                    let result = lint_only(
                         case.code(),
                         &case.path(),
                         None,
                         settings,
                         flags::Noqa::Enabled,
                         flags::Autofix::Enabled,
-                    )
+                    );
+
+                    // Assert that file contains no parse errors
+                    assert_eq!(result.error, None);
                 });
             },
         );


### PR DESCRIPTION
## Summary

This PR adds the new benchmark group `linter/all-rules` (and renames the existing group to `linter/default-rules`). 

The motivation of benchmarking all rules is new rules are not part of the default-set and are, thus, not benchmarked. This can result in us missing a new rule that regresses the performance for all users enabling it. 

## Considerations

Why not change the existing benchmark to run all rules: The default rules benchmark allows us to track the performance of Ruff's infrastructure better. The cost of our infrastructure (scope analysis, traversing the tree) is neglectable when running all rules but is more significant when only running some rules. At least now, the cost of running some more benchmarks is "cheap" because the CI job spends most time building the benchmark.