### PR TITLE
Revert "Replace `logical_lines` feature with `debug_assertions` (#3648)"

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -74,4 +74,5 @@ test-case = { workspace = true }
 
 [features]
 default = []
+logical_lines = []
 jupyter_notebook = []

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -165,10 +165,10 @@ pub fn check_logical_lines(
                 }
             }
 
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "logical_lines")]
             let should_fix = autofix.into() && settings.rules.should_fix(Rule::MissingWhitespace);
 
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "logical_lines"))]
             let should_fix = false;
 
             for diagnostic in
@@ -181,11 +181,11 @@ pub fn check_logical_lines(
         }
 
         if line.flags.contains(TokenFlags::BRACKET) {
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "logical_lines")]
             let should_fix =
                 autofix.into() && settings.rules.should_fix(Rule::WhitespaceBeforeParameters);
 
-            #[cfg(not(debug_assertions))]
+            #[cfg(not(feature = "logical_lines"))]
             let should_fix = false;
 
             for diagnostic in whitespace_before_parameters(&line.tokens, should_fix) {

--- a/crates/ruff/src/codes.rs
+++ b/crates/ruff/src/codes.rs
@@ -26,67 +26,67 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<Rule> {
     Some(match (linter, code) {
         // pycodestyle errors
         (Pycodestyle, "E101") => Rule::MixedSpacesAndTabs,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E111") => Rule::IndentationWithInvalidMultiple,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E112") => Rule::NoIndentedBlock,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E113") => Rule::UnexpectedIndentation,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E114") => Rule::IndentationWithInvalidMultipleComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E115") => Rule::NoIndentedBlockComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E116") => Rule::UnexpectedIndentationComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E117") => Rule::OverIndented,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E201") => Rule::WhitespaceAfterOpenBracket,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E202") => Rule::WhitespaceBeforeCloseBracket,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E203") => Rule::WhitespaceBeforePunctuation,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E211") => Rule::WhitespaceBeforeParameters,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E221") => Rule::MultipleSpacesBeforeOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E222") => Rule::MultipleSpacesAfterOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E223") => Rule::TabBeforeOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E224") => Rule::TabAfterOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E225") => Rule::MissingWhitespaceAroundOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E226") => Rule::MissingWhitespaceAroundArithmeticOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E227") => Rule::MissingWhitespaceAroundBitwiseOrShiftOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E228") => Rule::MissingWhitespaceAroundModuloOperator,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E231") => Rule::MissingWhitespace,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E251") => Rule::UnexpectedSpacesAroundKeywordParameterEquals,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E252") => Rule::MissingWhitespaceAroundParameterEquals,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E261") => Rule::TooFewSpacesBeforeInlineComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E262") => Rule::NoSpaceAfterInlineComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E265") => Rule::NoSpaceAfterBlockComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E266") => Rule::MultipleLeadingHashesForBlockComment,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E271") => Rule::MultipleSpacesAfterKeyword,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E272") => Rule::MultipleSpacesBeforeKeyword,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E273") => Rule::TabAfterKeyword,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E274") => Rule::TabBeforeKeyword,
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "logical_lines")]
         (Pycodestyle, "E275") => Rule::MissingWhitespaceAfterKeyword,
         (Pycodestyle, "E401") => Rule::MultipleImportsOnOneLine,
         (Pycodestyle, "E402") => Rule::ModuleImportNotAtTopOfFile,

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -14,67 +14,67 @@ pub use rule_set::{RuleSet, RuleSetIterator};
 ruff_macros::register_rules!(
     // pycodestyle errors
     rules::pycodestyle::rules::MixedSpacesAndTabs,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::IndentationWithInvalidMultiple,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::NoIndentedBlock,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::UnexpectedIndentation,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::IndentationWithInvalidMultipleComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::NoIndentedBlockComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::UnexpectedIndentationComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::OverIndented,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::WhitespaceAfterOpenBracket,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::WhitespaceBeforeCloseBracket,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::WhitespaceBeforePunctuation,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MultipleSpacesBeforeOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MultipleSpacesAfterOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::TabBeforeOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::TabAfterOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::TooFewSpacesBeforeInlineComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::NoSpaceAfterInlineComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::NoSpaceAfterBlockComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MultipleLeadingHashesForBlockComment,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MultipleSpacesAfterKeyword,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespace,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAfterKeyword,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MultipleSpacesBeforeKeyword,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAroundOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAroundArithmeticOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAroundBitwiseOrShiftOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAroundModuloOperator,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::TabAfterKeyword,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::UnexpectedSpacesAroundKeywordParameterEquals,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::MissingWhitespaceAroundParameterEquals,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::WhitespaceBeforeParameters,
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     rules::pycodestyle::rules::TabBeforeKeyword,
     rules::pycodestyle::rules::MultipleImportsOnOneLine,
     rules::pycodestyle::rules::ModuleImportNotAtTopOfFile,
@@ -906,7 +906,7 @@ impl Rule {
             Rule::IOError => LintSource::Io,
             Rule::UnsortedImports | Rule::MissingRequiredImport => LintSource::Imports,
             Rule::ImplicitNamespacePackage | Rule::InvalidModuleName => LintSource::Filesystem,
-            #[cfg(debug_assertions)]
+            #[cfg(feature = "logical_lines")]
             Rule::IndentationWithInvalidMultiple
             | Rule::IndentationWithInvalidMultipleComment
             | Rule::MissingWhitespace

--- a/crates/ruff/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/mod.rs
@@ -79,7 +79,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "logical_lines")]
     #[test_case(Rule::IndentationWithInvalidMultiple, Path::new("E11.py"))]
     #[test_case(Rule::IndentationWithInvalidMultipleComment, Path::new("E11.py"))]
     #[test_case(Rule::MultipleLeadingHashesForBlockComment, Path::new("E26.py"))]

