### PR TITLE
[flake8-bugbear] Add more immutable functions for `B008`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -1,5 +1,6 @@
 import collections
 import datetime as dt
+from decimal import Decimal
 import logging
 import operator
 import random
@@ -162,6 +163,11 @@ def float_int_is_wrong(value=float(3)):
 
 
 def float_str_not_inf_or_nan_is_wrong(value=float("3.14")):
+    pass
+
+
+# Allow decimals
+def decimal_okay(value=Decimal("0.1")):
     pass
 
 

--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B006_B008.py
@@ -170,6 +170,17 @@ def float_str_not_inf_or_nan_is_wrong(value=float("3.14")):
 def decimal_okay(value=Decimal("0.1")):
     pass
 
+# Allow dates
+def date_okay(value=dt.date(2023, 3, 27)):
+    pass
+
+# Allow datetimes
+def datetime_okay(value=dt.datetime(2023, 3, 27, 13, 51, 59)):
+    pass
+
+# Allow timedeltas
+def timedelta_okay(value=dt.timedelta(hours=1)):
+    pass
 
 # B006 and B008
 # We should handle arbitrary nesting of these B008.

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -32,6 +32,9 @@ impl Violation for FunctionCallInDefaultArgument {
 const IMMUTABLE_FUNCS: &[&[&str]] = &[
     &["", "tuple"],
     &["", "frozenset"],
+    &["datetime", "date"],
+    &["datetime", "datetime"],
+    &["datetime", "timedelta"],
     &["decimal", "Decimal"],
     &["operator", "attrgetter"],
     &["operator", "itemgetter"],

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -32,6 +32,7 @@ impl Violation for FunctionCallInDefaultArgument {
 const IMMUTABLE_FUNCS: &[&[&str]] = &[
     &["", "tuple"],
     &["", "frozenset"],
+    &["decimal", "Decimal"],
     &["operator", "attrgetter"],
     &["operator", "itemgetter"],
     &["operator", "methodcaller"],

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -148,10 +148,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 176
+    row: 187
     column: 19
   end_location:
-    row: 176
+    row: 187
     column: 48
   fix:
     edits: []
@@ -162,10 +162,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 209
+    row: 220
     column: 26
   end_location:
-    row: 209
+    row: 220
     column: 28
   fix:
     edits: []
@@ -176,10 +176,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 210
+    row: 221
     column: 34
   end_location:
-    row: 210
+    row: 221
     column: 36
   fix:
     edits: []
@@ -190,10 +190,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 211
+    row: 222
     column: 61
   end_location:
-    row: 211
+    row: 222
     column: 66
   fix:
     edits: []

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B006_B006_B008.py.snap
@@ -8,10 +8,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 60
+    row: 61
     column: 24
   end_location:
-    row: 60
+    row: 61
     column: 33
   fix:
     edits: []
@@ -22,10 +22,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 64
+    row: 65
     column: 29
   end_location:
-    row: 64
+    row: 65
     column: 31
   fix:
     edits: []
@@ -36,10 +36,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 68
+    row: 69
     column: 19
   end_location:
-    row: 68
+    row: 69
     column: 24
   fix:
     edits: []
@@ -50,10 +50,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 72
+    row: 73
     column: 19
   end_location:
-    row: 72
+    row: 73
     column: 44
   fix:
     edits: []
@@ -64,10 +64,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 76
+    row: 77
     column: 31
   end_location:
-    row: 76
+    row: 77
     column: 56
   fix:
     edits: []
@@ -78,10 +78,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 80
+    row: 81
     column: 25
   end_location:
-    row: 80
+    row: 81
     column: 44
   fix:
     edits: []
@@ -92,10 +92,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 85
+    row: 86
     column: 45
   end_location:
-    row: 85
+    row: 86
     column: 69
   fix:
     edits: []
@@ -106,10 +106,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 89
+    row: 90
     column: 45
   end_location:
-    row: 89
+    row: 90
     column: 72
   fix:
     edits: []
@@ -120,10 +120,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 93
+    row: 94
     column: 44
   end_location:
-    row: 93
+    row: 94
     column: 68
   fix:
     edits: []
@@ -134,10 +134,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 97
+    row: 98
     column: 32
   end_location:
-    row: 97
+    row: 98
     column: 34
   fix:
     edits: []
@@ -148,10 +148,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 170
+    row: 176
     column: 19
   end_location:
-    row: 170
+    row: 176
     column: 48
   fix:
     edits: []
@@ -162,10 +162,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 203
+    row: 209
     column: 26
   end_location:
-    row: 203
+    row: 209
     column: 28
   fix:
     edits: []
@@ -176,10 +176,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 204
+    row: 210
     column: 34
   end_location:
-    row: 204
+    row: 210
     column: 36
   fix:
     edits: []
@@ -190,10 +190,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 205
+    row: 211
     column: 61
   end_location:
-    row: 205
+    row: 211
     column: 66
   fix:
     edits: []

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -8,10 +8,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 85
+    row: 86
     column: 60
   end_location:
-    row: 85
+    row: 86
     column: 68
   fix:
     edits: []
@@ -22,10 +22,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 89
+    row: 90
     column: 63
   end_location:
-    row: 89
+    row: 90
     column: 71
   fix:
     edits: []
@@ -36,10 +36,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 93
+    row: 94
     column: 59
   end_location:
-    row: 93
+    row: 94
     column: 67
   fix:
     edits: []
@@ -50,10 +50,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 109
+    row: 110
     column: 38
   end_location:
-    row: 109
+    row: 110
     column: 49
   fix:
     edits: []
@@ -64,10 +64,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 113
+    row: 114
     column: 11
   end_location:
-    row: 113
+    row: 114
     column: 28
   fix:
     edits: []
@@ -78,10 +78,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 113
+    row: 114
     column: 31
   end_location:
-    row: 113
+    row: 114
     column: 51
   fix:
     edits: []
@@ -92,10 +92,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 117
+    row: 118
     column: 29
   end_location:
-    row: 117
+    row: 118
     column: 44
   fix:
     edits: []
@@ -106,10 +106,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 155
+    row: 156
     column: 33
   end_location:
-    row: 155
+    row: 156
     column: 47
   fix:
     edits: []
@@ -120,10 +120,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 160
+    row: 161
     column: 29
   end_location:
-    row: 160
+    row: 161
     column: 37
   fix:
     edits: []
@@ -134,10 +134,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 164
+    row: 165
     column: 44
   end_location:
-    row: 164
+    row: 165
     column: 57
   fix:
     edits: []
@@ -148,10 +148,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 170
+    row: 176
     column: 20
   end_location:
-    row: 170
+    row: 176
     column: 28
   fix:
     edits: []
@@ -162,10 +162,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 170
+    row: 176
     column: 30
   end_location:
-    row: 170
+    row: 176
     column: 47
   fix:
     edits: []
@@ -176,10 +176,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 176
+    row: 182
     column: 21
   end_location:
-    row: 176
+    row: 182
     column: 62
   fix:
     edits: []
@@ -190,10 +190,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 181
+    row: 187
     column: 18
   end_location:
-    row: 181
+    row: 187
     column: 59
   fix:
     edits: []
@@ -204,10 +204,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 181
+    row: 187
     column: 36
   end_location:
-    row: 181
+    row: 187
     column: 53
   fix:
     edits: []

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B008_B006_B008.py.snap
@@ -74,20 +74,6 @@ expression: diagnostics
   parent: ~
 - kind:
     name: FunctionCallInDefaultArgument
-    body: "Do not perform function call `dt.timedelta` in argument defaults"
-    suggestion: ~
-    fixable: false
-  location:
-    row: 114
-    column: 31
-  end_location:
-    row: 114
-    column: 51
-  fix:
-    edits: []
-  parent: ~
-- kind:
-    name: FunctionCallInDefaultArgument
     body: Do not perform function call in argument defaults
     suggestion: ~
     fixable: false
@@ -148,10 +134,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 176
+    row: 187
     column: 20
   end_location:
-    row: 176
+    row: 187
     column: 28
   fix:
     edits: []
@@ -162,10 +148,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 176
+    row: 187
     column: 30
   end_location:
-    row: 176
+    row: 187
     column: 47
   fix:
     edits: []
@@ -176,10 +162,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 182
+    row: 193
     column: 21
   end_location:
-    row: 182
+    row: 193
     column: 62
   fix:
     edits: []
@@ -190,10 +176,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 187
+    row: 198
     column: 18
   end_location:
-    row: 187
+    row: 198
     column: 59
   fix:
     edits: []
@@ -204,10 +190,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 187
+    row: 198
     column: 36
   end_location:
-    row: 187
+    row: 198
     column: 53
   fix:
     edits: []


### PR DESCRIPTION
- [flake8-bugbear] Allow `decimal.Decimal` in a function argument defaults for B008
- [flake8-bugbear] Allow `datetime.date()`, `datetime.datetime()`, and `datetime.timedelta()` in a function argument defaults for B008

ref: #3762
