### PR TITLE
Bitflag based RuleSet

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -424,15 +424,16 @@ where
                     flake8_bugbear::rules::cached_instance_method(self, decorator_list);
                 }
 
-                if self.settings.rules.enabled(Rule::UnnecessaryReturnNone)
-                    || self.settings.rules.enabled(Rule::ImplicitReturnValue)
-                    || self.settings.rules.enabled(Rule::ImplicitReturn)
-                    || self.settings.rules.enabled(Rule::UnnecessaryAssign)
-                    || self.settings.rules.enabled(Rule::SuperfluousElseReturn)
-                    || self.settings.rules.enabled(Rule::SuperfluousElseRaise)
-                    || self.settings.rules.enabled(Rule::SuperfluousElseContinue)
-                    || self.settings.rules.enabled(Rule::SuperfluousElseBreak)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::UnnecessaryReturnNone,
+                    Rule::ImplicitReturnValue,
+                    Rule::ImplicitReturn,
+                    Rule::UnnecessaryAssign,
+                    Rule::SuperfluousElseReturn,
+                    Rule::SuperfluousElseRaise,
+                    Rule::SuperfluousElseContinue,
+                    Rule::SuperfluousElseBreak,
+                ]) {
                     flake8_return::rules::function(self, body);
                 }
 
@@ -498,48 +499,19 @@ where
                     }
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestFixturePositionalArgs)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestExtraneousScopeFunction)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestMissingFixtureNameUnderscore)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestIncorrectFixtureNameUnderscore)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestFixtureParamWithoutValue)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestDeprecatedYieldFixture)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestFixtureFinalizerCallback)
-                    || self.settings.rules.enabled(Rule::PytestUselessYieldFixture)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestErroneousUseFixturesOnFixture)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::PytestFixtureIncorrectParenthesesStyle,
+                    Rule::PytestFixturePositionalArgs,
+                    Rule::PytestExtraneousScopeFunction,
+                    Rule::PytestMissingFixtureNameUnderscore,
+                    Rule::PytestIncorrectFixtureNameUnderscore,
+                    Rule::PytestFixtureParamWithoutValue,
+                    Rule::PytestDeprecatedYieldFixture,
+                    Rule::PytestFixtureFinalizerCallback,
+                    Rule::PytestUselessYieldFixture,
+                    Rule::PytestUnnecessaryAsyncioMarkOnFixture,
+                    Rule::PytestErroneousUseFixturesOnFixture,
+                ]) {
                     flake8_pytest_style::rules::fixture(
                         self,
                         stmt,
@@ -550,27 +522,17 @@ where
                     );
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestParametrizeNamesWrongType)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestParametrizeValuesWrongType)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::PytestParametrizeNamesWrongType,
+                    Rule::PytestParametrizeValuesWrongType,
+                ]) {
                     flake8_pytest_style::rules::parametrize(self, decorator_list);
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestIncorrectMarkParenthesesStyle)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::PytestUseFixturesWithoutParameters)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::PytestIncorrectMarkParenthesesStyle,
+                    Rule::PytestUseFixturesWithoutParameters,
+                ]) {
                     flake8_pytest_style::rules::marks(self, decorator_list);
                 }
 
@@ -788,15 +750,10 @@ where
                 }
 
                 if !self.is_stub {
-                    if self
-                        .settings
-                        .rules
-                        .enabled(Rule::AbstractBaseClassWithoutAbstractMethod)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::EmptyMethodWithoutAbstractDecorator)
-                    {
+                    if self.settings.rules.any_enabled(&[
+                        Rule::AbstractBaseClassWithoutAbstractMethod,
+                        Rule::EmptyMethodWithoutAbstractDecorator,
+                    ]) {
                         flake8_bugbear::rules::abstract_base_class(
                             self, stmt, name, bases, keywords, body,
                         );
@@ -1480,10 +1437,11 @@ where
                         flake8_bugbear::rules::cannot_raise_literal(self, exc);
                     }
                 }
-                if self.settings.rules.enabled(Rule::RawStringInException)
-                    || self.settings.rules.enabled(Rule::FStringInException)
-                    || self.settings.rules.enabled(Rule::DotFormatInException)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::RawStringInException,
+                    Rule::FStringInException,
+                    Rule::DotFormatInException,
+                ]) {
                     if let Some(exc) = exc {
                         flake8_errmsg::rules::string_in_exception(self, exc);
                     }
@@ -1727,12 +1685,10 @@ where
                         self.diagnostics.push(diagnostic);
                     }
                 }
-                if self.settings.rules.enabled(Rule::DuplicateHandlerException)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::DuplicateTryBlockException)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::DuplicateHandlerException,
+                    Rule::DuplicateTryBlockException,
+                ]) {
                     flake8_bugbear::rules::duplicate_exceptions(self, handlers);
                 }
                 if self
@@ -2224,11 +2180,12 @@ where
                     self.ctx.in_literal = true;
                 }
 
-                if self.settings.rules.enabled(Rule::SysVersionSlice3)
-                    || self.settings.rules.enabled(Rule::SysVersion2)
-                    || self.settings.rules.enabled(Rule::SysVersion0)
-                    || self.settings.rules.enabled(Rule::SysVersionSlice1)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::SysVersionSlice3,
+                    Rule::SysVersion2,
+                    Rule::SysVersion0,
+                    Rule::SysVersionSlice1,
+                ]) {
                     flake8_2020::rules::subscript(self, value, slice);
                 }
             }
@@ -2350,16 +2307,17 @@ where
                 args,
                 keywords,
             } => {
-                // pyflakes
-                if self.settings.rules.enabled(Rule::StringDotFormatInvalidFormat)
-                    || self.settings.rules.enabled(Rule::StringDotFormatExtraNamedArguments)
-                    || self.settings.rules.enabled(Rule::StringDotFormatExtraPositionalArguments)
-                    || self.settings.rules.enabled(Rule::StringDotFormatMissingArguments)
-                    || self.settings.rules.enabled(Rule::StringDotFormatMixingAutomatic)
+                if self.settings.rules.any_enabled(&[
+                    // pyflakes
+                    Rule::StringDotFormatInvalidFormat,
+                    Rule::StringDotFormatExtraNamedArguments,
+                    Rule::StringDotFormatExtraPositionalArguments,
+                    Rule::StringDotFormatMissingArguments,
+                    Rule::StringDotFormatMixingAutomatic,
                     // pyupgrade
-                    || self.settings.rules.enabled(Rule::FormatLiterals)
-                    || self.settings.rules.enabled(Rule::FString)
-                {
+                    Rule::FormatLiterals,
+                    Rule::FString,
+                ]) {
                     if let ExprKind::Attribute { value, attr, .. } = &func.node {
                         if let ExprKind::Constant {
                             value: Constant::Str(value),
@@ -2478,8 +2436,10 @@ where
                 }
 
                 // flake8-print
-                if self.settings.rules.enabled(Rule::Print)
-                    || self.settings.rules.enabled(Rule::PPrint)
+                if self
+                    .settings
+                    .rules
+                    .any_enabled(&[Rule::Print, Rule::PPrint])
                 {
                     flake8_print::rules::print_call(self, func, keywords);
                 }
@@ -2864,12 +2824,10 @@ where
                     }
                 }
 
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestRaisesWithoutException)
-                    || self.settings.rules.enabled(Rule::PytestRaisesTooBroad)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::PytestRaisesWithoutException,
+                    Rule::PytestRaisesTooBroad,
+                ]) {
                     flake8_pytest_style::rules::raises_call(self, func, args, keywords);
                 }
 
