### PR TITLE
Make `collect_call_path` return an `Option`

### DIFF
--- a/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
@@ -107,8 +107,7 @@ pub fn check_positional_boolean_in_def(
     }
 
     if decorator_list.iter().any(|expr| {
-        let call_path = collect_call_path(expr);
-        call_path.as_slice() == [name, "setter"]
+        collect_call_path(expr).map_or(false, |call_path| call_path.as_slice() == [name, "setter"])
     }) {
         return;
     }
@@ -151,8 +150,7 @@ pub fn check_boolean_default_value_in_function_definition(
     }
 
     if decorator_list.iter().any(|expr| {
-        let call_path = collect_call_path(expr);
-        call_path.as_slice() == [name, "setter"]
+        collect_call_path(expr).map_or(false, |call_path| call_path.as_slice() == [name, "setter"])
     }) {
         return;
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -70,8 +70,7 @@ fn duplicate_handler_exceptions<'a>(
     let mut duplicates: FxHashSet<CallPath> = FxHashSet::default();
     let mut unique_elts: Vec<&Expr> = Vec::default();
     for type_ in elts {
-        let call_path = call_path::collect_call_path(type_);
-        if !call_path.is_empty() {
+        if let Some(call_path) = call_path::collect_call_path(type_) {
             if seen.contains_key(&call_path) {
                 duplicates.insert(call_path);
             } else {
@@ -125,8 +124,7 @@ pub fn duplicate_exceptions(checker: &mut Checker, handlers: &[Excepthandler]) {
         };
         match &type_.node {
             ExprKind::Attribute { .. } | ExprKind::Name { .. } => {
-                let call_path = call_path::collect_call_path(type_);
-                if !call_path.is_empty() {
+                if let Some(call_path) = call_path::collect_call_path(type_) {
                     if seen.contains(&call_path) {
                         duplicates.entry(call_path).or_default().push(type_);
                     } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind};
 use ruff_diagnostics::Violation;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::to_call_path;
+use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::call_path::{compose_call_path, CallPath};
 use ruff_python_ast::types::Range;
 use ruff_python_ast::visitor;
@@ -123,7 +123,7 @@ pub fn function_call_argument_default(checker: &mut Checker, arguments: &Argumen
         .flake8_bugbear
         .extend_immutable_calls
         .iter()
-        .map(|target| to_call_path(target))
+        .map(|target| from_qualified_name(target))
         .collect();
     let diagnostics = {
         let mut visitor = ArgumentDefaultVisitor {

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -2,14 +2,11 @@ use rustpython_parser::ast::{Expr, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::format_call_path;
+use ruff_python_ast::call_path::{format_call_path, from_unqualified_name, CallPath};
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
-
-use super::types::DebuggerUsingType;
-
-// flake8-debugger
+use crate::rules::flake8_debugger::types::DebuggerUsingType;
 
 #[violation]
 pub struct Debugger {
@@ -70,9 +67,12 @@ pub fn debugger_import(stmt: &Stmt, module: Option<&str>, name: &str) -> Option<
     }
 
     if let Some(module) = module {
-        let mut call_path = module.split('.').collect::<Vec<_>>();
+        let mut call_path: CallPath = from_unqualified_name(module);
         call_path.push(name);
-        if DEBUGGERS.iter().any(|target| call_path == **target) {
+        if DEBUGGERS
+            .iter()
+            .any(|target| call_path.as_slice() == *target)
+        {
             return Some(Diagnostic::new(
                 Debugger {
                     using_type: DebuggerUsingType::Import(format_call_path(&call_path)),
@@ -81,10 +81,10 @@ pub fn debugger_import(stmt: &Stmt, module: Option<&str>, name: &str) -> Option<
             ));
         }
     } else {
-        let parts = name.split('.').collect::<Vec<_>>();
+        let parts: CallPath = from_unqualified_name(name);
         if DEBUGGERS
             .iter()
-            .any(|call_path| call_path[..call_path.len() - 1] == parts)
+            .any(|call_path| &call_path[..call_path.len() - 1] == parts.as_slice())
         {
             return Some(Diagnostic::new(
                 Debugger {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Expr, ExprKind, Keyword, Stmt, StmtKind, Withitem};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::format_call_path;
-use ruff_python_ast::call_path::to_call_path;
+use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
@@ -157,7 +157,7 @@ fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
                         .flake8_pytest_style
                         .raises_extend_require_match_for,
                 )
-                .any(|target| call_path == to_call_path(target));
+                .any(|target| call_path == from_qualified_name(target));
             if is_broad_exception {
                 Some(format_call_path(&call_path))
             } else {

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
-use ruff_python_ast::call_path::CallPath;
+use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::types::Range;
 
 use crate::checkers::ast::Checker;
@@ -103,7 +103,7 @@ pub fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
             .flake8_tidy_imports
             .banned_api
             .iter()
-            .find(|(banned_path, ..)| call_path == banned_path.split('.').collect::<CallPath>())
+            .find(|(banned_path, ..)| call_path == from_qualified_name(banned_path))
     }) {
         checker.diagnostics.push(Diagnostic::new(
             BannedApi {

--- a/crates/ruff/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/helpers.rs
@@ -2,7 +2,7 @@ use num_traits::Zero;
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
 use ruff_python_ast::binding::{Binding, BindingKind, ExecutionContext};
-use ruff_python_ast::call_path::to_call_path;
+use ruff_python_ast::call_path::from_qualified_name;
 use ruff_python_ast::context::Context;
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::scope::ScopeKind;
@@ -78,7 +78,7 @@ fn runtime_evaluated_base_class(context: &Context, base_classes: &[String]) -> b
             if let Some(call_path) = context.resolve_call_path(base) {
                 if base_classes
                     .iter()
-                    .any(|base_class| to_call_path(base_class) == call_path)
+                    .any(|base_class| from_qualified_name(base_class) == call_path)
                 {
                     return true;
                 }
@@ -94,7 +94,7 @@ fn runtime_evaluated_decorators(context: &Context, decorators: &[String]) -> boo
             if let Some(call_path) = context.resolve_call_path(map_callable(decorator)) {
                 if decorators
                     .iter()
-                    .any(|decorator| to_call_path(decorator) == call_path)
+                    .any(|decorator| from_qualified_name(decorator) == call_path)
                 {
                     return true;
                 }

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::call_path::to_call_path;
+use ruff_python_ast::call_path::from_qualified_name;
 use std::collections::BTreeSet;
 
 use ruff_python_ast::cast;
@@ -53,7 +53,7 @@ pub(crate) fn should_ignore_definition(
             if let Some(call_path) = checker.ctx.resolve_call_path(map_callable(decorator)) {
                 if ignore_decorators
                     .iter()
-                    .any(|decorator| to_call_path(decorator) == call_path)
+                    .any(|decorator| from_qualified_name(decorator) == call_path)
                 {
                     return true;
                 }

--- a/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -5,7 +5,7 @@ use once_cell::sync::Lazy;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::call_path::{to_call_path, CallPath};
+use ruff_python_ast::call_path::{from_qualified_name, CallPath};
 use ruff_python_ast::cast;
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::types::Range;
@@ -33,7 +33,7 @@ pub fn non_imperative_mood(
 
     let property_decorators = property_decorators
         .iter()
-        .map(|decorator| to_call_path(decorator))
+        .map(|decorator| from_qualified_name(decorator))
         .collect::<Vec<CallPath>>();
 
     if is_test(cast::name(parent))

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -39,7 +39,9 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
             call_path.as_slice() == ["datetime", "timezone", "utc"]
         })
     {
-        let straight_import = collect_call_path(expr).as_slice() == ["datetime", "timezone", "utc"];
+        let straight_import = collect_call_path(expr).map_or(false, |call_path| {
+            call_path.as_slice() == ["datetime", "timezone", "utc"]
+        });
         let mut diagnostic =
             Diagnostic::new(DatetimeTimezoneUTC { straight_import }, Range::from(expr));
         if checker.patch(diagnostic.kind.rule()) {

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -248,7 +248,9 @@ fn format_import_from(
 /// UP026
 pub fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
     if let ExprKind::Attribute { value, .. } = &expr.node {
-        if collect_call_path(value).as_slice() == ["mock", "mock"] {
+        if collect_call_path(value)
+            .map_or(false, |call_path| call_path.as_slice() == ["mock", "mock"])
+        {
             let mut diagnostic = Diagnostic::new(
                 DeprecatedMockImport {
                     reference_type: MockReference::Attribute,

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -12,7 +12,7 @@ use crate::binding::{
     Binding, BindingId, BindingKind, Bindings, Exceptions, ExecutionContext, FromImportation,
     Importation, SubmoduleImportation,
 };
-use crate::call_path::{collect_call_path, CallPath};
+use crate::call_path::{collect_call_path, from_unqualified_name, CallPath};
 use crate::helpers::from_relative_import;
 use crate::scope::{Scope, ScopeId, ScopeKind, ScopeStack, Scopes};
 use crate::types::RefEquality;
@@ -117,7 +117,7 @@ impl<'a> Context<'a> {
         }
 
         if self.typing_modules.iter().any(|module| {
-            let mut module: CallPath = module.split('.').collect();
+            let mut module: CallPath = from_unqualified_name(module);
             module.push(target);
             *call_path == module
         }) {
@@ -156,7 +156,9 @@ impl<'a> Context<'a> {
     where
         'b: 'a,
     {
-        let call_path = collect_call_path(value);
+        let Some(call_path) = collect_call_path(value) else {
+            return None;
+        };
         let Some(head) = call_path.first() else {
             return None;
         };
@@ -177,7 +179,7 @@ impl<'a> Context<'a> {
                         None
                     }
                 } else {
-                    let mut source_path: CallPath = name.split('.').collect();
+                    let mut source_path: CallPath = from_unqualified_name(name);
                     source_path.extend(call_path.into_iter().skip(1));
                     Some(source_path)
                 }
@@ -194,7 +196,7 @@ impl<'a> Context<'a> {
                         None
                     }
                 } else {
-                    let mut source_path: CallPath = name.split('.').collect();
+                    let mut source_path: CallPath = from_unqualified_name(name);
                     source_path.extend(call_path.into_iter().skip(1));
                     Some(source_path)
                 }

--- a/crates/ruff_python_ast/src/function_type.rs
+++ b/crates/ruff_python_ast/src/function_type.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use crate::call_path::to_call_path;
+use crate::call_path::from_qualified_name;
 use crate::context::Context;
 use crate::helpers::map_callable;
 use crate::scope::{Scope, ScopeKind};
@@ -36,7 +36,7 @@ pub fn classify(
                 call_path.as_slice() == ["", "staticmethod"]
                     || staticmethod_decorators
                         .iter()
-                        .any(|decorator| call_path == to_call_path(decorator))
+                        .any(|decorator| call_path == from_qualified_name(decorator))
             })
     }) {
         FunctionType::StaticMethod
@@ -56,7 +56,7 @@ pub fn classify(
                 call_path.as_slice() == ["", "classmethod"] ||
                 classmethod_decorators
                     .iter()
-                    .any(|decorator| call_path == to_call_path(decorator))
+                    .any(|decorator| call_path == from_qualified_name(decorator))
             })
         })
     {

--- a/crates/ruff_python_ast/src/logging.rs
+++ b/crates/ruff_python_ast/src/logging.rs
@@ -43,9 +43,11 @@ impl LoggingLevel {
 /// ```
 pub fn is_logger_candidate(context: &Context, func: &Expr) -> bool {
     if let ExprKind::Attribute { value, .. } = &func.node {
-        let call_path = context
+        let Some(call_path) = context
             .resolve_call_path(value)
-            .unwrap_or_else(|| collect_call_path(value));
+            .or_else(|| collect_call_path(value)) else {
+            return false;
+        };
         if let Some(tail) = call_path.last() {
             if tail.starts_with("log") || tail.ends_with("logger") || tail.ends_with("logging") {
                 return true;

--- a/crates/ruff_python_ast/src/typing.rs
+++ b/crates/ruff_python_ast/src/typing.rs
@@ -4,6 +4,7 @@ use rustpython_parser::ast::{Expr, ExprKind, Location};
 
 use ruff_python_stdlib::typing::{PEP_585_BUILTINS_ELIGIBLE, PEP_593_SUBSCRIPTS, SUBSCRIPTS};
 
+use crate::call_path::{from_unqualified_name, CallPath};
 use crate::context::Context;
 use crate::relocate::relocate_expr;
 use crate::source_code::Locator;
@@ -47,7 +48,7 @@ pub fn match_annotated_subscript<'a>(
         }
 
         for module in typing_modules {
-            let module_call_path = module.split('.').collect::<Vec<_>>();
+            let module_call_path: CallPath = from_unqualified_name(module);
             if call_path.starts_with(&module_call_path) {
                 for subscript in SUBSCRIPTS.iter() {
                     if call_path.last() == subscript.last() {

--- a/crates/ruff_python_ast/src/visibility.rs
+++ b/crates/ruff_python_ast/src/visibility.rs
@@ -183,9 +183,10 @@ pub fn method_visibility(stmt: &Stmt) -> Visibility {
         } => {
             // Is this a setter or deleter?
             if decorator_list.iter().any(|expr| {
-                let call_path = collect_call_path(expr);
-                call_path.as_slice() == [name, "setter"]
-                    || call_path.as_slice() == [name, "deleter"]
+                collect_call_path(expr).map_or(false, |call_path| {
+                    call_path.as_slice() == [name, "setter"]
+                        || call_path.as_slice() == [name, "deleter"]
+                })
             }) {
                 return Visibility::Private;
             }


### PR DESCRIPTION
## Summary

This probably should've always returned an `Option`. I suspect that right now, if you ran `collect_call_path` over `foo.bar()`, we'd return `["foo"]`, which is incorrect.
