### PR TITLE
Avoid removing comment hash for noqa's with trailing content

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
@@ -2,14 +2,24 @@
 # noqa # comment
 print()  # noqa
 print()  # noqa # comment
+print()  # noqa  # comment
 print()  # noqa comment
+print()  # noqa  comment
 print(a)  # noqa
 print(a)  # noqa # comment
+print(a)  # noqa  # comment
 print(a)  # noqa comment
+print(a)  # noqa  comment
 
 # noqa: E501, F821
 # noqa: E501, F821 # comment
 print()  # noqa: E501, F821
 print()  # noqa: E501, F821 # comment
+print()  # noqa: E501, F821  # comment
+print()  # noqa: E501, F821 comment
+print()  # noqa: E501, F821  comment
 print(a)  # noqa: E501, F821
 print(a)  # noqa: E501, F821 # comment
+print(a)  # noqa: E501, F821  # comment
+print(a)  # noqa: E501, F821 comment
+print(a)  # noqa: E501, F821  comment

--- a/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF100_3.py
@@ -2,8 +2,10 @@
 # noqa # comment
 print()  # noqa
 print()  # noqa # comment
+print()  # noqa comment
 print(a)  # noqa
 print(a)  # noqa # comment
+print(a)  # noqa comment
 
 # noqa: E501, F821
 # noqa: E501, F821 # comment

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -161,10 +161,15 @@ pub fn check_noqa(
                                     Location::new(row + 1, start - leading_spaces),
                                     Location::new(row + 1, end + trailing_spaces),
                                 ));
-                            } else {
+                            } else if lines[row].chars().nth(end + 1).map_or(false, |c| c == '#') {
                                 diagnostic.amend(Fix::deletion(
                                     Location::new(row + 1, start),
                                     Location::new(row + 1, end + trailing_spaces),
+                                ));
+                            } else {
+                                diagnostic.amend(Fix::deletion(
+                                    Location::new(row + 1, start + 1),
+                                    Location::new(row + 1, end),
                                 ));
                             }
                         }
@@ -242,10 +247,19 @@ pub fn check_noqa(
                                         Location::new(row + 1, start - leading_spaces),
                                         Location::new(row + 1, end + trailing_spaces),
                                     ));
