### PR TITLE
Make `scope.bindings` private

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -209,7 +209,7 @@ where
                             source: Some(RefEquality(stmt)),
                             context,
                         });
-                        scope.bindings.insert(name, id);
+                        scope.add(name, id);
                     }
                 }
 
@@ -238,7 +238,7 @@ where
                             source: Some(RefEquality(stmt)),
                             context,
                         });
-                        scope.bindings.insert(name, id);
+                        scope.add(name, id);
                     }
 
                     // Mark the binding in the defining scopes as used too. (Skip the global scope
@@ -250,9 +250,7 @@ where
                         scopes_iter.next_back();
 
                         for index in scopes_iter.skip(1) {
-                            if let Some(index) =
-                                self.ctx.scopes[*index].bindings.get(&name.as_str())
-                            {
+                            if let Some(index) = self.ctx.scopes[*index].get(name.as_str()) {
                                 exists = true;
                                 self.ctx.bindings[*index].runtime_usage = usage;
                             }
@@ -1875,7 +1873,6 @@ where
                     if self
                         .ctx
                         .global_scope()
-                        .bindings
                         .get(name)
                         .map_or(true, |index| self.ctx.bindings[*index].kind.is_annotation())
                     {
@@ -1888,7 +1885,7 @@ where
                             source: Some(RefEquality(stmt)),
                             context: self.ctx.execution_context(),
                         });
-                        self.ctx.global_scope_mut().bindings.insert(name, id);
+                        self.ctx.global_scope_mut().add(name, id);
                     }
                 }
 
@@ -1938,7 +1935,6 @@ where
                     if self
                         .ctx
                         .global_scope()
-                        .bindings
                         .get(name)
                         .map_or(true, |index| self.ctx.bindings[*index].kind.is_annotation())
                     {
@@ -1951,7 +1947,7 @@ where
                             source: Some(RefEquality(stmt)),
                             context: self.ctx.execution_context(),
                         });
-                        self.ctx.global_scope_mut().bindings.insert(name, id);
+                        self.ctx.global_scope_mut().add(name, id);
                     }
                 }
 
@@ -3714,7 +3710,7 @@ where
                         let name_range =
                             helpers::excepthandler_name_range(excepthandler, self.locator).unwrap();
 
