### PR TITLE
Consider same-site fixes to be overlapping

### DIFF
--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -219,8 +219,6 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        // This is the last statement in the function. So it has to be followed by
-                        // a newline, or comments, or nothing.
                         diagnostic.amend(Fix::insertion(
                             content,
                             end_of_statement(stmt, checker.locator),


### PR DESCRIPTION
## Summary

This PR makes our autofixer a little more cautious by considering fixes that start and end at the same location to be "overlapping". Previously, a fix had to start _before_ the end of the preceding fix to be considered "overlapping".

This isn't a great fix, but it helps avoid classes of bugs like the following:

```py
if not _DEBUG:
    if _types_coroutine is None:
        wrapper = coro
    else:
        wrapper = _types_coroutine(coro)
```

Here, one rule wants to add a `return None` within the `else`, like:

```py
if not _DEBUG:
    if _types_coroutine is None:
        wrapper = coro
    else:
        wrapper = _types_coroutine(coro)
        return None
```

But another rule wants to collapse the `else`-`if` into an `IfExp`:

```py
if not _DEBUG:
    wrapper = coro if _types_coroutine is None else _types_coroutine(coro)
```

Applying both of these fixes at present yields a syntax error:

```py
if not _DEBUG:
    wrapper = coro if _types_coroutine is None else _types_coroutine(coro)
        return None
```

We can avoid these classes of collisions (removing a block _and_ adding something to the end) by considering them to be overlapping fixes, since the second fix starts at the same location at which the first fix ends.

Closes #3617.