--- a/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/extraneous_whitespace.rs
@@ -106,7 +106,7 @@ static EXTRANEOUS_WHITESPACE_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"([\[({][ \t]|[ \t][]}),;:])").unwrap());
 
 /// E201, E202, E203
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn extraneous_whitespace(line: &str) -> Vec<(usize, DiagnosticKind)> {
     let mut diagnostics = vec![];
     for line_match in EXTRANEOUS_WHITESPACE_REGEX.captures_iter(line) {
@@ -127,7 +127,7 @@ pub fn extraneous_whitespace(line: &str) -> Vec<(usize, DiagnosticKind)> {
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn extraneous_whitespace(_line: &str) -> Vec<(usize, DiagnosticKind)> {
     vec![]
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/indentation.rs
@@ -230,7 +230,7 @@ impl Violation for OverIndented {
 }
 
 /// E111, E114, E112, E113, E115, E116, E117
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn indentation(
     logical_line: &LogicalLine,
     prev_logical_line: Option<&LogicalLine>,
@@ -284,7 +284,7 @@ pub fn indentation(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn indentation(
     _logical_line: &LogicalLine,
     _prev_logical_line: Option<&LogicalLine>,

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace.rs
@@ -28,7 +28,7 @@ impl AlwaysAutofixableViolation for MissingWhitespace {
 }
 
 /// E231
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn missing_whitespace(
     line: &str,
     row: usize,
@@ -86,7 +86,7 @@ pub fn missing_whitespace(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn missing_whitespace(
     _line: &str,
     _row: usize,

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_after_keyword.rs
@@ -20,7 +20,7 @@ impl Violation for MissingWhitespaceAfterKeyword {
 }
 
 /// E275
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn missing_whitespace_after_keyword(
     tokens: &[(Location, &Tok, Location)],
 ) -> Vec<(Location, DiagnosticKind)> {
@@ -43,7 +43,7 @@ pub fn missing_whitespace_after_keyword(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn missing_whitespace_after_keyword(
     _tokens: &[(Location, &Tok, Location)],
 ) -> Vec<(Location, DiagnosticKind)> {

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_whitespace_around_operator.rs
@@ -57,7 +57,7 @@ impl Violation for MissingWhitespaceAroundModuloOperator {
 }
 
 /// E225, E226, E227, E228
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 #[allow(clippy::if_same_then_else)]
 pub fn missing_whitespace_around_operator(
     tokens: &[(Location, &Tok, Location)],
@@ -188,7 +188,7 @@ pub fn missing_whitespace_around_operator(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn missing_whitespace_around_operator(
     _tokens: &[(Location, &Tok, Location)],
 ) -> Vec<(Location, DiagnosticKind)> {

--- a/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/space_around_operator.rs
@@ -127,7 +127,7 @@ static OPERATOR_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"[^,\s](\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)").unwrap());
 
 /// E221, E222, E223, E224
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn space_around_operator(line: &str) -> Vec<(usize, DiagnosticKind)> {
     let mut diagnostics = vec![];
     for line_match in OPERATOR_REGEX.captures_iter(line) {
@@ -149,7 +149,7 @@ pub fn space_around_operator(line: &str) -> Vec<(usize, DiagnosticKind)> {
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn space_around_operator(_line: &str) -> Vec<(usize, DiagnosticKind)> {
     vec![]
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_keywords.rs
@@ -115,7 +115,7 @@ static KEYWORD_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// E271, E272, E273, E274
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn whitespace_around_keywords(line: &str) -> Vec<(usize, DiagnosticKind)> {
     let mut diagnostics = vec![];
     for line_match in KEYWORD_REGEX.captures_iter(line) {
@@ -137,7 +137,7 @@ pub fn whitespace_around_keywords(line: &str) -> Vec<(usize, DiagnosticKind)> {
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn whitespace_around_keywords(_line: &str) -> Vec<(usize, DiagnosticKind)> {
     vec![]
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_around_named_parameter_equals.rs
@@ -9,7 +9,7 @@ use ruff_diagnostics::DiagnosticKind;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 use crate::rules::pycodestyle::helpers::is_op_token;
 
 #[violation]
@@ -36,7 +36,7 @@ static STARTSWITH_DEF_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^(async\s+def|def)\b").unwrap());
 
 /// E251, E252
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn whitespace_around_named_parameter_equals(
     tokens: &[(Location, &Tok, Location)],
     line: &str,
@@ -104,7 +104,7 @@ pub fn whitespace_around_named_parameter_equals(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn whitespace_around_named_parameter_equals(
     _tokens: &[(Location, &Tok, Location)],
     _line: &str,

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_comment.rs
@@ -139,7 +139,7 @@ impl Violation for MultipleLeadingHashesForBlockComment {
 }
 
 /// E261, E262, E265, E266
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn whitespace_before_comment(
     tokens: &[(Location, &Tok, Location)],
     locator: &Locator,
@@ -199,7 +199,7 @@ pub fn whitespace_before_comment(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn whitespace_before_comment(
     _tokens: &[(Location, &Tok, Location)],
     _locator: &Locator,

--- a/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/whitespace_before_parameters.rs
@@ -29,7 +29,7 @@ impl AlwaysAutofixableViolation for WhitespaceBeforeParameters {
 }
 
 /// E211
-#[cfg(debug_assertions)]
+#[cfg(feature = "logical_lines")]
 pub fn whitespace_before_parameters(
     tokens: &[(Location, &Tok, Location)],
     autofix: bool,
@@ -66,7 +66,7 @@ pub fn whitespace_before_parameters(
     diagnostics
 }
 
-#[cfg(not(debug_assertions))]
+#[cfg(not(feature = "logical_lines"))]
 pub fn whitespace_before_parameters(
     _tokens: &[(Location, &Tok, Location)],
     _autofix: bool,


### PR DESCRIPTION
This reverts commit 27903cdb11cfa5988f5c704837e77ec5d7d4422e.

I tried different configurations with `debug_assertions` and `logical_lines` together but could not make it work.
I think the easiest solution is to revert and run with `--all-features` when working on `logical_lines`.

- Close #3686

- This is needed for #3707 too