-                        if self.ctx.scope().bindings.contains_key(&name.as_str()) {
+                        if self.ctx.scope().defines(name.as_str()) {
                             self.handle_node_store(
                                 name,
                                 &Expr::new(
@@ -3728,7 +3724,7 @@ where
                             );
                         }
 
-                        let definition = self.ctx.scope().bindings.get(&name.as_str()).copied();
+                        let definition = self.ctx.scope().get(name.as_str()).copied();
                         self.handle_node_store(
                             name,
                             &Expr::new(
@@ -3745,7 +3741,7 @@ where
 
                         if let Some(index) = {
                             let scope = self.ctx.scope_mut();
-                            &scope.bindings.remove(&name.as_str())
+                            &scope.remove(name.as_str())
                         } {
                             if !self.ctx.bindings[*index].used() {
                                 if self.settings.rules.enabled(Rule::UnusedVariable) {
@@ -3779,7 +3775,7 @@ where
 
                         if let Some(index) = definition {
                             let scope = self.ctx.scope_mut();
-                            scope.bindings.insert(name, index);
+                            scope.add(name, index);
                         }
                     }
                     None => walk_excepthandler(self, excepthandler),
@@ -3934,14 +3930,17 @@ impl<'a> Checker<'a> {
         'b: 'a,
     {
         let binding_id = self.ctx.bindings.next_id();
-        if let Some((stack_index, scope_index)) = self
+        if let Some((stack_index, existing_binding_index)) = self
             .ctx
             .scope_stack
             .iter()
             .enumerate()
-            .find(|(_, scope_index)| self.ctx.scopes[**scope_index].bindings.contains_key(&name))
+            .find_map(|(stack_index, scope_index)| {
+                self.ctx.scopes[*scope_index]
+                    .get(name)
+                    .map(|binding_id| (stack_index, *binding_id))
+            })
         {
-            let existing_binding_index = self.ctx.scopes[*scope_index].bindings[&name];
             let existing = &self.ctx.bindings[existing_binding_index];
             let in_current_scope = stack_index == 0;
             if !existing.kind.is_builtin()
@@ -4013,7 +4012,7 @@ impl<'a> Checker<'a> {
         }
 
         let scope = self.ctx.scope();
-        let binding = if let Some(index) = scope.bindings.get(&name) {
+        let binding = if let Some(index) = scope.get(name) {
             let existing = &self.ctx.bindings[*index];
             match &existing.kind {
                 BindingKind::Builtin => {
@@ -4045,8 +4044,8 @@ impl<'a> Checker<'a> {
         // Don't treat annotations as assignments if there is an existing value
         // in scope.
         let scope = self.ctx.scope_mut();
-        if !(binding.kind.is_annotation() && scope.bindings.contains_key(name)) {
-            if let Some(rebound_index) = scope.bindings.insert(name, binding_id) {
+        if !(binding.kind.is_annotation() && scope.defines(name)) {
+            if let Some(rebound_index) = scope.add(name, binding_id) {
                 scope
                     .rebounds
                     .entry(name)
@@ -4077,7 +4076,7 @@ impl<'a> Checker<'a> {
                 source: None,
                 context: ExecutionContext::Runtime,
             });
-            scope.bindings.insert(builtin, id);
+            scope.add(builtin, id);
         }
     }
 
@@ -4102,7 +4101,7 @@ impl<'a> Checker<'a> {
                 }
             }
 
-            if let Some(index) = scope.bindings.get(&id.as_str()) {
+            if let Some(index) = scope.get(id.as_str()) {
                 // Mark the binding as used.
                 let context = self.ctx.execution_context();
                 self.ctx.bindings[*index].mark_used(scope_id, Range::from(expr), context);
@@ -4132,7 +4131,7 @@ impl<'a> Checker<'a> {
                             .unwrap_or_default();
                         if has_alias {
                             // Mark the sub-importation as used.
-                            if let Some(index) = scope.bindings.get(full_name) {
+                            if let Some(index) = scope.get(full_name) {
                                 self.ctx.bindings[*index].mark_used(
                                     scope_id,
                                     Range::from(expr),
@@ -4149,7 +4148,7 @@ impl<'a> Checker<'a> {
                             .unwrap_or_default();
                         if has_alias {
                             // Mark the sub-importation as used.
-                            if let Some(index) = scope.bindings.get(full_name.as_str()) {
+                            if let Some(index) = scope.get(full_name.as_str()) {
                                 self.ctx.bindings[*index].mark_used(
                                     scope_id,
                                     Range::from(expr),
@@ -4174,11 +4173,7 @@ impl<'a> Checker<'a> {
                 let mut from_list = vec![];
                 for scope_index in self.ctx.scope_stack.iter() {
                     let scope = &self.ctx.scopes[*scope_index];
-                    for binding in scope
-                        .bindings
-                        .values()
-                        .map(|index| &self.ctx.bindings[*index])
-                    {
+                    for binding in scope.binding_ids().map(|index| &self.ctx.bindings[*index]) {
                         if let BindingKind::StarImportation(level, module) = &binding.kind {
                             from_list.push(helpers::format_import_from(
                                 level.as_ref(),
@@ -4261,7 +4256,6 @@ impl<'a> Checker<'a> {
                 if !self
                     .ctx
                     .scope()
-                    .bindings
                     .get(id)
                     .map_or(false, |index| self.ctx.bindings[*index].kind.is_global())
                 {
@@ -4434,7 +4428,7 @@ impl<'a> Checker<'a> {
         }
 
         let scope = self.ctx.scope_mut();
-        if scope.bindings.remove(&id.as_str()).is_some() {
+        if scope.remove(id.as_str()).is_some() {
             return;
         }
         if !self.settings.rules.enabled(Rule::UndefinedName) {
@@ -4664,7 +4658,6 @@ impl<'a> Checker<'a> {
         let all_bindings: Option<(Vec<BindingId>, Range)> = {
             let global_scope = self.ctx.global_scope();
             let all_names: Option<(&Vec<String>, Range)> = global_scope
-                .bindings
                 .get("__all__")
                 .map(|index| &self.ctx.bindings[*index])
                 .and_then(|binding| match &binding.kind {
@@ -4676,7 +4669,7 @@ impl<'a> Checker<'a> {
                 (
                     names
                         .iter()
-                        .filter_map(|name| global_scope.bindings.get(name.as_str()).copied())
+                        .filter_map(|name| global_scope.get(name.as_str()).copied())
                         .collect(),
                     range,
                 )
@@ -4697,7 +4690,6 @@ impl<'a> Checker<'a> {
         let all_names: Option<(Vec<&str>, Range)> = self
             .ctx
             .global_scope()
-            .bindings
             .get("__all__")
             .map(|index| &self.ctx.bindings[*index])
             .and_then(|binding| match &binding.kind {
@@ -4719,8 +4711,7 @@ impl<'a> Checker<'a> {
                     .iter()
                     .map(|scope| {
                         scope
-                            .bindings
-                            .values()
+                            .binding_ids()
                             .map(|index| &self.ctx.bindings[*index])
                             .filter(|binding| {
                                 flake8_type_checking::helpers::is_valid_runtime_import(binding)
@@ -4750,7 +4741,7 @@ impl<'a> Checker<'a> {
 
             // PLW0602
             if self.settings.rules.enabled(Rule::GlobalVariableNotAssigned) {
-                for (name, index) in &scope.bindings {
+                for (name, index) in scope.bindings() {
                     let binding = &self.ctx.bindings[*index];
                     if binding.kind.is_global() {
                         if let Some(stmt) = &binding.source {
@@ -4776,7 +4767,7 @@ impl<'a> Checker<'a> {
             // unused. Note that we only store references in `redefinitions` if
             // the bindings are in different scopes.
             if self.settings.rules.enabled(Rule::RedefinedWhileUnused) {
-                for (name, index) in &scope.bindings {
+                for (name, index) in scope.bindings() {
                     let binding = &self.ctx.bindings[*index];
 
                     if matches!(
@@ -4819,11 +4810,7 @@ impl<'a> Checker<'a> {
                 if scope.import_starred {
                     if let Some((names, range)) = &all_names {
                         let mut from_list = vec![];
-                        for binding in scope
-                            .bindings
-                            .values()
-                            .map(|index| &self.ctx.bindings[*index])
-                        {
+                        for binding in scope.binding_ids().map(|index| &self.ctx.bindings[*index]) {
                             if let BindingKind::StarImportation(level, module) = &binding.kind {
                                 from_list.push(helpers::format_import_from(
                                     level.as_ref(),
@@ -4834,7 +4821,7 @@ impl<'a> Checker<'a> {
                         from_list.sort();
 
                         for &name in names {
-                            if !scope.bindings.contains_key(name) {
+                            if !scope.defines(name) {
                                 diagnostics.push(Diagnostic::new(
                                     pyflakes::rules::ImportStarUsage {
                                         name: name.to_string(),
@@ -4860,7 +4847,7 @@ impl<'a> Checker<'a> {
                         .copied()
                         .collect()
                 };
-                for (.., index) in &scope.bindings {
+                for index in scope.binding_ids() {
                     let binding = &self.ctx.bindings[*index];
 
                     if let Some(diagnostic) =
@@ -4896,7 +4883,7 @@ impl<'a> Checker<'a> {
                 let mut ignored: FxHashMap<BindingContext, Vec<UnusedImport>> =
                     FxHashMap::default();
 
-                for index in scope.bindings.values() {
+                for index in scope.binding_ids() {
                     let binding = &self.ctx.bindings[*index];
 
                     let full_name = match &binding.kind {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -165,7 +165,6 @@ pub fn unused_loop_control_variable(
                 // Find the `BindingKind::LoopVar` corresponding to the name.
                 let scope = checker.ctx.scope();
                 let binding = scope
-                    .bindings
                     .get(name)
                     .into_iter()
                     .chain(scope.rebounds.get(name).into_iter().flatten())

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -28,7 +28,7 @@ pub fn undefined_export(
     let mut diagnostics = Vec::new();
     if !scope.import_starred && !path.ends_with("__init__.py") {
         for name in names {
-            if !scope.bindings.contains_key(name) {
+            if !scope.defines(name) {
                 diagnostics.push(Diagnostic::new(
                     UndefinedExport {
                         name: (*name).to_string(),

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -20,10 +20,10 @@ impl Violation for UndefinedLocal {
 /// F821
 pub fn undefined_local(name: &str, scopes: &[&Scope], bindings: &Bindings) -> Option<Diagnostic> {
     let current = &scopes.last().expect("No current scope found");
-    if matches!(current.kind, ScopeKind::Function(_)) && !current.bindings.contains_key(name) {
+    if matches!(current.kind, ScopeKind::Function(_)) && !current.defines(name) {
         for scope in scopes.iter().rev().skip(1) {
             if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Module) {
-                if let Some(binding) = scope.bindings.get(name).map(|index| &bindings[*index]) {
+                if let Some(binding) = scope.get(name).map(|index| &bindings[*index]) {
                     if let Some((scope_id, location)) = binding.runtime_usage {
                         if scope_id == current.id {
                             return Some(Diagnostic::new(

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -21,8 +21,7 @@ impl Violation for UnusedAnnotation {
 pub fn unused_annotation(checker: &mut Checker, scope: ScopeId) {
     let scope = &checker.ctx.scopes[scope];
     for (name, binding) in scope
-        .bindings
-        .iter()
+        .bindings()
         .map(|(name, index)| (name, &checker.ctx.bindings[*index]))
     {
         if !binding.used()

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -320,8 +320,7 @@ pub fn unused_variable(checker: &mut Checker, scope: ScopeId) {
     }
 
     for (name, binding) in scope
-        .bindings
-        .iter()
+        .bindings()
         .map(|(name, index)| (name, &checker.ctx.bindings[*index]))
     {
         if !binding.used()

--- a/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
+++ b/crates/ruff/src/rules/pylint/rules/consider_using_sys_exit.rs
@@ -30,7 +30,7 @@ impl Violation for ConsiderUsingSysExit {
 /// sys import *`).
 fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
     checker.ctx.scopes().any(|scope| {
-        scope.bindings.values().any(|index| {
+        scope.binding_ids().any(|index| {
             if let BindingKind::StarImportation(_, name) = &checker.ctx.bindings[*index].kind {
                 name.as_ref().map(|name| name == module).unwrap_or_default()
             } else {
@@ -45,8 +45,7 @@ fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
 fn get_member_import_name_alias(checker: &Checker, module: &str, member: &str) -> Option<String> {
     checker.ctx.scopes().find_map(|scope| {
         scope
-            .bindings
-            .values()
+            .binding_ids()
             .find_map(|index| match &checker.ctx.bindings[*index].kind {
                 // e.g. module=sys object=exit
                 // `import sys`         -> `sys.exit`

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -53,7 +53,7 @@ impl Violation for GlobalStatement {
 /// PLW0603
 pub fn global_statement(checker: &mut Checker, name: &str) {
     let scope = checker.ctx.scope();
-    if let Some(index) = scope.bindings.get(name) {
+    if let Some(index) = scope.get(name) {
         let binding = &checker.ctx.bindings[*index];
         if binding.kind.is_global() {
             let source: &Stmt = binding

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -36,10 +36,7 @@ fn rule(name: &str, bases: &[Expr], scope: &Scope, bindings: &Bindings) -> Optio
             continue;
         }
         if !matches!(
-            scope
-                .bindings
-                .get(&id.as_str())
-                .map(|index| &bindings[*index]),
+            scope.get(id.as_str()).map(|index| &bindings[*index]),
             None | Some(Binding {
                 kind: BindingKind::Builtin,
                 ..

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -125,7 +125,7 @@ impl<'a> Context<'a> {
     /// Return the current `Binding` for a given `name`.
     pub fn find_binding(&self, member: &str) -> Option<&Binding> {
         self.scopes()
-            .find_map(|scope| scope.bindings.get(member))
+            .find_map(|scope| scope.get(member))
             .map(|index| &self.bindings[*index])
     }
 

--- a/crates/ruff_python_ast/src/operations.rs
+++ b/crates/ruff_python_ast/src/operations.rs
@@ -95,7 +95,7 @@ pub fn extract_all_names(
 
     // Grab the existing bound __all__ values.
     if let StmtKind::AugAssign { .. } = &stmt.node {
-        if let Some(index) = scope.bindings.get("__all__") {
+        if let Some(index) = scope.get("__all__") {
             if let BindingKind::Export(existing) = &ctx.bindings[*index].kind {
                 names.extend_from_slice(existing);
             }

--- a/crates/ruff_python_ast/src/scope.rs
+++ b/crates/ruff_python_ast/src/scope.rs
@@ -11,7 +11,7 @@ pub struct Scope<'a> {
     pub import_starred: bool,
     pub uses_locals: bool,
     /// A map from bound name to binding index, for live bindings.
-    pub bindings: FxHashMap<&'a str, BindingId>,
+    bindings: FxHashMap<&'a str, BindingId>,
     /// A map from bound name to binding index, for bindings that were created
     /// in the scope but rebound (and thus overridden) later on in the same
     /// scope.
@@ -28,6 +28,35 @@ impl<'a> Scope<'a> {
             bindings: FxHashMap::default(),
             rebounds: FxHashMap::default(),
         }
+    }
+
+    /// Returns the [id](BindingId) of the binding with the given name.
+    pub fn get(&self, name: &str) -> Option<&BindingId> {
+        self.bindings.get(name)
+    }
+
+    /// Adds a new binding with the given name to this scope.
+    pub fn add(&mut self, name: &'a str, id: BindingId) -> Option<BindingId> {
+        self.bindings.insert(name, id)
+    }
+
+    /// Returns `true` if this scope defines a binding with the given name.
+    pub fn defines(&self, name: &str) -> bool {
+        self.bindings.contains_key(name)
+    }
+
+    /// Removes the binding with the given name
+    pub fn remove(&mut self, name: &str) -> Option<BindingId> {
+        self.bindings.remove(name)
+    }
+
+    /// Returns the ids of all bindings defined in this scope.
+    pub fn binding_ids(&self) -> std::collections::hash_map::Values<&str, BindingId> {
+        self.bindings.values()
+    }
+
+    pub fn bindings(&self) -> std::collections::hash_map::Iter<&'a str, BindingId> {
+        self.bindings.iter()
     }
 }
 


### PR DESCRIPTION
This PR makes `Scope.bindings` private and instead adds semantic APIs to `Scope` that allow querying the bindings. 

This reduces the nesting on call sites `scope.bindings.get(name)` vs `scope.get(name)`