### PR TITLE
Avoid parsing `ForwardRef` contents as type references

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F821_13.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F821_13.py
@@ -1,0 +1,8 @@
+"""Test case: ForwardRef."""
+
+from typing import ForwardRef, TypeVar
+
+X = ForwardRef("List[int]")
+Y: ForwardRef("List[int]")
+
+Z = TypeVar("X", "List[int]", "int")

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -3426,9 +3426,7 @@ where
                 keywords,
             } => {
                 let callable = self.ctx.resolve_call_path(func).and_then(|call_path| {
-                    if self.ctx.match_typing_call_path(&call_path, "ForwardRef") {
-                        Some(Callable::ForwardRef)
-                    } else if self.ctx.match_typing_call_path(&call_path, "cast") {
+                    if self.ctx.match_typing_call_path(&call_path, "cast") {
                         Some(Callable::Cast)
                     } else if self.ctx.match_typing_call_path(&call_path, "NewType") {
                         Some(Callable::NewType)
@@ -3455,12 +3453,6 @@ where
                     }
                 });
                 match callable {
-                    Some(Callable::ForwardRef) => {
-                        self.visit_expr(func);
-                        for expr in args {
-                            visit_type_definition!(self, expr);
-                        }
-                    }
                     Some(Callable::Cast) => {
                         self.visit_expr(func);
                         if !args.is_empty() {

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -107,6 +107,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_10.py"); "F821_10")]
     #[test_case(Rule::UndefinedName, Path::new("F821_11.py"); "F821_11")]
     #[test_case(Rule::UndefinedName, Path::new("F821_12.py"); "F821_12")]
+    #[test_case(Rule::UndefinedName, Path::new("F821_13.py"); "F821_13")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"); "F822_0")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"); "F822_1")]
     #[test_case(Rule::UndefinedExport, Path::new("F822_2.py"); "F822_2")]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_13.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F821_F821_13.py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+expression: diagnostics
+---
+- kind:
+    name: UndefinedName
+    body: "Undefined name `List`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 8
+    column: 18
+  end_location:
+    row: 8
+    column: 22
+  fix: ~
+  parent: ~
+

--- a/crates/ruff_python_ast/src/typing.rs
+++ b/crates/ruff_python_ast/src/typing.rs
@@ -11,7 +11,6 @@ use crate::str;
 use crate::types::Range;
 
 pub enum Callable {
-    ForwardRef,
     Cast,
     NewType,
     TypeVar,


### PR DESCRIPTION
## Summary

Today, we parse the inner contents of `ForwardRef` (e.g., the `"List[int]"` in `ForwardRef("List[int]")`) as a forward annotation. However, no other tools treat them like that. E.g., if you run this code through Flake8, or Mypy, or Pyright:

```py
from typing import TypeVar

X = TypeVar("X", "List[int]", int)
X = ForwardRef("List[int]")
```

...none of them flag the second `List[int]` as an undefined reference to `List`.

Closes #3678 although there's another fix coming to avoid a panic there.