### PR TITLE
Avoid adding dashed line outside of docstring

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
@@ -59,6 +59,15 @@ def no_underline_and_no_description():  # noqa: D416
 
 
 @expect(_D213)
+@expect("D407: Missing dashed underline after section ('Returns')")
+@expect("D414: Section has no content ('Returns')")
+def no_underline_and_no_newline():  # noqa: D416
+    """Toggle the gizmo.
+
+    Returns"""
+
+
+@expect(_D213)
 @expect("D410: Missing blank line after section ('Returns')")
 @expect("D414: Section has no content ('Returns')")
 @expect("D411: Missing blank line before section ('Yields')")

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -365,15 +365,15 @@ fn blanks_and_section_underline(
                 // Add a dashed line (of the appropriate length) under the section header.
                 let content = format!(
                     "{}{}{}",
+                    checker.stylist.line_ending().as_str(),
                     whitespace::clean(docstring.indentation),
                     "-".repeat(context.section_name.len()),
-                    checker.stylist.line_ending().as_str()
                 );
                 diagnostic.amend(Fix::insertion(
                     content,
                     Location::new(
-                        docstring.expr.location.row() + context.original_index + 1,
-                        0,
+                        docstring.expr.location.row() + context.original_index,
+                        context.line.trim_end().chars().count(),
                     ),
                 ));
             }
@@ -595,15 +595,15 @@ fn blanks_and_section_underline(
                 // Add a dashed line (of the appropriate length) under the section header.
                 let content = format!(
                     "{}{}{}",
+                    checker.stylist.line_ending().as_str(),
                     whitespace::clean(docstring.indentation),
                     "-".repeat(context.section_name.len()),
-                    checker.stylist.line_ending().as_str()
                 );
                 diagnostic.amend(Fix::insertion(
                     content,
                     Location::new(
-                        docstring.expr.location.row() + context.original_index + 1,
-                        0,
+                        docstring.expr.location.row() + context.original_index,
+                        context.line.trim_end().chars().count(),
                     ),
                 ));
             }
@@ -721,14 +721,14 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
+                    let line = context.following_lines.last().unwrap_or(&context.line);
                     diagnostic.amend(Fix::insertion(
-                        line_end.to_string(),
+                        format!("{}{}", line_end, docstring.indentation),
                         Location::new(
                             docstring.expr.location.row()
                                 + context.original_index
-                                + 1
                                 + context.following_lines.len(),
-                            0,
+                            line.trim_end().chars().count(),
                         ),
                     ));
                 }
@@ -744,14 +744,14 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
+                    let line = context.following_lines.last().unwrap_or(&context.line);
                     diagnostic.amend(Fix::insertion(
                         line_end.to_string(),
                         Location::new(
                             docstring.expr.location.row()
                                 + context.original_index
-                                + 1
                                 + context.following_lines.len(),
-                            0,
+                            line.trim_end().chars().count(),
                         ),
                     ));
                 }

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: "Remove over-indentation from \"Returns\""
     fixable: true
   location:
-    row: 135
+    row: 144
     column: 4
   end_location:
-    row: 141
+    row: 150
     column: 7
   fix:
     content: "    "
     location:
-      row: 137
+      row: 146
       column: 0
     end_location:
-      row: 137
+      row: 146
       column: 8
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D215_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D215_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: "Remove over-indentation from \"Returns\" underline"
     fixable: true
   location:
-    row: 147
+    row: 156
     column: 4
   end_location:
-    row: 153
+    row: 162
     column: 7
   fix:
     content: "    "
     location:
-      row: 150
+      row: 159
       column: 0
     end_location:
-      row: 150
+      row: 159
       column: 9
   parent: ~
 - kind:
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Remove over-indentation from \"Returns\" underline"
     fixable: true
   location:
-    row: 161
+    row: 170
     column: 4
   end_location:
-    row: 165
+    row: 174
     column: 7
   fix:
     content: "    "
     location:
-      row: 164
+      row: 173
       column: 0
     end_location:
