### PR TITLE
Remove star-import handling from `sys-exit-alias`

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -2,9 +2,8 @@ use rustpython_parser::ast::{Expr, ExprKind};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::scope::{
-    BindingKind, FromImportation, Importation, StarImportation, SubmoduleImportation,
-};
+use ruff_python_ast::context::Context;
+use ruff_python_ast::scope::{BindingKind, FromImportation, Importation, SubmoduleImportation};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
@@ -28,29 +27,14 @@ impl Violation for SysExitAlias {
         Some(|SysExitAlias { name }| format!("Replace `{name}` with `sys.exit()`"))
     }
 }
-/// Return `true` if the `module` was imported using a star import (e.g., `from
-/// sys import *`).
-fn is_module_star_imported(checker: &Checker, module: &str) -> bool {
-    checker.ctx.scopes().any(|scope| {
-        scope.binding_ids().any(|index| {
-            if let BindingKind::StarImportation(StarImportation { module: name, .. }) =
-                &checker.ctx.bindings[*index].kind
-            {
-                name.as_ref().map_or(false, |name| name == module)
-            } else {
-                false
-            }
-        })
-    })
-}
 
 /// Return the appropriate `sys.exit` reference based on the current set of
 /// imports, or `None` is `sys.exit` hasn't been imported.
-fn get_member_import_name_alias(checker: &Checker, module: &str, member: &str) -> Option<String> {
-    checker.ctx.scopes().find_map(|scope| {
+fn get_member_import_name_alias(context: &Context, module: &str, member: &str) -> Option<String> {
+    context.scopes().find_map(|scope| {
         scope
             .binding_ids()
-            .find_map(|index| match &checker.ctx.bindings[*index].kind {
+            .find_map(|index| match &context.bindings[*index].kind {
                 // e.g. module=sys object=exit
                 // `import sys`         -> `sys.exit`
                 // `import sys as sys2` -> `sys2.exit`
@@ -71,15 +55,6 @@ fn get_member_import_name_alias(checker: &Checker, module: &str, member: &str) -
                         && parts.next().is_none()
                     {
                         Some((*name).to_string())
-                    } else {
-                        None
-                    }
-                }
-                // e.g. module=os.path object=join
-                // `from os.path import *` -> `join`
-                BindingKind::StarImportation(StarImportation { module: name, .. }) => {
-                    if name.as_ref().map_or(false, |name| name == module) {
-                        Some(member.to_string())
                     } else {
                         None
                     }
@@ -108,9 +83,6 @@ pub fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
         if id != name {
             continue;
         }
-        if name == "exit" && is_module_star_imported(checker, "sys") {
-            continue;
-        }
         if !checker.ctx.is_builtin(name) {
             continue;
         }
@@ -121,7 +93,7 @@ pub fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
             Range::from(func),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            if let Some(content) = get_member_import_name_alias(checker, "sys", "exit") {
+            if let Some(content) = get_member_import_name_alias(&checker.ctx, "sys", "exit") {
                 diagnostic.set_fix(Edit::replacement(
                     content,
                     func.location,

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
@@ -4,6 +4,20 @@ expression: diagnostics
 ---
 - kind:
     name: SysExitAlias
+    body: "Use `sys.exit()` instead of `exit`"
+    suggestion: "Replace `exit` with `sys.exit()`"
+    fixable: true
+  location:
+    row: 3
+    column: 0
+  end_location:
+    row: 3
+    column: 4
+  fix:
+    edits: []
+  parent: ~
+- kind:
+    name: SysExitAlias
     body: "Use `sys.exit()` instead of `quit`"
     suggestion: "Replace `quit` with `sys.exit()`"
     fixable: true
@@ -14,14 +28,21 @@ expression: diagnostics
     row: 4
     column: 4
   fix:
-    edits:
-      - content: exit
-        location:
-          row: 4
-          column: 0
-        end_location:
-          row: 4
-          column: 4
+    edits: []
+  parent: ~
+- kind:
+    name: SysExitAlias
+    body: "Use `sys.exit()` instead of `exit`"
+    suggestion: "Replace `exit` with `sys.exit()`"
+    fixable: true
+  location:
+    row: 8
+    column: 4
+  end_location:
+    row: 8
+    column: 8
+  fix:
+    edits: []
   parent: ~
 - kind:
     name: SysExitAlias
@@ -35,13 +56,6 @@ expression: diagnostics
     row: 9
     column: 8
   fix:
-    edits:
-      - content: exit
-        location:
-          row: 9
-          column: 4
-        end_location:
-          row: 9
-          column: 8
+    edits: []
   parent: ~
 


### PR DESCRIPTION
## Summary

Right now, if you do:

```py
from sys import *

exit(1)
```

We'll avoid telling you to use sys.exit, since we hard-code handling of this specific case. But our star import handling is not very good -- and, for example, this will raise a lint error:

```py
from sys import *
from os import *

exit(1)  # PLR1722 [*] Use `sys.exit()` instead of `exit`
```

...for reasons that relate to implementation details.

I want to remove this handling, since so much stuff doesn't work properly with star imports anyway, and I want to instead revisit holistically rather than try to handle this one case.
