### PR TITLE
Add Openverse to users of ruff in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Ruff is used in a number of major open-source projects, including:
 - [nox](https://github.com/wntrblm/nox)
 - [Neon](https://github.com/neondatabase/neon)
 - [The Algorithms](https://github.com/TheAlgorithms/Python)
+- [Openverse](https://github.com/WordPress/openverse)
 
 ## License
 


### PR DESCRIPTION
We had a community contributor take this on in https://github.com/WordPress/openverse/pull/963 and we were so pleased with the results! Heard about this on Talk Python To Me and we're glad we did 😄 Thanks for the excellent tool!