-      row: 164
+      row: 173
       column: 9
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D405_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D405_sections.py.snap
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Capitalize \"Short summary\""
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: Short Summary
     location:
-      row: 209
+      row: 218
       column: 4
     end_location:
-      row: 209
+      row: 218
       column: 17
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D406_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D406_sections.py.snap
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Add newline after \"Raises\""
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: ""
     location:
-      row: 218
+      row: 227
       column: 10
     end_location:
-      row: 218
+      row: 227
       column: 11
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
@@ -14,13 +14,13 @@ expression: diagnostics
     row: 47
     column: 7
   fix:
-    content: "    -------\n"
+    content: "\n    -------"
     location:
-      row: 45
-      column: 0
+      row: 44
+      column: 11
     end_location:
-      row: 45
-      column: 0
+      row: 44
+      column: 11
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -34,53 +34,13 @@ expression: diagnostics
     row: 58
     column: 7
   fix:
-    content: "    -------\n"
+    content: "\n    -------"
     location:
-      row: 57
-      column: 0
+      row: 56
+      column: 11
     end_location:
-      row: 57
-      column: 0
-  parent: ~
-- kind:
-    name: DashedUnderlineAfterSection
-    body: "Missing dashed underline after section (\"Raises\")"
-    suggestion: "Add dashed line under \"Raises\""
-    fixable: true
-  location:
-    row: 207
-    column: 4
-  end_location:
-    row: 221
-    column: 7
-  fix:
-    content: "    ------\n"
-    location:
-      row: 219
-      column: 0
-    end_location:
-      row: 219
-      column: 0
-  parent: ~
-- kind:
-    name: DashedUnderlineAfterSection
-    body: "Missing dashed underline after section (\"Args\")"
-    suggestion: "Add dashed line under \"Args\""
-    fixable: true
-  location:
-    row: 252
-    column: 4
-  end_location:
-    row: 262
-    column: 7
-  fix:
-    content: "    ----\n"
-    location:
-      row: 255
-      column: 0
-    end_location:
-      row: 255
-      column: 0
+      row: 56
+      column: 11
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -88,19 +48,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Returns\""
     fixable: true
   location:
-    row: 252
+    row: 65
     column: 4
   end_location:
-    row: 262
-    column: 7
+    row: 67
+    column: 14
   fix:
-    content: "    -------\n"
+    content: "\n    -------"
     location:
-      row: 258
-      column: 0
+      row: 67
+      column: 11
     end_location:
-      row: 258
-      column: 0
+      row: 67
+      column: 11
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -108,19 +68,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Raises\""
     fixable: true
   location:
-    row: 252
+    row: 216
     column: 4
   end_location:
-    row: 262
+    row: 230
     column: 7
   fix:
-    content: "    ------\n"
+    content: "\n    ------"
     location:
-      row: 260
-      column: 0
+      row: 227
+      column: 11
     end_location:
-      row: 260
-      column: 0
+      row: 227
+      column: 11
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -128,19 +88,59 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 269
+    row: 261
     column: 4
   end_location:
-    row: 274
+    row: 271
     column: 7
   fix:
-    content: "    ----\n"
+    content: "\n    ----"
     location:
-      row: 272
-      column: 0
+      row: 263
+      column: 9
     end_location:
