### PR TITLE
Fix infinite loop due to rules `D207` & `W605`

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -100,6 +100,9 @@ fn cmp_fix(rule1: Rule, rule2: Rule, fix1: &Fix, fix2: &Fix) -> std::cmp::Orderi
             // Apply `EndsInPeriod` fixes before `NewLineAfterLastParagraph` fixes.
             (Rule::EndsInPeriod, Rule::NewLineAfterLastParagraph) => std::cmp::Ordering::Less,
             (Rule::NewLineAfterLastParagraph, Rule::EndsInPeriod) => std::cmp::Ordering::Greater,
+            // Apply `UnderIndentation` fixes before `InvalidEscapeSequence` fixes.
+            (Rule::UnderIndentation, Rule::InvalidEscapeSequence) => std::cmp::Ordering::Less,
+            (Rule::InvalidEscapeSequence, Rule::UnderIndentation) => std::cmp::Ordering::Greater,
             _ => std::cmp::Ordering::Equal,
         })
 }

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -100,9 +100,6 @@ fn cmp_fix(rule1: Rule, rule2: Rule, fix1: &Fix, fix2: &Fix) -> std::cmp::Orderi
             // Apply `EndsInPeriod` fixes before `NewLineAfterLastParagraph` fixes.
             (Rule::EndsInPeriod, Rule::NewLineAfterLastParagraph) => std::cmp::Ordering::Less,
             (Rule::NewLineAfterLastParagraph, Rule::EndsInPeriod) => std::cmp::Ordering::Greater,
-            // Apply `UnderIndentation` fixes before `InvalidEscapeSequence` fixes.
-            (Rule::UnderIndentation, Rule::InvalidEscapeSequence) => std::cmp::Ordering::Less,
-            (Rule::InvalidEscapeSequence, Rule::UnderIndentation) => std::cmp::Ordering::Greater,
             _ => std::cmp::Ordering::Equal,
         })
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -114,7 +114,10 @@ pub fn invalid_escape_sequence(
                     Range::new(location, end_location),
                 );
                 if autofix {
-                    diagnostic.amend(Fix::insertion(r"\".to_string(), location));
+                    diagnostic.amend(Fix::insertion(
+                        r"\".to_string(),
+                        Location::new(location.row(), location.column() + 1),
+                    ));
                 }
                 diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
@@ -17,10 +17,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 2
-      column: 9
+      column: 10
     end_location:
       row: 2
-      column: 9
+      column: 10
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -37,10 +37,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 6
-      column: 0
+      column: 1
     end_location:
       row: 6
-      column: 0
+      column: 1
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -57,10 +57,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 11
-      column: 5
+      column: 6
     end_location:
       row: 11
-      column: 5
+      column: 6
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -77,9 +77,9 @@ expression: diagnostics
     content: "\\"
     location:
       row: 18
-      column: 5
+      column: 6
     end_location:
       row: 18
-      column: 5
+      column: 6
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -17,10 +17,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 2
-      column: 9
+      column: 10
     end_location:
       row: 2
-      column: 9
+      column: 10
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -37,10 +37,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 6
-      column: 0
+      column: 1
     end_location:
       row: 6
-      column: 0
+      column: 1
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -57,10 +57,10 @@ expression: diagnostics
     content: "\\"
     location:
       row: 11
-      column: 5
+      column: 6
     end_location:
       row: 11
-      column: 5
+      column: 6
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -77,9 +77,9 @@ expression: diagnostics
     content: "\\"
     location:
       row: 18
-      column: 5
+      column: 6
     end_location:
       row: 18
-      column: 5
+      column: 6
   parent: ~
 


### PR DESCRIPTION
Closes #3522

 ### Issue addressed

Given the following example case:

```python
class A:
    """
\ a
    """
```

With the config:

```toml
select = [
  "D207", # bad docstring indentation
  "W605", # invalid escape sequence
]
```

Those two rules clash when autofixing, creating an infinite loop:

1. `W605` schedules an insertion of a `\` at column 0
2. `D207` schedules an insertion of `....` (four spaces) at column 0
3. End result: `\ a` -> `\` + `    ` + `\ a` -> `\    \ a`
4. GOTO 1

 ### Solution

The culprit is the fairly simplistic way that "fix overlaps" are calculated.

1. Firstly, add an explicit ordering of the rules so that they are applied
   in an order that doesn't break the intent (i.e. FIRST indent, THEN fix
   the escape sequence.
2. For future, similar clashes: make `W605` insert the second `\` AFTER the
   first one, rather than BEFORE. This marks one more character in the code
   as "dirty", postponing other fixes in that same column for the next
   autofix iteration.

 ### Test plan

- [ ] ~~Add a new test covering this pathological case. (TODO: how?)~~
- [x] Test manually that the above example now gets fixed correctly.

