### PR TITLE
Extended ecosystem check with scraped data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 crates/ruff/resources/test/cpython
 mkdocs.yml
 .overrides
+github_search.jsonl
 
 ###
 # Rust.gitignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,16 +81,6 @@ pre-commit run --all-files
 Your Pull Request will be reviewed by a maintainer, which may involve a few rounds of iteration
 prior to merging.
 
-### Ecosystem CI
-
-One GitHub actions job will check your changes against a number of real projects from GitHub and report the differences. You can also run those checks locally:
-
-```shell
-python scripts/check_ecosystem.py path/to/your/ruff path/to/older/ruff
-```
-
-Optionally, it is possible to run a docker container that checks against as many projects from GitHub as possible. To do so grab [known-github-tomls.json](https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl) as `github_search.jsonl` and follow the instructions in [scripts/Dockerfile.ecosystem](scripts/Dockerfile.ecosystem). This will check will take a long time and has high CPU and network usage.
-
 ### Project Structure
 
 Ruff is structured as a monorepo with a [flat crate structure](https://matklad.github.io/2021/08/22/large-rust-workspaces.html),
@@ -224,6 +214,20 @@ them to [PyPI](https://pypi.org/project/ruff/).
 
 Ruff follows the [semver](https://semver.org/) versioning standard. However, as pre-1.0 software,
 even patch releases may contain [non-backwards-compatible changes](https://semver.org/#spec-item-4).
+
+## Ecosystem CI
+
+GitHub Actions will run your changes against a number of real-world projects from GitHub and
+report on any diagnostic differences. You can also run those checks locally via:
+
+```shell
+python scripts/check_ecosystem.py path/to/your/ruff path/to/older/ruff
+```
+
+You can also run the Ecosystem CI check in a Docker container across a larger set of projects by
+downloading the [`known-github-tomls.json`](https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl)
+as `github_search.jsonl` and following the instructions in [scripts/Dockerfile.ecosystem](scripts/Dockerfile.ecosystem).
+Note that this check will take a while to run.
 
 ## Benchmarks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,16 @@ pre-commit run --all-files
 Your Pull Request will be reviewed by a maintainer, which may involve a few rounds of iteration
 prior to merging.
 
+### Ecosystem CI
+
+One GitHub actions job will check your changes against a number of real projects from GitHub and report the differences. You can also run those checks locally:
+
+```shell
+python scripts/check_ecosystem.py path/to/your/ruff path/to/older/ruff
+```
+
+Optionally, it is possible to run a docker container that checks against as many projects from GitHub as possible. To do so grab [known-github-tomls.json](https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl) as `github_search.jsonl` and follow the instructions in [scripts/Dockerfile.ecosystem](scripts/Dockerfile.ecosystem). This will check will take a long time and has high CPU and network usage.
+
 ### Project Structure
 
 Ruff is structured as a monorepo with a [flat crate structure](https://matklad.github.io/2021/08/22/large-rust-workspaces.html),

--- a/scripts/Dockerfile.ecosystem
+++ b/scripts/Dockerfile.ecosystem
@@ -1,3 +1,10 @@
+# [crates](https://github.com/rust-lang/crater) inspired check that tests against a large number of projects, mainly
+# from https://github.com/akx/ruff-usage-aggregate.
+# We run this in a Docker container because ruff isn't designed for untrusted inputs
+#
+# Either download https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl as
+# `github_search.jsonl` or follow the instructions in the readme to scrape your own dataset.
+#
 # From the project root:
 # ```
 # cargo build

--- a/scripts/Dockerfile.ecosystem
+++ b/scripts/Dockerfile.ecosystem
@@ -1,9 +1,10 @@
-# [crates](https://github.com/rust-lang/crater) inspired check that tests against a large number of projects, mainly
-# from https://github.com/akx/ruff-usage-aggregate.
-# We run this in a Docker container because ruff isn't designed for untrusted inputs
+# [crater](https://github.com/rust-lang/crater)-inspired check that tests against a large number of
+# projects, mainly from https://github.com/akx/ruff-usage-aggregate.
+#
+# We run this in a Docker container as Ruff isn't designed for untrusted inputs.
 #
 # Either download https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl as
-# `github_search.jsonl` or follow the instructions in the readme to scrape your own dataset.
+# `github_search.jsonl` or follow the instructions in the README to scrape your own dataset.
 #
 # From the project root:
 # ```

--- a/scripts/Dockerfile.ecosystem
+++ b/scripts/Dockerfile.ecosystem
@@ -1,0 +1,14 @@
+# From the project root:
+# ```
+# cargo build
+# docker buildx build -f scripts/Dockerfile.ecosystem -t ruff-ecosystem-checker --load .
+# docker run --rm ruff-ecosystem-checker
+# ```
+
+FROM python:3.11
+RUN python -m venv .venv && .venv/bin/pip install ruff
+ADD scripts/check_ecosystem.py check_ecosystem.py
+ADD github_search.jsonl github_search.jsonl
+ADD target/debug/ruff ruff-new
+
+CMD ["python", "check_ecosystem.py", "--verbose", "--projects", "github_search.jsonl", "ruff-new", ".venv/bin/ruff"]

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -6,9 +6,6 @@ Example usage:
     scripts/check_ecosystem.py <path/to/ruff1> <path/to/ruff2>
 """
 
-# ruff: noqa: G004
-# ruff: noqa: T201
-
 import argparse
 import asyncio
 import difflib
@@ -197,19 +194,19 @@ def read_projects_jsonl(projects_jsonl: Path) -> dict[str, Repository]:
     repositories = {}
     for line in projects_jsonl.read_text().splitlines():
         data = json.loads(line)
-        # Check which format we got
+        # Check the input format.
         if "items" in data:
             for item in data["items"]:
-                # Pick only the easier case for now
+                # Pick only the easier case for now.
                 if item["path"] != "pyproject.toml":
                     continue
                 repository = item["repository"]
                 assert re.fullmatch(r"[a-zA-Z0-9_.-]+", repository["name"]), repository[
                     "name"
                 ]
-                # :/ GitHub doesn't give us any branch or pure rev info
-                # This would give us the revision, but there's no way with git to just
-                # do `git clone --depth 1` with a specific ref
+                # GitHub doesn't give us any branch or pure rev info.  This would give
+                # us the revision, but there's no way with git to just do
+                # `git clone --depth 1` with a specific ref.
                 # `ref = item["url"].split("?ref=")[1]` would be exact
                 repositories[repository["name"]] = Repository(
                     repository["owner"]["login"],
@@ -218,7 +215,7 @@ def read_projects_jsonl(projects_jsonl: Path) -> dict[str, Repository]:
                 )
         else:
             assert "owner" in data, "Unknown ruff-usage-aggregate format"
-            # Pick only the easier case for now
+            # Pick only the easier case for now.
             if data["path"] != "pyproject.toml":
                 continue
             repositories[data["repo"]] = Repository(
@@ -312,9 +309,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--projects",
         type=Path,
-        help="Optional json files with set of projects from "
-        "https://github.com/akx/ruff-usage-aggregate to use over the default ones "
-        "(supports both github_search_*.jsonl and known-github-tomls.jsonl)",
+        help=(
+            "Optional JSON files to use over the default repositories. "
+            "Supports both github_search_*.jsonl and known-github-tomls.jsonl."
+        ),
     )
     parser.add_argument(
         "-v",

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -56,7 +56,7 @@ class Repository(NamedTuple):
             if self.ref:
                 git_command.extend(["--branch", self.ref])
 
-          	git_command.extend(
+            git_command.extend(
                 [
                     f"https://github.com/{self.org}/{self.repo}",
                     tmpdir,

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -55,7 +55,8 @@ class Repository(NamedTuple):
             ]
             if self.ref:
                 git_command.extend(["--branch", self.ref])
-            git_command.extend(
+
+          	git_command.extend(
                 [
                     f"https://github.com/{self.org}/{self.repo}",
                     tmpdir,

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -14,6 +14,8 @@ ignore = [
   "C901", # McCabe complexity
   "PL",   # pylint
   "S",    # bandit
+  "G",    # flake8-logging
+  "T",    # flake8-print
 ]
 
 [tool.ruff.pydocstyle]


### PR DESCRIPTION
This allows running the ecosystem CI locally in an isolated docker container using the data from https://github.com/akx/ruff-usage-aggregate. It also changes the output format of the ecosystem CI a little to include the repository URL.

CC @akx @sciyoshi i merged your efforts in one locally runnable docker container