### PR TITLE
Consistent Style/Levels in Usage 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,12 +43,12 @@ _unless_ you enable autofix, in which case, Ruff's pre-commit hook should run _b
 and other formatting tools, as Ruff's autofix behavior can output code changes that require
 reformatting.
 
-### VS Code
+## VS Code
 
 Ruff can also be used as a [VS Code extension](https://github.com/charliermarsh/ruff-vscode) or
 alongside any other editor through the [Ruff LSP](https://github.com/charliermarsh/ruff-lsp).
 
-### GitHub Action
+## GitHub Action
 
 Ruff can also be used as a GitHub Action via [`ruff-action`](https://github.com/chartboost/ruff-action).
 


### PR DESCRIPTION
<img width="201" alt="Screen Shot 2023-04-04 at 7 57 58 PM" src="https://user-images.githubusercontent.com/5032356/229970122-9592e885-0d31-4899-ba1c-cd9991779e02.png">

I imagine it is desirable for pre-commit to be at the same 'level' or style as VS Code and GH Action?  