-      row: 272
-      column: 0
+      row: 263
+      column: 9
+  parent: ~
+- kind:
+    name: DashedUnderlineAfterSection
+    body: "Missing dashed underline after section (\"Returns\")"
+    suggestion: "Add dashed line under \"Returns\""
+    fixable: true
+  location:
+    row: 261
+    column: 4
+  end_location:
+    row: 271
+    column: 7
+  fix:
+    content: "\n    -------"
+    location:
+      row: 266
+      column: 12
+    end_location:
+      row: 266
+      column: 12
+  parent: ~
+- kind:
+    name: DashedUnderlineAfterSection
+    body: "Missing dashed underline after section (\"Raises\")"
+    suggestion: "Add dashed line under \"Raises\""
+    fixable: true
+  location:
+    row: 261
+    column: 4
+  end_location:
+    row: 271
+    column: 7
+  fix:
+    content: "\n    ------"
+    location:
+      row: 268
+      column: 11
+    end_location:
+      row: 268
+      column: 11
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -148,39 +148,59 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 284
+    row: 278
+    column: 4
+  end_location:
+    row: 283
+    column: 7
+  fix:
+    content: "\n    ----"
+    location:
+      row: 280
+      column: 8
+    end_location:
+      row: 280
+      column: 8
+  parent: ~
+- kind:
+    name: DashedUnderlineAfterSection
+    body: "Missing dashed underline after section (\"Args\")"
+    suggestion: "Add dashed line under \"Args\""
+    fixable: true
+  location:
+    row: 293
     column: 8
   end_location:
-    row: 292
-    column: 11
-  fix:
-    content: "        ----\n"
-    location:
-      row: 289
-      column: 0
-    end_location:
-      row: 289
-      column: 0
-  parent: ~
-- kind:
-    name: DashedUnderlineAfterSection
-    body: "Missing dashed underline after section (\"Args\")"
-    suggestion: "Add dashed line under \"Args\""
-    fixable: true
-  location:
     row: 301
+    column: 11
+  fix:
+    content: "\n        ----"
+    location:
+      row: 297
+      column: 13
+    end_location:
+      row: 297
+      column: 13
+  parent: ~
+- kind:
+    name: DashedUnderlineAfterSection
+    body: "Missing dashed underline after section (\"Args\")"
+    suggestion: "Add dashed line under \"Args\""
+    fixable: true
+  location:
+    row: 310
     column: 4
   end_location:
-    row: 306
+    row: 315
     column: 7
   fix:
-    content: "    ----\n"
+    content: "\n    ----"
     location:
-      row: 304
-      column: 0
+      row: 312
+      column: 9
     end_location:
-      row: 304
-      column: 0
+      row: 312
+      column: 9
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -188,19 +208,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 313
+    row: 322
     column: 8
   end_location:
-    row: 319
+    row: 328
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 316
-      column: 0
+      row: 324
+      column: 13
     end_location:
-      row: 316
-      column: 0
+      row: 324
+      column: 13
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -208,19 +228,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 325
+    row: 334
     column: 8
   end_location:
-    row: 330
+    row: 339
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 328
-      column: 0
+      row: 336
+      column: 13
     end_location:
-      row: 328
-      column: 0
+      row: 336
+      column: 13
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -228,19 +248,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 337
+    row: 346
     column: 8
   end_location:
-    row: 343
+    row: 352
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 340
-      column: 0
+      row: 348
+      column: 13
     end_location:
-      row: 340
-      column: 0
+      row: 348
+      column: 13
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -248,39 +268,19 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 350
+    row: 359
     column: 8
   end_location:
-    row: 355
+    row: 364
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 353
-      column: 0
+      row: 361
+      column: 13
     end_location:
-      row: 353
-      column: 0
-  parent: ~
-- kind:
-    name: DashedUnderlineAfterSection
-    body: "Missing dashed underline after section (\"Args\")"
-    suggestion: "Add dashed line under \"Args\""
-    fixable: true
-  location:
-    row: 362
-    column: 8
-  end_location:
-    row: 367
-    column: 11
-  fix:
-    content: "        ----\n"
-    location:
-      row: 365
-      column: 0
-    end_location:
-      row: 365
-      column: 0
+      row: 361
+      column: 13
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -291,16 +291,16 @@ expression: diagnostics
     row: 371
     column: 8
   end_location:
-    row: 382
+    row: 376
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 374
-      column: 0
+      row: 373
+      column: 13
     end_location:
-      row: 374
-      column: 0
+      row: 373
+      column: 13
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -308,18 +308,38 @@ expression: diagnostics
     suggestion: "Add dashed line under \"Args\""
     fixable: true
   location:
-    row: 490
+    row: 380
     column: 8
   end_location:
