### PR TITLE
Use import alias locations for pep8-naming import rules

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -962,10 +962,7 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
-                                    stmt,
-                                    name,
-                                    asname,
-                                    self.locator,
+                                    name, asname, alias, stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -979,10 +976,7 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
-                                    stmt,
-                                    name,
-                                    asname,
-                                    self.locator,
+                                    name, asname, alias, stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -996,10 +990,7 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
-                                    stmt,
-                                    name,
-                                    asname,
-                                    self.locator,
+                                    name, asname, alias, stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1013,10 +1004,7 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
-                                    stmt,
-                                    name,
-                                    asname,
-                                    self.locator,
+                                    name, asname, alias, stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1030,10 +1018,7 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
-                                    stmt,
-                                    name,
-                                    asname,
-                                    self.locator,
+                                    name, asname, alias, stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1344,10 +1329,10 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::constant_imported_as_non_constant(
-                                    stmt,
                                     &alias.node.name,
                                     asname,
-                                    self.locator,
+                                    alias,
+                                    stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1361,10 +1346,10 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::lowercase_imported_as_non_lowercase(
-                                    stmt,
                                     &alias.node.name,
                                     asname,
-                                    self.locator,
+                                    alias,
+                                    stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1378,10 +1363,10 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_lowercase(
-                                    stmt,
                                     &alias.node.name,
                                     asname,
-                                    self.locator,
+                                    alias,
+                                    stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1395,10 +1380,10 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_constant(
-                                    stmt,
                                     &alias.node.name,
                                     asname,
-                                    self.locator,
+                                    alias,
+                                    stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);
@@ -1412,10 +1397,10 @@ where
                         {
                             if let Some(diagnostic) =
                                 pep8_naming::rules::camelcase_imported_as_acronym(
-                                    stmt,
                                     &alias.node.name,
                                     asname,
-                                    self.locator,
+                                    alias,
+                                    stmt,
                                 )
                             {
                                 self.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_acronym.rs
@@ -1,9 +1,8 @@
-use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::{Alias, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::identifier_range;
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::types::Range;
 use ruff_python_stdlib::str::{self};
 
 use crate::rules::pep8_naming::helpers;
@@ -50,23 +49,25 @@ impl Violation for CamelcaseImportedAsAcronym {
 
 /// N817
 pub fn camelcase_imported_as_acronym(
-    import_from: &Stmt,
     name: &str,
     asname: &str,
-    locator: &Locator,
+    alias: &Alias,
+    stmt: &Stmt,
 ) -> Option<Diagnostic> {
     if helpers::is_camelcase(name)
         && !str::is_lower(asname)
         && str::is_upper(asname)
         && helpers::is_acronym(name, asname)
     {
-        return Some(Diagnostic::new(
+        let mut diagnostic = Diagnostic::new(
             CamelcaseImportedAsAcronym {
                 name: name.to_string(),
                 asname: asname.to_string(),
             },
-            identifier_range(import_from, locator),
-        ));
+            Range::from(alias),
+        );
+        diagnostic.set_parent(stmt.location);
+        return Some(diagnostic);
     }
     None
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/camelcase_imported_as_lowercase.rs
@@ -1,9 +1,8 @@
-use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::{Alias, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::identifier_range;
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::types::Range;
 use ruff_python_stdlib::str;
 
 use crate::rules::pep8_naming::helpers;
@@ -47,19 +46,21 @@ impl Violation for CamelcaseImportedAsLowercase {
 
 /// N813
 pub fn camelcase_imported_as_lowercase(
-    import_from: &Stmt,
     name: &str,
     asname: &str,
-    locator: &Locator,
+    alias: &Alias,
+    stmt: &Stmt,
 ) -> Option<Diagnostic> {
     if helpers::is_camelcase(name) && str::is_lower(asname) {
-        return Some(Diagnostic::new(
+        let mut diagnostic = Diagnostic::new(
             CamelcaseImportedAsLowercase {
                 name: name.to_string(),
                 asname: asname.to_string(),
             },
-            identifier_range(import_from, locator),
-        ));
+            Range::from(alias),
+        );
+        diagnostic.set_parent(stmt.location);
+        return Some(diagnostic);
     }
     None
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/constant_imported_as_non_constant.rs
@@ -1,9 +1,8 @@
-use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::{Alias, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::identifier_range;
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::types::Range;
 use ruff_python_stdlib::str;
 
 /// ## What it does
@@ -46,19 +45,21 @@ impl Violation for ConstantImportedAsNonConstant {
 
 /// N811
 pub fn constant_imported_as_non_constant(
-    import_from: &Stmt,
     name: &str,
     asname: &str,
-    locator: &Locator,
+    alias: &Alias,
+    stmt: &Stmt,
 ) -> Option<Diagnostic> {
     if str::is_upper(name) && !str::is_upper(asname) {
-        return Some(Diagnostic::new(
+        let mut diagnostic = Diagnostic::new(
             ConstantImportedAsNonConstant {
                 name: name.to_string(),
                 asname: asname.to_string(),
             },
-            identifier_range(import_from, locator),
-        ));
+            Range::from(alias),
+        );
+        diagnostic.set_parent(stmt.location);
+        return Some(diagnostic);
     }
     None
 }

--- a/crates/ruff/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/lowercase_imported_as_non_lowercase.rs
@@ -1,9 +1,8 @@
-use rustpython_parser::ast::Stmt;
+use rustpython_parser::ast::{Alias, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::helpers::identifier_range;
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::types::Range;
 use ruff_python_stdlib::str;
 
 /// ## What it does
@@ -45,19 +44,21 @@ impl Violation for LowercaseImportedAsNonLowercase {
 
 /// N812
 pub fn lowercase_imported_as_non_lowercase(
-    import_from: &Stmt,
     name: &str,
     asname: &str,
-    locator: &Locator,
+    alias: &Alias,
+    stmt: &Stmt,
 ) -> Option<Diagnostic> {
     if !str::is_upper(name) && str::is_lower(name) && asname.to_lowercase() != asname {
-        return Some(Diagnostic::new(
+        let mut diagnostic = Diagnostic::new(
             LowercaseImportedAsNonLowercase {
                 name: name.to_string(),
                 asname: asname.to_string(),
             },
-            identifier_range(import_from, locator),
-        ));
+            Range::from(alias),
+        );
+        diagnostic.set_parent(stmt.location);
+        return Some(diagnostic);
     }
     None
 }

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N811_N811.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N811_N811.py.snap
@@ -9,13 +9,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 1
-    column: 0
+    column: 7
   end_location:
     row: 1
     column: 25
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 1
+    column: 0
 - kind:
     name: ConstantImportedAsNonConstant
     body: "Constant `CONSTANT` imported as non-constant `constant`"
@@ -23,13 +25,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 36
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 - kind:
     name: ConstantImportedAsNonConstant
     body: "Constant `ANOTHER_CONSTANT` imported as non-constant `another_constant`"
@@ -37,11 +41,13 @@ expression: diagnostics
     fixable: false
   location:
     row: 3
-    column: 0
+    column: 16
   end_location:
     row: 3
     column: 52
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 3
+    column: 0
 

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N812_N812.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N812_N812.py.snap
@@ -9,13 +9,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 1
-    column: 0
+    column: 7
   end_location:
     row: 1
     column: 30
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 1
+    column: 0
 - kind:
     name: LowercaseImportedAsNonLowercase
     body: "Lowercase `lowercase` imported as non-lowercase `Lowercase`"
@@ -23,13 +25,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 38
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 - kind:
     name: LowercaseImportedAsNonLowercase
     body: "Lowercase `another_lowercase` imported as non-lowercase `AnotherLowercase`"
@@ -37,11 +41,13 @@ expression: diagnostics
     fixable: false
   location:
     row: 3
-    column: 0
+    column: 16
   end_location:
     row: 3
     column: 53
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 3
+    column: 0
 

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N813_N813.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N813_N813.py.snap
@@ -9,13 +9,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 1
-    column: 0
+    column: 7
   end_location:
     row: 1
     column: 25
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 1
+    column: 0
 - kind:
     name: CamelcaseImportedAsLowercase
     body: "Camelcase `CamelCase` imported as lowercase `camelcase`"
@@ -23,13 +25,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 38
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 - kind:
     name: CamelcaseImportedAsLowercase
     body: "Camelcase `AnotherCamelCase` imported as lowercase `another_camelcase`"
@@ -37,11 +41,13 @@ expression: diagnostics
     fixable: false
   location:
     row: 3
-    column: 0
+    column: 16
   end_location:
     row: 3
     column: 53
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 3
+    column: 0
 

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N814_N814.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N814_N814.py.snap
@@ -9,13 +9,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 1
-    column: 0
+    column: 7
   end_location:
     row: 1
     column: 25
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 1
+    column: 0
 - kind:
     name: CamelcaseImportedAsConstant
     body: "Camelcase `CamelCase` imported as constant `CAMELCASE`"
@@ -23,13 +25,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 38
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 - kind:
     name: CamelcaseImportedAsConstant
     body: "Camelcase `AnotherCamelCase` imported as constant `ANOTHER_CAMELCASE`"
@@ -37,11 +41,13 @@ expression: diagnostics
     fixable: false
   location:
     row: 3
-    column: 0
+    column: 16
   end_location:
     row: 3
     column: 53
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 3
+    column: 0
 

--- a/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N817_N817.py.snap
+++ b/crates/ruff/src/rules/pep8_naming/snapshots/ruff__rules__pep8_naming__tests__N817_N817.py.snap
@@ -9,13 +9,15 @@ expression: diagnostics
     fixable: false
   location:
     row: 1
-    column: 0
+    column: 7
   end_location:
     row: 1
     column: 22
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 1
+    column: 0
 - kind:
     name: CamelcaseImportedAsAcronym
     body: "CamelCase `CamelCase` imported as acronym `CC`"
@@ -23,11 +25,13 @@ expression: diagnostics
     fixable: false
   location:
     row: 2
-    column: 0
+    column: 16
   end_location:
     row: 2
     column: 31
   fix:
     edits: []
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 


### PR DESCRIPTION
Closes #3763.