### PR TITLE
Scope and Binding IDs

### DIFF
--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -1,3 +1,4 @@
+use ruff_python_ast::context::ScopeStack;
 use rustpython_parser::ast::{Expr, Stmt};
 
 use ruff_python_ast::types::Range;
@@ -7,7 +8,7 @@ use ruff_python_ast::visibility::{Visibility, VisibleScope};
 use crate::checkers::ast::AnnotationContext;
 use crate::docstrings::definition::Definition;
 
-type Context<'a> = (Vec<usize>, Vec<RefEquality<'a, Stmt>>);
+type Context<'a> = (ScopeStack, Vec<RefEquality<'a, Stmt>>);
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -30,7 +30,7 @@ fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
 
 /// B019
 pub fn cached_instance_method(checker: &mut Checker, decorator_list: &[Expr]) {
-    if !matches!(checker.ctx.current_scope().kind, ScopeKind::Class(_)) {
+    if !matches!(checker.ctx.scope().kind, ScopeKind::Class(_)) {
         return;
     }
     for decorator in decorator_list {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -163,7 +163,7 @@ pub fn unused_loop_control_variable(
         if let Some(rename) = rename {
             if certainty.into() && checker.patch(diagnostic.kind.rule()) {
                 // Find the `BindingKind::LoopVar` corresponding to the name.
-                let scope = checker.ctx.current_scope();
+                let scope = checker.ctx.scope();
                 let binding = scope
                     .bindings
                     .get(name)

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -93,7 +93,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
     }
 
     // Avoid flagging issues in dunder implementations.
-    if let ScopeKind::Function(def) = &checker.ctx.current_scope().kind {
+    if let ScopeKind::Function(def) = &checker.ctx.scope().kind {
         if DUNDER_METHODS.contains(&def.name) {
             return;
         }
@@ -144,7 +144,7 @@ pub fn negation_with_not_equal_op(
     }
 
     // Avoid flagging issues in dunder implementations.
-    if let ScopeKind::Function(def) = &checker.ctx.current_scope().kind {
+    if let ScopeKind::Function(def) = &checker.ctx.scope().kind {
         if DUNDER_METHODS.contains(&def.name) {
             return;
         }

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -71,7 +71,7 @@ pub fn runtime_evaluated(
 }
 
 fn runtime_evaluated_base_class(context: &Context, base_classes: &[String]) -> bool {
-    if let ScopeKind::Class(class_def) = &context.current_scope().kind {
+    if let ScopeKind::Class(class_def) = &context.scope().kind {
         for base in class_def.bases.iter() {
             if let Some(call_path) = context.resolve_call_path(base) {
                 if base_classes
@@ -87,7 +87,7 @@ fn runtime_evaluated_base_class(context: &Context, base_classes: &[String]) -> b
 }
 
 fn runtime_evaluated_decorators(context: &Context, decorators: &[String]) -> bool {
-    if let ScopeKind::Class(class_def) = &context.current_scope().kind {
+    if let ScopeKind::Class(class_def) = &context.scope().kind {
         for decorator in class_def.decorator_list.iter() {
             if let Some(call_path) = context.resolve_call_path(map_callable(decorator)) {
                 if decorators

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
@@ -6,9 +6,10 @@ use rustpython_parser::ast::{Arg, Arguments};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::context::Bindings;
 use ruff_python_ast::function_type;
 use ruff_python_ast::function_type::FunctionType;
-use ruff_python_ast::types::{Binding, FunctionDef, Lambda, Scope, ScopeKind};
+use ruff_python_ast::types::{BindingId, FunctionDef, Lambda, Scope, ScopeKind};
 use ruff_python_ast::visibility;
 
 use crate::checkers::ast::Checker;
@@ -85,8 +86,8 @@ impl Violation for UnusedLambdaArgument {
 fn function(
     argumentable: &Argumentable,
     args: &Arguments,
-    values: &FxHashMap<&str, usize>,
-    bindings: &[Binding],
+    values: &FxHashMap<&str, BindingId>,
+    bindings: &Bindings,
     dummy_variable_rgx: &Regex,
     ignore_variadic_names: bool,
 ) -> Vec<Diagnostic> {
@@ -112,8 +113,8 @@ fn function(
 fn method(
     argumentable: &Argumentable,
     args: &Arguments,
-    values: &FxHashMap<&str, usize>,
-    bindings: &[Binding],
+    values: &FxHashMap<&str, BindingId>,
+    bindings: &Bindings,
     dummy_variable_rgx: &Regex,
     ignore_variadic_names: bool,
 ) -> Vec<Diagnostic> {
@@ -139,8 +140,8 @@ fn method(
 fn call<'a>(
     argumentable: &Argumentable,
     args: impl Iterator<Item = &'a Arg>,
-    values: &FxHashMap<&str, usize>,
-    bindings: &[Binding],
+    values: &FxHashMap<&str, BindingId>,
+    bindings: &Bindings,
     dummy_variable_rgx: &Regex,
 ) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
@@ -168,7 +169,7 @@ pub fn unused_arguments(
     checker: &Checker,
     parent: &Scope,
     scope: &Scope,
-    bindings: &[Binding],
+    bindings: &Bindings,
 ) -> Vec<Diagnostic> {
     match &scope.kind {
         ScopeKind::Function(FunctionDef {

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -65,7 +65,7 @@ pub fn lambda_assignment(checker: &mut Checker, target: &Expr, value: &Expr, stm
             // package like dataclasses, which wouldn't consider the
             // rewritten function definition to be equivalent.
             // See https://github.com/charliermarsh/ruff/issues/3046
-            let fixable = !matches!(checker.ctx.current_scope().kind, ScopeKind::Class(_));
+            let fixable = !matches!(checker.ctx.scope().kind, ScopeKind::Class(_));
 
             let mut diagnostic = Diagnostic::new(
                 LambdaAssignment {

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -17,7 +17,7 @@ impl Violation for ReturnOutsideFunction {
 }
 
 pub fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
-    if let Some(&index) = checker.ctx.scope_stack.last() {
+    if let Some(index) = checker.ctx.scope_stack.top() {
         if matches!(
             checker.ctx.scopes[index].kind,
             ScopeKind::Class(_) | ScopeKind::Module

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -2,7 +2,8 @@ use std::string::ToString;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::types::{Binding, Scope, ScopeKind};
+use ruff_python_ast::context::Bindings;
+use ruff_python_ast::types::{Scope, ScopeKind};
 
 #[violation]
 pub struct UndefinedLocal {
@@ -18,7 +19,7 @@ impl Violation for UndefinedLocal {
 }
 
 /// F821
-pub fn undefined_local(name: &str, scopes: &[&Scope], bindings: &[Binding]) -> Option<Diagnostic> {
+pub fn undefined_local(name: &str, scopes: &[&Scope], bindings: &Bindings) -> Option<Diagnostic> {
     let current = &scopes.last().expect("No current scope found");
     if matches!(current.kind, ScopeKind::Function(_)) && !current.bindings.contains_key(name) {
         for scope in scopes.iter().rev().skip(1) {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -1,5 +1,6 @@
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::types::ScopeId;
 
 use crate::checkers::ast::Checker;
 
@@ -17,7 +18,7 @@ impl Violation for UnusedAnnotation {
 }
 
 /// F842
-pub fn unused_annotation(checker: &mut Checker, scope: usize) {
+pub fn unused_annotation(checker: &mut Checker, scope: ScopeId) {
     let scope = &checker.ctx.scopes[scope];
     for (name, binding) in scope
         .bindings

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -7,7 +7,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::source_code::Locator;
-use ruff_python_ast::types::{Range, RefEquality, ScopeKind};
+use ruff_python_ast::types::{Range, RefEquality, ScopeId, ScopeKind};
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
@@ -312,7 +312,7 @@ fn remove_unused_variable(
 }
 
 /// F841
-pub fn unused_variable(checker: &mut Checker, scope: usize) {
+pub fn unused_variable(checker: &mut Checker, scope: ScopeId) {
     let scope = &checker.ctx.scopes[scope];
     if scope.uses_locals && matches!(scope.kind, ScopeKind::Function(..)) {
         return;

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -40,7 +40,7 @@ impl Violation for YieldOutsideFunction {
 
 pub fn yield_outside_function(checker: &mut Checker, expr: &Expr) {
     if matches!(
-        checker.ctx.current_scope().kind,
+        checker.ctx.scope().kind,
         ScopeKind::Class(_) | ScopeKind::Module
     ) {
         let keyword = match expr.node {

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::types::{FunctionDef, ScopeKind};
 use crate::checkers::ast::Checker;
 
 pub fn in_dunder_init(checker: &Checker) -> bool {
-    let scope = checker.ctx.current_scope();
+    let scope = checker.ctx.scope();
     let ScopeKind::Function(FunctionDef {
         name,
         decorator_list,
@@ -16,7 +16,7 @@ pub fn in_dunder_init(checker: &Checker) -> bool {
     if name != "__init__" {
         return false;
     }
-    let Some(parent) = checker.ctx.current_scope_parent() else {
+    let Some(parent) = checker.ctx.parent_scope() else {
         return false;
     };
 

--- a/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
@@ -20,7 +20,7 @@ impl Violation for AwaitOutsideAsync {
 pub fn await_outside_async(checker: &mut Checker, expr: &Expr) {
     if !checker
         .ctx
-        .current_scopes()
+        .scopes()
         .find_map(|scope| {
             if let ScopeKind::Function(FunctionDef { async_, .. }) = &scope.kind {
                 Some(*async_)

--- a/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
+++ b/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
@@ -28,7 +28,7 @@ impl Violation for ConsiderUsingSysExit {
 /// Return `true` if the `module` was imported using a star import (e.g., `from
 /// sys import *`).
 fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
-    checker.ctx.current_scopes().any(|scope| {
+    checker.ctx.scopes().any(|scope| {
         scope.bindings.values().any(|index| {
             if let BindingKind::StarImportation(_, name) = &checker.ctx.bindings[*index].kind {
                 name.as_ref().map(|name| name == module).unwrap_or_default()
@@ -42,7 +42,7 @@ fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
 /// Return the appropriate `sys.exit` reference based on the current set of
 /// imports, or `None` is `sys.exit` hasn't been imported.
 fn get_member_import_name_alias(checker: &Checker, module: &str, member: &str) -> Option<String> {
-    checker.ctx.current_scopes().find_map(|scope| {
+    checker.ctx.scopes().find_map(|scope| {
         scope
             .bindings
             .values()

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -52,7 +52,7 @@ impl Violation for GlobalStatement {
 
 /// PLW0603
 pub fn global_statement(checker: &mut Checker, name: &str) {
-    let scope = checker.ctx.current_scope();
+    let scope = checker.ctx.scope();
     if let Some(index) = scope.bindings.get(name) {
         let binding = &checker.ctx.bindings[*index];
         if binding.kind.is_global() {

--- a/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/used_prior_global_declaration.rs
@@ -21,7 +21,7 @@ impl Violation for UsedPriorGlobalDeclaration {
 }
 /// PLE0118
 pub fn used_prior_global_declaration(checker: &mut Checker, name: &str, expr: &Expr) {
-    let globals = match &checker.ctx.current_scope().kind {
+    let globals = match &checker.ctx.scope().kind {
         ScopeKind::Class(class_def) => &class_def.globals,
         ScopeKind::Function(function_def) => &function_def.globals,
         _ => return,

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -38,7 +38,7 @@ pub fn super_call_with_parameters(checker: &mut Checker, expr: &Expr, func: &Exp
     if !is_super_call_with_arguments(func, args) {
         return;
     }
-    let scope = checker.ctx.current_scope();
+    let scope = checker.ctx.scope();
     let parents: Vec<&Stmt> = checker.ctx.parents.iter().map(Into::into).collect();
 
     // Check: are we in a Function scope?

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{Expr, ExprKind, Keyword, Stmt};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::context::Bindings;
 use ruff_python_ast::types::{Binding, BindingKind, Range, Scope};
 
 use crate::checkers::ast::Checker;
@@ -26,7 +27,7 @@ impl AlwaysAutofixableViolation for UselessObjectInheritance {
     }
 }
 
-fn rule(name: &str, bases: &[Expr], scope: &Scope, bindings: &[Binding]) -> Option<Diagnostic> {
+fn rule(name: &str, bases: &[Expr], scope: &Scope, bindings: &Bindings) -> Option<Diagnostic> {
     for expr in bases {
         let ExprKind::Name { id, .. } = &expr.node else {
             continue;
@@ -65,7 +66,7 @@ pub fn useless_object_inheritance(
     bases: &[Expr],
     keywords: &[Keyword],
 ) {
-    let Some(mut diagnostic) = rule(name, bases, checker.ctx.current_scope(), &checker.ctx.bindings) else {
+    let Some(mut diagnostic) = rule(name, bases, checker.ctx.scope(), &checker.ctx.bindings) else {
         return;
     };
     if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -338,14 +338,14 @@ impl<'a> Scopes<'a> {
     /// Pushes a new scope and returns its unique id
     fn push_scope(&mut self, kind: ScopeKind<'a>) -> ScopeId {
         let next_id = ScopeId::try_from(self.0.len()).unwrap();
-        self.0.push(Scope::new(next_id, kind));
+        self.0.push(Scope::local(next_id, kind));
         next_id
     }
 }
 
 impl Default for Scopes<'_> {
     fn default() -> Self {
-        Self(vec![Scope::new(ScopeId::global(), ScopeKind::Module)])
+        Self(vec![Scope::global(ScopeKind::Module)])
     }
 }
 

--- a/crates/ruff_python_ast/src/types.rs
+++ b/crates/ruff_python_ast/src/types.rs
@@ -81,9 +81,9 @@ pub enum ScopeKind<'a> {
 
 /// Id uniquely identifying a scope in a program.
 ///
-/// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`:
-/// A new scope requires a statement with a block body (and the right indention). That means, the upper bound of
-/// scopes is defined by `u32::max / 8` (`if 1:\n x`)
+/// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`
+/// and it is impossible to have more scopes than characters in the file (because defining a function or class
+/// requires more than one character).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct ScopeId(u32);
 
@@ -129,7 +129,11 @@ pub struct Scope<'a> {
 }
 
 impl<'a> Scope<'a> {
-    pub fn new(id: ScopeId, kind: ScopeKind<'a>) -> Self {
+    pub fn global(kind: ScopeKind<'a>) -> Self {
+        Self::local(ScopeId::global(), kind)
+    }
+
+    pub fn local(id: ScopeId, kind: ScopeKind<'a>) -> Self {
         Scope {
             id,
             kind,

--- a/crates/ruff_python_ast/src/types.rs
+++ b/crates/ruff_python_ast/src/types.rs
@@ -1,13 +1,8 @@
+use std::num::TryFromIntError;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Arguments, Expr, Keyword, Located, Location, Stmt};
-
-fn id() -> usize {
-    static COUNTER: AtomicUsize = AtomicUsize::new(1);
-    COUNTER.fetch_add(1, Ordering::Relaxed)
-}
 
 #[derive(Clone)]
 pub enum Node<'a> {
@@ -84,24 +79,59 @@ pub enum ScopeKind<'a> {
     Lambda(Lambda<'a>),
 }
 
+/// Id uniquely identifying a scope in a program.
+///
+/// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`:
+/// A new scope requires a statement with a block body (and the right indention). That means, the upper bound of
+/// scopes is defined by `u32::max / 8` (`if 1:\n x`)
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ScopeId(u32);
+
+impl ScopeId {
+    /// Returns the ID for the global scope
+    #[inline]
+    pub const fn global() -> Self {
+        ScopeId(0)
+    }
+
+    /// Returns `true` if this is the id of the global scope
+    pub const fn is_global(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl TryFrom<usize> for ScopeId {
+    type Error = TryFromIntError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(Self(u32::try_from(value)?))
+    }
+}
+
+impl From<ScopeId> for usize {
+    fn from(value: ScopeId) -> Self {
+        value.0 as usize
+    }
+}
+
 #[derive(Debug)]
 pub struct Scope<'a> {
-    pub id: usize,
+    pub id: ScopeId,
     pub kind: ScopeKind<'a>,
     pub import_starred: bool,
     pub uses_locals: bool,
     /// A map from bound name to binding index, for live bindings.
-    pub bindings: FxHashMap<&'a str, usize>,
+    pub bindings: FxHashMap<&'a str, BindingId>,
     /// A map from bound name to binding index, for bindings that were created
     /// in the scope but rebound (and thus overridden) later on in the same
     /// scope.
-    pub rebounds: FxHashMap<&'a str, Vec<usize>>,
+    pub rebounds: FxHashMap<&'a str, Vec<BindingId>>,
 }
 
 impl<'a> Scope<'a> {
-    pub fn new(kind: ScopeKind<'a>) -> Self {
+    pub fn new(id: ScopeId, kind: ScopeKind<'a>) -> Self {
         Scope {
-            id: id(),
+            id,
             kind,
             import_starred: false,
             uses_locals: false,
@@ -148,6 +178,30 @@ pub enum BindingKind<'a> {
     SubmoduleImportation(&'a str, &'a str),
 }
 
+/// ID uniquely identifying a [Binding] in a program.
+///
+/// Using a `u32` to identify [Binding]s should is sufficient because Ruff only supports documents with a
+/// size smaller than or equal to `u32::max`. A document with the size of `u32::max` must have fewer than `u32::max`
+/// bindings because bindings must be separated by whitespace (and have an assignment).
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct BindingId(u32);
+
+impl From<BindingId> for usize {
+    fn from(value: BindingId) -> Self {
+        value.0 as usize
+    }
+}
+
+impl TryFrom<usize> for BindingId {
+    type Error = TryFromIntError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(Self(u32::try_from(value)?))
+    }
+}
+
+impl nohash_hasher::IsEnabled for BindingId {}
+
 #[derive(Debug, Clone)]
 pub struct Binding<'a> {
     pub kind: BindingKind<'a>,
@@ -158,15 +212,15 @@ pub struct Binding<'a> {
     pub source: Option<RefEquality<'a, Stmt>>,
     /// Tuple of (scope index, range) indicating the scope and range at which
     /// the binding was last used in a runtime context.
-    pub runtime_usage: Option<(usize, Range)>,
+    pub runtime_usage: Option<(ScopeId, Range)>,
     /// Tuple of (scope index, range) indicating the scope and range at which
     /// the binding was last used in a typing-time context.
-    pub typing_usage: Option<(usize, Range)>,
+    pub typing_usage: Option<(ScopeId, Range)>,
     /// Tuple of (scope index, range) indicating the scope and range at which
     /// the binding was last used in a synthetic context. This is used for
     /// (e.g.) `__future__` imports, explicit re-exports, and other bindings
     /// that should be considered used even if they're never referenced.
-    pub synthetic_usage: Option<(usize, Range)>,
+    pub synthetic_usage: Option<(ScopeId, Range)>,
 }
 
 #[derive(Copy, Debug, Clone)]
@@ -176,7 +230,7 @@ pub enum ExecutionContext {
 }
 
 impl<'a> Binding<'a> {
-    pub fn mark_used(&mut self, scope: usize, range: Range, context: ExecutionContext) {
+    pub fn mark_used(&mut self, scope: ScopeId, range: Range, context: ExecutionContext) {
         match context {
             ExecutionContext::Runtime => self.runtime_usage = Some((scope, range)),
             ExecutionContext::Typing => self.typing_usage = Some((scope, range)),


### PR DESCRIPTION
This PR introduces the new `ScopeId` and `BindingId` types instead of using the generic `usize` type. 

Using a specific type allows us to enforce that `bindings` and `scopes` can only be indexed with the corresponding id-types, reducing the risk that they get mixed up. To do this, I had to introduce new `Scopes`, `Bindings` and `ScopeStack` wrapper types. 

This PR removes the `AtomicUsize` that computes the next scope id and instead uses `scopes.len()` to compute the next id. 