-                                } else {
+                                } else if lines[row]
+                                    .chars()
+                                    .nth(end + 1)
+                                    .map_or(false, |c| c == '#')
+                                {
                                     diagnostic.amend(Fix::deletion(
                                         Location::new(row + 1, start),
                                         Location::new(row + 1, end + trailing_spaces),
+                                    ));
+                                } else {
+                                    diagnostic.amend(Fix::deletion(
+                                        Location::new(row + 1, start + 1),
+                                        Location::new(row + 1, end),
                                     ));
                                 }
                             } else {

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -84,22 +84,42 @@ expression: diagnostics
   parent: ~
 - kind:
     name: UnusedNOQA
+    body: "Unused blanket `noqa` directive"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 5
+    column: 9
+  end_location:
+    row: 5
+    column: 15
+  fix:
+    content: ""
+    location:
+      row: 5
+      column: 10
+    end_location:
+      row: 5
+      column: 15
+  parent: ~
+- kind:
+    name: UnusedNOQA
     body: "Unused `noqa` directive (unused: `E501`, `F821`)"
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 8
+    row: 10
     column: 0
   end_location:
-    row: 8
+    row: 10
     column: 18
   fix:
     content: ""
     location:
-      row: 8
+      row: 10
       column: 0
     end_location:
-      row: 9
+      row: 11
       column: 0
   parent: ~
 - kind:
@@ -108,18 +128,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 9
+    row: 11
     column: 0
   end_location:
-    row: 9
+    row: 11
     column: 18
   fix:
     content: ""
     location:
-      row: 9
+      row: 11
       column: 0
     end_location:
-      row: 9
+      row: 11
       column: 19
   parent: ~
 - kind:
@@ -128,18 +148,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 10
+    row: 12
     column: 9
   end_location:
-    row: 10
+    row: 12
     column: 27
   fix:
     content: ""
     location:
-      row: 10
+      row: 12
       column: 7
     end_location:
-      row: 10
+      row: 12
       column: 27
   parent: ~
 - kind:
@@ -148,18 +168,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 11
+    row: 13
     column: 9
   end_location:
-    row: 11
+    row: 13
     column: 27
   fix:
     content: ""
     location:
-      row: 11
+      row: 13
       column: 9
     end_location:
-      row: 11
+      row: 13
       column: 28
   parent: ~
 - kind:
@@ -168,18 +188,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 12
+    row: 14
     column: 10
   end_location:
-    row: 12
+    row: 14
     column: 28
   fix:
     content: "# noqa: F821"
     location:
-      row: 12
+      row: 14
       column: 10
     end_location:
-      row: 12
+      row: 14
       column: 28
   parent: ~
 - kind:
@@ -188,18 +208,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 13
+    row: 15
     column: 10
   end_location:
-    row: 13
+    row: 15
     column: 28
   fix:
     content: "# noqa: F821"
     location:
-      row: 13
+      row: 15
       column: 10
     end_location:
-      row: 13
+      row: 15
       column: 28
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -97,10 +97,50 @@ expression: diagnostics
     content: ""
     location:
       row: 5
-      column: 10
+      column: 9
     end_location:
       row: 5
-      column: 15
+      column: 17
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused blanket `noqa` directive"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 6
+    column: 9
+  end_location:
+    row: 6
+    column: 15
+  fix:
+    content: ""
+    location:
+      row: 6
+      column: 11
+    end_location:
+      row: 6
+      column: 16
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused blanket `noqa` directive"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 7
+    column: 9
+  end_location:
+    row: 7
+    column: 15
+  fix:
+    content: ""
+    location:
+      row: 7
+      column: 11
+    end_location:
+      row: 7
+      column: 17
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -108,18 +148,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 10
+    row: 14
     column: 0
   end_location:
-    row: 10
+    row: 14
     column: 18
   fix:
     content: ""
     location:
-      row: 10
+      row: 14
       column: 0
     end_location:
-      row: 11
+      row: 15
       column: 0
   parent: ~
 - kind:
@@ -128,18 +168,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 11
+    row: 15
     column: 0
   end_location:
-    row: 11
+    row: 15
     column: 18
   fix:
     content: ""
     location:
-      row: 11
+      row: 15
       column: 0
     end_location:
-      row: 11
+      row: 15
       column: 19
   parent: ~
 - kind:
@@ -148,18 +188,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 12
+    row: 16
     column: 9
   end_location:
-    row: 12
+    row: 16
     column: 27
   fix:
     content: ""
     location:
-      row: 12
+      row: 16
       column: 7
     end_location:
-      row: 12
+      row: 16
       column: 27
   parent: ~
 - kind:
@@ -168,18 +208,98 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 13
+    row: 17
     column: 9
   end_location:
-    row: 13
+    row: 17
     column: 27
   fix:
     content: ""
     location:
-      row: 13
+      row: 17
       column: 9
     end_location:
-      row: 13
+      row: 17
+      column: 28
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`, `F821`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 18
+    column: 9
+  end_location:
+    row: 18
+    column: 27
+  fix:
+    content: ""
+    location:
+      row: 18
+      column: 9
+    end_location:
+      row: 18
+      column: 29
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`, `F821`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 19
+    column: 9
+  end_location:
+    row: 19
+    column: 27
+  fix:
+    content: ""
+    location:
+      row: 19
+      column: 11
+    end_location:
+      row: 19
+      column: 28
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`, `F821`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 20
+    column: 9
+  end_location:
+    row: 20
+    column: 27
+  fix:
+    content: ""
+    location:
+      row: 20
+      column: 11
+    end_location:
+      row: 20
+      column: 29
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 21
+    column: 10
+  end_location:
+    row: 21
+    column: 28
+  fix:
+    content: "# noqa: F821"
+    location:
+      row: 21
+      column: 10
+    end_location:
+      row: 21
       column: 28
   parent: ~
 - kind:
@@ -188,18 +308,18 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 14
+    row: 22
     column: 10
   end_location:
-    row: 14
+    row: 22
     column: 28
   fix:
     content: "# noqa: F821"
     location:
-      row: 14
+      row: 22
       column: 10
     end_location:
-      row: 14
+      row: 22
       column: 28
   parent: ~
 - kind:
@@ -208,18 +328,58 @@ expression: diagnostics
     suggestion: "Remove unused `noqa` directive"
     fixable: true
   location:
-    row: 15
+    row: 23
     column: 10
   end_location:
-    row: 15
+    row: 23
     column: 28
   fix:
     content: "# noqa: F821"
     location:
-      row: 15
+      row: 23
       column: 10
     end_location:
-      row: 15
+      row: 23
+      column: 28
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 24
+    column: 10
+  end_location:
+    row: 24
+    column: 28
+  fix:
+    content: "# noqa: F821"
+    location:
+      row: 24
+      column: 10
+    end_location:
+      row: 24
+      column: 28
+  parent: ~
+- kind:
+    name: UnusedNOQA
+    body: "Unused `noqa` directive (unused: `E501`)"
+    suggestion: "Remove unused `noqa` directive"
+    fixable: true
+  location:
+    row: 25
+    column: 10
+  end_location:
+    row: 25
+    column: 28
+  fix:
+    content: "# noqa: F821"
+    location:
+      row: 25
+      column: 10
+    end_location:
+      row: 25
       column: 28
   parent: ~
 


### PR DESCRIPTION
## Summary

Right now, if you have a comment like `# noqa bar`, then when removing the blanket `# noqa`, we leave `bar` behind -- which is a syntax error.

It if the comment that trails the `noqa` is not itself a "partial comment" (like `# noqa # bar`), then we need to shift the deletion to _exclude_ the `#`.

Closes #3586.
