### PR TITLE
Add documentation for flake8-type-checking

### DIFF
--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -9,6 +9,33 @@ use ruff_python_semantic::binding::{
 use crate::rules::isort::{categorize, ImportType};
 use crate::settings::Settings;
 
+/// ## What it does
+/// Checks for first-party imports used only for type annotation that are not in a type-checking block.
+///
+/// ## Why is this bad?
+/// Unused imports will add a performance overhead at runtime. They also risk circular imports.
+///
+/// ## Example
+/// ```python
+/// import A
+///
+/// def foo(a: A) -> int:
+///     return len(a)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///     import A
+///
+/// def foo(a: A) -> int:
+///     return len(a)
+/// ```
+///
+/// ## References
+/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyFirstPartyImport {
     pub full_name: String,
@@ -24,6 +51,33 @@ impl Violation for TypingOnlyFirstPartyImport {
     }
 }
 
+/// ## What it does
+/// Checks for third-party imports used only for type annotation that are not in a type-checking block.
+///
+/// ## Why is this bad?
+/// Unused imports will add a performance overhead at runtime. They also risk circular imports.
+///
+/// ## Example
+/// ```python
+/// import pandas
+///
+/// def foo(df: pandas.DataFrame) -> int:
+///     return len(df)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///     import pandas
+///
+/// def foo(df: pandas.DataFrame) -> int:
+///     return len(df)
+/// ```
+///
+/// ## References
+/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyThirdPartyImport {
     pub full_name: String,
@@ -39,6 +93,33 @@ impl Violation for TypingOnlyThirdPartyImport {
     }
 }
 
+/// ## What it does
+/// Checks for standard library imports used only for type annotation that are not in a type-checking block.
+///
+/// ## Why is this bad?
+/// Unused imports will add a performance overhead at runtime. They also risk circular imports.
+///
+/// ## Example
+/// ```python
+/// from pathlib import Path
+///
+/// def foo(path: Path) -> str:
+///     return str(path)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///     from pathlib import Path
+///
+/// def foo(path: Path) -> str:
+///     return str(path)
+/// ```
+///
+/// ## References
+/// - [PEP 536](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct TypingOnlyStandardLibraryImport {
     pub full_name: String,


### PR DESCRIPTION
Add documentation to the flake8-type-checking rules that check for imports used only for type annotation that are not in a type-checking block.

Related to #2646.