### PR TITLE
Allow `pairwise` diagnostics for `zip(..., strict=True)`

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF007.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF007.py
@@ -11,8 +11,6 @@ list(zip(input, otherInput))  # nested call
 zip(input, input[1::2])  # not successive
 zip(foo[:-1], foo[1:], foo, strict=False)  # more than 2 inputs
 zip(foo[:-1], foo[1:], foo, strict=True)  # more than 2 inputs
-zip(foo[:-1], foo[1:], strict=True)  # use strict
-zip(foo[:-1], foo[1:], strict=bool(foo))  # use strict
 
 # Errors
 zip(input, input[1:])
@@ -22,4 +20,6 @@ zip(input[1:], input[2:])
 zip(input[1:-1], input[2:])
 list(zip(input, input[1:]))
 list(zip(input[:-1], input[1:]))
+zip(foo[:-1], foo[1:], strict=True)
 zip(foo[:-1], foo[1:], strict=False)
+zip(foo[:-1], foo[1:], strict=bool(foo))

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2872,7 +2872,7 @@ where
 
                 if self.settings.rules.enabled(Rule::PairwiseOverZipped) {
                     if self.settings.target_version >= PythonVersion::Py310 {
-                        ruff::rules::pairwise_over_zipped(self, func, args, keywords);
+                        ruff::rules::pairwise_over_zipped(self, func, args);
                     }
                 }
 

--- a/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -1,5 +1,5 @@
 use num_traits::ToPrimitive;
-use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, KeywordData, Unaryop};
+use rustpython_parser::ast::{Constant, Expr, ExprKind, Unaryop};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -88,43 +88,13 @@ fn to_bound(expr: &Expr) -> Option<i64> {
 }
 
 /// RUF007
-pub fn pairwise_over_zipped(
-    checker: &mut Checker,
-    func: &Expr,
-    args: &[Expr],
-    keywords: &[Keyword],
-) {
+pub fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[Expr]) {
     let ExprKind::Name { id, .. } = &func.node else {
         return;
     };
 
     // Require exactly two positional arguments.
     if args.len() != 2 {
-        return;
-    }
-
-    // Allow `strict=False`, but no other keyword arguments.
-    if keywords.iter().any(|keyword| {
-        let KeywordData {
-            arg: Some(arg),
-            value,
-        } = &keyword.node else {
-            return true;
-        };
-        if arg != "strict" {
-            return true;
-        }
-        if matches!(
-            value.node,
-            ExprKind::Constant {
-                value: Constant::Bool(false),
-                ..
-            }
-        ) {
-            return false;
-        }
-        true
-    }) {
         return;
     }
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_pairwise_over_zipped.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_pairwise_over_zipped.snap
@@ -8,6 +8,32 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
+    row: 16
+    column: 0
+  end_location:
+    row: 16
+    column: 3
+  fix: ~
+  parent: ~
+- kind:
+    name: PairwiseOverZipped
+    body: "Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 17
+    column: 0
+  end_location:
+    row: 17
+    column: 3
+  fix: ~
+  parent: ~
+- kind:
+    name: PairwiseOverZipped
+    body: "Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs"
+    suggestion: ~
+    fixable: false
+  location:
     row: 18
     column: 0
   end_location:
@@ -48,10 +74,10 @@ expression: diagnostics
     fixable: false
   location:
     row: 21
-    column: 0
+    column: 5
   end_location:
     row: 21
-    column: 3
+    column: 8
   fix: ~
   parent: ~
 - kind:
@@ -61,9 +87,22 @@ expression: diagnostics
     fixable: false
   location:
     row: 22
+    column: 5
+  end_location:
+    row: 22
+    column: 8
+  fix: ~
+  parent: ~
+- kind:
+    name: PairwiseOverZipped
+    body: "Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 23
     column: 0
   end_location:
-    row: 22
+    row: 23
     column: 3
   fix: ~
   parent: ~
@@ -73,24 +112,11 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 23
-    column: 5
-  end_location:
-    row: 23
-    column: 8
-  fix: ~
-  parent: ~
-- kind:
-    name: PairwiseOverZipped
-    body: "Prefer `itertools.pairwise()` over `zip()` when iterating over successive pairs"
-    suggestion: ~
-    fixable: false
-  location:
     row: 24
-    column: 5
+    column: 0
   end_location:
     row: 24
-    column: 8
+    column: 3
   fix: ~
   parent: ~
 - kind:


### PR DESCRIPTION
See: https://github.com/charliermarsh/ruff/pull/3654#discussion_r1144959468.