@@ -2893,31 +2851,32 @@ where
                 }
 
                 // flake8-use-pathlib
-                if self.settings.rules.enabled(Rule::PathlibAbspath)
-                    || self.settings.rules.enabled(Rule::PathlibChmod)
-                    || self.settings.rules.enabled(Rule::PathlibMkdir)
-                    || self.settings.rules.enabled(Rule::PathlibMakedirs)
-                    || self.settings.rules.enabled(Rule::PathlibRename)
-                    || self.settings.rules.enabled(Rule::PathlibReplace)
-                    || self.settings.rules.enabled(Rule::PathlibRmdir)
-                    || self.settings.rules.enabled(Rule::PathlibRemove)
-                    || self.settings.rules.enabled(Rule::PathlibUnlink)
-                    || self.settings.rules.enabled(Rule::PathlibGetcwd)
-                    || self.settings.rules.enabled(Rule::PathlibExists)
-                    || self.settings.rules.enabled(Rule::PathlibExpanduser)
-                    || self.settings.rules.enabled(Rule::PathlibIsDir)
-                    || self.settings.rules.enabled(Rule::PathlibIsFile)
-                    || self.settings.rules.enabled(Rule::PathlibIsLink)
-                    || self.settings.rules.enabled(Rule::PathlibReadlink)
-                    || self.settings.rules.enabled(Rule::PathlibStat)
-                    || self.settings.rules.enabled(Rule::PathlibIsAbs)
-                    || self.settings.rules.enabled(Rule::PathlibJoin)
-                    || self.settings.rules.enabled(Rule::PathlibBasename)
-                    || self.settings.rules.enabled(Rule::PathlibSamefile)
-                    || self.settings.rules.enabled(Rule::PathlibSplitext)
-                    || self.settings.rules.enabled(Rule::PathlibOpen)
-                    || self.settings.rules.enabled(Rule::PathlibPyPath)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::PathlibAbspath,
+                    Rule::PathlibChmod,
+                    Rule::PathlibMkdir,
+                    Rule::PathlibMakedirs,
+                    Rule::PathlibRename,
+                    Rule::PathlibReplace,
+                    Rule::PathlibRmdir,
+                    Rule::PathlibRemove,
+                    Rule::PathlibUnlink,
+                    Rule::PathlibGetcwd,
+                    Rule::PathlibExists,
+                    Rule::PathlibExpanduser,
+                    Rule::PathlibIsDir,
+                    Rule::PathlibIsFile,
+                    Rule::PathlibIsLink,
+                    Rule::PathlibReadlink,
+                    Rule::PathlibStat,
+                    Rule::PathlibIsAbs,
+                    Rule::PathlibJoin,
+                    Rule::PathlibBasename,
+                    Rule::PathlibSamefile,
+                    Rule::PathlibSplitext,
+                    Rule::PathlibOpen,
+                    Rule::PathlibPyPath,
+                ]) {
                     flake8_use_pathlib::helpers::replaceable_by_pathlib(self, func);
                 }
 
@@ -2927,21 +2886,24 @@ where
                 }
 
                 // flake8-logging-format
-                if self.settings.rules.enabled(Rule::LoggingStringFormat)
-                    || self.settings.rules.enabled(Rule::LoggingPercentFormat)
-                    || self.settings.rules.enabled(Rule::LoggingStringConcat)
-                    || self.settings.rules.enabled(Rule::LoggingFString)
-                    || self.settings.rules.enabled(Rule::LoggingWarn)
-                    || self.settings.rules.enabled(Rule::LoggingExtraAttrClash)
-                    || self.settings.rules.enabled(Rule::LoggingExcInfo)
-                    || self.settings.rules.enabled(Rule::LoggingRedundantExcInfo)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::LoggingStringFormat,
+                    Rule::LoggingPercentFormat,
+                    Rule::LoggingStringConcat,
+                    Rule::LoggingFString,
+                    Rule::LoggingWarn,
+                    Rule::LoggingExtraAttrClash,
+                    Rule::LoggingExcInfo,
+                    Rule::LoggingRedundantExcInfo,
+                ]) {
                     flake8_logging_format::rules::logging_call(self, func, args, keywords);
                 }
 
                 // pylint logging checker
-                if self.settings.rules.enabled(Rule::LoggingTooFewArgs)
-                    || self.settings.rules.enabled(Rule::LoggingTooManyArgs)
+                if self
+                    .settings
+                    .rules
+                    .any_enabled(&[Rule::LoggingTooFewArgs, Rule::LoggingTooManyArgs])
                 {
                     pylint::rules::logging_call(self, func, args, keywords);
                 }
@@ -2956,15 +2918,10 @@ where
                 }
             }
             ExprKind::Dict { keys, values } => {
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::MultiValueRepeatedKeyLiteral)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::MultiValueRepeatedKeyVariable)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::MultiValueRepeatedKeyLiteral,
+                    Rule::MultiValueRepeatedKeyVariable,
+                ]) {
                     pyflakes::rules::repeated_keys(self, keys, values);
                 }
 
