### PR TITLE
Use references for `Export` binding type

### DIFF
--- a/crates/ruff_python_ast/src/binding.rs
+++ b/crates/ruff_python_ast/src/binding.rs
@@ -207,9 +207,9 @@ pub struct StarImportation<'a> {
 //        FutureImportation
 
 #[derive(Clone, Debug)]
-pub struct Export {
+pub struct Export<'a> {
     /// The names of the bindings exported via `__all__`.
-    pub names: Vec<String>,
+    pub names: Vec<&'a str>,
 }
 
 #[derive(Clone, Debug)]
@@ -258,7 +258,7 @@ pub enum BindingKind<'a> {
     Builtin,
     ClassDefinition,
     FunctionDefinition,
-    Export(Export),
+    Export(Export<'a>),
     FutureImportation,
     Importation(Importation<'a>),
     FromImportation(FromImportation<'a>),


### PR DESCRIPTION
## Summary

Non-behavioral refactor to use references for `Export` bindings. For context, `Export` bindings are those created via assignment to Python's special `__all__` identifier:

```py
__all__ = ["foo", "bar"]
```

This also removes a dependency in `all.rs` on `Context`.
