### PR TITLE
Use `wild::args()` and add `wild` as a dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
  "tikv-jemallocator",
  "ureq",
  "walkdir",
+ "wild",
 ]
 
 [[package]]
@@ -3271,6 +3272,15 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -56,6 +56,7 @@ similar = { workspace = true }
 strum = { workspace = true, features = [] }
 textwrap = { workspace = true }
 walkdir = { version = "2.3.2" }
+wild = "2"
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.8" }

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -56,7 +56,7 @@ similar = { workspace = true }
 strum = { workspace = true, features = [] }
 textwrap = { workspace = true }
 walkdir = { version = "2.3.2" }
-wild = "2"
+wild = { version = "2" }
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.8" }

--- a/crates/ruff_cli/src/bin/ruff.rs
+++ b/crates/ruff_cli/src/bin/ruff.rs
@@ -22,8 +22,6 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// use wild::args() instead of std::env::args() to support wildcard expansion on Windows terminals
-// from https://gitlab.com/kornelski/wild
 pub fn main() -> ExitCode {
     let mut args: Vec<_> = wild::args().collect();
 

--- a/crates/ruff_cli/src/bin/ruff.rs
+++ b/crates/ruff_cli/src/bin/ruff.rs
@@ -22,8 +22,10 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+// use wild::args() instead of std::env::args() to support wildcard expansion on Windows terminals
+// from https://gitlab.com/kornelski/wild
 pub fn main() -> ExitCode {
-    let mut args: Vec<_> = std::env::args().collect();
+    let mut args: Vec<_> = wild::args().collect();
 
     // Clap doesn't support default subcommands but we want to run `check` by
     // default for convenience and backwards-compatibility, so we just


### PR DESCRIPTION
A small fix to close #3301 

### Summary
This replaces `std::env::args()` with `wild::args()` from https://gitlab.com/kornelski/wild and adds `wild` as a dependency in `ruff_cli/Cargo.toml`. 

### Checks

 * [x] Auto-formatting and linting
 * [x] Tests passing on local