@@ -3027,43 +2984,17 @@ where
                     ..
                 } = &left.node
                 {
-                    if self
-                        .settings
-                        .rules
-                        .enabled(Rule::PercentFormatInvalidFormat)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatExpectedMapping)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatExpectedSequence)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatExtraNamedArguments)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatMissingArgument)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatMixedPositionalAndNamed)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatPositionalCountMismatch)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatStarRequiresSequence)
-                        || self
-                            .settings
-                            .rules
-                            .enabled(Rule::PercentFormatUnsupportedFormatCharacter)
-                    {
+                    if self.settings.rules.any_enabled(&[
+                        Rule::PercentFormatInvalidFormat,
+                        Rule::PercentFormatExpectedMapping,
+                        Rule::PercentFormatExpectedSequence,
+                        Rule::PercentFormatExtraNamedArguments,
+                        Rule::PercentFormatMissingArgument,
+                        Rule::PercentFormatMixedPositionalAndNamed,
+                        Rule::PercentFormatPositionalCountMismatch,
+                        Rule::PercentFormatStarRequiresSequence,
+                        Rule::PercentFormatUnsupportedFormatCharacter,
+                    ]) {
                         let location = Range::from(expr);
                         match pyflakes::cformat::CFormatSummary::try_from(value.as_str()) {
                             Err(CFormatError {
@@ -3261,12 +3192,13 @@ where
                     pycodestyle::rules::type_comparison(self, expr, ops, comparators);
                 }
 
-                if self.settings.rules.enabled(Rule::SysVersionCmpStr3)
-                    || self.settings.rules.enabled(Rule::SysVersionInfo0Eq3)
-                    || self.settings.rules.enabled(Rule::SysVersionInfo1CmpInt)
-                    || self.settings.rules.enabled(Rule::SysVersionInfoMinorCmpInt)
-                    || self.settings.rules.enabled(Rule::SysVersionCmpStr10)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::SysVersionCmpStr3,
+                    Rule::SysVersionInfo0Eq3,
+                    Rule::SysVersionInfo1CmpInt,
+                    Rule::SysVersionInfoMinorCmpInt,
+                    Rule::SysVersionCmpStr10,
+                ]) {
                     flake8_2020::rules::compare(self, left, ops, comparators);
                 }
 
@@ -3300,9 +3232,10 @@ where
                 }
 
                 if self.is_stub {
-                    if self.settings.rules.enabled(Rule::UnrecognizedPlatformCheck)
-                        || self.settings.rules.enabled(Rule::UnrecognizedPlatformName)
-                    {
+                    if self.settings.rules.any_enabled(&[
+                        Rule::UnrecognizedPlatformCheck,
+                        Rule::UnrecognizedPlatformName,
+                    ]) {
                         flake8_pyi::rules::unrecognized_platform(
                             self,
                             expr,
@@ -4654,15 +4587,13 @@ impl<'a> Checker<'a> {
 
             if !self.is_stub {
                 // flake8-unused-arguments
-                if self.settings.rules.enabled(Rule::UnusedFunctionArgument)
-                    || self.settings.rules.enabled(Rule::UnusedMethodArgument)
-                    || self.settings.rules.enabled(Rule::UnusedClassMethodArgument)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::UnusedStaticMethodArgument)
-                    || self.settings.rules.enabled(Rule::UnusedLambdaArgument)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::UnusedFunctionArgument,
+                    Rule::UnusedMethodArgument,
+                    Rule::UnusedClassMethodArgument,
+                    Rule::UnusedStaticMethodArgument,
+                    Rule::UnusedLambdaArgument,
+                ]) {
                     self.diagnostics
                         .extend(flake8_unused_arguments::rules::unused_arguments(
                             self,
@@ -4695,32 +4626,21 @@ impl<'a> Checker<'a> {
 
     fn check_dead_scopes(&mut self) {
         let enforce_typing_imports = !self.is_stub
-            && (self.settings.rules.enabled(Rule::GlobalVariableNotAssigned)
-                || self
-                    .settings
-                    .rules
-                    .enabled(Rule::RuntimeImportInTypeCheckingBlock)
-                || self
-                    .settings
-                    .rules
-                    .enabled(Rule::TypingOnlyFirstPartyImport)
-                || self
-                    .settings
-                    .rules
-                    .enabled(Rule::TypingOnlyThirdPartyImport)
-                || self
-                    .settings
-                    .rules
-                    .enabled(Rule::TypingOnlyStandardLibraryImport));
+            && self.settings.rules.any_enabled(&[
+                Rule::GlobalVariableNotAssigned,
+                Rule::RuntimeImportInTypeCheckingBlock,
+                Rule::TypingOnlyFirstPartyImport,
+                Rule::TypingOnlyThirdPartyImport,
+                Rule::TypingOnlyStandardLibraryImport,
+            ]);
 
-        if !(self.settings.rules.enabled(Rule::UnusedImport)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::UndefinedLocalWithImportStarUsage)
-            || self.settings.rules.enabled(Rule::RedefinedWhileUnused)
-            || self.settings.rules.enabled(Rule::UndefinedExport)
-            || enforce_typing_imports)
+        if !(enforce_typing_imports
+            || self.settings.rules.any_enabled(&[
+                Rule::UnusedImport,
+                Rule::UndefinedLocalWithImportStarUsage,
+                Rule::RedefinedWhileUnused,
+                Rule::UndefinedExport,
+            ]))
         {
             return;
         }
@@ -5088,102 +5008,67 @@ impl<'a> Checker<'a> {
     }
 
     fn check_definitions(&mut self) {
-        let enforce_annotations = self
-            .settings
-            .rules
-            .enabled(Rule::MissingTypeFunctionArgument)
-            || self.settings.rules.enabled(Rule::MissingTypeArgs)
-            || self.settings.rules.enabled(Rule::MissingTypeKwargs)
-            || self.settings.rules.enabled(Rule::MissingTypeSelf)
-            || self.settings.rules.enabled(Rule::MissingTypeCls)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeUndocumentedPublicFunction)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypePrivateFunction)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeSpecialMethod)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeStaticMethod)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeClassMethod)
-            || self.settings.rules.enabled(Rule::AnyType);
-        let enforce_docstrings = self.settings.rules.enabled(Rule::UndocumentedPublicModule)
-            || self.settings.rules.enabled(Rule::UndocumentedPublicClass)
-            || self.settings.rules.enabled(Rule::UndocumentedPublicMethod)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicFunction)
-            || self.settings.rules.enabled(Rule::UndocumentedPublicPackage)
-            || self.settings.rules.enabled(Rule::UndocumentedMagicMethod)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicNestedClass)
-            || self.settings.rules.enabled(Rule::UndocumentedPublicInit)
-            || self.settings.rules.enabled(Rule::FitsOnOneLine)
-            || self.settings.rules.enabled(Rule::NoBlankLineBeforeFunction)
-            || self.settings.rules.enabled(Rule::NoBlankLineAfterFunction)
-            || self.settings.rules.enabled(Rule::OneBlankLineBeforeClass)
-            || self.settings.rules.enabled(Rule::OneBlankLineAfterClass)
-            || self.settings.rules.enabled(Rule::BlankLineAfterSummary)
-            || self.settings.rules.enabled(Rule::IndentWithSpaces)
-            || self.settings.rules.enabled(Rule::UnderIndentation)
-            || self.settings.rules.enabled(Rule::OverIndentation)
-            || self.settings.rules.enabled(Rule::NewLineAfterLastParagraph)
-            || self.settings.rules.enabled(Rule::SurroundingWhitespace)
-            || self.settings.rules.enabled(Rule::BlankLineBeforeClass)
-            || self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::MultiLineSummarySecondLine)
-            || self.settings.rules.enabled(Rule::SectionNotOverIndented)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::SectionUnderlineNotOverIndented)
-            || self.settings.rules.enabled(Rule::TripleSingleQuotes)
-            || self.settings.rules.enabled(Rule::EscapeSequenceInDocstring)
-            || self.settings.rules.enabled(Rule::EndsInPeriod)
-            || self.settings.rules.enabled(Rule::NonImperativeMood)
-            || self.settings.rules.enabled(Rule::NoSignature)
-            || self.settings.rules.enabled(Rule::FirstLineCapitalized)
-            || self.settings.rules.enabled(Rule::DocstringStartsWithThis)
-            || self.settings.rules.enabled(Rule::CapitalizeSectionName)
-            || self.settings.rules.enabled(Rule::NewLineAfterSectionName)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::DashedUnderlineAfterSection)
-            || self.settings.rules.enabled(Rule::SectionUnderlineAfterName)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::SectionUnderlineMatchesSectionLength)
-            || self.settings.rules.enabled(Rule::NoBlankLineAfterSection)
-            || self.settings.rules.enabled(Rule::NoBlankLineBeforeSection)
-            || self
-                .settings
-                .rules
-                .enabled(Rule::BlankLinesBetweenHeaderAndContent)
-            || self.settings.rules.enabled(Rule::BlankLineAfterLastSection)
-            || self.settings.rules.enabled(Rule::EmptyDocstringSection)
-            || self.settings.rules.enabled(Rule::EndsInPunctuation)
-            || self.settings.rules.enabled(Rule::SectionNameEndsInColon)
-            || self.settings.rules.enabled(Rule::UndocumentedParam)
-            || self.settings.rules.enabled(Rule::OverloadWithDocstring)
-            || self.settings.rules.enabled(Rule::EmptyDocstring);
+        let enforce_annotations = self.settings.rules.any_enabled(&[
+            Rule::MissingTypeFunctionArgument,
+            Rule::MissingTypeArgs,
+            Rule::MissingTypeKwargs,
+            Rule::MissingTypeSelf,
+            Rule::MissingTypeCls,
+            Rule::MissingReturnTypeUndocumentedPublicFunction,
+            Rule::MissingReturnTypePrivateFunction,
+            Rule::MissingReturnTypeSpecialMethod,
+            Rule::MissingReturnTypeStaticMethod,
+            Rule::MissingReturnTypeClassMethod,
+            Rule::AnyType,
+        ]);
+        let enforce_docstrings = self.settings.rules.any_enabled(&[
+            Rule::UndocumentedPublicModule,
+            Rule::UndocumentedPublicClass,
+            Rule::UndocumentedPublicMethod,
+            Rule::UndocumentedPublicFunction,
+            Rule::UndocumentedPublicPackage,
+            Rule::UndocumentedMagicMethod,
+            Rule::UndocumentedPublicNestedClass,
+            Rule::UndocumentedPublicInit,
+            Rule::FitsOnOneLine,
+            Rule::NoBlankLineBeforeFunction,
+            Rule::NoBlankLineAfterFunction,
+            Rule::OneBlankLineBeforeClass,
+            Rule::OneBlankLineAfterClass,
+            Rule::BlankLineAfterSummary,
+            Rule::IndentWithSpaces,
+            Rule::UnderIndentation,
+            Rule::OverIndentation,
+            Rule::NewLineAfterLastParagraph,
+            Rule::SurroundingWhitespace,
+            Rule::BlankLineBeforeClass,
+            Rule::MultiLineSummaryFirstLine,
+            Rule::MultiLineSummarySecondLine,
+            Rule::SectionNotOverIndented,
+            Rule::SectionUnderlineNotOverIndented,
+            Rule::TripleSingleQuotes,
+            Rule::EscapeSequenceInDocstring,
+            Rule::EndsInPeriod,
+            Rule::NonImperativeMood,
+            Rule::NoSignature,
+            Rule::FirstLineCapitalized,
+            Rule::DocstringStartsWithThis,
+            Rule::CapitalizeSectionName,
+            Rule::NewLineAfterSectionName,
+            Rule::DashedUnderlineAfterSection,
+            Rule::SectionUnderlineAfterName,
+            Rule::SectionUnderlineMatchesSectionLength,
+            Rule::NoBlankLineAfterSection,
+            Rule::NoBlankLineBeforeSection,
+            Rule::BlankLinesBetweenHeaderAndContent,
+            Rule::BlankLineAfterLastSection,
+            Rule::EmptyDocstringSection,
+            Rule::EndsInPunctuation,
+            Rule::SectionNameEndsInColon,
+            Rule::UndocumentedParam,
+            Rule::OverloadWithDocstring,
+            Rule::EmptyDocstring,
+        ]);
 
         let mut overloaded_name: Option<String> = None;
         self.deferred.definitions.reverse();
