### PR TITLE
Ensure that line-length and doc-length behavior is consistent with Flake8 

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
@@ -11,8 +11,5 @@ def f():
 
     print("Here's a string that's over the limit, but it's not a docstring.")
 
-# E501 & not W505
-looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_var = 10
 
-# W505 & not E501
-"This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit."
+"This is also considered a docstring, and is over the limit."

--- a/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
@@ -11,6 +11,8 @@ def f():
 
     print("Here's a string that's over the limit, but it's not a docstring.")
 
-qweruyqwoeruiyqweruioqyweroiquwyeroqiuweyrqwoieuryqwoeiruyqweoiruyqweoriuqyweroiuqwyeoriuqwyeroqiweuryqwoeiuryqweoiruyqweioruyqweoriuqyweorqwuyerqowieuryqweoiuryqwoeiry = 10
-# update: let W505 overrides E501
+# E501 & not W505
+looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong_var = 10
+
+# W505 & not E501
 "This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit."

--- a/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/W505.py
@@ -11,5 +11,6 @@ def f():
 
     print("Here's a string that's over the limit, but it's not a docstring.")
 
-
-"This is also considered a docstring, and is over the limit."
+qweruyqwoeruiyqweruioqyweroiquwyeroqiuweyrqwoieuryqwoeiruyqweoiruyqweoriuqyweroiuqwyeoriuqwyeroqiweuryqwoeiuryqweoiruyqweioruyqweoriuqyweorqwuyerqowieuryqweoiuryqwoeiry = 10
+# update: let W505 overrides E501
+"This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit. This is also considered a docstring, and is over the limit."

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -140,7 +140,7 @@ pub fn check_physical_lines(
         }
 
         if enforce_line_too_long
-            && !doc_line_length_takes_precedence(enforce_doc_line_too_long, doc_lines, &index)
+            && !doc_line_length_takes_precedence(enforce_doc_line_too_long, doc_lines, index)
         {
             if let Some(diagnostic) = line_too_long(index, line, settings) {
                 diagnostics.push(diagnostic);

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -139,8 +139,9 @@ pub fn check_physical_lines(
             }
         }
 
-        
-        if enforce_line_too_long && !doc_line_length_takes_precedence(enforce_doc_line_too_long, doc_lines, &index) {
+        if enforce_line_too_long
+            && !doc_line_length_takes_precedence(enforce_doc_line_too_long, doc_lines, &index)
+        {
             if let Some(diagnostic) = line_too_long(index, line, settings) {
                 diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -11,6 +11,7 @@ use crate::rules::flake8_executable::helpers::{extract_shebang, ShebangDirective
 use crate::rules::flake8_executable::rules::{
     shebang_missing, shebang_newline, shebang_not_executable, shebang_python, shebang_whitespace,
 };
+use crate::rules::pycodestyle::helpers::doc_line_length_takes_precedence;
 use crate::rules::pycodestyle::rules::{
     doc_line_too_long, line_too_long, mixed_spaces_and_tabs, no_newline_at_end_of_file,
     tab_indentation, trailing_whitespace,
@@ -138,7 +139,8 @@ pub fn check_physical_lines(
             }
         }
 
-        if enforce_line_too_long {
+        
+        if enforce_line_too_long && !doc_line_length_takes_precedence(enforce_doc_line_too_long, doc_lines, &index) {
             if let Some(diagnostic) = line_too_long(index, line, settings) {
                 diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/pycodestyle/helpers.rs
+++ b/crates/ruff/src/rules/pycodestyle/helpers.rs
@@ -59,7 +59,7 @@ pub fn is_overlong(
 pub fn doc_line_length_takes_precedence(
     doc_line_length_is_set: bool,
     doc_lines: &[usize],
-    idx: &usize,
+    idx: usize,
 ) -> bool {
     doc_line_length_is_set && doc_lines.contains(&(idx + 1))
 }

--- a/crates/ruff/src/rules/pycodestyle/helpers.rs
+++ b/crates/ruff/src/rules/pycodestyle/helpers.rs
@@ -55,3 +55,11 @@ pub fn is_overlong(
 
     true
 }
+
+pub fn doc_line_length_takes_precedence(
+    doc_line_length_is_set: bool,
+    doc_lines: &[usize],
+    idx: &usize,
+) -> bool {
+    doc_line_length_is_set && doc_lines.contains(&(idx + 1))
+}


### PR DESCRIPTION
Here is my proposed fix for:
https://github.com/charliermarsh/ruff/issues/2756

It's certainly not the most elegant solution, it's just a proposal and i'm curious to hear if anyone sees a better solution.

I'm also very much unsure how to test this at the moment. Currently I'm using a custom pyproject.toml like:
```toml
[tool.ruff]
line-length = 120

[tool.ruff.pycodestyle]
max-doc-length = 180
```

Then I include it in the command:
```
cargo run -p ruff_cli -- check crates/ruff/resources/test/fixtures/pycodestyle/W505.py --no-cache --config crates/ruff/resources/test/fixtures/pycodestyle/pyproject.toml --select W505 --extend-select E501
```

Help would be very much appreciated!