### PR TITLE
Use cache in cargo udeps CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,12 +184,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Install Rust toolchain"
-        run: rustup toolchain install nightly
+        # Only pinned to make caching work, update freely
+        run: rustup toolchain install nightly-2023-03-30
+      - uses: Swatinem/rust-cache@v2
       - name: "Install cargo-udeps"
         uses: taiki-e/install-action@cargo-udeps
       - name: "Run cargo-udeps"
         run: |
-          unused_dependencies=$(cargo +nightly udeps > unused.txt && cat unused.txt | cut -d $'\n' -f 2-)
+          unused_dependencies=$(cargo +nightly-2023-03-30 udeps > unused.txt && cat unused.txt | cut -d $'\n' -f 2-)
           if [ -z "$unused_dependencies" ]; then
             echo "No unused dependencies found" > $GITHUB_STEP_SUMMARY
             exit 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: "Install Rust toolchain"
+      - name: "Install nightly Rust toolchain"
         # Only pinned to make caching work, update freely
         run: rustup toolchain install nightly-2023-03-30
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,7 @@ jobs:
             echo "No unused dependencies found" > $GITHUB_STEP_SUMMARY
             exit 0
           else
-            echo "Unused dependencies found" > $GITHUB_STEP_SUMMARY
+            echo "Found unused dependencies" > $GITHUB_STEP_SUMMARY
             echo '```console' >> $GITHUB_STEP_SUMMARY
             echo "$unused_dependencies" >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Checking for unused dependencies is currently the slowest step just after the cargo test runs