### PR TITLE
Fix Ruff pre-commit hook errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         pass_filenames: false
       - id: ruff
         name: ruff
-        entry: cargo run -p ruff_cli -- check --no-cache --force-exclude --fix --exit-non-zero-on-fix
+        entry: cargo run -p ruff_cli -- check --no-cache --force-exclude --fix --exit-non-zero-on-fix --extend-ignore=E203
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -178,7 +178,7 @@ async def main(*, ruff1: Path, ruff2: Path) -> None:
         return_exceptions=True,
     )
 
-    diffs = {name: result for name, result in zip(REPOSITORIES, results, strict=True)}
+    diffs = dict(zip(REPOSITORIES, results, strict=True))
 
     total_removed = total_added = 0
     errors = 0


### PR DESCRIPTION
use `--extend-ignore=E203` as it should not be present. 