### PR TITLE
Flag, but don't fix, unused imports in `ModuleNotFoundError` blocks

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F401_10.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F401_10.py
@@ -1,10 +1,19 @@
-"""Test: imports within `ModuleNotFoundError` handlers."""
+"""Test: imports within `ModuleNotFoundError` and `ImportError` handlers."""
 
 
-def check_orjson():
+def module_not_found_error():
     try:
         import orjson
 
         return True
     except ModuleNotFoundError:
+        return False
+
+
+def import_error():
+    try:
+        import orjson
+
+        return True
+    except ImportError:
         return False

--- a/crates/ruff/src/rules/pyflakes/rules/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/mod.rs
@@ -10,7 +10,7 @@ pub use if_tuple::{if_tuple, IfTuple};
 pub use imports::{
     future_feature_not_defined, FutureFeatureNotDefined, ImportShadowedByLoopVar, LateFutureImport,
     UndefinedLocalWithImportStar, UndefinedLocalWithImportStarUsage,
-    UndefinedLocalWithNestedImportStarUsage, UnusedImport,
+    UndefinedLocalWithNestedImportStarUsage, UnusedImport, UnusedImportContext,
 };
 pub use invalid_literal_comparisons::{invalid_literal_comparison, IsLiteral};
 pub use invalid_print_syntax::{invalid_print_syntax, InvalidPrintSyntax};

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
@@ -2,5 +2,37 @@
 source: crates/ruff/src/rules/pyflakes/mod.rs
 expression: diagnostics
 ---
-[]
+- kind:
+    name: UnusedImport
+    body: "`orjson` imported but unused; consider using `importlib.util.find_spec` to test for availability"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 6
+    column: 15
+  end_location:
+    row: 6
+    column: 21
+  fix: ~
+  parent: ~
+- kind:
+    name: UnusedImport
+    body: "`orjson` imported but unused"
+    suggestion: "Remove unused import: `orjson`"
+    fixable: true
+  location:
+    row: 15
+    column: 15
+  end_location:
+    row: 15
+    column: 21
+  fix:
+    content: ""
+    location:
+      row: 15
+      column: 0
+    end_location:
+      row: 16
+      column: 0
+  parent: ~
 

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -8,10 +8,10 @@ use smallvec::smallvec;
 use ruff_python_stdlib::path::is_python_stub_file;
 use ruff_python_stdlib::typing::TYPING_EXTENSIONS;
 
-use crate::helpers::{collect_call_path, from_relative_import, Exceptions};
+use crate::helpers::{collect_call_path, from_relative_import};
 use crate::scope::{
-    Binding, BindingId, BindingKind, Bindings, ExecutionContext, Scope, ScopeId, ScopeKind,
-    ScopeStack, Scopes,
+    Binding, BindingId, BindingKind, Bindings, Exceptions, ExecutionContext, Scope, ScopeId,
+    ScopeKind, ScopeStack, Scopes,
 };
 use crate::types::{CallPath, RefEquality};
 use crate::visibility::{module_visibility, Modifier, VisibleScope};
@@ -308,6 +308,7 @@ impl<'a> Context<'a> {
         self.in_exception_handler
     }
 
+    /// Return the [`ExecutionContext`] of the current scope.
     pub const fn execution_context(&self) -> ExecutionContext {
         if self.in_type_checking_block
             || self.in_annotation
@@ -317,5 +318,14 @@ impl<'a> Context<'a> {
         } else {
             ExecutionContext::Runtime
         }
+    }
+
+    /// Return the union of all handled exceptions as an [`Exceptions`] bitflag.
+    pub fn exceptions(&self) -> Exceptions {
+        let mut exceptions = Exceptions::empty();
+        for exception in &self.handled_exceptions {
+            exceptions.insert(*exception);
+        }
+        exceptions
     }
 }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use bitflags::bitflags;
 use itertools::Itertools;
 use log::error;
 use once_cell::sync::Lazy;
@@ -575,13 +574,6 @@ pub fn has_non_none_keyword(keywords: &[Keyword], keyword: &str) -> bool {
         let KeywordData { value, .. } = &keyword.node;
         !is_const_none(value)
     })
-}
-
-bitflags! {
-    pub struct Exceptions: u32 {
-        const NAME_ERROR = 0b0000_0001;
-        const MODULE_NOT_FOUND_ERROR = 0b0000_0010;
-    }
 }
 
 /// Extract the names of all handled exceptions.

--- a/crates/ruff_python_ast/src/scope.rs
+++ b/crates/ruff_python_ast/src/scope.rs
@@ -1,4 +1,5 @@
 use crate::types::{Range, RefEquality};
+use bitflags::bitflags;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Arguments, Expr, Keyword, Stmt};
 use std::num::TryFromIntError;
@@ -222,6 +223,14 @@ impl Default for ScopeStack {
     }
 }
 
+bitflags! {
+    pub struct Exceptions: u32 {
+        const NAME_ERROR = 0b0000_0001;
+        const MODULE_NOT_FOUND_ERROR = 0b0000_0010;
+        const IMPORT_ERROR = 0b0000_0100;
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Binding<'a> {
     pub kind: BindingKind<'a>,
@@ -241,6 +250,8 @@ pub struct Binding<'a> {
     /// (e.g.) `__future__` imports, explicit re-exports, and other bindings
     /// that should be considered used even if they're never referenced.
     pub synthetic_usage: Option<(ScopeId, Range)>,
+    /// The exceptions that were handled when the binding was defined.
+    pub exceptions: Exceptions,
 }
 
 impl<'a> Binding<'a> {


### PR DESCRIPTION
## Summary

This PR acts on the resolved solution from #3378. In https://github.com/charliermarsh/ruff/pull/3288, we changed Ruff to avoid flagging unused import in `ModuleNotFoundError` blocks, like:

```py
try:
    import orjson

    return True
except ModuleNotFoundError:
    return False
```

This is a common pattern used to detect module availability, and removing those imports tends to break code.

However, these imports _are_ unused, and it's confusing that Ruff doesn't flag them. Further, this isn't the recommended way to test for module availability -- we have `importlib` APIs for that.

So this PR modifies the logic to (1) flag unused imports in blocks like the above, but (2) avoid autofixing them, and (3) using a dedicated message to point the user to those `importlib` APIs.

Closes #3378.
