### PR TITLE
Rename `Fix` to `Edit`

### DIFF
--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -3,7 +3,7 @@
 use nohash_hasher::IntMap;
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
 
@@ -223,7 +223,7 @@ pub fn check_noqa(
                                     trailing_spaces,
                                 ));
                             } else {
-                                diagnostic.amend(Fix::replacement(
+                                diagnostic.amend(Edit::replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     Location::new(row + 1, start_char),
                                     Location::new(row + 1, end_char),
@@ -242,7 +242,7 @@ pub fn check_noqa(
     ignored_diagnostics
 }
 
-/// Generate a [`Fix`] to delete a `noqa` directive.
+/// Generate a [`Edit`] to delete a `noqa` directive.
 fn delete_noqa(
     row: usize,
     line: &str,
@@ -250,15 +250,15 @@ fn delete_noqa(
     start_byte: usize,
     end_byte: usize,
     trailing_spaces: usize,
-) -> Fix {
+) -> Edit {
     if start_byte - leading_spaces == 0 && end_byte == line.len() {
         // Ex) `# noqa`
-        Fix::deletion(Location::new(row + 1, 0), Location::new(row + 2, 0))
+        Edit::deletion(Location::new(row + 1, 0), Location::new(row + 2, 0))
     } else if end_byte == line.len() {
         // Ex) `x = 1  # noqa`
         let start_char = line[..start_byte].chars().count();
         let end_char = start_char + line[start_byte..end_byte].chars().count();
-        Fix::deletion(
+        Edit::deletion(
             Location::new(row + 1, start_char - leading_spaces),
             Location::new(row + 1, end_char + trailing_spaces),
         )
@@ -266,7 +266,7 @@ fn delete_noqa(
         // Ex) `x = 1  # noqa  # type: ignore`
         let start_char = line[..start_byte].chars().count();
         let end_char = start_char + line[start_byte..end_byte].chars().count();
-        Fix::deletion(
+        Edit::deletion(
             Location::new(row + 1, start_char),
             Location::new(row + 1, end_char + trailing_spaces),
         )
@@ -274,7 +274,7 @@ fn delete_noqa(
         // Ex) `x = 1  # noqa here`
         let start_char = line[..start_byte].chars().count();
         let end_char = start_char + line[start_byte..end_byte].chars().count();
-        Fix::deletion(
+        Edit::deletion(
             Location::new(row + 1, start_char + 1 + 1),
             Location::new(row + 1, end_char + trailing_spaces),
         )

--- a/crates/ruff/src/message.rs
+++ b/crates/ruff/src/message.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 pub use rustpython_parser::ast::Location;
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
+use ruff_diagnostics::{Diagnostic, DiagnosticKind, Edit};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
@@ -12,7 +12,7 @@ pub struct Message {
     pub kind: DiagnosticKind,
     pub location: Location,
     pub end_location: Location,
-    pub fix: Option<Fix>,
+    pub fix: Option<Edit>,
     pub filename: String,
     pub source: Option<Source>,
     pub noqa_row: usize,

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -62,7 +62,7 @@ pub fn commented_out_code(
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, Range::new(start, end));
         if autofix.into() && settings.rules.should_fix(Rule::CommentedOutCode) {
-            diagnostic.amend(Fix::deletion(location, end_location));
+            diagnostic.amend(Edit::deletion(location, end_location));
         }
         Some(diagnostic)
     } else {

--- a/crates/ruff/src/rules/flake8_annotations/fixes.rs
+++ b/crates/ruff/src/rules/flake8_annotations/fixes.rs
@@ -2,12 +2,12 @@ use anyhow::{bail, Result};
 use rustpython_parser::ast::Stmt;
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
 
 /// ANN204
-pub fn add_return_annotation(locator: &Locator, stmt: &Stmt, annotation: &str) -> Result<Fix> {
+pub fn add_return_annotation(locator: &Locator, stmt: &Stmt, annotation: &str) -> Result<Edit> {
     let range = Range::from(stmt);
     let contents = locator.slice(range);
 
@@ -18,7 +18,7 @@ pub fn add_return_annotation(locator: &Locator, stmt: &Stmt, annotation: &str) -
     for (start, tok, ..) in lexer::lex_located(contents, Mode::Module, range.location).flatten() {
         if seen_lpar && seen_rpar {
             if matches!(tok, Tok::Colon) {
-                return Ok(Fix::insertion(format!(" -> {annotation}"), start));
+                return Ok(Edit::insertion(format!(" -> {annotation}"), start));
             }
         }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::types::Range;
@@ -63,7 +63,7 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
 
     let mut diagnostic = Diagnostic::new(AssertFalse, Range::from(test));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_stmt(&assertion_error(msg), checker.stylist),
             stmt.location,
             stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -5,7 +5,7 @@ use rustpython_parser::ast::{
 };
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::unparse_expr;
@@ -98,7 +98,7 @@ fn duplicate_handler_exceptions<'a>(
                 Range::from(expr),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     if unique_elts.len() == 1 {
                         unparse_expr(unique_elts[0], checker.stylist)
                     } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -65,7 +65,7 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, Range::from(expr));
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(&attribute(obj, value), checker.stylist),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -48,7 +48,7 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             Range::from(type_),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_expr(elt, checker.stylist),
                 type_.location,
                 type_.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Location, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::source_code::Stylist;
@@ -80,7 +80,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, Range::from(expr));
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     assignment(obj, name, value, checker.stylist),
                     expr.location,
                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -22,7 +22,7 @@ use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_ast::visitor::Visitor;
@@ -178,7 +178,7 @@ pub fn unused_loop_control_variable(
                 if let Some(binding) = binding {
                     if binding.kind.is_loop_var() {
                         if !binding.used() {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 rename,
                                 expr.location,
                                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -3,7 +3,7 @@ use rustpython_parser::lexer::{LexResult, Spanned};
 use rustpython_parser::Tok;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -261,7 +261,7 @@ pub fn trailing_commas(
                 },
             );
             if autofix.into() && settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
-                diagnostic.amend(Fix::deletion(comma.0, comma.2));
+                diagnostic.amend(Edit::deletion(comma.0, comma.2));
             }
             diagnostics.push(diagnostic);
         }
@@ -310,7 +310,7 @@ pub fn trailing_commas(
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
                 let contents = locator.slice(Range::new(missing_comma.0, missing_comma.2));
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     format!("{contents},"),
                     missing_comma.0,
                     missing_comma.2,

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -7,7 +7,7 @@ use libcst_native::{
     RightParen, RightSquareBracket, Set, SetComp, SimpleString, SimpleWhitespace, Tuple,
 };
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 
 use crate::cst::matchers::{match_expr, match_module};
@@ -33,7 +33,7 @@ pub fn fix_unnecessary_generator_list(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(GeneratorExp)))) -> Expr(ListComp)))
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -67,7 +67,7 @@ pub fn fix_unnecessary_generator_list(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -80,7 +80,7 @@ pub fn fix_unnecessary_generator_set(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
     parent: Option<&rustpython_parser::ast::Expr>,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(GeneratorExp)))) -> Expr(SetComp)))
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -124,7 +124,7 @@ pub fn fix_unnecessary_generator_set(
         }
     }
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         content,
         expr.location,
         expr.end_location.unwrap(),
@@ -138,7 +138,7 @@ pub fn fix_unnecessary_generator_dict(
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
     parent: Option<&rustpython_parser::ast::Expr>,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -198,7 +198,7 @@ pub fn fix_unnecessary_generator_dict(
         }
     }
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         content,
         expr.location,
         expr.end_location.unwrap(),
@@ -210,7 +210,7 @@ pub fn fix_unnecessary_list_comprehension_set(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(ListComp)))) ->
     // Expr(SetComp)))
     let module_text = locator.slice(expr);
@@ -243,7 +243,7 @@ pub fn fix_unnecessary_list_comprehension_set(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -256,7 +256,7 @@ pub fn fix_unnecessary_list_comprehension_dict(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -299,7 +299,7 @@ pub fn fix_unnecessary_list_comprehension_dict(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -354,7 +354,7 @@ pub fn fix_unnecessary_literal_set(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(List|Tuple)))) -> Expr(Set)))
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -393,7 +393,7 @@ pub fn fix_unnecessary_literal_set(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -405,7 +405,7 @@ pub fn fix_unnecessary_literal_dict(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(List|Tuple)))) -> Expr(Dict)))
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -466,7 +466,7 @@ pub fn fix_unnecessary_literal_dict(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -478,7 +478,7 @@ pub fn fix_unnecessary_collection_call(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call("list" | "tuple" | "dict")))) -> Expr(List|Tuple|Dict)
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -582,7 +582,7 @@ pub fn fix_unnecessary_collection_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -594,7 +594,7 @@ pub fn fix_unnecessary_literal_within_tuple_call(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -641,7 +641,7 @@ pub fn fix_unnecessary_literal_within_tuple_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -653,7 +653,7 @@ pub fn fix_unnecessary_literal_within_list_call(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -702,7 +702,7 @@ pub fn fix_unnecessary_literal_within_list_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -714,7 +714,7 @@ pub fn fix_unnecessary_list_call(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(Call(List|Tuple)))) -> Expr(List|Tuple)))
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
@@ -731,7 +731,7 @@ pub fn fix_unnecessary_list_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -745,7 +745,7 @@ pub fn fix_unnecessary_call_around_sorted(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -860,7 +860,7 @@ pub fn fix_unnecessary_call_around_sorted(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -872,7 +872,7 @@ pub fn fix_unnecessary_double_cast_or_process(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let body = match_expr(&mut tree)?;
@@ -899,7 +899,7 @@ pub fn fix_unnecessary_double_cast_or_process(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -911,7 +911,7 @@ pub fn fix_unnecessary_comprehension(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -995,7 +995,7 @@ pub fn fix_unnecessary_comprehension(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),
@@ -1009,7 +1009,7 @@ pub fn fix_unnecessary_map(
     expr: &rustpython_parser::ast::Expr,
     parent: Option<&rustpython_parser::ast::Expr>,
     kind: &str,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(expr);
     let mut tree = match_module(module_text)?;
     let mut body = match_expr(&mut tree)?;
@@ -1162,7 +1162,7 @@ pub fn fix_unnecessary_map(
             }
         }
 
-        Ok(Fix::replacement(
+        Ok(Edit::replacement(
             content,
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -36,7 +36,7 @@ pub fn shebang_whitespace(
                 ),
             );
             if autofix {
-                diagnostic.amend(Fix::deletion(
+                diagnostic.amend(Edit::deletion(
                     Location::new(lineno + 1, 0),
                     Location::new(lineno + 1, *n_spaces),
                 ));

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Location, Operator};
 
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_python_ast::helpers::{find_keyword, is_logger_candidate, SimpleCallArgs};
 use ruff_python_ast::logging::LoggingLevel;
 use ruff_python_ast::types::Range;
@@ -156,7 +156,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             {
                 let mut diagnostic = Diagnostic::new(LoggingWarn, level_call_range);
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         "warning".to_string(),
                         level_call_range.location,
                         level_call_range.end_location,

--- a/crates/ruff/src/rules/flake8_pie/fixes.rs
+++ b/crates/ruff/src/rules/flake8_pie/fixes.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, Expression, GeneratorExp};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 
 use crate::cst::matchers::{match_call, match_expression};
@@ -11,7 +11,7 @@ pub fn fix_unnecessary_comprehension_any_all(
     locator: &Locator,
     stylist: &Stylist,
     expr: &rustpython_parser::ast::Expr,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Expr(ListComp) -> Expr(GeneratorExp)
     let expression_text = locator.slice(expr);
     let mut tree = match_expression(expression_text)?;
@@ -42,7 +42,7 @@ pub fn fix_unnecessary_comprehension_any_all(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         expr.location,
         expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -9,7 +9,7 @@ use rustpython_parser::ast::{
 };
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{create_expr, match_trailing_comment, unparse_expr};
@@ -184,7 +184,7 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                 let mut diagnostic = Diagnostic::new(UnnecessaryPass, Range::from(pass_stmt));
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = match_trailing_comment(pass_stmt, checker.locator) {
-                        diagnostic.amend(Fix::deletion(
+                        diagnostic.amend(Edit::deletion(
                             pass_stmt.location,
                             Location::new(
                                 pass_stmt.end_location.unwrap().row(),
@@ -498,7 +498,7 @@ pub fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                         .collect(),
                 });
 
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.location,
                     expr.end_location.unwrap(),
@@ -524,7 +524,7 @@ pub fn reimplemented_list_builtin(checker: &mut Checker, expr: &Expr) {
             if elts.is_empty() {
                 let mut diagnostic = Diagnostic::new(ReimplementedListBuiltin, Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         "list".to_string(),
                         expr.location,
                         expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind, Operator, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -217,7 +217,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, Range::from(default));
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 "...".to_string(),
                                 default.location,
                                 default.end_location.unwrap(),
@@ -244,7 +244,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, Range::from(default));
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 "...".to_string(),
                                 default.location,
                                 default.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -10,7 +10,7 @@ use rustpython_parser::ast::{
     Unaryop,
 };
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments_in, unparse_stmt};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -206,7 +206,7 @@ pub fn unittest_assertion(
                 );
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             unparse_stmt(&stmt, checker.stylist),
                             expr.location,
                             expr.end_location.unwrap(),
@@ -317,7 +317,7 @@ fn negate<'a>(expression: &Expression<'a>) -> Expression<'a> {
 
 /// Replace composite condition `assert a == "hello" and b == "world"` with two statements
 /// `assert a == "hello"` and `assert b == "world"`.
-fn fix_composite_condition(stmt: &Stmt, locator: &Locator, stylist: &Stylist) -> Result<Fix> {
+fn fix_composite_condition(stmt: &Stmt, locator: &Locator, stylist: &Stylist) -> Result<Edit> {
     // Infer the indentation of the outer block.
     let Some(outer_indent) = whitespace::indentation(locator, stmt) else {
         bail!("Unable to fix multiline statement");
@@ -418,7 +418,7 @@ fn fix_composite_condition(stmt: &Stmt, locator: &Locator, stylist: &Stylist) ->
         .unwrap()
         .to_string();
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         contents,
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Keyword, Location, Stmt, StmtKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{collect_arg_names, collect_call_path};
 use ruff_python_ast::source_code::Locator;
@@ -236,7 +236,7 @@ fn has_abstractmethod_decorator(decorators: &[Expr], checker: &Checker) -> bool 
 fn pytest_fixture_parentheses(
     checker: &mut Checker,
     decorator: &Expr,
-    fix: Fix,
+    fix: Edit,
     preferred: &str,
     actual: &str,
 ) {
@@ -260,7 +260,7 @@ pub fn fix_extraneous_scope_function(
     expr_end: Location,
     args: &[Expr],
     keywords: &[Keyword],
-) -> Result<Fix> {
+) -> Result<Edit> {
     remove_argument(locator, stmt_at, expr_at, expr_end, args, keywords, false)
 }
 
@@ -282,7 +282,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 && keywords.is_empty()
             {
                 let fix =
-                    Fix::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
+                    Edit::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
                 pytest_fixture_parentheses(checker, decorator, fix, "", "()");
             }
 
@@ -341,7 +341,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
                 && checker.settings.flake8_pytest_style.fixture_parentheses
             {
-                let fix = Fix::insertion("()".to_string(), decorator.end_location.unwrap());
+                let fix = Edit::insertion("()".to_string(), decorator.end_location.unwrap());
                 pytest_fixture_parentheses(checker, decorator, fix, "()", "");
             }
         }
@@ -401,7 +401,7 @@ fn check_fixture_returns(checker: &mut Checker, func: &Stmt, func_name: &str, bo
                             Range::from(stmt),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 "return".to_string(),
                                 stmt.location,
                                 Location::new(
@@ -479,7 +479,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                 if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);
-                    diagnostic.amend(Fix::deletion(start, end));
+                    diagnostic.amend(Edit::deletion(start, end));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -496,7 +496,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                 if checker.patch(diagnostic.kind.rule()) {
                     let start = Location::new(mark.location.row(), 0);
                     let end = Location::new(mark.end_location.unwrap().row() + 1, 0);
-                    diagnostic.amend(Fix::deletion(start, end));
+                    diagnostic.amend(Edit::deletion(start, end));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind, Location};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -52,7 +52,7 @@ impl AlwaysAutofixableViolation for PytestUseFixturesWithoutParameters {
 fn pytest_mark_parentheses(
     checker: &mut Checker,
     decorator: &Expr,
-    fix: Fix,
+    fix: Edit,
     preferred: &str,
     actual: &str,
 ) {
@@ -83,13 +83,13 @@ fn check_mark_parentheses(checker: &mut Checker, decorator: &Expr) {
                 && keywords.is_empty()
             {
                 let fix =
-                    Fix::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
+                    Edit::deletion(func.end_location.unwrap(), decorator.end_location.unwrap());
                 pytest_mark_parentheses(checker, decorator, fix, "", "()");
             }
         }
         _ => {
             if checker.settings.flake8_pytest_style.mark_parentheses {
-                let fix = Fix::insertion("()".to_string(), decorator.end_location.unwrap());
+                let fix = Edit::insertion("()".to_string(), decorator.end_location.unwrap());
                 pytest_mark_parentheses(checker, decorator, fix, "()", "");
             }
         }
@@ -114,7 +114,7 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr) {
             Diagnostic::new(PytestUseFixturesWithoutParameters, Range::from(decorator));
         if checker.patch(diagnostic.kind.rule()) {
             let at_start = Location::new(decorator.location.row(), decorator.location.column() - 1);
-            diagnostic.amend(Fix::deletion(at_start, decorator.end_location.unwrap()));
+            diagnostic.amend(Edit::deletion(at_start, decorator.end_location.unwrap()));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -100,7 +100,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 format!(
                                     "({})",
                                     unparse_expr(
@@ -133,7 +133,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
                                         elts: names
@@ -175,7 +175,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
                                         elts: elts.clone(),
@@ -198,7 +198,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
-                                diagnostic.amend(Fix::replacement(
+                                diagnostic.amend(Edit::replacement(
                                     content,
                                     expr.location,
                                     expr.end_location.unwrap(),
@@ -226,7 +226,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                             Range::from(expr),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 format!(
                                     "({})",
                                     unparse_expr(
@@ -252,7 +252,7 @@ fn check_names(checker: &mut Checker, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
-                                diagnostic.amend(Fix::replacement(
+                                diagnostic.amend(Edit::replacement(
                                     content,
                                     expr.location,
                                     expr.end_location.unwrap(),
@@ -329,7 +329,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(&create_expr(value.node.clone()), checker.stylist),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::Location;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -291,7 +291,7 @@ fn docstring(
         fixed_contents.push_str(&quote);
         fixed_contents.push_str(string_contents);
         fixed_contents.push_str(&quote);
-        diagnostic.amend(Fix::replacement(fixed_contents, start, end));
+        diagnostic.amend(Edit::replacement(fixed_contents, start, end));
     }
     Some(diagnostic)
 }
@@ -366,7 +366,7 @@ fn strings(
                 fixed_contents.push_str(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push_str(quote);
-                diagnostic.amend(Fix::replacement(fixed_contents, *start, *end));
+                diagnostic.amend(Edit::replacement(fixed_contents, *start, *end));
             }
             diagnostics.push(diagnostic);
         } else {
@@ -430,7 +430,7 @@ fn strings(
 
                         fixed_contents.push(quote);
 
-                        diagnostic.amend(Fix::replacement(fixed_contents, *start, *end));
+                        diagnostic.amend(Edit::replacement(fixed_contents, *start, *end));
                     }
                     diagnostics.push(diagnostic);
                 }
@@ -453,7 +453,7 @@ fn strings(
                     fixed_contents.push(quote);
                     fixed_contents.push_str(string_contents);
                     fixed_contents.push(quote);
-                    diagnostic.amend(Fix::replacement(fixed_contents, *start, *end));
+                    diagnostic.amend(Edit::replacement(fixed_contents, *start, *end));
                 }
                 diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::match_parens;
 
@@ -34,7 +34,7 @@ pub fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: &Expr) 
                 .expect("Expected call to include parentheses");
             let mut diagnostic = Diagnostic::new(UnnecessaryParenOnRaiseException, range);
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::deletion(
+                diagnostic.amend(Edit::deletion(
                     func.end_location.unwrap(),
                     range.end_location,
                 ));

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Stmt, StmtKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_const_none;
 use ruff_python_ast::helpers::{elif_else_range, end_of_statement};
@@ -140,7 +140,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, Range::from(*stmt));
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "return".to_string(),
                 stmt.location,
                 stmt.end_location.unwrap(),
@@ -158,7 +158,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(ImplicitReturnValue, Range::from(*stmt));
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "return None".to_string(),
                 stmt.location,
                 stmt.end_location.unwrap(),
@@ -220,7 +220,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.amend(Fix::insertion(
+                        diagnostic.amend(Edit::insertion(
                             content,
                             end_of_statement(stmt, checker.locator),
                         ));
@@ -258,7 +258,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.amend(Fix::insertion(
+                        diagnostic.amend(Edit::insertion(
                             content,
                             end_of_statement(stmt, checker.locator),
                         ));
@@ -297,7 +297,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     content.push_str(checker.stylist.line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
-                    diagnostic.amend(Fix::insertion(
+                    diagnostic.amend(Edit::insertion(
                         content,
                         end_of_statement(stmt, checker.locator),
                     ));

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -4,7 +4,7 @@ use std::iter;
 use itertools::Either::{Left, Right};
 use rustpython_parser::ast::{Boolop, Cmpop, Constant, Expr, ExprContext, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{contains_effect, create_expr, has_comments, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -254,7 +254,7 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                 // Populate the `Fix`. Replace the _entire_ `BoolOp`. Note that if we have
                 // multiple duplicates, the fixes will conflict.
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.location,
                     expr.end_location.unwrap(),
@@ -357,7 +357,7 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
                     values: iter::once(in_expr).chain(unmatched).collect(),
                 })
             };
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_expr(&in_expr, checker.stylist),
                 expr.location,
                 expr.end_location.unwrap(),
@@ -409,7 +409,7 @@ pub fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     Range::from(expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         "False".to_string(),
                         expr.location,
                         expr.end_location.unwrap(),
@@ -463,7 +463,7 @@ pub fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     Range::from(expr),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         "True".to_string(),
                         expr.location,
                         expr.end_location.unwrap(),
@@ -491,7 +491,7 @@ pub fn expr_or_true(checker: &mut Checker, expr: &Expr) {
         {
             let mut diagnostic = Diagnostic::new(ExprOrTrue, Range::from(value));
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     "True".to_string(),
                     expr.location,
                     expr.end_location.unwrap(),
@@ -518,7 +518,7 @@ pub fn expr_and_false(checker: &mut Checker, expr: &Expr) {
         {
             let mut diagnostic = Diagnostic::new(ExprAndFalse, Range::from(value));
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     "False".to_string(),
                     expr.location,
                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -73,7 +73,7 @@ pub fn use_capital_environment_variables(checker: &mut Checker, expr: &Expr) {
             value: capital_env_var.into(),
             kind: kind.clone(),
         });
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(&new_env_var, checker.stylist),
             arg.location,
             arg.end_location.unwrap(),
@@ -115,7 +115,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             value: capital_env_var.into(),
             kind: kind.clone(),
         });
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(&new_env_var, checker.stylist),
             slice.location,
             slice.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 use unicode_width::UnicodeWidthStr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr, ComparableStmt};
 use ruff_python_ast::helpers::{
@@ -356,7 +356,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
     if fixable && checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
             // If the condition is a comparison, we can replace it with the condition.
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
                         value: Some(test.clone()),
@@ -369,7 +369,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
         } else {
             // Otherwise, we need to wrap the condition in a call to `bool`. (We've already
             // verified, above, that `bool` is a builtin.)
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
                         value: Some(Box::new(create_expr(ExprKind::Call {
@@ -504,7 +504,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
         Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             contents,
             stmt.location,
             stmt.end_location.unwrap(),
@@ -853,7 +853,7 @@ pub fn use_dict_get_with_default(
         Range::from(stmt),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             contents,
             stmt.location,
             stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -101,13 +101,13 @@ pub fn explicit_true_false_in_ifexpr(
     );
     if checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_expr(&test.clone(), checker.stylist),
                 expr.location,
                 expr.end_location.unwrap(),
             ));
         } else if checker.ctx.is_builtin("bool") {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 unparse_expr(
                     &create_expr(ExprKind::Call {
                         func: Box::new(create_expr(ExprKind::Name {
@@ -155,7 +155,7 @@ pub fn explicit_false_true_in_ifexpr(
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(
                 &create_expr(ExprKind::UnaryOp {
                     op: Unaryop::Not,
@@ -204,7 +204,7 @@ pub fn twisted_arms_in_ifexpr(
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(
                 &create_expr(ExprKind::IfExp {
                     test: Box::new(create_expr(orelse.node.clone())),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Stmt, StmtKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::scope::ScopeKind;
@@ -108,7 +108,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
                     left: left.clone(),
@@ -159,7 +159,7 @@ pub fn negation_with_not_equal_op(
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
                     left: left.clone(),
@@ -194,7 +194,7 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_expr(operand, checker.stylist),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -6,7 +6,7 @@ use libcst_native::{
 };
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
@@ -33,7 +33,7 @@ pub(crate) fn fix_nested_if_statements(
     locator: &Locator,
     stylist: &Stylist,
     stmt: &rustpython_parser::ast::Stmt,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Infer the indentation of the outer block.
     let Some(outer_indent) = whitespace::indentation(locator, stmt) else {
         bail!("Unable to fix multiline statement");
@@ -135,7 +135,7 @@ pub(crate) fn fix_nested_if_statements(
         module_text.to_string()
     };
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         contents,
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, CompoundStatement, Statement, Suite, With};
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace;
@@ -14,7 +14,7 @@ pub(crate) fn fix_multiple_with_statements(
     locator: &Locator,
     stylist: &Stylist,
     stmt: &rustpython_parser::ast::Stmt,
-) -> Result<Fix> {
+) -> Result<Edit> {
     // Infer the indentation of the outer block.
     let Some(outer_indent) = whitespace::indentation(locator, stmt) else {
         bail!("Unable to fix multiline statement");
@@ -95,7 +95,7 @@ pub(crate) fn fix_multiple_with_statements(
             .to_string()
     };
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         contents,
         Location::new(stmt.location.row(), 0),
         Location::new(stmt.end_location.unwrap().row() + 1, 0),

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -3,7 +3,7 @@ use libcst_native::{Codegen, CodegenState};
 use log::error;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -91,7 +91,7 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: Range) {
         range,
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             value_content,
             right.location,
             right.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -223,7 +223,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     Range::from(stmt),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("any") {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         contents,
                         stmt.location,
                         loop_info.terminal,
@@ -300,7 +300,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     Range::from(stmt),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("all") {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         contents,
                         stmt.location,
                         loop_info.terminal,

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use libcst_native::{Codegen, CodegenState, CompOp};
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -162,7 +162,7 @@ pub fn yoda_conditions(
             Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 suggestion,
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Stmt, StmtKind};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
 use ruff_python_ast::helpers::{create_stmt, from_relative_import, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -90,7 +90,7 @@ fn fix_banned_relative_import(
     module: Option<&str>,
     module_path: Option<&Vec<String>>,
     stylist: &Stylist,
-) -> Option<Fix> {
+) -> Option<Edit> {
     // Only fix is the module path is known.
     if let Some(mut parts) = module_path.cloned() {
         if *level? >= parts.len() {
@@ -140,7 +140,7 @@ fn fix_banned_relative_import(
             stylist,
         );
 
-        Some(Fix::replacement(
+        Some(Edit::replacement(
             content,
             stmt.location,
             stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -4,7 +4,7 @@ use log::error;
 use rustpython_parser as parser;
 use rustpython_parser::ast::{Location, StmtKind, Suite};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -194,7 +194,7 @@ fn add_required_import(
         }
 
         // Construct the fix.
-        diagnostic.amend(Fix::insertion(contents, splice));
+        diagnostic.amend(Edit::insertion(contents, splice));
     }
     Some(diagnostic)
 }

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -4,7 +4,7 @@ use itertools::{EitherOrBoth, Itertools};
 use rustpython_parser::ast::{Location, Stmt};
 use textwrap::indent;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{
     count_trailing_lines, followed_by_multi_statement_line, preceded_by_multi_statement_line,
@@ -155,7 +155,7 @@ pub fn organize_imports(
     } else {
         let mut diagnostic = Diagnostic::new(UnsortedImports, range);
         if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 indent(&expected, indentation),
                 range.location,
                 range.end_location,

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -71,7 +71,7 @@ pub fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
             Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 match type_name {
                     "unicode" => "str",
                     "long" => "int",

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword, Location};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -33,7 +33,7 @@ pub fn fix_inplace_argument(
     violation_end: Location,
     args: &[Expr],
     keywords: &[Keyword],
-) -> Option<Fix> {
+) -> Option<Edit> {
     if let Ok(fix) = remove_argument(
         locator,
         expr.location,
@@ -44,7 +44,7 @@ pub fn fix_inplace_argument(
         false,
     ) {
         // Reset the line index.
-        let fix_me = Fix::deletion(
+        let fix_me = Edit::deletion(
             helpers::to_relative(fix.location, expr.location),
             helpers::to_relative(fix.end_location, expr.location),
         );
@@ -61,7 +61,7 @@ pub fn fix_inplace_argument(
         let new_contents = format!("{name} = {output}");
 
         // Create the new fix.
-        Some(Fix::replacement(
+        Some(Edit::replacement(
             new_contents,
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -2,7 +2,7 @@ use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -163,7 +163,7 @@ pub fn compound_statements(
                 if let Some((start, end)) = semi {
                     let mut diagnostic = Diagnostic::new(UselessSemicolon, Range::new(start, end));
                     if autofix.into() && settings.rules.should_fix(Rule::UselessSemicolon) {
-                        diagnostic.amend(Fix::deletion(start, end));
+                        diagnostic.amend(Edit::deletion(start, end));
                     };
                     diagnostics.push(diagnostic);
                 }

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::error;
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::source_code::Locator;
@@ -114,7 +114,7 @@ pub fn invalid_escape_sequence(
                     Range::new(location, end_location),
                 );
                 if autofix {
-                    diagnostic.amend(Fix::insertion(
+                    diagnostic.amend(Edit::insertion(
                         r"\".to_string(),
                         Location::new(location.row(), location.column() + 1),
                     ));

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Location, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{match_leading_content, match_trailing_content, unparse_stmt};
 use ruff_python_ast::newlines::StrExt;
@@ -99,7 +99,7 @@ pub fn lambda_assignment(checker: &mut Checker, target: &Expr, value: &Expr, stm
                         indented.push_str(line);
                     }
                 }
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     indented,
                     stmt.location,
                     stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -2,7 +2,7 @@ use itertools::izip;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::types::Range;
@@ -273,7 +273,7 @@ pub fn literal_comparisons(
             .collect::<Vec<_>>();
         let content = compare(left, &ops, comparators, checker.stylist);
         for diagnostic in &mut diagnostics {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 content.to_string(),
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -51,7 +51,7 @@ pub fn no_newline_at_end_of_file(
             let mut diagnostic =
                 Diagnostic::new(MissingNewlineAtEndOfFile, Range::new(location, location));
             if autofix {
-                diagnostic.amend(Fix::insertion(stylist.line_ending().to_string(), location));
+                diagnostic.amend(Edit::insertion(stylist.line_ending().to_string(), location));
             }
             return Some(diagnostic);
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
@@ -75,7 +75,7 @@ pub fn missing_whitespace(
             );
 
             if autofix {
-                diagnostic.amend(Fix::insertion(
+                diagnostic.amend(Edit::insertion(
                     " ".to_string(),
                     Location::new(row, indent_level + idx + 1),
                 ));

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -98,7 +98,7 @@ pub fn not_tests(
                         if check_not_in {
                             let mut diagnostic = Diagnostic::new(NotInTest, Range::from(operand));
                             if checker.patch(diagnostic.kind.rule()) && should_fix {
-                                diagnostic.amend(Fix::replacement(
+                                diagnostic.amend(Edit::replacement(
                                     compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
                                     expr.location,
                                     expr.end_location.unwrap(),
@@ -111,7 +111,7 @@ pub fn not_tests(
                         if check_not_is {
                             let mut diagnostic = Diagnostic::new(NotIsTest, Range::from(operand));
                             if checker.patch(diagnostic.kind.rule()) && should_fix {
-                                diagnostic.amend(Fix::replacement(
+                                diagnostic.amend(Edit::replacement(
                                     compare(left, &[Cmpop::IsNot], comparators, checker.stylist),
                                     expr.location,
                                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -94,7 +94,7 @@ pub fn trailing_whitespace(
                 if matches!(autofix, flags::Autofix::Enabled)
                     && settings.rules.should_fix(Rule::BlankLineWithWhitespace)
                 {
-                    diagnostic.amend(Fix::deletion(start, end));
+                    diagnostic.amend(Edit::deletion(start, end));
                 }
                 return Some(diagnostic);
             }
@@ -103,7 +103,7 @@ pub fn trailing_whitespace(
             if matches!(autofix, flags::Autofix::Enabled)
                 && settings.rules.should_fix(Rule::TrailingWhitespace)
             {
-                diagnostic.amend(Fix::deletion(start, end));
+                diagnostic.amend(Edit::deletion(start, end));
             }
             return Some(diagnostic);
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
@@ -3,7 +3,7 @@
 use rustpython_parser::ast::Location;
 use rustpython_parser::Tok;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -56,7 +56,7 @@ pub fn whitespace_before_parameters(
             let mut diagnostic = Diagnostic::new(kind, Range::new(start, end));
 
             if autofix {
-                diagnostic.amend(Fix::deletion(start, end));
+                diagnostic.amend(Edit::deletion(start, end));
             }
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
@@ -74,7 +74,7 @@ pub fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
                 }
 
                 // Insert one blank line after the summary (replacing any existing lines).
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     Location::new(docstring.expr.location.row() + summary_line + 1, 0),
                     Location::new(

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
@@ -88,7 +88,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
-                    diagnostic.amend(Fix::deletion(
+                    diagnostic.amend(Edit::deletion(
                         Location::new(docstring.expr.location.row() - blank_lines_before, 0),
                         Location::new(docstring.expr.location.row(), 0),
                     ));
@@ -110,7 +110,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         checker.stylist.line_ending().to_string(),
                         Location::new(docstring.expr.location.row() - blank_lines_before, 0),
                         Location::new(docstring.expr.location.row(), 0),
@@ -149,7 +149,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     Location::new(docstring.expr.end_location.unwrap().row() + 1, 0),
                     Location::new(

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
@@ -82,7 +82,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
-                diagnostic.amend(Fix::deletion(
+                diagnostic.amend(Edit::deletion(
                     Location::new(docstring.expr.location.row() - blank_lines_before, 0),
                     Location::new(docstring.expr.location.row(), 0),
                 ));
@@ -137,7 +137,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
-                diagnostic.amend(Fix::deletion(
+                diagnostic.amend(Edit::deletion(
                     Location::new(docstring.expr.end_location.unwrap().row() + 1, 0),
                     Location::new(
                         docstring.expr.end_location.unwrap().row() + 1 + blank_lines_after,

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -1,6 +1,6 @@
 use strum::IntoEnumIterator;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::str::leading_quote;
@@ -81,7 +81,7 @@ pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
                         trimmed.chars().count(),
                     ))
                 } {
-                    diagnostic.amend(Fix::insertion(".".to_string(), Location::new(row, column)));
+                    diagnostic.amend(Edit::insertion(".".to_string(), Location::new(row, column)));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -1,6 +1,6 @@
 use strum::IntoEnumIterator;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::str::leading_quote;
@@ -80,7 +80,7 @@ pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {
                         trimmed.chars().count(),
                     ))
                 } {
-                    diagnostic.amend(Fix::insertion(".".to_string(), Location::new(row, column)));
+                    diagnostic.amend(Edit::insertion(".".to_string(), Location::new(row, column)));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::types::Range;
@@ -94,7 +94,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                     ),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         whitespace::clean(docstring.indentation),
                         Location::new(docstring.expr.location.row() + i, 0),
                         Location::new(docstring.expr.location.row() + i, line_indent.len()),
@@ -144,7 +144,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                         ),
                     );
                     if checker.patch(diagnostic.kind.rule()) {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             whitespace::clean(docstring.indentation),
                             Location::new(docstring.expr.location.row() + i, 0),
                             Location::new(docstring.expr.location.row() + i, line_indent.len()),
@@ -168,7 +168,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                     ),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         whitespace::clean(docstring.indentation),
                         Location::new(docstring.expr.location.row() + i, 0),
                         Location::new(docstring.expr.location.row() + i, line_indent.len()),

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{NewlineWithTrailingNewline, StrExt};
 use ruff_python_ast::str::{is_triple_quote, leading_quote};
@@ -69,7 +69,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                         let start =
                             Location::new(location.row(), location.column() + first_line.len());
                         let end = Location::new(end_row, end_column);
-                        diagnostic.amend(Fix::deletion(start, end));
+                        diagnostic.amend(Edit::deletion(start, end));
                         break;
                     }
                     end_row += 1;
@@ -123,7 +123,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                         indentation,
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         repl,
                         Location::new(location.row(), location.column() + prefix.len()),
                         Location::new(location.row(), location.column() + first_line.len()),

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{NewlineWithTrailingNewline, StrExt};
 use ruff_python_ast::types::Range;
@@ -52,7 +52,7 @@ pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring
                             checker.stylist.line_ending().as_str(),
                             whitespace::clean(docstring.indentation)
                         );
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             content,
                             Location::new(
                                 docstring.expr.end_location.unwrap().row(),

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::str::leading_quote;
@@ -49,7 +49,7 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
                 && !trimmed.starts_with(pattern.chars().last().unwrap())
                 && !ends_with_backslash(trimmed)
             {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     trimmed.to_string(),
                     Location::new(
                         docstring.expr.location.row(),

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::str::{leading_quote, trailing_quote};
@@ -49,7 +49,7 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                 if !trimmed.ends_with(trailing.chars().last().unwrap())
                     && !trimmed.starts_with(leading.chars().last().unwrap())
                 {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.expr.location,
                         docstring.expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::StmtKind;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Fix};
+use ruff_diagnostics::{Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
@@ -369,7 +369,7 @@ fn blanks_and_section_underline(
                     whitespace::clean(docstring.indentation),
                     "-".repeat(context.section_name.len()),
                 );
-                diagnostic.amend(Fix::insertion(
+                diagnostic.amend(Edit::insertion(
                     content,
                     Location::new(
                         docstring.expr.location.row() + context.original_index,
@@ -410,7 +410,7 @@ fn blanks_and_section_underline(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and the underline.
-                    diagnostic.amend(Fix::deletion(
+                    diagnostic.amend(Edit::deletion(
                         Location::new(
                             docstring.expr.location.row() + context.original_index + 1,
                             0,
@@ -454,7 +454,7 @@ fn blanks_and_section_underline(
                         "-".repeat(context.section_name.len()),
                         checker.stylist.line_ending().as_str()
                     );
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         content,
                         Location::new(
                             docstring.expr.location.row()
@@ -492,7 +492,7 @@ fn blanks_and_section_underline(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Replace the existing indentation with whitespace of the appropriate length.
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         whitespace::clean(docstring.indentation),
                         Location::new(
                             docstring.expr.location.row()
@@ -547,7 +547,7 @@ fn blanks_and_section_underline(
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
-                            diagnostic.amend(Fix::deletion(
+                            diagnostic.amend(Edit::deletion(
                                 Location::new(
                                     docstring.expr.location.row()
                                         + context.original_index
@@ -599,7 +599,7 @@ fn blanks_and_section_underline(
                     whitespace::clean(docstring.indentation),
                     "-".repeat(context.section_name.len()),
                 );
-                diagnostic.amend(Fix::insertion(
+                diagnostic.amend(Edit::insertion(
                     content,
                     Location::new(
                         docstring.expr.location.row() + context.original_index,
@@ -623,7 +623,7 @@ fn blanks_and_section_underline(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete any blank lines between the header and content.
-                    diagnostic.amend(Fix::deletion(
+                    diagnostic.amend(Edit::deletion(
                         Location::new(
                             docstring.expr.location.row() + context.original_index + 1,
                             0,
@@ -660,7 +660,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                     // Map from bytes to characters.
                     let section_name_start = &context.line[..index].chars().count();
                     let section_name_length = &context.section_name.chars().count();
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         capitalized_section_name.to_string(),
                         Location::new(
                             docstring.expr.location.row() + context.original_index,
@@ -688,7 +688,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the existing indentation with whitespace of the appropriate length.
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     whitespace::clean(docstring.indentation),
                     Location::new(docstring.expr.location.row() + context.original_index, 0),
                     Location::new(
@@ -722,7 +722,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
                     let line = context.following_lines.last().unwrap_or(&context.line);
-                    diagnostic.amend(Fix::insertion(
+                    diagnostic.amend(Edit::insertion(
                         format!("{}{}", line_end, docstring.indentation),
                         Location::new(
                             docstring.expr.location.row()
@@ -749,7 +749,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
                     let line = context.following_lines.last().unwrap_or(&context.line);
-                    diagnostic.amend(Fix::insertion(
+                    diagnostic.amend(Edit::insertion(
                         line_end.to_string(),
                         Location::new(
                             docstring.expr.location.row()
@@ -778,7 +778,7 @@ fn common_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
-                diagnostic.amend(Fix::insertion(
+                diagnostic.amend(Edit::insertion(
                     line_end.to_string(),
                     Location::new(docstring.expr.location.row() + context.original_index, 0),
                 ));
@@ -981,7 +981,7 @@ fn numpy_section(checker: &mut Checker, docstring: &Docstring, context: &Section
                         .chars()
                         .count();
                     let suffix_length = suffix.chars().count();
-                    diagnostic.amend(Fix::deletion(
+                    diagnostic.amend(Edit::deletion(
                         Location::new(
                             docstring.expr.location.row() + context.original_index,
                             *suffix_start,
@@ -1028,7 +1028,7 @@ fn google_section(checker: &mut Checker, docstring: &Docstring, context: &Sectio
                         .chars()
                         .count();
                     let suffix_length = suffix.chars().count();
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         ":".to_string(),
                         Location::new(
                             docstring.expr.location.row() + context.original_index,

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -3,7 +3,7 @@ use libcst_native::{Codegen, CodegenState, DictElement, Expression};
 use rustpython_parser::ast::{Excepthandler, Expr};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::str::raw_contents;
 use ruff_python_ast::types::Range;
@@ -15,13 +15,13 @@ use crate::cst::matchers::{
     match_attribute, match_call, match_dict, match_expression, match_simple_string,
 };
 
-/// Generate a [`Fix`] to remove unused keys from format dict.
+/// Generate a [`Edit`] to remove unused keys from format dict.
 pub fn remove_unused_format_arguments_from_dict(
     unused_arguments: &[&str],
     stmt: &Expr,
     locator: &Locator,
     stylist: &Stylist,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(stmt);
     let mut tree = match_expression(module_text)?;
     let dict = match_dict(&mut tree)?;
@@ -40,20 +40,20 @@ pub fn remove_unused_format_arguments_from_dict(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         stmt.location,
         stmt.end_location.unwrap(),
     ))
 }
 
-/// Generate a [`Fix`] to remove unused keyword arguments from a `format` call.
+/// Generate a [`Edit`] to remove unused keyword arguments from a `format` call.
 pub fn remove_unused_keyword_arguments_from_format_call(
     unused_arguments: &[&str],
     location: Range,
     locator: &Locator,
     stylist: &Stylist,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(location);
     let mut tree = match_expression(module_text)?;
     let call = match_call(&mut tree)?;
@@ -68,7 +68,7 @@ pub fn remove_unused_keyword_arguments_from_format_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         location.location,
         location.end_location,
@@ -133,14 +133,14 @@ fn update_field_types(format_string: &FormatString, min_unused: usize) -> String
         .collect()
 }
 
-/// Generate a [`Fix`] to remove unused positional arguments from a `format` call.
+/// Generate a [`Edit`] to remove unused positional arguments from a `format` call.
 pub fn remove_unused_positional_arguments_from_format_call(
     unused_arguments: &[usize],
     location: Range,
     locator: &Locator,
     stylist: &Stylist,
     format_string: &FormatString,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let module_text = locator.slice(location);
     let mut tree = match_expression(module_text)?;
     let call = match_call(&mut tree)?;
@@ -176,18 +176,18 @@ pub fn remove_unused_positional_arguments_from_format_call(
     };
     tree.codegen(&mut state);
 
-    Ok(Fix::replacement(
+    Ok(Edit::replacement(
         state.to_string(),
         location.location,
         location.end_location,
     ))
 }
 
-/// Generate a [`Fix`] to remove the binding from an exception handler.
+/// Generate a [`Edit`] to remove the binding from an exception handler.
 pub fn remove_exception_handler_assignment(
     excepthandler: &Excepthandler,
     locator: &Locator,
-) -> Result<Fix> {
+) -> Result<Edit> {
     let contents = locator.slice(excepthandler);
     let mut fix_start = None;
     let mut fix_end = None;
@@ -208,7 +208,7 @@ pub fn remove_exception_handler_assignment(
     }
 
     if let (Some(start), Some(end)) = (fix_start, fix_end) {
-        Ok(Fix::deletion(start, end))
+        Ok(Edit::deletion(start, end))
     } else {
         bail!("Could not find span of exception handler")
     }

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_useless_f_strings;
 use ruff_python_ast::types::Range;
@@ -55,12 +55,12 @@ fn fix_f_string_missing_placeholders(
     prefix_range: &Range,
     tok_range: &Range,
     checker: &mut Checker,
-) -> Fix {
+) -> Edit {
     let content = checker.locator.slice(Range::new(
         prefix_range.end_location,
         tok_range.end_location,
     ));
-    Fix::replacement(
+    Edit::replacement(
         unescape_f_string(content),
         prefix_range.location,
         tok_range.end_location,

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -3,7 +3,7 @@ use log::error;
 use once_cell::unsync::Lazy;
 use rustpython_parser::ast::{Cmpop, Expr};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 use ruff_python_ast::operations::locate_cmpops;
@@ -79,7 +79,7 @@ pub fn invalid_literal_comparison(
                             None
                         }
                     } {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             content,
                             helpers::to_absolute(located_op.location, location.location),
                             helpers::to_absolute(

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -47,7 +47,7 @@ pub fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     };
     let mut diagnostic = Diagnostic::new(RaiseNotImplemented, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             "NotImplementedError".to_string(),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -3,7 +3,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr};
 use ruff_python_ast::helpers::unparse_expr;
@@ -110,7 +110,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
-                                    diagnostic.amend(Fix::deletion(
+                                    diagnostic.amend(Edit::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),
                                     ));
@@ -138,7 +138,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
-                                    diagnostic.amend(Fix::deletion(
+                                    diagnostic.amend(Edit::deletion(
                                         values[i - 1].end_location.unwrap(),
                                         values[i].end_location.unwrap(),
                                     ));

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -3,7 +3,7 @@ use log::error;
 use rustpython_parser::ast::{ExprKind, Located, Stmt, StmtKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::scope::{ScopeId, ScopeKind};
@@ -188,13 +188,13 @@ enum DeletionKind {
     Partial,
 }
 
-/// Generate a [`Fix`] to remove an unused variable assignment, given the
+/// Generate a [`Edit`] to remove an unused variable assignment, given the
 /// enclosing [`Stmt`] and the [`Range`] of the variable binding.
 fn remove_unused_variable(
     stmt: &Stmt,
     range: &Range,
     checker: &Checker,
-) -> Option<(DeletionKind, Fix)> {
+) -> Option<(DeletionKind, Edit)> {
     // First case: simple assignment (`x = 1`)
     if let StmtKind::Assign { targets, value, .. } = &stmt.node {
         if let Some(target) = targets.iter().find(|target| {
@@ -206,7 +206,7 @@ fn remove_unused_variable(
                     // but preserve the right-hand side.
                     Some((
                         DeletionKind::Partial,
-                        Fix::deletion(
+                        Edit::deletion(
                             target.location,
                             match_token_after(target, checker.locator, |tok| tok == Tok::Equal)
                                 .location,
@@ -252,7 +252,7 @@ fn remove_unused_variable(
                 // but preserve the right-hand side.
                 Some((
                     DeletionKind::Partial,
-                    Fix::deletion(
+                    Edit::deletion(
                         stmt.location,
                         match_token_after(stmt, checker.locator, |tok| tok == Tok::Equal).location,
                     ),
@@ -294,7 +294,7 @@ fn remove_unused_variable(
                 {
                     return Some((
                         DeletionKind::Partial,
-                        Fix::deletion(
+                        Edit::deletion(
                             item.context_expr.end_location.unwrap(),
                             // The end of the `Withitem` is the colon, comma, or closing
                             // parenthesis following the `optional_vars`.

--- a/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast::Location;
 
 use ruff_diagnostics::AlwaysAutofixableViolation;
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
@@ -197,7 +197,7 @@ pub fn invalid_string_characters(
             let end_location = Location::new(location.row(), location.column() + 1);
             let mut diagnostic = Diagnostic::new(rule, Range::new(location, end_location));
             if autofix {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     replacement.to_string(),
                     location,
                     end_location,

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_stmt, unparse_stmt};
 use ruff_python_ast::types::Range;
@@ -54,7 +54,7 @@ pub fn manual_from_import(checker: &mut Checker, stmt: &Stmt, alias: &Alias, nam
         Range::from(alias),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             unparse_stmt(
                 &create_stmt(StmtKind::ImportFrom {
                     module: Some(module.to_string()),

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::scope::{
     BindingKind, FromImportation, Importation, StarImportation, SubmoduleImportation,
@@ -122,7 +122,7 @@ pub fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
         );
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(content) = get_member_import_name_alias(checker, "sys", "exit") {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     content,
                     func.location,
                     func.end_location.unwrap(),

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Alias;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -35,7 +35,7 @@ pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic = Diagnostic::new(UselessImportAlias, Range::from(alias));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             asname.to_string(),
             alias.location,
             alias.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -3,14 +3,13 @@ use libcst_native::{
     Codegen, CodegenState, CompoundStatement, Expression, ParenthesizableWhitespace,
     SmallStatement, Statement, Suite,
 };
-use rustpython_parser::ast::{Expr, Keyword, Location};
+use rustpython_parser::ast::{Expr, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
 
-use crate::autofix::helpers::remove_argument;
 use crate::cst::matchers::match_module;
 
 /// Safely adjust the indentation of the indented block at [`Range`].
@@ -50,20 +49,8 @@ pub fn adjust_indentation(
     Ok(module_text)
 }
 
-/// Generate a fix to remove a base from a `ClassDef` statement.
-pub fn remove_class_def_base(
-    locator: &Locator,
-    stmt_at: Location,
-    expr_at: Location,
-    expr_end: Location,
-    bases: &[Expr],
-    keywords: &[Keyword],
-) -> Result<Fix> {
-    remove_argument(locator, stmt_at, expr_at, expr_end, bases, keywords, true)
-}
-
 /// Generate a fix to remove arguments from a `super` call.
-pub fn remove_super_arguments(locator: &Locator, stylist: &Stylist, expr: &Expr) -> Option<Fix> {
+pub fn remove_super_arguments(locator: &Locator, stylist: &Stylist, expr: &Expr) -> Option<Edit> {
     let range = Range::from(expr);
     let contents = locator.slice(range);
 
@@ -90,7 +77,7 @@ pub fn remove_super_arguments(locator: &Locator, stylist: &Stylist, expr: &Expr)
     };
     tree.codegen(&mut state);
 
-    Some(Fix::replacement(
+    Some(Edit::replacement(
         state.to_string(),
         range.location,
         range.end_location,

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -164,8 +164,8 @@ fn convert_to_class(
     body: Vec<Stmt>,
     base_class: &Expr,
     stylist: &Stylist,
-) -> Fix {
-    Fix::replacement(
+) -> Edit {
+    Edit::replacement(
         unparse_stmt(&create_class_def_stmt(typename, body, base_class), stylist),
         stmt.location,
         stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::debug;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Keyword, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -211,8 +211,8 @@ fn convert_to_class(
     total_keyword: Option<&Keyword>,
     base_class: &Expr,
     stylist: &Stylist,
-) -> Fix {
-    Fix::replacement(
+) -> Edit {
+    Edit::replacement(
         unparse_stmt(
             &create_class_def_stmt(class_name, body, total_keyword, base_class),
             stylist,

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::types::Range;
@@ -44,7 +44,7 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
             Diagnostic::new(DatetimeTimezoneUTC { straight_import }, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
             if straight_import {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     "datetime.UTC".to_string(),
                     expr.location,
                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Located, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -25,7 +25,7 @@ fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, Range::from(node));
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator.slice(node);
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.location,
             node.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, AliasData, Stmt};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -552,7 +552,7 @@ pub fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     content,
                     stmt.location,
                     stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -6,7 +6,7 @@ use libcst_native::{
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::collect_call_path;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -256,7 +256,7 @@ pub fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 Range::from(value),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     "mock".to_string(),
                     value.location,
                     value.end_location.unwrap(),
@@ -303,7 +303,7 @@ pub fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             Range::from(name),
                         );
                         if let Some(content) = content.as_ref() {
-                            diagnostic.amend(Fix::replacement(
+                            diagnostic.amend(Edit::replacement(
                                 content.clone(),
                                 stmt.location,
                                 stmt.end_location.unwrap(),
@@ -335,7 +335,7 @@ pub fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                         diagnostic.try_amend(|| {
                             format_import_from(stmt, indent, checker.locator, checker.stylist).map(
                                 |content| {
-                                    Fix::replacement(
+                                    Edit::replacement(
                                         content,
                                         stmt.location,
                                         stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -70,7 +70,7 @@ pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         Range::from(expr),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             format!("self.{target}"),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -139,7 +139,7 @@ pub fn extraneous_parentheses(
                     Diagnostic::new(ExtraneousParentheses, Range::new(*start, *end));
                 if autofix.into() && settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents = locator.slice(Range::new(*start, *end));
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         *start,
                         *end,

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -4,7 +4,7 @@ use rustpython_common::format::{
 };
 use rustpython_parser::ast::{Constant, Expr, ExprKind, KeywordData, Location};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{is_implicit_concatenation, leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
@@ -271,7 +271,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
 
     let mut diagnostic = Diagnostic::new(FString, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             contents,
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::types::Range;
@@ -146,7 +146,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
         if let Ok(contents) =
             generate_call(expr, &summary.indexes, checker.locator, checker.stylist)
         {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 contents,
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, KeywordData};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -59,7 +59,7 @@ pub fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list: &[Expr
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     if let ExprKind::Attribute { value, ctx, .. } = &func.node {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             unparse_expr(
                                 &create_expr(ExprKind::Attribute {
                                     value: value.clone(),

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -48,7 +48,7 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
                 Range::new(func.end_location.unwrap(), expr.end_location.unwrap()),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     unparse_expr(func, checker.stylist),
                     expr.location,
                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::is_implicit_concatenation;
 use ruff_python_ast::types::Range;
@@ -65,7 +65,7 @@ pub fn native_literals(
                 LiteralType::Bytes
             }}, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
                         content.push('b');
@@ -129,7 +129,7 @@ pub fn native_literals(
             Range::from(expr),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 arg_code.to_string(),
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -39,7 +39,7 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
             .map_or(true, |binding| binding.kind.is_builtin());
         let mut diagnostic = Diagnostic::new(OpenAlias { fixable }, Range::from(expr));
         if fixable && checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "open".to_string(),
                 func.location,
                 func.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::context::Context;
 use ruff_python_ast::helpers::{compose_call_path, create_expr, unparse_expr};
@@ -63,7 +63,7 @@ fn atom_diagnostic(checker: &mut Checker, target: &Expr) {
         Range::from(target),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             "OSError".to_string(),
             target.location,
             target.end_location.unwrap(),
@@ -104,13 +104,13 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
         }
 
         if remaining.len() == 1 {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "OSError".to_string(),
                 target.location,
                 target.end_location.unwrap(),
             ));
         } else {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 format!(
                     "({})",
                     unparse_expr(

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -5,7 +5,7 @@ use num_bigint::{BigInt, Sign};
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind, Located, Location, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::{Range, RefEquality};
@@ -157,7 +157,7 @@ fn fix_py2_block(
     body: &[Stmt],
     orelse: &[Stmt],
     block: &BlockMetadata,
-) -> Option<Fix> {
+) -> Option<Edit> {
     if orelse.is_empty() {
         // Delete the entire statement. If this is an `elif`, know it's the only child
         // of its parent, so avoid passing in the parent at all. Otherwise,
@@ -195,7 +195,7 @@ fn fix_py2_block(
 
         if indentation(checker.locator, start).is_none() {
             // Inline `else` block (e.g., `else: x = 1`).
-            Some(Fix::replacement(
+            Some(Edit::replacement(
                 checker
                     .locator
                     .slice(Range::new(start.location, end.end_location.unwrap()))
@@ -218,7 +218,7 @@ fn fix_py2_block(
                     .ok()
                 })
                 .map(|contents| {
-                    Fix::replacement(
+                    Edit::replacement(
                         contents,
                         Location::new(stmt.location.row(), 0),
                         stmt.end_location.unwrap(),
@@ -241,7 +241,7 @@ fn fix_py2_block(
                 end_location = body.last().unwrap().end_location.unwrap();
             }
         }
-        Some(Fix::deletion(stmt.location, end_location))
+        Some(Edit::deletion(stmt.location, end_location))
     }
 }
 
@@ -252,7 +252,7 @@ fn fix_py3_block(
     test: &Expr,
     body: &[Stmt],
     block: &BlockMetadata,
-) -> Option<Fix> {
+) -> Option<Edit> {
     match block.starter {
         Tok::If => {
             // If the first statement is an if, use the body of this statement, and ignore
@@ -262,7 +262,7 @@ fn fix_py3_block(
 
             if indentation(checker.locator, start).is_none() {
                 // Inline `if` block (e.g., `if ...: x = 1`).
-                Some(Fix::replacement(
+                Some(Edit::replacement(
                     checker
                         .locator
                         .slice(Range::new(start.location, end.end_location.unwrap()))
@@ -285,7 +285,7 @@ fn fix_py3_block(
                         .ok()
                     })
                     .map(|contents| {
-                        Fix::replacement(
+                        Edit::replacement(
                             contents,
                             Location::new(stmt.location.row(), 0),
                             stmt.end_location.unwrap(),
@@ -301,7 +301,7 @@ fn fix_py3_block(
                 test.end_location.unwrap(),
                 end.end_location.unwrap(),
             ));
-            Some(Fix::replacement(
+            Some(Edit::replacement(
                 format!("else{text}"),
                 stmt.location,
                 stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -6,7 +6,7 @@ use rustpython_common::cformat::{
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
@@ -437,7 +437,7 @@ pub(crate) fn printf_string_formatting(
 
     let mut diagnostic = Diagnostic::new(PrintfStringFormatting, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             contents,
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -23,7 +23,7 @@ impl AlwaysAutofixableViolation for QuotedAnnotation {
 pub fn quoted_annotation(checker: &mut Checker, annotation: &str, range: Range) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
     if checker.patch(Rule::QuotedAnnotation) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             annotation.to_string(),
             range.location,
             range.end_location,

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Location};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::Locator;
@@ -115,7 +115,7 @@ fn create_check(
     );
     if patch {
         if let Some(content) = replacement_value {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 content,
                 mode_param.location,
                 mode_param.end_location.unwrap(),
@@ -127,7 +127,7 @@ fn create_check(
     diagnostic
 }
 
-fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) -> Result<Fix> {
+fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) -> Result<Edit> {
     let content = locator.slice(Range::new(expr.location, expr.end_location.unwrap()));
     // Find the last comma before mode_param and create a deletion fix
     // starting from the comma and ending after mode_param.
@@ -160,7 +160,7 @@ fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) ->
         }
     }
     match (fix_start, fix_end) {
-        (Some(start), Some(end)) => Ok(Fix::deletion(start, end)),
+        (Some(start), Some(end)) => Ok(Edit::deletion(start, end)),
         _ => Err(anyhow::anyhow!(
             "Failed to locate start and end parentheses"
         )),

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, Keyword};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -61,13 +61,13 @@ fn extract_middle(contents: &str) -> Option<MiddleContent> {
     })
 }
 
-/// Generate a [`Fix`] for a `stdout` and `stderr` [`Keyword`] pair.
+/// Generate a [`Edit`] for a `stdout` and `stderr` [`Keyword`] pair.
 fn generate_fix(
     stylist: &Stylist,
     locator: &Locator,
     stdout: &Keyword,
     stderr: &Keyword,
-) -> Option<Fix> {
+) -> Option<Edit> {
     let line_end = stylist.line_ending().as_str();
     let first = if stdout.location < stderr.location {
         stdout
@@ -96,7 +96,7 @@ fn generate_fix(
         }
         contents.push_str(middle.contents);
     }
-    Some(Fix::replacement(
+    Some(Edit::replacement(
         contents,
         first.location,
         last.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, Keyword, Location};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::types::Range;
@@ -41,7 +41,7 @@ pub fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwargs: &[
         );
         let mut diagnostic = Diagnostic::new(ReplaceUniversalNewlines, range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "text".to_string(),
                 range.location,
                 range.end_location,

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -47,7 +47,7 @@ pub fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr, args: 
     };
     let mut diagnostic = Diagnostic::new(TypeOfPrimitive { primitive }, Range::from(expr));
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             primitive.builtin(),
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -32,7 +32,7 @@ pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 "str".to_string(),
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, Location};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -27,7 +27,7 @@ pub fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, kind: Option<&str
         if const_kind.to_lowercase() == "u" {
             let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, Range::from(expr));
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::deletion(
+                diagnostic.amend(Edit::deletion(
                     expr.location,
                     Location::new(expr.location.row(), expr.location.column() + 1),
                 ));

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Location;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -34,7 +34,7 @@ pub fn unnecessary_coding_comment(lineno: usize, line: &str, autofix: bool) -> O
             Range::new(Location::new(lineno + 1, 0), Location::new(lineno + 2, 0)),
         );
         if autofix {
-            diagnostic.amend(Fix::deletion(
+            diagnostic.amend(Edit::deletion(
                 Location::new(lineno + 1, 0),
                 Location::new(lineno + 2, 0),
             ));

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -67,7 +67,7 @@ fn is_default_encode(args: &[Expr], kwargs: &[Keyword]) -> bool {
     }
 }
 
-/// Return a [`Fix`] for a default `encode` call removing the encoding argument,
+/// Return a [`Edit`] for a default `encode` call removing the encoding argument,
 /// keyword, or positional.
 fn delete_default_encode_arg_or_kwarg(
     expr: &Expr,
@@ -78,13 +78,13 @@ fn delete_default_encode_arg_or_kwarg(
     if let Some(arg) = args.get(0) {
         let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from(expr));
         if patch {
-            diagnostic.amend(Fix::deletion(arg.location, arg.end_location.unwrap()));
+            diagnostic.amend(Edit::deletion(arg.location, arg.end_location.unwrap()));
         }
         Some(diagnostic)
     } else if let Some(kwarg) = kwargs.get(0) {
         let mut diagnostic = Diagnostic::new(UnnecessaryEncodeUTF8, Range::from(expr));
         if patch {
-            diagnostic.amend(Fix::deletion(kwarg.location, kwarg.end_location.unwrap()));
+            diagnostic.amend(Edit::deletion(kwarg.location, kwarg.end_location.unwrap()));
         }
         Some(diagnostic)
     } else {
@@ -92,7 +92,7 @@ fn delete_default_encode_arg_or_kwarg(
     }
 }
 
-/// Return a [`Fix`] replacing the call to encode by a `"b"` prefix on the string.
+/// Return a [`Edit`] replacing the call to encode by a `"b"` prefix on the string.
 fn replace_with_bytes_literal(
     expr: &Expr,
     constant: &Expr,
@@ -127,7 +127,7 @@ fn replace_with_bytes_literal(
             }
             prev = Some(end);
         }
-        diagnostic.amend(Fix::replacement(
+        diagnostic.amend(Edit::replacement(
             replacement,
             expr.location,
             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 
@@ -102,7 +102,7 @@ pub fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr], valu
                 content.push('(');
                 content.push_str(&existing[1..existing.len() - 1]);
                 content.push(')');
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     content,
                     value.location,
                     value.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::typing::AnnotationKind;
@@ -56,7 +56,7 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
         if fixable && checker.patch(diagnostic.kind.rule()) {
             let binding = binding.to_lowercase();
             if checker.ctx.is_builtin(&binding) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     binding,
                     expr.location,
                     expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Location, Operator};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -111,7 +111,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
             let mut diagnostic =
                 Diagnostic::new(NonPEP604Annotation { fixable }, Range::from(expr));
             if fixable && checker.patch(diagnostic.kind.rule()) {
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     unparse_expr(&optional(slice), checker.stylist),
                     expr.location,
                     expr.end_location.unwrap(),
@@ -128,7 +128,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                         // Invalid type annotation.
                     }
                     ExprKind::Tuple { elts, .. } => {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             unparse_expr(&union(elts), checker.stylist),
                             expr.location,
                             expr.end_location.unwrap(),
@@ -136,7 +136,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                     }
                     _ => {
                         // Single argument.
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             unparse_expr(slice, checker.stylist),
                             expr.location,
                             expr.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind, Location, Operator};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
@@ -94,7 +94,7 @@ pub fn use_pep604_isinstance(checker: &mut Checker, expr: &Expr, func: &Expr, ar
                 let mut diagnostic =
                     Diagnostic::new(NonPEP604Isinstance { kind }, Range::from(expr));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.amend(Fix::replacement(
+                    diagnostic.amend(Edit::replacement(
                         unparse_expr(&union(elts), checker.stylist),
                         types.location,
                         types.end_location.unwrap(),

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -5,10 +5,9 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::scope::{Binding, BindingKind, Bindings, Scope};
 use ruff_python_ast::types::Range;
 
+use crate::autofix::helpers::remove_argument;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
-
-use super::super::fixes;
 
 #[violation]
 pub struct UselessObjectInheritance {
@@ -68,13 +67,14 @@ pub fn useless_object_inheritance(
             let location = diagnostic.location;
             let end_location = diagnostic.end_location;
             diagnostic.try_amend(|| {
-                fixes::remove_class_def_base(
+                remove_argument(
                     checker.locator,
                     stmt.location,
                     location,
                     end_location,
                     bases,
                     keywords,
+                    true,
                 )
             });
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_ast::visitor;
@@ -176,7 +176,7 @@ pub fn yield_in_for_loop(checker: &mut Checker, stmt: &Stmt) {
             if checker.patch(diagnostic.kind.rule()) {
                 let contents = checker.locator.slice(item.iter);
                 let contents = format!("yield from {contents}");
-                diagnostic.amend(Fix::replacement(
+                diagnostic.amend(Edit::replacement(
                     contents,
                     item.stmt.location,
                     item.stmt.end_location.unwrap(),

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::types::Range;
@@ -1730,7 +1730,7 @@ pub fn ambiguous_unicode_character(
                 );
                 if settings.rules.enabled(diagnostic.kind.rule()) {
                     if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
-                        diagnostic.amend(Fix::replacement(
+                        diagnostic.amend(Edit::replacement(
                             (*representant as char).to_string(),
                             location,
                             end_location,

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Operator};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, has_comments, unparse_expr};
 use ruff_python_ast::types::Range;
@@ -112,7 +112,7 @@ pub fn collection_literal_concatenation(checker: &mut Checker, expr: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if fixable {
-            diagnostic.amend(Fix::replacement(
+            diagnostic.amend(Edit::replacement(
                 contents,
                 expr.location,
                 expr.end_location.unwrap(),

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use ruff_python_ast::types::Range;
 
-use crate::fix::Fix;
+use crate::edit::Edit;
 
 #[derive(Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -27,7 +27,7 @@ pub struct Diagnostic {
     pub kind: DiagnosticKind,
     pub location: Location,
     pub end_location: Location,
-    pub fix: Option<Fix>,
+    pub fix: Option<Edit>,
     pub parent: Option<Location>,
 }
 
@@ -42,12 +42,12 @@ impl Diagnostic {
         }
     }
 
-    pub fn amend(&mut self, fix: Fix) -> &mut Self {
+    pub fn amend(&mut self, fix: Edit) -> &mut Self {
         self.fix = Some(fix);
         self
     }
 
-    pub fn try_amend(&mut self, func: impl FnOnce() -> Result<Fix>) -> &mut Self {
+    pub fn try_amend(&mut self, func: impl FnOnce() -> Result<Edit>) -> &mut Self {
         match func() {
             Ok(fix) => self.fix = Some(fix),
             Err(err) => error!("Failed to create fix: {}", err),

--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -4,13 +4,16 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Fix {
+pub struct Edit {
+    /// The replacement content to insert between the start and end locations.
     pub content: String,
+    /// The start location of the edit.
     pub location: Location,
+    /// The end location of the edit.
     pub end_location: Location,
 }
 
-impl Fix {
+impl Edit {
     pub const fn deletion(start: Location, end: Location) -> Self {
         Self {
             content: String::new(),

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,7 +1,7 @@
 pub use diagnostic::{Diagnostic, DiagnosticKind};
-pub use fix::Fix;
+pub use edit::Edit;
 pub use violation::{AlwaysAutofixableViolation, AutofixKind, Violation};
 
 mod diagnostic;
-mod fix;
+mod edit;
 mod violation;


### PR DESCRIPTION
## Summary

I want to extend the autofix API to support multiple edits, similar to the LSP `WorkspaceEdit` API. (This is also necessary to support, e.g., inserting required imports for relevant fixes.) As part of that change, I'm proposing that we rename `Fix` to `Edit`, such that a `Fix` can in the future be modeled as a collection of edits.

This PR is a straight rename of the struct with no functional changes.
