### PR TITLE
Avoid raising PEP 604 errors with forward-referenced members

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP007.py
@@ -46,3 +46,8 @@ def f(x: Union[("str", "int"), float]) -> None:
 def f() -> None:
     x: Optional[str]
     x = Optional[str]
+
+    x = Union[str, int]
+    x = Union["str", "int"]
+    x: Union[str, int]
+    x: Union["str", "int"]

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -184,32 +184,6 @@ expression: diagnostics
 - kind:
     name: NonPEP604Annotation
     body: "Use `X | Y` for type annotations"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 38
-    column: 9
-  end_location:
-    row: 38
-    column: 26
-  fix: ~
-  parent: ~
-- kind:
-    name: NonPEP604Annotation
-    body: "Use `X | Y` for type annotations"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 42
-    column: 9
-  end_location:
-    row: 42
-    column: 37
-  fix: ~
-  parent: ~
-- kind:
-    name: NonPEP604Annotation
-    body: "Use `X | Y` for type annotations"
     suggestion: "Convert to `X | Y`"
     fixable: true
   location:
@@ -226,5 +200,25 @@ expression: diagnostics
     end_location:
       row: 47
       column: 20
+  parent: ~
+- kind:
+    name: NonPEP604Annotation
+    body: "Use `X | Y` for type annotations"
+    suggestion: "Convert to `X | Y`"
+    fixable: true
+  location:
+    row: 52
+    column: 7
+  end_location:
+    row: 52
+    column: 22
+  fix:
+    content: str | int
+    location:
+      row: 52
+      column: 7
+    end_location:
+      row: 52
+      column: 22
   parent: ~
 


### PR DESCRIPTION
Small follow-up to #3593.