### PR TITLE
Track star imports on `Scope` directly

### DIFF
--- a/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_attr.rs
@@ -82,7 +82,6 @@ pub fn check_attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &E
                     | BindingKind::FunctionDefinition
                     | BindingKind::Export(..)
                     | BindingKind::FutureImportation
-                    | BindingKind::StarImportation(..)
                     | BindingKind::Importation(..)
                     | BindingKind::FromImportation(..)
                     | BindingKind::SubmoduleImportation(..)

--- a/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/check_call.rs
@@ -99,7 +99,6 @@ pub fn check_call(checker: &mut Checker, func: &Expr) {
                         | BindingKind::FunctionDefinition
                         | BindingKind::Export(..)
                         | BindingKind::FutureImportation
-                        | BindingKind::StarImportation(..)
                         | BindingKind::Importation(..)
                         | BindingKind::FromImportation(..)
                         | BindingKind::SubmoduleImportation(..)

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::scope::Scope;
@@ -19,14 +17,9 @@ impl Violation for UndefinedExport {
 }
 
 /// F822
-pub fn undefined_export(
-    names: &[&str],
-    range: &Range,
-    path: &Path,
-    scope: &Scope,
-) -> Vec<Diagnostic> {
+pub fn undefined_export(names: &[&str], range: &Range, scope: &Scope) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
-    if !scope.import_starred && !path.ends_with("__init__.py") {
+    if !scope.uses_star_imports() {
         for name in names {
             if !scope.defines(name) {
                 diagnostics.push(Diagnostic::new(


### PR DESCRIPTION
## Summary

Prior to this PR, when we saw a star import in the AST, like:

```py
from sys import *
```

We added a binding to the symbol table under the name `*`, with a kind of `StarImportation`. This had a number of strange consequences -- for example, if you have multiple star imports in the same scope, we only keep track of the "last" one.

This PR modifies the behavior to instead track the list of star imports on the `Scope`, rather than adding any bindings at all. To me, this better maps to the intent: we often want to know if we had any star imports to account for undefined variables, so we can now traverse over the list of star imports directly.

Note that, ideally, upon seeing `from sys import *`, we'd add an import binding for every _member_ in `sys`. But we don't have any way to detect the imported members, so for now, we don't add _any_ bindings.