-    row: 497
+    row: 391
     column: 11
   fix:
-    content: "        ----\n"
+    content: "\n        ----"
     location:
-      row: 495
-      column: 0
+      row: 382
+      column: 13
     end_location:
-      row: 495
-      column: 0
+      row: 382
+      column: 13
+  parent: ~
+- kind:
+    name: DashedUnderlineAfterSection
+    body: "Missing dashed underline after section (\"Args\")"
+    suggestion: "Add dashed line under \"Args\""
+    fixable: true
+  location:
+    row: 499
+    column: 8
+  end_location:
+    row: 506
+    column: 11
+  fix:
+    content: "\n        ----"
+    location:
+      row: 503
+      column: 13
+    end_location:
+      row: 503
+      column: 13
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D408_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D408_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: "Add underline to \"Returns\""
     fixable: true
   location:
-    row: 85
+    row: 94
     column: 4
   end_location:
-    row: 92
+    row: 101
     column: 7
   fix:
     content: ""
     location:
-      row: 88
+      row: 97
       column: 0
     end_location:
-      row: 89
+      row: 98
       column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D409_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D409_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: "Adjust underline length to match \"Returns\""
     fixable: true
   location:
-    row: 99
+    row: 108
     column: 4
   end_location:
-    row: 105
+    row: 114
     column: 7
   fix:
     content: "    -------\n"
     location:
-      row: 102
+      row: 111
       column: 0
     end_location:
-      row: 103
+      row: 112
       column: 0
   parent: ~
 - kind:
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Adjust underline length to match \"Returns\""
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: "    -------\n"
     location:
-      row: 216
+      row: 225
       column: 0
     end_location:
-      row: 217
+      row: 226
       column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D410_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D410_sections.py.snap
@@ -8,19 +8,19 @@ expression: diagnostics
     suggestion: "Add blank line after \"Returns\""
     fixable: true
   location:
-    row: 67
+    row: 76
     column: 4
   end_location:
-    row: 78
+    row: 87
     column: 7
   fix:
     content: "\n"
     location:
-      row: 71
-      column: 0
+      row: 79
+      column: 11
     end_location:
-      row: 71
-      column: 0
+      row: 79
+      column: 11
   parent: ~
 - kind:
     name: BlankLineAfterSection
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Add blank line after \"Returns\""
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: "\n"
     location:
-      row: 218
-      column: 0
+      row: 226
+      column: 31
     end_location:
-      row: 218
-      column: 0
+      row: 226
+      column: 31
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D411_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D411_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: "Add blank line before \"Yields\""
     fixable: true
   location:
-    row: 67
+    row: 76
     column: 4
   end_location:
-    row: 78
+    row: 87
     column: 7
   fix:
     content: "\n"
     location:
-      row: 71
+      row: 80
       column: 0
     end_location:
-      row: 71
+      row: 80
       column: 0
   parent: ~
 - kind:
@@ -28,18 +28,18 @@ expression: diagnostics
     suggestion: "Add blank line before \"Returns\""
     fixable: true
   location:
-    row: 122
+    row: 131
     column: 4
   end_location:
-    row: 129
+    row: 138
     column: 7
   fix:
     content: "\n"
     location:
-      row: 125
+      row: 134
       column: 0
     end_location:
-      row: 125
+      row: 134
       column: 0
   parent: ~
 - kind:
@@ -48,18 +48,18 @@ expression: diagnostics
     suggestion: "Add blank line before \"Raises\""
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: "\n"
     location:
-      row: 218
+      row: 227
       column: 0
     end_location:
-      row: 218
+      row: 227
       column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D412_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D412_sections.py.snap
@@ -8,18 +8,18 @@ expression: diagnostics
     suggestion: Remove blank line(s)
     fixable: true
   location:
-    row: 207
+    row: 216
     column: 4
   end_location:
-    row: 221
+    row: 230
     column: 7
   fix:
     content: ""
     location:
-      row: 211
+      row: 220
       column: 0
     end_location:
