### PR TITLE
Avoid overlong-line errors for lines that end with URLs

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E501.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E501.py
@@ -56,7 +56,29 @@ sit amet  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labor
 # OK
 # https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com
 
-# Not OK
+# OK
 _ = """
 Source: https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533
 """
+
+# OK
+_ = """
+[this-is-ok](https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533)
+[this is ok](https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533)
+"""
+
+
+# OK
+class Foo:
+    """
+    @see https://looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com
+
+    :param dynamodb_scan_kwargs: kwargs pass to <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Table.scan>
+    """
+
+
+# Error
+class Bar:
+    """
+    This is a long sentence that ends with a shortened URL and, therefore, could easily be broken across multiple lines ([source](https://ruff.rs))
+    """

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E501_E501.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E501_E501.py.snap
@@ -69,15 +69,15 @@ expression: diagnostics
   parent: ~
 - kind:
     name: LineTooLong
-    body: Line too long (129 > 88 characters)
+    body: Line too long (147 > 88 characters)
     suggestion: ~
     fixable: false
   location:
-    row: 61
+    row: 83
     column: 88
   end_location:
-    row: 61
-    column: 129
+    row: 83
+    column: 147
   fix: ~
   parent: ~
 


### PR DESCRIPTION
## Summary

This is (maybe?) a controversial change. Prior to this PR, we ignored overlong lines in a few cases:

1. The line contains a single "word" that can't be split up.

```py
"""Lorem ipsum dolor sit amet.

    https://github.com/PyCQA/pycodestyle/pull/258/files#diff-841c622497a8033d10152bfdfb15b20b92437ecdea21a260944ea86b77b51533

Lorem ipsum dolor sit amet.
"""
```

2. The line is an own-line comment, and the comment consists solely of a URL.

```py
# OK
# https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com
```

3. (Not relevant) The line is a `TODO` comment, and the user has `ignore_overlong_task_comments` enabled.

There are a few cases that _aren't_ covered, but arguably should be. The motivating issue used this example:

```py
def func():
    """
    [this-is-ok](https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog.url.com)
    [this is not](https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog.url.com)
    """
    ...
```

The first line (`[this-is-ok]`) is _not_ flagged as overlong, because there's no whitespace, so the line can't be split up. The second line _is_ flagged as overlong. You can fix it by changing to:

```py
def func():
    """
    [this-is-ok](https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog.url.com)
    [this is not](
        https://loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog.url.com
    )
    """
    ...
```

But, is that really better?

This also came up in another issue:

```py
class Foo:
    """
    @see https://looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong.url.com
    """
```

The change enacted here is that we avoid overlong line errors if the last word contains a URL (even if it does not _start_ with a URL, and even if the line could be split up further).

Closes #3625.

Closes #3051.
