### PR TITLE
Change "indexes" to "indices" in various contexts

### DIFF
--- a/crates/ruff/src/rules/pyflakes/format.rs
+++ b/crates/ruff/src/rules/pyflakes/format.rs
@@ -23,7 +23,7 @@ pub(crate) fn error_to_string(err: &FormatParseError) -> String {
 #[derive(Debug)]
 pub(crate) struct FormatSummary {
     pub autos: Vec<usize>,
-    pub indexes: Vec<usize>,
+    pub indices: Vec<usize>,
     pub keywords: Vec<String>,
     pub has_nested_parts: bool,
     pub format_string: FormatString,
@@ -36,7 +36,7 @@ impl TryFrom<&str> for FormatSummary {
         let format_string = FormatString::from_str(literal)?;
 
         let mut autos = Vec::new();
-        let mut indexes = Vec::new();
+        let mut indices = Vec::new();
         let mut keywords = Vec::new();
         let mut has_nested_parts = false;
 
@@ -51,7 +51,7 @@ impl TryFrom<&str> for FormatSummary {
             let parsed = FieldName::parse(field_name)?;
             match parsed.field_type {
                 FieldType::Auto => autos.push(autos.len()),
-                FieldType::Index(i) => indexes.push(i),
+                FieldType::Index(i) => indices.push(i),
                 FieldType::Keyword(k) => keywords.push(k),
             };
 
@@ -63,7 +63,7 @@ impl TryFrom<&str> for FormatSummary {
                 let parsed = FieldName::parse(&field_name)?;
                 match parsed.field_type {
                     FieldType::Auto => autos.push(autos.len()),
-                    FieldType::Index(i) => indexes.push(i),
+                    FieldType::Index(i) => indices.push(i),
                     FieldType::Keyword(k) => keywords.push(k),
                 };
                 has_nested_parts = true;
@@ -72,7 +72,7 @@ impl TryFrom<&str> for FormatSummary {
 
         Ok(FormatSummary {
             autos,
-            indexes,
+            indices,
             keywords,
             has_nested_parts,
             format_string,
@@ -89,7 +89,7 @@ mod tests {
         let literal = "foo{foo}a{}b{2}c{2}d{1}{}{}e{bar}{foo}f{spam}";
 
         let expected_autos = [0usize, 1usize, 2usize].to_vec();
-        let expected_indexes = [2usize, 2usize, 1usize].to_vec();
+        let expected_indices = [2usize, 2usize, 1usize].to_vec();
         let expected_keywords: Vec<_> = ["foo", "bar", "foo", "spam"]
             .into_iter()
             .map(String::from)
@@ -98,7 +98,7 @@ mod tests {
         let format_summary = FormatSummary::try_from(literal).unwrap();
 
         assert_eq!(format_summary.autos, expected_autos);
-        assert_eq!(format_summary.indexes, expected_indexes);
+        assert_eq!(format_summary.indices, expected_indices);
         assert_eq!(format_summary.keywords, expected_keywords);
         assert!(!format_summary.has_nested_parts);
     }
@@ -108,7 +108,7 @@ mod tests {
         let literal = "foo{foo}a{:{}{}}b{2:{3}{4}}c{2}d{1}{}e{bar:{spam}{eggs}}";
 
         let expected_autos = [0usize, 1usize, 2usize, 3usize].to_vec();
-        let expected_indexes = [2usize, 3usize, 4usize, 2usize, 1usize].to_vec();
+        let expected_indices = [2usize, 3usize, 4usize, 2usize, 1usize].to_vec();
         let expected_keywords: Vec<_> = ["foo", "bar", "spam", "eggs"]
             .into_iter()
             .map(String::from)
@@ -117,7 +117,7 @@ mod tests {
         let format_summary = FormatSummary::try_from(literal).unwrap();
 
         assert_eq!(format_summary.autos, expected_autos);
-        assert_eq!(format_summary.indexes, expected_indexes);
+        assert_eq!(format_summary.indices, expected_indices);
         assert_eq!(format_summary.keywords, expected_keywords);
         assert!(format_summary.has_nested_parts);
     }

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -498,7 +498,7 @@ pub(crate) fn string_dot_format_extra_positional_arguments(
     }
 
     let missing: Vec<usize> = (0..args.len())
-        .filter(|i| !(summary.autos.contains(i) || summary.indexes.contains(i)))
+        .filter(|i| !(summary.autos.contains(i) || summary.indices.contains(i)))
         .collect();
 
     if missing.is_empty() {
@@ -551,7 +551,7 @@ pub(crate) fn string_dot_format_missing_argument(
     let missing: Vec<String> = summary
         .autos
         .iter()
-        .chain(summary.indexes.iter())
+        .chain(summary.indices.iter())
         .filter(|&&i| i >= args.len())
         .map(ToString::to_string)
         .chain(
@@ -577,7 +577,7 @@ pub(crate) fn string_dot_format_mixing_automatic(
     summary: &FormatSummary,
     location: Range,
 ) {
-    if !(summary.autos.is_empty() || summary.indexes.is_empty()) {
+    if !(summary.autos.is_empty() || summary.indices.is_empty()) {
         checker
             .diagnostics
             .push(Diagnostic::new(StringDotFormatMixingAutomatic, location));

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -24,7 +24,7 @@ impl AlwaysAutofixableViolation for FormatLiterals {
     }
 
     fn autofix_title(&self) -> String {
-        "Remove explicit positional indexes".to_string()
+        "Remove explicit positional indices".to_string()
     }
 }
 
@@ -135,7 +135,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
     if !summary.autos.is_empty() {
         return;
     }
-    if !(0..summary.indexes.len()).all(|index| summary.indexes.contains(&index)) {
+    if !(0..summary.indices.len()).all(|index| summary.indices.contains(&index)) {
         return;
     }
 
@@ -144,7 +144,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
         // Currently, the only issue we know of is in LibCST:
         // https://github.com/Instagram/LibCST/issues/846
         if let Ok(contents) =
-            generate_call(expr, &summary.indexes, checker.locator, checker.stylist)
+            generate_call(expr, &summary.indices, checker.locator, checker.stylist)
         {
             diagnostic.set_fix(Edit::replacement(
                 contents,

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
@@ -5,7 +5,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 3
@@ -26,7 +26,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 5
@@ -47,7 +47,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 9
@@ -68,7 +68,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 11
@@ -89,7 +89,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 13
@@ -110,7 +110,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 15
@@ -131,7 +131,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 17
@@ -152,7 +152,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 20
@@ -173,7 +173,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 22
@@ -194,7 +194,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 24
@@ -208,7 +208,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 29
@@ -222,7 +222,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 34

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
@@ -5,7 +5,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 6
@@ -26,7 +26,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 8
@@ -47,7 +47,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 10
@@ -68,7 +68,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 12
@@ -89,7 +89,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 14
@@ -103,7 +103,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 16
@@ -124,7 +124,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 18
@@ -145,7 +145,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 20
@@ -166,7 +166,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 22
@@ -187,7 +187,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 24
@@ -208,7 +208,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 26
@@ -229,7 +229,7 @@ expression: diagnostics
 - kind:
     name: FormatLiterals
     body: Use implicit references for positional format fields
-    suggestion: Remove explicit positional indexes
+    suggestion: Remove explicit positional indices
     fixable: true
   location:
     row: 28

--- a/crates/ruff_python_ast/src/context.rs
+++ b/crates/ruff_python_ast/src/context.rs
@@ -23,14 +23,14 @@ use crate::visibility::{module_visibility, Modifier, VisibleScope};
 pub struct Context<'a> {
     pub typing_modules: &'a [String],
     pub module_path: Option<Vec<String>>,
-    // Retain all scopes and parent nodes, along with a stack of indexes to track which are active
+    // Retain all scopes and parent nodes, along with a stack of indices to track which are active
     // at various points in time.
     pub parents: Vec<RefEquality<'a, Stmt>>,
     pub depths: FxHashMap<RefEquality<'a, Stmt>, usize>,
     pub child_to_parent: FxHashMap<RefEquality<'a, Stmt>, RefEquality<'a, Stmt>>,
     // A stack of all bindings created in any scope, at any point in execution.
     pub bindings: Bindings<'a>,
-    // Map from binding index to indexes of bindings that redefine it in other scopes.
+    // Map from binding index to indices of bindings that redefine it in other scopes.
     pub redefinitions:
         std::collections::HashMap<BindingId, Vec<BindingId>, BuildNoHashHasher<BindingId>>,
     pub exprs: Vec<RefEquality<'a, Expr>>,


### PR DESCRIPTION
Both Rust and Python seem to use `indices` in public-facing API, so let's mirror that.