-      row: 212
+      row: 221
       column: 0
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D413_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D413_sections.py.snap
@@ -1,6 +1,25 @@
 ---
-source: src/rules/pydocstyle/mod.rs
+source: crates/ruff/src/rules/pydocstyle/mod.rs
 expression: diagnostics
 ---
-[]
+- kind:
+    name: BlankLineAfterLastSection
+    body: "Missing blank line after last section (\"Returns\")"
+    suggestion: "Add blank line after \"Returns\""
+    fixable: true
+  location:
+    row: 65
+    column: 4
+  end_location:
+    row: 67
+    column: 14
+  fix:
+    content: "\n    "
+    location:
+      row: 67
+      column: 11
+    end_location:
+      row: 67
+      column: 11
+  parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D414_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D414_sections.py.snap
@@ -21,10 +21,23 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 67
+    row: 65
     column: 4
   end_location:
-    row: 78
+    row: 67
+    column: 14
+  fix: ~
+  parent: ~
+- kind:
+    name: EmptyDocstringSection
+    body: "Section has no content (\"Returns\")"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 76
+    column: 4
+  end_location:
+    row: 87
     column: 7
   fix: ~
   parent: ~
@@ -34,10 +47,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 67
+    row: 76
     column: 4
   end_location:
-    row: 78
+    row: 87
     column: 7
   fix: ~
   parent: ~
@@ -47,10 +60,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 161
+    row: 170
     column: 4
   end_location:
-    row: 165
+    row: 174
     column: 7
   fix: ~
   parent: ~
@@ -60,10 +73,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 252
+    row: 261
     column: 4
   end_location:
-    row: 262
+    row: 271
     column: 7
   fix: ~
   parent: ~

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D417_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D417_sections.py.snap
@@ -8,10 +8,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 283
+    row: 292
     column: 8
   end_location:
-    row: 283
+    row: 292
     column: 11
   fix: ~
   parent: ~
@@ -21,10 +21,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 300
+    row: 309
     column: 4
   end_location:
-    row: 300
+    row: 309
     column: 28
   fix: ~
   parent: ~
@@ -34,10 +34,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 324
+    row: 333
     column: 8
   end_location:
-    row: 324
+    row: 333
     column: 25
   fix: ~
   parent: ~
@@ -47,10 +47,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 336
+    row: 345
     column: 8
   end_location:
-    row: 336
+    row: 345
     column: 38
   fix: ~
   parent: ~
@@ -60,10 +60,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 349
+    row: 358
     column: 8
   end_location:
-    row: 349
+    row: 358
     column: 39
   fix: ~
   parent: ~
@@ -73,10 +73,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 361
+    row: 370
     column: 8
   end_location:
-    row: 361
+    row: 370
     column: 30
   fix: ~
   parent: ~
@@ -86,10 +86,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 389
+    row: 398
     column: 4
   end_location:
-    row: 389
+    row: 398
     column: 27
   fix: ~
   parent: ~
@@ -99,10 +99,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 425
+    row: 434
     column: 8
   end_location:
-    row: 425
+    row: 434
     column: 25
   fix: ~
   parent: ~
@@ -112,10 +112,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 440
+    row: 449
     column: 8
   end_location:
-    row: 440
+    row: 449
     column: 38
   fix: ~
   parent: ~
@@ -125,10 +125,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 459
+    row: 468
     column: 8
   end_location:
-    row: 459
+    row: 468
     column: 39
   fix: ~
   parent: ~
@@ -138,10 +138,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 489
+    row: 498
     column: 8
   end_location:
-    row: 489
+    row: 498
     column: 29
   fix: ~
   parent: ~


### PR DESCRIPTION
If you have a docstring like:

```py
def no_underline_and_no_newline():  # noqa: D416
    """Toggle the gizmo.
    Returns"""
```

Then right now, when we inject the dashed underline under `Returns`, we end up putting it _outside_ of the docstring 🤦 This PR adds handling for this (uncommon) "no following lines" case.

Closes #3534.
