### PR TITLE
Add support for `.log(level, msg)` calls in `flake8-logging-format`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
@@ -2,4 +2,5 @@ import logging
 import logging as foo
 
 logging.info("Hello {}".format("World!"))
+logging.log(logging.INFO, "Hello {}".format("World!"))
 foo.info("Hello {}".format("World!"))

--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
@@ -4,3 +4,6 @@ import logging as foo
 logging.info("Hello {}".format("World!"))
 logging.log(logging.INFO, "Hello {}".format("World!"))
 foo.info("Hello {}".format("World!"))
+logging.log(logging.INFO, msg="Hello {}".format("World!"))
+logging.log(level=logging.INFO, msg="Hello {}".format("World!"))
+logging.log(msg="Hello {}".format("World!"), level=logging.INFO)

--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G002.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G002.py
@@ -1,3 +1,4 @@
 import logging
 
 logging.info("Hello %s" % "World!")
+logging.log(logging.INFO, "Hello %s" % "World!")

--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G003.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G003.py
@@ -1,3 +1,4 @@
 import logging
 
 logging.info("Hello" + " " + "World!")
+logging.log(logging.INFO, "Hello" + " " + "World!")

--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G004.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G004.py
@@ -2,3 +2,4 @@ import logging
 
 name = "world"
 logging.info(f"Hello {name}")
+logging.log(logging.INFO, f"Hello {name}")

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -126,9 +126,9 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
 }
 
 enum LoggingCallType {
-    /// Logging call with a level method i.e., `logging.info`
+    /// Logging call with a level method, e.g., `logging.info`.
     LevelCall(LoggingLevel),
-    /// Logging call with an integer level as an argument i.e., `logger.log(level, ...)`
+    /// Logging call with an integer level as an argument, e.g., `logger.log(level, ...)`.
     LogCall,
 }
 

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -137,8 +137,7 @@ impl LoggingCallType {
         if attr == "log" {
             Some(LoggingCallType::LogCall)
         } else {
-            LoggingLevel::from_attribute(attr)
-                .and_then(|level| Some(LoggingCallType::LevelCall(level)))
+            LoggingLevel::from_attribute(attr).map(LoggingCallType::LevelCall)
         }
     }
 }
@@ -164,11 +163,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             );
 
             // G001 - G004
-            let msg_pos = if matches!(logging_call_type, LoggingCallType::LogCall) {
-                1
-            } else {
-                0
-            };
+            let msg_pos = usize::from(matches!(logging_call_type, LoggingCallType::LogCall));
             if let Some(format_arg) = call_args.argument("msg", msg_pos) {
                 check_msg(checker, format_arg);
             }

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
@@ -41,4 +41,43 @@ expression: diagnostics
     column: 36
   fix: ~
   parent: ~
+- kind:
+    name: LoggingStringFormat
+    body: "Logging statement uses `string.format()`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 7
+    column: 30
+  end_location:
+    row: 7
+    column: 57
+  fix: ~
+  parent: ~
+- kind:
+    name: LoggingStringFormat
+    body: "Logging statement uses `string.format()`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 8
+    column: 36
+  end_location:
+    row: 8
+    column: 63
+  fix: ~
+  parent: ~
+- kind:
+    name: LoggingStringFormat
+    body: "Logging statement uses `string.format()`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 9
+    column: 16
+  end_location:
+    row: 9
+    column: 43
+  fix: ~
+  parent: ~
 

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
@@ -22,9 +22,22 @@ expression: diagnostics
     fixable: false
   location:
     row: 5
-    column: 9
+    column: 26
   end_location:
     row: 5
+    column: 53
+  fix: ~
+  parent: ~
+- kind:
+    name: LoggingStringFormat
+    body: "Logging statement uses `string.format()`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 6
+    column: 9
+  end_location:
+    row: 6
     column: 36
   fix: ~
   parent: ~

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G002.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G002.py.snap
@@ -15,4 +15,17 @@ expression: diagnostics
     column: 34
   fix: ~
   parent: ~
+- kind:
+    name: LoggingPercentFormat
+    body: "Logging statement uses `%`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 4
+    column: 26
+  end_location:
+    row: 4
+    column: 47
+  fix: ~
+  parent: ~
 

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G003.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G003.py.snap
@@ -15,4 +15,17 @@ expression: diagnostics
     column: 37
   fix: ~
   parent: ~
+- kind:
+    name: LoggingStringConcat
+    body: "Logging statement uses `+`"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 4
+    column: 26
+  end_location:
+    row: 4
+    column: 50
+  fix: ~
+  parent: ~
 

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G004.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G004.py.snap
@@ -15,4 +15,17 @@ expression: diagnostics
     column: 28
   fix: ~
   parent: ~
+- kind:
+    name: LoggingFString
+    body: Logging statement uses f-string
+    suggestion: ~
+    fixable: false
+  location:
+    row: 5
+    column: 26
+  end_location:
+    row: 5
+    column: 41
+  fix: ~
+  parent: ~
 


### PR DESCRIPTION
fixes: #2562 