### PR TITLE
Enable ANSI colors on Windows 10

### DIFF
--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -69,6 +69,10 @@ quoting the executed command, along with the relevant file contents and `pyproje
         }));
     }
 
+    // Enabled ANSI colors on Windows 10.
+    #[cfg(windows)]
+    assert!(colored::control::set_virtual_terminal(true).is_ok());
+
     let log_level: LogLevel = (&log_level_args).into();
     set_up_logging(&log_level)?;
 


### PR DESCRIPTION
## Summary

It looks like our color output is failing on Windows 10 (yet we're still outputting the color markers). There's some discussion in https://github.com/mackwic/colored/issues/59, and the recommended fix is to enable the virtual terminal in that case (https://docs.rs/colored/2.0.0/x86_64-pc-windows-msvc/colored/control/fn.set_virtual_terminal.html).

## Test Plan

See: #3568, where @copperfield42 tested locally before and after.
