### PR TITLE
Avoid attempting infinite open fix with re-bound builtin

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP020.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP020.py
@@ -1,9 +1,9 @@
-from io import open
-
-with open("f.txt") as f:
-    print(f.read())
-
 import io
 
 with io.open("f.txt", mode="r", buffering=-1, **kwargs) as f:
+    print(f.read())
+
+from io import open
+
+with open("f.txt") as f:
     print(f.read())

--- a/crates/ruff/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff/src/rules/pyupgrade/mod.rs
@@ -38,6 +38,7 @@ mod tests {
     #[test_case(Rule::RedundantOpenModes, Path::new("UP015.py"); "UP015")]
     #[test_case(Rule::NativeLiterals, Path::new("UP018.py"); "UP018")]
     #[test_case(Rule::TypingTextStrAlias, Path::new("UP019.py"); "UP019")]
+    #[test_case(Rule::OpenAlias, Path::new("UP020.py"); "UP020")]
     #[test_case(Rule::ReplaceUniversalNewlines, Path::new("UP021.py"); "UP021")]
     #[test_case(Rule::ReplaceStdoutStderr, Path::new("UP022.py"); "UP022")]
     #[test_case(Rule::DeprecatedCElementTree, Path::new("UP023.py"); "UP023")]

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP020.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP020.py.snap
@@ -1,0 +1,38 @@
+---
+source: crates/ruff/src/rules/pyupgrade/mod.rs
+expression: diagnostics
+---
+- kind:
+    name: OpenAlias
+    body: "Use builtin `open`"
+    suggestion: "Replace with builtin `open`"
+    fixable: true
+  location:
+    row: 3
+    column: 5
+  end_location:
+    row: 3
+    column: 55
+  fix:
+    content: open
+    location:
+      row: 3
+      column: 5
+    end_location:
+      row: 3
+      column: 12
+  parent: ~
+- kind:
+    name: OpenAlias
+    body: "Use builtin `open`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 8
+    column: 5
+  end_location:
+    row: 8
+    column: 18
+  fix: ~
+  parent: ~
+


### PR DESCRIPTION
## Summary

This PR addresses an autofix infinite-loop in which the user imports `io.open` via `from io import open`, which we then attempt to fix by replacing `open` with `open` (intending the latter to be the builtin).

Closes #3647.
