### PR TITLE
Move keyword checks into `is_identifier`

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -5,7 +5,6 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -58,7 +57,7 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     if !is_identifier(value) {
         return;
     }
-    if KWLIST.contains(&value.as_str()) || is_mangled_private(value.as_str()) {
+    if is_mangled_private(value.as_str()) {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -6,7 +6,6 @@ use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -69,7 +68,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     if !is_identifier(name) {
         return;
     }
-    if KWLIST.contains(&name.as_str()) || is_mangled_private(name.as_str()) {
+    if is_mangled_private(name.as_str()) {
         return;
     }
     // We can only replace a `setattr` call (which is an `Expr`) with an assignment

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -1,7 +1,7 @@
-use itertools::Either::{Left, Right};
 use std::collections::BTreeMap;
 use std::iter;
 
+use itertools::Either::{Left, Right};
 use log::error;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{
@@ -15,7 +15,6 @@ use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{any_over_expr, create_expr, match_trailing_comment, unparse_expr};
 use ruff_python_ast::types::{Range, RefEquality};
 use ruff_python_stdlib::identifiers::is_identifier;
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::autofix::helpers::delete_stmt;
 use crate::checkers::ast::Checker;
@@ -374,7 +373,7 @@ fn is_valid_kwarg_name(key: &Expr) -> bool {
         ..
     } = &key.node
     {
-        is_identifier(value) && !KWLIST.contains(&value.as_str())
+        is_identifier(value)
     } else {
         false
     }

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -8,7 +8,6 @@ use ruff_python_ast::helpers::{create_stmt, from_relative_import, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::is_identifier;
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -109,10 +108,7 @@ fn fix_banned_relative_import(
             let call_path = from_relative_import(&parts, module);
             // Require import to be a valid module:
             // https://python.org/dev/peps/pep-0008/#package-and-module-names
-            if !call_path
-                .iter()
-                .all(|part| is_identifier(part) && !KWLIST.contains(part))
-            {
+            if !call_path.iter().all(|part| is_identifier(part)) {
                 return None;
             }
             call_path.as_slice().join(".")
@@ -121,20 +117,14 @@ fn fix_banned_relative_import(
             let call_path = from_relative_import(&parts, &module);
             // Require import to be a valid module:
             // https://python.org/dev/peps/pep-0008/#package-and-module-names
-            if !call_path
-                .iter()
-                .all(|part| is_identifier(part) && !KWLIST.contains(part))
-            {
+            if !call_path.iter().all(|part| is_identifier(part)) {
                 return None;
             }
             call_path.as_slice().join(".")
         } else {
             // Require import to be a valid module:
             // https://python.org/dev/peps/pep-0008/#package-and-module-names
-            if !parts
-                .iter()
-                .all(|part| is_identifier(part) && !KWLIST.contains(&part.as_str()))
-            {
+            if !parts.iter().all(|part| is_identifier(part)) {
                 return None;
             }
             parts.join(".")

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -8,7 +8,6 @@ use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::is_identifier;
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -135,7 +134,7 @@ fn create_properties_from_args(args: &[Expr], defaults: &[Expr]) -> Result<Vec<S
             } = &field_name.node else {
                 bail!("Expected `field_name` to be `Constant::Str`")
             };
-            if !is_identifier(property) || KWLIST.contains(&property.as_str()) {
+            if !is_identifier(property) {
                 bail!("Invalid property name: {}", property)
             }
             Ok(create_property_assignment_stmt(

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -8,7 +8,6 @@ use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
 use ruff_python_ast::types::Range;
 use ruff_python_stdlib::identifiers::is_identifier;
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -117,7 +116,7 @@ fn properties_from_dict_literal(keys: &[Option<Expr>], values: &[Expr]) -> Resul
                     },
                 ..
             }) => {
-                if is_identifier(property) && !KWLIST.contains(&property.as_str()) {
+                if is_identifier(property) {
                     Ok(create_property_assignment_stmt(property, &value.node))
                 } else {
                     bail!("Property name is not valid identifier: {}", property)

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -12,7 +12,6 @@ use ruff_python_ast::str::{leading_quote, trailing_quote};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::whitespace::indentation;
 use ruff_python_stdlib::identifiers::is_identifier;
-use ruff_python_stdlib::keyword::KWLIST;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -175,10 +174,6 @@ fn clean_params_dictionary(checker: &mut Checker, right: &Expr) -> Option<String
                     {
                         // If the dictionary key is not a valid variable name, abort.
                         if !is_identifier(key_string) {
-                            return None;
-                        }
-                        // If the key is a Python keyword, abort.
-                        if KWLIST.contains(&key_string.as_str()) {
                             return None;
                         }
                         // If there are multiple entries of the same key, abort.

--- a/crates/ruff_python_stdlib/src/identifiers.rs
+++ b/crates/ruff_python_stdlib/src/identifiers.rs
@@ -13,7 +13,16 @@ pub fn is_identifier(name: &str) -> bool {
     }
 
     // Are the rest of the characters letters, digits, or underscores?
-    chars.all(|c| c.is_alphanumeric() || c == '_')
+    if !chars.all(|c| c.is_alphanumeric() || c == '_') {
+        return false;
+    }
+
+    // Is the identifier a keyword?
+    if KWLIST.contains(&name) {
+        return false;
+    }
+
+    true
 }
 
 /// Returns `true` if a string is a private identifier, such that, when the
@@ -28,11 +37,6 @@ pub fn is_mangled_private(id: &str) -> bool {
 /// Returns `true` if a string is a PEP 8-compliant module name (i.e., consists of lowercase
 /// letters, numbers, underscores, and is not a keyword).
 pub fn is_module_name(name: &str) -> bool {
-    // Is the string a keyword?
-    if KWLIST.contains(&name) {
-        return false;
-    }
-
     // Is the first character a letter or underscore?
     let mut chars = name.chars();
     if !chars
@@ -43,19 +47,34 @@ pub fn is_module_name(name: &str) -> bool {
     }
 
     // Are the rest of the characters letters, digits, or underscores?
-    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
-}
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
+        return false;
+    }
 
-/// Returns `true` if a string appears to be a valid migration file name (e.g., `0001_initial.py`).
-pub fn is_migration_name(name: &str) -> bool {
-    // Is the string a keyword?
+    // Is the identifier a keyword?
     if KWLIST.contains(&name) {
         return false;
     }
 
+    true
+}
+
+/// Returns `true` if a string appears to be a valid migration file name (e.g., `0001_initial.py`).
+pub fn is_migration_name(name: &str) -> bool {
     // Are characters letters, digits, or underscores?
-    name.chars()
+    if !name
+        .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return false;
+    }
+
+    // Is the identifier a keyword?
+    if KWLIST.contains(&name) {
+        return false;
+    }
+
+    true
 }
 
 #[cfg(test)]

--- a/crates/ruff_python_stdlib/src/keyword.rs
+++ b/crates/ruff_python_stdlib/src/keyword.rs
@@ -1,5 +1,5 @@
 // See: https://github.com/python/cpython/blob/9d692841691590c25e6cf5b2250a594d3bf54825/Lib/keyword.py#L18
-pub const KWLIST: [&str; 35] = [
+pub(crate) const KWLIST: [&str; 35] = [
     "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
     "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
     "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",


### PR DESCRIPTION
## Summary

Everywhere that we check `is_identifier`, we subsequently check whether the identifier is a keyword. You can't use keywords as identifiers, so I think this should just be part of that check.