### PR TITLE
Avoid panics for implicitly-concatenated docstrings

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/sections.py
@@ -504,3 +504,12 @@ Testing this incorrectly indented docstring.
             x: Test argument.
 
         """
+
+
+def implicit_string_concatenation():
+    """Toggle the gizmo.
+
+    Returns
+    A value of some sort.
+
+    """"Extra content"

--- a/crates/ruff/src/docstrings/extraction.rs
+++ b/crates/ruff/src/docstrings/extraction.rs
@@ -2,15 +2,18 @@
 
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt, StmtKind};
 
-use crate::docstrings::definition::{Definition, DefinitionKind, Documentable};
 use ruff_python_ast::visibility::{Modifier, VisibleScope};
+
+use crate::docstrings::definition::{Definition, DefinitionKind, Documentable};
 
 /// Extract a docstring from a function or class body.
 pub fn docstring_from(suite: &[Stmt]) -> Option<&Expr> {
     let stmt = suite.first()?;
+    // Require the docstring to be a standalone expression.
     let StmtKind::Expr { value } = &stmt.node else {
         return None;
     };
+    // Only match strings.
     if !matches!(
         &value.node,
         ExprKind::Constant {

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeSet;
 use ruff_python_ast::cast;
 use ruff_python_ast::helpers::{map_callable, to_call_path};
 use ruff_python_ast::newlines::StrExt;
+use ruff_python_ast::str::is_implicit_concatenation;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{Definition, DefinitionKind};
@@ -59,4 +60,12 @@ pub fn should_ignore_definition(
         }
     }
     false
+}
+
+/// Check if a docstring should be ignored.
+pub fn should_ignore_docstring(contents: &str) -> bool {
+    // Avoid analyzing docstrings that contain implicit string concatenations.
+    // Python does consider these docstrings, but they're almost certainly a
+    // user error, and supporting them "properly" is extremely difficult.
+    is_implicit_concatenation(contents)
 }

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -9,7 +9,7 @@ use crate::checkers::ast::Checker;
 use crate::docstrings::definition::{Definition, DefinitionKind};
 
 /// Return the index of the first logical line in a string.
-pub fn logical_line(content: &str) -> Option<usize> {
+pub(crate) fn logical_line(content: &str) -> Option<usize> {
     // Find the first logical line.
     let mut logical_line = None;
     for (i, line) in content.universal_newlines().enumerate() {
@@ -28,14 +28,14 @@ pub fn logical_line(content: &str) -> Option<usize> {
 
 /// Normalize a word by removing all non-alphanumeric characters
 /// and converting it to lowercase.
-pub fn normalize_word(first_word: &str) -> String {
+pub(crate) fn normalize_word(first_word: &str) -> String {
     first_word
         .replace(|c: char| !c.is_alphanumeric(), "")
         .to_lowercase()
 }
 
 /// Check decorator list to see if function should be ignored.
-pub fn should_ignore_definition(
+pub(crate) fn should_ignore_definition(
     checker: &Checker,
     definition: &Definition,
     ignore_decorators: &BTreeSet<String>,
@@ -63,7 +63,7 @@ pub fn should_ignore_definition(
 }
 
 /// Check if a docstring should be ignored.
-pub fn should_ignore_docstring(contents: &str) -> bool {
+pub(crate) fn should_ignore_docstring(contents: &str) -> bool {
     // Avoid analyzing docstrings that contain implicit string concatenations.
     // Python does consider these docstrings, but they're almost certainly a
     // user error, and supporting them "properly" is extremely difficult.

--- a/crates/ruff_python_ast/src/str.rs
+++ b/crates/ruff_python_ast/src/str.rs
@@ -1,3 +1,5 @@
+use rustpython_parser::{lexer, Mode, Tok};
+
 /// See: <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>
 const TRIPLE_QUOTE_STR_PREFIXES: &[&str] = &[
     "u\"\"\"", "u'''", "r\"\"\"", "r'''", "U\"\"\"", "U'''", "R\"\"\"", "R'''", "\"\"\"", "'''",
@@ -65,6 +67,15 @@ pub fn trailing_quote(content: &str) -> Option<&&str> {
 /// Return `true` if the string is a triple-quote string or byte prefix.
 pub fn is_triple_quote(content: &str) -> bool {
     TRIPLE_QUOTE_STR_PREFIXES.contains(&content) || TRIPLE_QUOTE_BYTE_PREFIXES.contains(&content)
+}
+
+/// Return `true` if the string expression is an implicit concatenation.
+pub fn is_implicit_concatenation(content: &str) -> bool {
+    lexer::lex(content, Mode::Module)
+        .flatten()
+        .filter(|(_, tok, _)| matches!(tok, Tok::String { .. }))
+        .nth(1)
+        .is_some()
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_ast/src/str.rs
+++ b/crates/ruff_python_ast/src/str.rs
@@ -1,5 +1,3 @@
-use rustpython_parser::{lexer, Mode, Tok};
-
 /// See: <https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals>
 const TRIPLE_QUOTE_STR_PREFIXES: &[&str] = &[
     "u\"\"\"", "u'''", "r\"\"\"", "r'''", "U\"\"\"", "U'''", "R\"\"\"", "R'''", "\"\"\"", "'''",
@@ -70,23 +68,70 @@ pub fn is_triple_quote(content: &str) -> bool {
 }
 
 /// Return `true` if the string expression is an implicit concatenation.
+///
+/// ## Examples
+///
+/// ```rust
+/// use ruff_python_ast::str::is_implicit_concatenation;
+///
+/// assert!(is_implicit_concatenation(r#"'abc' 'def'"#));
+/// assert!(!is_implicit_concatenation(r#"'abcdef'"#));
+/// ```
 pub fn is_implicit_concatenation(content: &str) -> bool {
-    lexer::lex(content, Mode::Module)
-        .flatten()
-        .filter(|(_, tok, _)| matches!(tok, Tok::String { .. }))
-        .nth(1)
-        .is_some()
+    let Some(leading_quote_str) = leading_quote(content) else {
+        return false;
+    };
+    let Some(trailing_quote_str) = trailing_quote(content) else {
+        return false;
+    };
+
+    // If the trailing quote doesn't match the _expected_ trailing quote, then the string is
+    // implicitly concatenated.
+    //
+    // For example, given:
+    // ```python
+    // u"""abc""" 'def'
+    // ```
+    //
+    // The leading quote would be `u"""`, and the trailing quote would be `'`, but the _expected_
+    // trailing quote would be `"""`. Since `'` does not equal `"""`, we'd return `true`.
+    if trailing_quote_str != trailing_quote(leading_quote_str).unwrap() {
+        return true;
+    }
+
+    // Search for any trailing quotes _before_ the end of the string.
+    let mut rest = &content[leading_quote_str.len()..content.len() - trailing_quote_str.len()];
+    while let Some(index) = rest.find(trailing_quote_str) {
+        let mut chars = rest[..index].chars().rev();
+        if let Some('\\') = chars.next() {
+            // If the quote is double-escaped, then it's _not_ escaped, so the string is
+            // implicitly concatenated.
+            if let Some('\\') = chars.next() {
+                return true;
+            }
+        } else {
+            // If the quote is _not_ escaped, then it's implicitly concatenated.
+            return true;
+        }
+        rest = &rest[index + trailing_quote_str.len()..];
+    }
+
+    // Otherwise, we know the string ends with the expected trailing quote, so it's not implicitly
+    // concatenated.
+    false
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::str::is_implicit_concatenation;
+
     use super::{
         SINGLE_QUOTE_BYTE_PREFIXES, SINGLE_QUOTE_STR_PREFIXES, TRIPLE_QUOTE_BYTE_PREFIXES,
         TRIPLE_QUOTE_STR_PREFIXES,
     };
 
     #[test]
