### PR TITLE
Check indentation level when executing E231

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E23.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E23.py
@@ -13,3 +13,8 @@ result = {
     'key1': 'value',
     'key2': 'value',
 }
+
+def foo() -> None:
+    #: E231
+    if (1,2):
+        pass

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -171,7 +171,9 @@ pub fn check_logical_lines(
             #[cfg(not(debug_assertions))]
             let should_fix = false;
 
-            for diagnostic in missing_whitespace(&line.text, start_loc.row(), should_fix) {
+            for diagnostic in
+                missing_whitespace(&line.text, start_loc.row(), should_fix, indent_level)
+            {
                 if settings.rules.enabled(diagnostic.kind.rule()) {
                     diagnostics.push(diagnostic);
                 }

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
@@ -33,7 +33,12 @@ impl AlwaysAutofixableViolation for MissingWhitespace {
 
 /// E231
 #[cfg(debug_assertions)]
-pub fn missing_whitespace(line: &str, row: usize, autofix: bool) -> Vec<Diagnostic> {
+pub fn missing_whitespace(
+    line: &str,
+    row: usize,
+    autofix: bool,
+    indent_level: usize,
+) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
     for (idx, char) in line.chars().enumerate() {
         if idx + 1 == line.len() {
@@ -62,11 +67,17 @@ pub fn missing_whitespace(line: &str, row: usize, autofix: bool) -> Vec<Diagnost
 
             let mut diagnostic = Diagnostic::new(
                 kind,
-                Range::new(Location::new(row, idx), Location::new(row, idx)),
+                Range::new(
+                    Location::new(row, indent_level + idx),
+                    Location::new(row, indent_level + idx),
+                ),
             );
 
             if autofix {
-                diagnostic.amend(Fix::insertion(" ".to_string(), Location::new(row, idx + 1)));
+                diagnostic.amend(Fix::insertion(
+                    " ".to_string(),
+                    Location::new(row, indent_level + idx + 1),
+                ));
             }
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
@@ -62,4 +62,24 @@ expression: diagnostics
       row: 6
       column: 10
   parent: ~
+- kind:
+    name: MissingWhitespace
+    body: "Missing whitespace after ','"
+    suggestion: "Added missing whitespace after ','"
+    fixable: true
+  location:
+    row: 19
+    column: 9
+  end_location:
+    row: 19
+    column: 9
+  fix:
+    content: " "
+    location:
+      row: 19
+      column: 10
+    end_location:
+      row: 19
+      column: 10
+  parent: ~
 


### PR DESCRIPTION
close #3620

Currently,`missing_whitespace` does not have indentation depth information.
However, `line: &str` does not contain indentation information, so the position of indentation is not taken into account in `Fix::insertion`.

This behavior causes a bug because spaces are repeatedly inserted in the wrong position.

## reproduction case
```python
def foo() -> None:
    if (1,2):
        pass
```