### PR TITLE
Fix `cargo test --doc`

### DIFF
--- a/crates/ruff_macros/src/map_codes.rs
+++ b/crates/ruff_macros/src/map_codes.rs
@@ -278,9 +278,7 @@ struct Entry {
 }
 
 impl Parse for Entry {
-    /// Parses a match arm like:
-    ///
-    ///     (Pycodestyle, "E101") => Rule::MixedSpacesAndTabs,
+    /// Parses a match arm such as `(Pycodestyle, "E101") => Rule::MixedSpacesAndTabs,`
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let attrs = Attribute::parse_outer(input)?;
         let pat_tuple;


### PR DESCRIPTION
See https://github.com/charliermarsh/ruff/issues/3752#issuecomment-1484243217

I don't understand why this didn't show up earlier, i thought `cargo test` would include `cargo test --doc`