-    fn test_prefixes() {
+    fn prefix_uniqueness() {
         let prefixes = TRIPLE_QUOTE_STR_PREFIXES
             .iter()
             .chain(TRIPLE_QUOTE_BYTE_PREFIXES)
@@ -103,5 +148,39 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn implicit_concatenation() {
+        // Positive cases.
+        assert!(is_implicit_concatenation(r#""abc" "def""#));
+        assert!(is_implicit_concatenation(r#""abc" 'def'"#));
+        assert!(is_implicit_concatenation(r#""""abc""" "def""#));
+        assert!(is_implicit_concatenation(r#"'''abc''' 'def'"#));
+        assert!(is_implicit_concatenation(r#""""abc""" 'def'"#));
+        assert!(is_implicit_concatenation(r#"'''abc''' "def""#));
+        assert!(is_implicit_concatenation(r#""""abc""""def""#));
+        assert!(is_implicit_concatenation(r#"'''abc''''def'"#));
+        assert!(is_implicit_concatenation(r#""""abc"""'def'"#));
+        assert!(is_implicit_concatenation(r#"'''abc'''"def""#));
+
+        // Negative cases.
+        assert!(!is_implicit_concatenation(r#""abc""#));
+        assert!(!is_implicit_concatenation(r#"'abc'"#));
+        assert!(!is_implicit_concatenation(r#""""abc""""#));
+        assert!(!is_implicit_concatenation(r#"'''abc'''"#));
+        assert!(!is_implicit_concatenation(r#""""ab"c""""#));
+        assert!(!is_implicit_concatenation(r#"'''ab'c'''"#));
+        assert!(!is_implicit_concatenation(r#""""ab'c""""#));
+        assert!(!is_implicit_concatenation(r#"'''ab"c'''"#));
+        assert!(!is_implicit_concatenation(r#""""ab'''c""""#));
+        assert!(!is_implicit_concatenation(r#"'''ab"""c'''"#));
+
+        // Positive cases with escaped quotes.
+        assert!(is_implicit_concatenation(r#""abc\\""def""#));
+        assert!(is_implicit_concatenation(r#""abc\\""def""#));
+
+        // Negative cases with escaped quotes.
+        assert!(!is_implicit_concatenation(r#""abc\"def""#));
     }
 }


### PR DESCRIPTION
## Summary

In the rare event that a docstring contains an implicit string concatenation, we currently have the potential to panic, because we assume that if a string starts with triple quotes, it _ends_ with triple quotes. But with implicit concatenation, that's not the case: a single `Expr` could start and end with different quote styles, because it can contain multiple string tokens.

Supporting these "properly" is pretty hard. In some cases it's hard to even know what the "right" behavior is. So for now, I'm just detecting and warning, which is better than a panic.

Closes #3543.

Closes #3585.
