### PR TITLE
CI Checks: Fix malformed markdown

### DIFF
--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -65,6 +65,7 @@ jobs:
           then
             echo "### Ecosystem" >> $GITHUB_OUTPUT
             cat pr/ecosystem/ecosystem-result >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
           fi
 
           if [[ -f pr/benchmark/summary.md ]]


### PR DESCRIPTION
## Summary 
The Benchmark results aren't formatted properly if the ecosystem check finds differences because the ecosystem check doesn't emit a trailing newline.

This PR enforces a new line between the ecosystem and benchmark results. 

## Test Plan

I manually triggered the [PR Comment Workflow](https://github.com/charliermarsh/ruff/actions/runs/4454806535) (with the version on this branch) for #3569. The [updated comment](https://github.com/charliermarsh/ruff/pull/3569#issuecomment-1473062469) is correctly formatted.