### PR TITLE
Removed unnecessary pipe escape

### DIFF
--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -29,7 +29,7 @@ fn generate_table(table_out: &mut String, rules: impl IntoIterator<Item = Rule>,
                 .is_some()
                 .then_some(format_args!("[{rule_name}](rules/{rule_name}.md)"))
                 .unwrap_or(format_args!("{rule_name}")),
-            rule.message_formats()[0].replace('|', r"\|"),
+            rule.message_formats()[0],
             fix_token
         ));
         table_out.push('\n');


### PR DESCRIPTION
It seems like https://github.com/squidfunk/mkdocs-material handles `|`s in code blocks automatically so there's no need to escape them for table columns.