### PR TITLE
Set parents even in same-line cases

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4960,9 +4960,7 @@ impl<'a> Checker<'a> {
                     let child: &Stmt = defined_by.into();
 
                     let diagnostic_lineno = binding.range.location.row();
-                    let parent_lineno = if matches!(child.node, StmtKind::ImportFrom { .. })
-                        && child.location.row() != diagnostic_lineno
-                    {
+                    let parent_lineno = if matches!(child.node, StmtKind::ImportFrom { .. }) {
                         Some(child.location.row())
                     } else {
                         None
@@ -5038,9 +5036,7 @@ impl<'a> Checker<'a> {
                             },
                             *range,
                         );
-                        if matches!(child.node, StmtKind::ImportFrom { .. })
-                            && child.location.row() != range.location.row()
-                        {
+                        if matches!(child.node, StmtKind::ImportFrom { .. }) {
                             diagnostic.set_parent(child.location);
                         }
                         if let Some(fix) = fix.as_ref() {
@@ -5072,9 +5068,7 @@ impl<'a> Checker<'a> {
                             },
                             *range,
                         );
-                        if matches!(child.node, StmtKind::ImportFrom { .. })
-                            && child.location.row() != range.location.row()
-                        {
+                        if matches!(child.node, StmtKind::ImportFrom { .. }) {
                             diagnostic.set_parent(child.location);
                         }
                         diagnostics.push(diagnostic);

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -68,33 +68,36 @@ pub fn check_noqa(
             FileExemption::None => {}
         }
 
+        let diagnostic_lineno = diagnostic.location.row();
+
         // Is the violation ignored by a `noqa` directive on the parent line?
         if let Some(parent_lineno) = diagnostic.parent.map(|location| location.row()) {
-            let noqa_lineno = noqa_line_for.get(&parent_lineno).unwrap_or(&parent_lineno);
-            if commented_lines.contains(noqa_lineno) {
-                let noqa = noqa_directives.entry(noqa_lineno - 1).or_insert_with(|| {
-                    (noqa::extract_noqa_directive(lines[noqa_lineno - 1]), vec![])
-                });
-                match noqa {
-                    (Directive::All(..), matches) => {
-                        matches.push(diagnostic.kind.rule().noqa_code());
-                        ignored_diagnostics.push(index);
-                        continue;
-                    }
-                    (Directive::Codes(.., codes, _), matches) => {
-                        if noqa::includes(diagnostic.kind.rule(), codes) {
+            if parent_lineno != diagnostic_lineno {
+                let noqa_lineno = noqa_line_for.get(&parent_lineno).unwrap_or(&parent_lineno);
+                if commented_lines.contains(noqa_lineno) {
+                    let noqa = noqa_directives.entry(noqa_lineno - 1).or_insert_with(|| {
+                        (noqa::extract_noqa_directive(lines[noqa_lineno - 1]), vec![])
+                    });
+                    match noqa {
+                        (Directive::All(..), matches) => {
                             matches.push(diagnostic.kind.rule().noqa_code());
                             ignored_diagnostics.push(index);
                             continue;
                         }
+                        (Directive::Codes(.., codes, _), matches) => {
+                            if noqa::includes(diagnostic.kind.rule(), codes) {
+                                matches.push(diagnostic.kind.rule().noqa_code());
+                                ignored_diagnostics.push(index);
+                                continue;
+                            }
+                        }
+                        (Directive::None, ..) => {}
                     }
-                    (Directive::None, ..) => {}
                 }
             }
         }
 
         // Is the diagnostic ignored by a `noqa` directive on the same line?
-        let diagnostic_lineno = diagnostic.location.row();
         let noqa_lineno = noqa_line_for
             .get(&diagnostic_lineno)
             .unwrap_or(&diagnostic_lineno);

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_11.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_11.py.snap
@@ -22,5 +22,7 @@ expression: diagnostics
         end_location:
           row: 4
           column: 34
-  parent: ~
+  parent:
+    row: 4
+    column: 0
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_5.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_5.py.snap
@@ -22,7 +22,9 @@ expression: diagnostics
         end_location:
           row: 3
           column: 0
-  parent: ~
+  parent:
+    row: 2
+    column: 0
 - kind:
     name: UnusedImport
     body: "`d.e.f` imported but unused"
@@ -43,7 +45,9 @@ expression: diagnostics
         end_location:
           row: 4
           column: 0
-  parent: ~
+  parent:
+    row: 3
+    column: 0
 - kind:
     name: UnusedImport
     body: "`h.i` imported but unused"

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_6.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_6.py.snap
@@ -22,7 +22,9 @@ expression: diagnostics
         end_location:
           row: 8
           column: 0
-  parent: ~
+  parent:
+    row: 7
+    column: 0
 - kind:
     name: UnusedImport
     body: "`.datastructures.UploadFile` imported but unused"
@@ -43,7 +45,9 @@ expression: diagnostics
         end_location:
           row: 11
           column: 0
-  parent: ~
+  parent:
+    row: 10
+    column: 0
 - kind:
     name: UnusedImport
     body: "`background` imported but unused"

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_7.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_7.py.snap
@@ -45,7 +45,9 @@ expression: diagnostics
         end_location:
           row: 67
           column: 0
-  parent: ~
+  parent:
+    row: 66
+    column: 0
 - kind:
     name: UnusedImport
     body: "`typing.AwaitableGenerator` imported but unused"
@@ -66,5 +68,7 @@ expression: diagnostics
         end_location:
           row: 67
           column: 0
-  parent: ~
+  parent:
+    row: 66
+    column: 0
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_9.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_9.py.snap
@@ -22,5 +22,7 @@ expression: diagnostics
         end_location:
           row: 4
           column: 24
-  parent: ~
+  parent:
+    row: 4
+    column: 0
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
@@ -129,7 +129,9 @@ expression: diagnostics
         end_location:
           row: 89
           column: 52
-  parent: ~
+  parent:
+    row: 89
+    column: 4
 - kind:
     name: UnusedImport
     body: "`typing.AwaitableGenerator` imported but unused"
@@ -150,7 +152,9 @@ expression: diagnostics
         end_location:
           row: 89
           column: 52
-  parent: ~
+  parent:
+    row: 89
+    column: 4
 - kind:
     name: UnusedNOQA
     body: "Unused `noqa` directive (non-enabled: `F501`)"


### PR DESCRIPTION
## Summary

It's a little simpler to set the parent statement regardless, and defer to higher-level utilities to skip unneeded work.