@@ -5261,24 +5146,27 @@ impl<'a> Checker<'a> {
                 if self.settings.rules.enabled(Rule::FitsOnOneLine) {
                     pydocstyle::rules::one_liner(self, &docstring);
                 }
-                if self.settings.rules.enabled(Rule::NoBlankLineBeforeFunction)
-                    || self.settings.rules.enabled(Rule::NoBlankLineAfterFunction)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::NoBlankLineBeforeFunction,
+                    Rule::NoBlankLineAfterFunction,
+                ]) {
                     pydocstyle::rules::blank_before_after_function(self, &docstring);
                 }
-                if self.settings.rules.enabled(Rule::OneBlankLineBeforeClass)
-                    || self.settings.rules.enabled(Rule::OneBlankLineAfterClass)
-                    || self.settings.rules.enabled(Rule::BlankLineBeforeClass)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::OneBlankLineBeforeClass,
+                    Rule::OneBlankLineAfterClass,
+                    Rule::BlankLineBeforeClass,
+                ]) {
                     pydocstyle::rules::blank_before_after_class(self, &docstring);
                 }
                 if self.settings.rules.enabled(Rule::BlankLineAfterSummary) {
                     pydocstyle::rules::blank_after_summary(self, &docstring);
                 }
-                if self.settings.rules.enabled(Rule::IndentWithSpaces)
-                    || self.settings.rules.enabled(Rule::UnderIndentation)
-                    || self.settings.rules.enabled(Rule::OverIndentation)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::IndentWithSpaces,
+                    Rule::UnderIndentation,
+                    Rule::OverIndentation,
+                ]) {
                     pydocstyle::rules::indent(self, &docstring);
                 }
                 if self.settings.rules.enabled(Rule::NewLineAfterLastParagraph) {
@@ -5287,12 +5175,10 @@ impl<'a> Checker<'a> {
                 if self.settings.rules.enabled(Rule::SurroundingWhitespace) {
                     pydocstyle::rules::no_surrounding_whitespace(self, &docstring);
                 }
-                if self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::MultiLineSummarySecondLine)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::MultiLineSummaryFirstLine,
+                    Rule::MultiLineSummarySecondLine,
+                ]) {
                     pydocstyle::rules::multi_line_summary_start(self, &docstring);
                 }
                 if self.settings.rules.enabled(Rule::TripleSingleQuotes) {
@@ -5326,34 +5212,23 @@ impl<'a> Checker<'a> {
                 if self.settings.rules.enabled(Rule::OverloadWithDocstring) {
                     pydocstyle::rules::if_needed(self, &docstring);
                 }
-                if self.settings.rules.enabled(Rule::MultiLineSummaryFirstLine)
-                    || self.settings.rules.enabled(Rule::SectionNotOverIndented)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::SectionUnderlineNotOverIndented)
-                    || self.settings.rules.enabled(Rule::CapitalizeSectionName)
-                    || self.settings.rules.enabled(Rule::NewLineAfterSectionName)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::DashedUnderlineAfterSection)
-                    || self.settings.rules.enabled(Rule::SectionUnderlineAfterName)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::SectionUnderlineMatchesSectionLength)
-                    || self.settings.rules.enabled(Rule::NoBlankLineAfterSection)
-                    || self.settings.rules.enabled(Rule::NoBlankLineBeforeSection)
-                    || self
-                        .settings
-                        .rules
-                        .enabled(Rule::BlankLinesBetweenHeaderAndContent)
-                    || self.settings.rules.enabled(Rule::BlankLineAfterLastSection)
-                    || self.settings.rules.enabled(Rule::EmptyDocstringSection)
-                    || self.settings.rules.enabled(Rule::SectionNameEndsInColon)
-                    || self.settings.rules.enabled(Rule::UndocumentedParam)
-                {
+                if self.settings.rules.any_enabled(&[
+                    Rule::MultiLineSummaryFirstLine,
+                    Rule::SectionNotOverIndented,
+                    Rule::SectionUnderlineNotOverIndented,
+                    Rule::CapitalizeSectionName,
+                    Rule::NewLineAfterSectionName,
+                    Rule::DashedUnderlineAfterSection,
+                    Rule::SectionUnderlineAfterName,
+                    Rule::SectionUnderlineMatchesSectionLength,
+                    Rule::NoBlankLineAfterSection,
+                    Rule::NoBlankLineBeforeSection,
+                    Rule::BlankLinesBetweenHeaderAndContent,
+                    Rule::BlankLineAfterLastSection,
+                    Rule::EmptyDocstringSection,
+                    Rule::SectionNameEndsInColon,
+                    Rule::UndocumentedParam,
+                ]) {
                     pydocstyle::rules::sections(
                         self,
                         &docstring,

--- a/crates/ruff/src/fs.rs
+++ b/crates/ruff/src/fs.rs
@@ -4,9 +4,8 @@ use anyhow::{anyhow, Result};
 use globset::GlobMatcher;
 use log::debug;
 use path_absolutize::{path_dedot, Absolutize};
-use rustc_hash::FxHashSet;
 
-use crate::registry::Rule;
+use crate::registry::RuleSet;
 
 /// Extract the absolute path and basename (as strings) from a Path.
 pub fn extract_path_names(path: &Path) -> Result<(&str, &str)> {
@@ -24,35 +23,34 @@ pub fn extract_path_names(path: &Path) -> Result<(&str, &str)> {
 /// Create a set with codes matching the pattern/code pairs.
 pub(crate) fn ignores_from_path(
     path: &Path,
-    pattern_code_pairs: &[(GlobMatcher, GlobMatcher, FxHashSet<Rule>)],
-) -> FxHashSet<Rule> {
+    pattern_code_pairs: &[(GlobMatcher, GlobMatcher, RuleSet)],
+) -> RuleSet {
     let (file_path, file_basename) = extract_path_names(path).expect("Unable to parse filename");
 
     pattern_code_pairs
         .iter()
-        .filter_map(|(absolute, basename, codes)| {
+        .filter_map(|(absolute, basename, rules)| {
             if basename.is_match(file_basename) {
                 debug!(
                     "Adding per-file ignores for {:?} due to basename match on {:?}: {:?}",
                     path,
                     basename.glob().regex(),
-                    codes
+                    rules
                 );
-                Some(codes)
+                Some(rules)
             } else if absolute.is_match(file_path) {
                 debug!(
                     "Adding per-file ignores for {:?} due to absolute match on {:?}: {:?}",
                     path,
                     absolute.glob().regex(),
-                    codes
+                    rules
                 );
-                Some(codes)
+                Some(rules)
             } else {
                 None
             }
         })
         .flatten()
-        .copied()
         .collect()
 }
 

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -204,7 +204,7 @@ pub fn check_path(
     if !diagnostics.is_empty() && !settings.per_file_ignores.is_empty() {
         let ignores = fs::ignores_from_path(path, &settings.per_file_ignores);
         if !ignores.is_empty() {
-            diagnostics.retain(|diagnostic| !ignores.contains(&diagnostic.kind.rule()));
+            diagnostics.retain(|diagnostic| !ignores.contains(diagnostic.kind.rule()));
         }
     };
 

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -8,7 +8,7 @@ use log::warn;
 use nohash_hasher::IntMap;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Location;
 
 use ruff_diagnostics::Diagnostic;
@@ -17,7 +17,7 @@ use ruff_python_ast::source_code::{LineEnding, Locator};
 use ruff_python_ast::types::Range;
 
 use crate::codes::NoqaCode;
-use crate::registry::{AsRule, Rule};
+use crate::registry::{AsRule, Rule, RuleSet};
 use crate::rule_redirects::get_redirect_target;
 
 static NOQA_LINE_REGEX: Lazy<Regex> = Lazy::new(|| {
@@ -174,7 +174,7 @@ fn add_noqa_inner(
     line_ending: &LineEnding,
 ) -> (usize, String) {
     // Map of line number to set of (non-ignored) diagnostic codes that are triggered on that line.
-    let mut matches_by_line: FxHashMap<usize, FxHashSet<Rule>> = FxHashMap::default();
+    let mut matches_by_line: FxHashMap<usize, RuleSet> = FxHashMap::default();
 
     // Whether the file is exempted from all checks.
     let mut file_exempted = false;
@@ -280,7 +280,7 @@ fn add_noqa_inner(
                         output.push_str("  # noqa: ");
 
                         // Add codes.
-                        push_codes(&mut output, rules.iter().map(Rule::noqa_code));
+                        push_codes(&mut output, rules.iter().map(|rule| rule.noqa_code()));
                         output.push_str(line_ending);
                         count += 1;
                     }

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -1,5 +1,7 @@
 //! Registry of all [`Rule`] implementations.
 
+mod rule_set;
+
 use strum_macros::{AsRefStr, EnumIter};
 
 use ruff_diagnostics::Violation;
@@ -7,6 +9,7 @@ use ruff_macros::RuleNamespace;
 
 use crate::codes::{self, RuleCodePrefix};
 use crate::rules;
+pub use rule_set::{RuleSet, RuleSetIterator};
 
 ruff_macros::register_rules!(
     // pycodestyle errors

--- a/crates/ruff/src/registry/rule_set.rs
+++ b/crates/ruff/src/registry/rule_set.rs
@@ -1,0 +1,365 @@
+use crate::registry::Rule;
+use ruff_macros::CacheKey;
+use std::fmt::{Debug, Formatter};
+use std::iter::FusedIterator;
+
+/// A set of [`Rule`]s.
+///
+/// Uses a bitset where a bit of one signals that the Rule with that [u16] is in this set.
+#[derive(Clone, Default, CacheKey, PartialEq, Eq)]
+pub struct RuleSet([u64; 9]);
+
+impl RuleSet {
+    const EMPTY: [u64; 9] = [0; 9];
+
+    // 64 fits into a u16 without truncation
+    #[allow(clippy::cast_possible_truncation)]
+    const SLICE_BITS: u16 = u64::BITS as u16;
+
+    /// Returns an empty rule set.
+    pub const fn empty() -> Self {
+        Self(Self::EMPTY)
+    }
+
+    pub fn clear(&mut self) {
+        self.0 = Self::EMPTY;
+    }
+
+    #[inline]
+    pub const fn from_rule(rule: Rule) -> Self {
+        let rule = rule as u16;
+
+        let index = (rule / Self::SLICE_BITS) as usize;
+
+        debug_assert!(
+            index < Self::EMPTY.len(),
+            "Rule index out of bounds. Increase the size of the bitset array."
+        );
+
+        // The bit-position of this specific rule in the slice
+        let shift = rule % Self::SLICE_BITS;
+        // Set the index for that rule to 1
+        let mask = 1 << shift;
+
+        let mut bits = Self::EMPTY;
+        bits[index] = mask;
+
+        Self(bits)
+    }
+
+    #[inline]
+    pub const fn from_rules(rules: &[Rule]) -> Self {
+        let mut set = RuleSet::empty();
+
+        let mut i = 0;
+
+        // Uses a while because for loops are not allowed in const functions.
+        while i < rules.len() {
+            set = set.union(&RuleSet::from_rule(rules[i]));
+            i += 1;
+        }
+
+        set
+    }
+
+    /// Returns the union of the two rule sets `self` and `other`
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    /// let set_2 = RuleSet::from_rules(&[
+    ///     Rule::BadQuotesInlineString,
+    ///     Rule::BooleanPositionalValueInFunctionCall,
+    /// ]);
+    ///
+    /// let union = set_1.union(&set_2);
+    ///
+    /// assert!(union.contains(Rule::AmbiguousFunctionName));
+    /// assert!(union.contains(Rule::AnyType));
+    /// assert!(union.contains(Rule::BadQuotesInlineString));
+    /// assert!(union.contains(Rule::BooleanPositionalValueInFunctionCall));
+    /// ```
+    #[must_use]
+    pub const fn union(mut self, other: &Self) -> Self {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            self.0[i] |= other.0[i];
+            i += 1;
+        }
+
+        self
+    }
+
+    /// Returns `self` without any of the rules contained in `other`.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    /// let set_2 = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::Debugger]);
+    ///
+    /// let subtract = set_1.subtract(&set_2);
+    ///
+    /// assert!(subtract.contains(Rule::AnyType));
+    /// assert!(!subtract.contains(Rule::AmbiguousFunctionName));
+    /// ```
+    #[must_use]
+    pub const fn subtract(mut self, other: &Self) -> Self {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            self.0[i] ^= other.0[i];
+            i += 1;
+        }
+
+        self
+    }
+
+    /// Returns true if `self` and `other` contain at least one common rule.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let set_1 = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    ///
+    /// assert!(set_1.intersects(&RuleSet::from_rules(&[
+    ///     Rule::AnyType,
+    ///     Rule::BadQuotesInlineString
+    /// ])));
+    ///
+    /// assert!(!set_1.intersects(&RuleSet::from_rules(&[
+    ///     Rule::BooleanPositionalValueInFunctionCall,
+    ///     Rule::BadQuotesInlineString
+    /// ])));
+    /// ```
+    pub const fn intersects(&self, other: &Self) -> bool {
+        let mut i = 0;
+
+        while i < self.0.len() {
+            if self.0[i] & other.0[i] != 0 {
+                return true;
+            }
+            i += 1;
+        }
+
+        false
+    }
+
+    /// Returns `true` if this set contains no rules, `false` otherwise.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// assert!(RuleSet::empty().is_empty());
+    ///         assert!(
+    ///             !RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::BadQuotesInlineString])
+    ///                 .is_empty()
+    ///         );
+    /// ```
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the number of rules in this set.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// assert_eq!(RuleSet::empty().len(), 0);
+    /// assert_eq!(
+    ///     RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::BadQuotesInlineString]).len(),
+    ///     2
+    /// );
+    pub const fn len(&self) -> usize {
+        let mut len: u32 = 0;
+
+        let mut i = 0;
+
+        while i < self.0.len() {
+            len += self.0[i].count_ones();
+            i += 1;
+        }
+
+        len as usize
+    }
+
+    /// Inserts `rule` into the set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let mut set = RuleSet::empty();
+    ///
+    /// assert!(!set.contains(Rule::AnyType));
+    ///
+    /// set.insert(Rule::AnyType);
+    ///
+    /// assert!(set.contains(Rule::AnyType));
+    /// ```
+    pub fn insert(&mut self, rule: Rule) {
+        let set = std::mem::take(self);
+        *self = set.union(&RuleSet::from_rule(rule));
+    }
+
+    /// Removes `rule` from the set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let mut set = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    ///
+    /// set.remove(Rule::AmbiguousFunctionName);
+    ///
+    /// assert!(set.contains(Rule::AnyType));
+    /// assert!(!set.contains(Rule::AmbiguousFunctionName));
+    /// ```
+    pub fn remove(&mut self, rule: Rule) {
+        let set = std::mem::take(self);
+        *self = set.subtract(&RuleSet::from_rule(rule));
+    }
+
+    /// Returns `true` if `rule` is in this set.
+    ///
+    /// ## Examples
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let set = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    ///
+    /// assert!(set.contains(Rule::AmbiguousFunctionName));
+    /// assert!(!set.contains(Rule::BreakOutsideLoop));
+    /// ```
+    pub const fn contains(&self, rule: Rule) -> bool {
+        let rule = rule as u16;
+        let index = rule as usize / Self::SLICE_BITS as usize;
+        let shift = rule % Self::SLICE_BITS;
+        let mask = 1 << shift;
+
+        self.0[index] & mask != 0
+    }
+
+    /// Returns an iterator over the rules in this set.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use ruff::registry::{Rule, RuleSet};
+    /// let set = RuleSet::from_rules(&[Rule::AmbiguousFunctionName, Rule::AnyType]);
+    ///
+    /// let iter: Vec<_> = set.iter().collect();
+    ///
+    /// assert_eq!(iter, vec![Rule::AmbiguousFunctionName, Rule::AnyType]);
+    /// ```
+    pub fn iter(&self) -> RuleSetIterator {
+        RuleSetIterator {
+            set: self.clone(),
+            index: 0,
+        }
+    }
+}
+
+impl Debug for RuleSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl FromIterator<Rule> for RuleSet {
+    fn from_iter<T: IntoIterator<Item = Rule>>(iter: T) -> Self {
+        let mut set = RuleSet::empty();
+
+        for rule in iter {
+            set.insert(rule);
+        }
+
+        set
+    }
+}
+
+impl Extend<Rule> for RuleSet {
+    fn extend<T: IntoIterator<Item = Rule>>(&mut self, iter: T) {
+        let set = std::mem::take(self);
+        *self = set.union(&RuleSet::from_iter(iter));
+    }
+}
+
+impl IntoIterator for RuleSet {
+    type Item = Rule;
+    type IntoIter = RuleSetIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl IntoIterator for &RuleSet {
+    type Item = Rule;
+    type IntoIter = RuleSetIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct RuleSetIterator {
+    set: RuleSet,
+    index: u16,
+}
+
+impl Iterator for RuleSetIterator {
+    type Item = Rule;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let slice = self.set.0.get_mut(self.index as usize)?;
+            // `trailing_zeros` is guaranteed to return a value in [0;64]
+            #[allow(clippy::cast_possible_truncation)]
+            let bit = slice.trailing_zeros() as u16;
+
+            if bit < RuleSet::SLICE_BITS {
+                *slice ^= 1 << bit;
+                let rule_value = self.index * RuleSet::SLICE_BITS + bit;
+                // SAFETY: RuleSet guarantees that only valid rules are stored in the set.
+                #[allow(unsafe_code)]
+                return Some(unsafe { std::mem::transmute(rule_value) });
+            }
+
+            self.index += 1;
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.set.len();
+
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for RuleSetIterator {}
+
+impl FusedIterator for RuleSetIterator {}
+
+#[cfg(test)]
+mod tests {
+    use crate::registry::{Rule, RuleSet};
+    use strum::IntoEnumIterator;
+
+    /// Tests that the set can contain all rules
+    #[test]
+    fn test_all_rules() {
+        for rule in Rule::iter() {
+            let set = RuleSet::from_rule(rule);
+
+            assert!(set.contains(rule));
+        }
+
+        let all_rules_set: RuleSet = Rule::iter().collect();
+        let all_rules: Vec<_> = all_rules_set.iter().collect();
+        let expected_rules: Vec<_> = Rule::iter().collect();
+        assert_eq!(all_rules, expected_rules);
+    }
+}

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -59,7 +59,7 @@ pub static EXCLUDE: Lazy<Vec<FilePattern>> = Lazy::new(|| {
 impl Default for Settings {
     fn default() -> Self {
         Self {
-            rules: PREFIXES.iter().flat_map(IntoIterator::into_iter).into(),
+            rules: PREFIXES.iter().flat_map(IntoIterator::into_iter).collect(),
             allowed_confusables: FxHashSet::from_iter([]),
             builtins: vec![],
             dummy_variable_rgx: DUMMY_VARIABLE_RGX.clone(),

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -13,7 +13,7 @@ use strum::IntoEnumIterator;
 use ruff_cache::cache_dir;
 use ruff_macros::CacheKey;
 
-use crate::registry::{Rule, RuleNamespace, INCOMPATIBLE_CODES};
+use crate::registry::{Rule, RuleNamespace, RuleSet, INCOMPATIBLE_CODES};
 use crate::rule_selector::{RuleSelector, Specificity};
 use crate::rules::{
     flake8_annotations, flake8_bandit, flake8_bugbear, flake8_builtins, flake8_comprehensions,
@@ -33,7 +33,7 @@ pub mod flags;
 pub mod options;
 pub mod options_base;
 pub mod pyproject;
-mod rule_table;
+pub mod rule_table;
 pub mod types;
 
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -80,7 +80,7 @@ pub struct CliSettings {
 #[allow(clippy::struct_excessive_bools)]
 pub struct Settings {
     pub rules: RuleTable,
-    pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, FxHashSet<Rule>)>,
+    pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 
     pub show_source: bool,
     pub target_version: PythonVersion,
@@ -229,7 +229,7 @@ impl Settings {
     #[cfg(test)]
     pub fn for_rule(rule_code: Rule) -> Self {
         Self {
-            rules: [rule_code].into(),
+            rules: RuleTable::from_iter([rule_code]),
             ..Self::default()
         }
     }
@@ -237,7 +237,7 @@ impl Settings {
     #[cfg(test)]
     pub fn for_rules(rules: impl IntoIterator<Item = Rule>) -> Self {
         Self {
-            rules: rules.into(),
+            rules: RuleTable::from_iter(rules),
             ..Self::default()
         }
     }
@@ -246,9 +246,9 @@ impl Settings {
 impl From<&Configuration> for RuleTable {
     fn from(config: &Configuration) -> Self {
         // The select_set keeps track of which rules have been selected.
-        let mut select_set: FxHashSet<Rule> = defaults::PREFIXES.iter().flatten().collect();
+        let mut select_set: RuleSet = defaults::PREFIXES.iter().flatten().collect();
         // The fixable set keeps track of which rules are fixable.
-        let mut fixable_set: FxHashSet<Rule> = RuleSelector::All.into_iter().collect();
+        let mut fixable_set: RuleSet = RuleSelector::All.into_iter().collect();
 
         // Ignores normally only subtract from the current set of selected
         // rules.  By that logic the ignore in `select = [], ignore = ["E501"]`
@@ -310,7 +310,7 @@ impl From<&Configuration> for RuleTable {
                     .filter(|s| s.specificity() == spec)
                 {
                     for rule in selector {
-                        fixable_set.remove(&rule);
+                        fixable_set.remove(rule);
                     }
                 }
             }
@@ -335,7 +335,7 @@ impl From<&Configuration> for RuleTable {
                     if enabled {
                         select_set.insert(rule);
                     } else {
-                        select_set.remove(&rule);
+                        select_set.remove(rule);
                     }
                 }
             }
@@ -374,7 +374,7 @@ impl From<&Configuration> for RuleTable {
         let mut rules = Self::empty();
 
         for rule in select_set {
-            let fix = fixable_set.contains(&rule);
+            let fix = fixable_set.contains(rule);
             rules.enable(rule, fix);
         }
 
@@ -406,7 +406,7 @@ impl From<&Configuration> for RuleTable {
 /// Given a list of patterns, create a `GlobSet`.
 pub fn resolve_per_file_ignores(
     per_file_ignores: Vec<PerFileIgnore>,
-) -> Result<Vec<(GlobMatcher, GlobMatcher, FxHashSet<Rule>)>> {
+) -> Result<Vec<(GlobMatcher, GlobMatcher, RuleSet)>> {
     per_file_ignores
         .into_iter()
         .map(|per_file_ignore| {
@@ -424,23 +424,20 @@ pub fn resolve_per_file_ignores(
 
 #[cfg(test)]
 mod tests {
-    use rustc_hash::FxHashSet;
-
     use crate::codes::{self, Pycodestyle};
-    use crate::registry::Rule;
+    use crate::registry::{Rule, RuleSet};
     use crate::settings::configuration::Configuration;
     use crate::settings::rule_table::RuleTable;
 
     use super::configuration::RuleSelection;
 
     #[allow(clippy::needless_pass_by_value)]
-    fn resolve_rules(selections: impl IntoIterator<Item = RuleSelection>) -> FxHashSet<Rule> {
+    fn resolve_rules(selections: impl IntoIterator<Item = RuleSelection>) -> RuleSet {
         RuleTable::from(&Configuration {
             rule_selections: selections.into_iter().collect(),
             ..Configuration::default()
         })
         .iter_enabled()
-        .copied()
         .collect()
     }
 
@@ -451,7 +448,7 @@ mod tests {
             ..RuleSelection::default()
         }]);
 
-        let expected = FxHashSet::from_iter([
+        let expected = RuleSet::from_rules(&[
             Rule::TrailingWhitespace,
             Rule::MissingNewlineAtEndOfFile,
             Rule::BlankLineWithWhitespace,
@@ -465,7 +462,7 @@ mod tests {
             select: Some(vec![Pycodestyle::W6.into()]),
             ..RuleSelection::default()
         }]);
-        let expected = FxHashSet::from_iter([Rule::InvalidEscapeSequence]);
+        let expected = RuleSet::from_rule(Rule::InvalidEscapeSequence);
         assert_eq!(actual, expected);
 
         let actual = resolve_rules([RuleSelection {
@@ -473,7 +470,7 @@ mod tests {
             ignore: vec![Pycodestyle::W292.into()],
             ..RuleSelection::default()
         }]);
-        let expected = FxHashSet::from_iter([
+        let expected = RuleSet::from_rules(&[
             Rule::TrailingWhitespace,
             Rule::BlankLineWithWhitespace,
             Rule::DocLineTooLong,
@@ -487,7 +484,7 @@ mod tests {
             ignore: vec![Pycodestyle::W.into()],
             ..RuleSelection::default()
         }]);
-        let expected = FxHashSet::from_iter([Rule::MissingNewlineAtEndOfFile]);
+        let expected = RuleSet::from_rule(Rule::MissingNewlineAtEndOfFile);
         assert_eq!(actual, expected);
 
         let actual = resolve_rules([RuleSelection {
@@ -495,7 +492,7 @@ mod tests {
             ignore: vec![Pycodestyle::W605.into()],
             ..RuleSelection::default()
         }]);
-        let expected = FxHashSet::from_iter([]);
+        let expected = RuleSet::empty();
         assert_eq!(actual, expected);
 
         let actual = resolve_rules([
@@ -509,7 +506,7 @@ mod tests {
                 ..RuleSelection::default()
             },
         ]);
-        let expected = FxHashSet::from_iter([
+        let expected = RuleSet::from_rules(&[
             Rule::TrailingWhitespace,
             Rule::MissingNewlineAtEndOfFile,
             Rule::BlankLineWithWhitespace,
@@ -531,7 +528,7 @@ mod tests {
                 ..RuleSelection::default()
             },
         ]);
-        let expected = FxHashSet::from_iter([Rule::MissingNewlineAtEndOfFile]);
+        let expected = RuleSet::from_rule(Rule::MissingNewlineAtEndOfFile);
         assert_eq!(actual, expected);
     }
 
@@ -548,7 +545,7 @@ mod tests {
                 ..RuleSelection::default()
             },
         ]);
-        let expected = FxHashSet::from_iter([
+        let expected = RuleSet::from_rules(&[
             Rule::TrailingWhitespace,
             Rule::BlankLineWithWhitespace,
             Rule::DocLineTooLong,
@@ -569,7 +566,7 @@ mod tests {
                 ..RuleSelection::default()
             },
         ]);
-        let expected = FxHashSet::from_iter([
+        let expected = RuleSet::from_rules(&[
             Rule::TrailingWhitespace,
             Rule::BlankLineWithWhitespace,
             Rule::InvalidEscapeSequence,

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -7,7 +7,6 @@ use std::string::ToString;
 use anyhow::{bail, Result};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use pep440_rs::{Version as Pep440Version, VersionSpecifiers};
-use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{de, Deserialize, Deserializer, Serialize};
 use strum::IntoEnumIterator;
@@ -17,7 +16,7 @@ use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_macros::CacheKey;
 
 use crate::fs;
-use crate::registry::Rule;
+use crate::registry::RuleSet;
 use crate::rule_selector::RuleSelector;
 
 #[derive(
@@ -157,12 +156,12 @@ impl CacheKey for FilePatternSet {
 pub struct PerFileIgnore {
     pub(crate) basename: String,
     pub(crate) absolute: PathBuf,
-    pub(crate) rules: FxHashSet<Rule>,
+    pub(crate) rules: RuleSet,
 }
 
 impl PerFileIgnore {
     pub fn new(pattern: String, prefixes: &[RuleSelector], project_root: Option<&Path>) -> Self {
-        let rules: FxHashSet<_> = prefixes.iter().flat_map(IntoIterator::into_iter).collect();
+        let rules: RuleSet = prefixes.iter().flat_map(IntoIterator::into_iter).collect();
         let path = Path::new(&pattern);
         let absolute = match project_root {
             Some(project_root) => fs::normalize_path_to(path, project_root),

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -81,7 +81,7 @@ fn benchmark_default_rules(criterion: &mut Criterion) {
 
 fn benchmark_all_rules(criterion: &mut Criterion) {
     let settings = Settings {
-        rules: RuleSelector::All.into_iter().into(),
+        rules: RuleSelector::All.into_iter().collect(),
         ..Settings::default()
     };
 

--- a/crates/ruff_macros/src/register_rules.rs
+++ b/crates/ruff_macros/src/register_rules.rs
@@ -42,6 +42,7 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
             AsRefStr,
             ::strum_macros::IntoStaticStr,
         )]
+        #[repr(u16)]
         #[strum(serialize_all = "kebab-case")]
         pub enum Rule { #rule_variants }
 


### PR DESCRIPTION
## Summary

This PR introduces a new `RuleSet` type that stores the rules as a bitset, rather than using a regular set. This works because the number of rules is "low" (<1000). Using a bitset has a few advantages:

* Many functions can be made `const` so that the compiler can evaluate parts of e.g. `any_enabled`
* Using an inline bitset array eliminates the need for heap allocations.
* The index fits into a single CPU cache line, reducing the number of cache misses 

## Considerations

The main downside of a bitflag based `RuleSet` is that it can't support plugins. My take is that having a `RuleSet` type will help us identify the places where Ruff uses "a set of rules" and a `RuleSet` with plugin support could be implemented as a mix of a bitset + a set for plugin rules.

## Benchmark

The cpython benchmark improves locally from ~190ms to ~182ms 