### PR TITLE
Merge Availability and AutofixKind

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -22,7 +22,7 @@ use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_ast::visitor::Visitor;
@@ -52,7 +52,7 @@ pub struct UnusedLoopControlVariable {
 }
 
 impl Violation for UnusedLoopControlVariable {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -2,7 +2,7 @@ use log::error;
 use rustpython_parser::ast::{Expr, ExprKind};
 
 use ruff_diagnostics::Diagnostic;
-use ruff_diagnostics::{AutofixKind, Availability, Violation};
+use ruff_diagnostics::{AutofixKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -44,7 +44,7 @@ pub struct UnnecessaryMap {
 }
 
 impl Violation for UnnecessaryMap {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -10,7 +10,7 @@ use rustpython_parser::ast::{
     Unaryop,
 };
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments_in, unparse_stmt};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -59,7 +59,7 @@ pub struct PytestCompositeAssertion {
 }
 
 impl Violation for PytestCompositeAssertion {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -104,7 +104,7 @@ pub struct PytestUnittestAssertion {
 }
 
 impl Violation for PytestUnittestAssertion {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -2,7 +2,7 @@ use log::error;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr, ComparableStmt};
 use ruff_python_ast::helpers::{
@@ -40,7 +40,7 @@ pub struct CollapsibleIf {
 }
 
 impl Violation for CollapsibleIf {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -60,7 +60,7 @@ pub struct NeedlessBool {
 }
 
 impl Violation for NeedlessBool {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -112,7 +112,7 @@ pub struct IfElseBlockInsteadOfIfExp {
 }
 
 impl Violation for IfElseBlockInsteadOfIfExp {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -165,7 +165,7 @@ pub struct IfElseBlockInsteadOfDictGet {
 }
 
 impl Violation for IfElseBlockInsteadOfDictGet {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -2,7 +2,7 @@ use log::error;
 use rustpython_parser::ast::{Located, Stmt, StmtKind, Withitem};
 
 use ruff_diagnostics::Diagnostic;
-use ruff_diagnostics::{AutofixKind, Availability, Violation};
+use ruff_diagnostics::{AutofixKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{first_colon_range, has_comments_in};
 use ruff_python_ast::newlines::StrExt;
@@ -46,7 +46,7 @@ pub struct MultipleWithStatements {
 }
 
 impl Violation for MultipleWithStatements {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use libcst_native::{Codegen, CodegenState, CompOp};
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -18,7 +18,7 @@ pub struct YodaConditions {
 }
 
 impl Violation for YodaConditions {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Stmt, StmtKind};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
 use ruff_python_ast::helpers::{create_stmt, from_relative_import, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -64,7 +64,7 @@ pub struct RelativeImports {
 }
 
 impl Violation for RelativeImports {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Location, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{match_leading_content, match_trailing_content, unparse_stmt};
 use ruff_python_ast::newlines::StrExt;
@@ -43,7 +43,7 @@ pub struct LambdaAssignment {
 }
 
 impl Violation for LambdaAssignment {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
@@ -17,7 +17,7 @@ fn fmt_blank_line_after_summary_autofix_msg(_: &BlankLineAfterSummary) -> String
     "Insert single blank line".to_string()
 }
 impl Violation for BlankLineAfterSummary {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyflakes/rules/imports.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/imports.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rustpython_parser::ast::Alias;
 
 use ruff_diagnostics::Diagnostic;
-use ruff_diagnostics::{AutofixKind, Availability, Violation};
+use ruff_diagnostics::{AutofixKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::future::ALL_FEATURE_NAMES;
@@ -25,7 +25,7 @@ fn fmt_unused_import_autofix_msg(unused_import: &UnusedImport) -> String {
     }
 }
 impl Violation for UnusedImport {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -3,7 +3,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr};
 use ruff_python_ast::helpers::unparse_expr;
@@ -19,7 +19,7 @@ pub struct MultiValueRepeatedKeyLiteral {
 }
 
 impl Violation for MultiValueRepeatedKeyLiteral {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {
@@ -45,7 +45,7 @@ pub struct MultiValueRepeatedKeyVariable {
 }
 
 impl Violation for MultiValueRepeatedKeyVariable {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_stmt, unparse_stmt};
 use ruff_python_ast::types::Range;
@@ -16,7 +16,7 @@ pub struct ManualFromImport {
 }
 
 impl Violation for ManualFromImport {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::scope::BindingKind;
 use ruff_python_ast::types::Range;
@@ -14,7 +14,7 @@ pub struct SysExitAlias {
 }
 
 impl Violation for SysExitAlias {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -20,7 +20,7 @@ pub struct ConvertNamedTupleFunctionalToClass {
 }
 
 impl Violation for ConvertNamedTupleFunctionalToClass {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -20,7 +20,7 @@ pub struct ConvertTypedDictFunctionalToClass {
 }
 
 impl Violation for ConvertTypedDictFunctionalToClass {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::types::Range;
@@ -14,7 +14,7 @@ pub struct DatetimeTimezoneUTC {
 }
 
 impl Violation for DatetimeTimezoneUTC {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, AliasData, Stmt};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -42,7 +42,7 @@ pub struct DeprecatedImport {
 }
 
 impl Violation for DeprecatedImport {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -14,7 +14,7 @@ pub struct NonPEP585Annotation {
 }
 
 impl Violation for NonPEP585Annotation {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Operator};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -14,7 +14,7 @@ pub struct NonPEP604Annotation {
 }
 
 impl Violation for NonPEP604Annotation {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Operator};
 
-use ruff_diagnostics::{AutofixKind, Availability, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, has_comments, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -15,7 +15,7 @@ pub struct CollectionLiteralConcatenation {
 }
 
 impl Violation for CollectionLiteralConcatenation {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Sometimes));
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use serde::Serialize;
 
 use ruff::registry::{Linter, Rule, RuleNamespace};
-use ruff_diagnostics::Availability;
+use ruff_diagnostics::AutofixKind;
 
 use crate::args::HelpFormat;
 
@@ -32,13 +32,18 @@ pub fn rule(rule: Rule, format: HelpFormat) -> Result<()> {
             output.push('\n');
             output.push('\n');
 
-            if let Some(autofix) = rule.autofixable() {
-                output.push_str(match autofix.available {
-                    Availability::Sometimes => "Autofix is sometimes available.",
-                    Availability::Always => "Autofix is always available.",
-                });
-                output.push('\n');
-                output.push('\n');
+            match rule.autofixable() {
+                AutofixKind::Sometimes => {
+                    output.push_str("Autofix is sometimes available.");
+                    output.push('\n');
+                    output.push('\n');
+                }
+                AutofixKind::Always => {
+                    output.push_str("Autofix is always available.");
+                    output.push('\n');
+                    output.push('\n');
+                }
+                AutofixKind::None => {}
             }
 
             if let Some(explanation) = rule.explanation() {

--- a/crates/ruff_cli/src/commands/rule.rs
+++ b/crates/ruff_cli/src/commands/rule.rs
@@ -32,18 +32,11 @@ pub fn rule(rule: Rule, format: HelpFormat) -> Result<()> {
             output.push('\n');
             output.push('\n');
 
-            match rule.autofixable() {
-                AutofixKind::Sometimes => {
-                    output.push_str("Autofix is sometimes available.");
-                    output.push('\n');
-                    output.push('\n');
-                }
-                AutofixKind::Always => {
-                    output.push_str("Autofix is always available.");
-                    output.push('\n');
-                    output.push('\n');
-                }
-                AutofixKind::None => {}
+            let autofix = rule.autofixable();
+            if matches!(autofix, AutofixKind::Always | AutofixKind::Sometimes) {
+                output.push_str(&autofix.to_string());
+                output.push('\n');
+                output.push('\n');
             }
 
             if let Some(explanation) = rule.explanation() {

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -10,7 +10,7 @@ use strum::IntoEnumIterator;
 
 use ruff::registry::{Linter, Rule, RuleNamespace};
 use ruff::settings::options::Options;
-use ruff_diagnostics::Availability;
+use ruff_diagnostics::AutofixKind;
 
 use crate::ROOT_DIR;
 
@@ -36,13 +36,18 @@ pub fn main(args: &Args) -> Result<()> {
                 output.push('\n');
             }
 
-            if let Some(autofix) = rule.autofixable() {
-                output.push_str(match autofix.available {
-                    Availability::Sometimes => "Autofix is sometimes available.",
-                    Availability::Always => "Autofix is always available.",
-                });
-                output.push('\n');
-                output.push('\n');
+            match rule.autofixable() {
+                AutofixKind::Sometimes => {
+                    output.push_str("Autofix is sometimes available.");
+                    output.push('\n');
+                    output.push('\n');
+                }
+                AutofixKind::Always => {
+                    output.push_str("Autofix is always available.");
+                    output.push('\n');
+                    output.push('\n');
+                }
+                AutofixKind::None => {}
             }
 
             process_documentation(explanation.trim(), &mut output);

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -36,18 +36,11 @@ pub fn main(args: &Args) -> Result<()> {
                 output.push('\n');
             }
 
-            match rule.autofixable() {
-                AutofixKind::Sometimes => {
-                    output.push_str("Autofix is sometimes available.");
-                    output.push('\n');
-                    output.push('\n');
-                }
-                AutofixKind::Always => {
-                    output.push_str("Autofix is always available.");
-                    output.push('\n');
-                    output.push('\n');
-                }
-                AutofixKind::None => {}
+            let autofix = rule.autofixable();
+            if matches!(autofix, AutofixKind::Always | AutofixKind::Sometimes) {
+                output.push_str(&autofix.to_string());
+                output.push('\n');
+                output.push('\n');
             }
 
             process_documentation(explanation.trim(), &mut output);

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -2,6 +2,7 @@
 
 use itertools::Itertools;
 use ruff::registry::{Linter, Rule, RuleNamespace, UpstreamCategory};
+use ruff_diagnostics::AutofixKind;
 use strum::IntoEnumIterator;
 
 const FIX_SYMBOL: &str = "🛠";
@@ -13,8 +14,8 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
     table_out.push('\n');
     for rule in rules {
         let fix_token = match rule.autofixable() {
-            None => "",
-            Some(_) => FIX_SYMBOL,
+            AutofixKind::None => "",
+            AutofixKind::Always | AutofixKind::Sometimes => FIX_SYMBOL,
         };
 
         let rule_name = rule.as_ref();

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 pub use diagnostic::{Diagnostic, DiagnosticKind};
 pub use fix::Fix;
-pub use violation::{AlwaysAutofixableViolation, AutofixKind, Availability, Violation};
+pub use violation::{AlwaysAutofixableViolation, AutofixKind, Violation};
 
 mod diagnostic;
 mod fix;

--- a/crates/ruff_diagnostics/src/violation.rs
+++ b/crates/ruff_diagnostics/src/violation.rs
@@ -1,24 +1,15 @@
 use std::fmt::Debug;
 
-pub enum Availability {
+pub enum AutofixKind {
     Sometimes,
     Always,
-}
-
-pub struct AutofixKind {
-    pub available: Availability,
-}
-
-impl AutofixKind {
-    pub const fn new(available: Availability) -> Self {
-        Self { available }
-    }
+    None,
 }
 
 pub trait Violation: Debug + PartialEq + Eq {
     /// `None` in the case an autofix is never available or otherwise Some
     /// [`AutofixKind`] describing the available autofix.
-    const AUTOFIX: Option<AutofixKind> = None;
+    const AUTOFIX: AutofixKind = AutofixKind::None;
 
     /// The message used to describe the violation.
     fn message(&self) -> String;
@@ -60,7 +51,7 @@ pub trait AlwaysAutofixableViolation: Debug + PartialEq + Eq {
 
 /// A blanket implementation.
 impl<VA: AlwaysAutofixableViolation> Violation for VA {
-    const AUTOFIX: Option<AutofixKind> = Some(AutofixKind::new(Availability::Always));
+    const AUTOFIX: AutofixKind = AutofixKind::Always;
 
     fn message(&self) -> String {
         <Self as AlwaysAutofixableViolation>::message(self)

--- a/crates/ruff_diagnostics/src/violation.rs
+++ b/crates/ruff_diagnostics/src/violation.rs
@@ -1,9 +1,19 @@
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 pub enum AutofixKind {
     Sometimes,
     Always,
     None,
+}
+
+impl Display for AutofixKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AutofixKind::Sometimes => write!(f, "Autofix is sometimes available."),
+            AutofixKind::Always => write!(f, "Autofix is always available."),
+            AutofixKind::None => write!(f, "Autofix is not available."),
+        }
+    }
 }
 
 pub trait Violation: Debug + PartialEq + Eq {

--- a/crates/ruff_macros/src/register_rules.rs
+++ b/crates/ruff_macros/src/register_rules.rs
@@ -58,7 +58,7 @@ pub fn register_rules(input: &Input) -> proc_macro2::TokenStream {
             }
 
             /// Returns the autofix status of this rule.
-            pub const fn autofixable(&self) -> Option<ruff_diagnostics::AutofixKind> {
+            pub const fn autofixable(&self) -> ruff_diagnostics::AutofixKind {
                 match self { #rule_autofixable_match_arms }
             }
         }


### PR DESCRIPTION
Implement suggestion from @MichaReiser 
> NIt: Unrelated to this change: A `Availability::None` would remove the need for `Option<AutofixKind>`. It would then simply be `AUTOFX: AutofixKind = AutofixKind::NONE` (we could even inline `Availability` into `AutofixKind`

_Originally posted by @MichaReiser in https://github.com/charliermarsh/ruff/pull/3593#discussion_r1141763825_
            