### PR TITLE
Visit comprehension to detect group name usage/overrides

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B031.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B031.py
@@ -79,6 +79,21 @@ for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
         collect_shop_items(shopper, section_items)  # B031
 
 for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    _ = [collect_shop_items(shopper, section_items) for shopper in shoppers]  # B031
+
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    # The variable is overridden, skip checking.
+    _ = [_ for section_items in range(3)]
+    _ = [collect_shop_items(shopper, section_items) for shopper in shoppers]
+
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    _ = [item for item in section_items]
+
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    # The iterator is being used for the second time.
+    _ = [(item1, item2) for item1 in section_items for item2 in section_items]  # B031
+
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
     if _section == "greens":
         collect_shop_items(shopper, section_items)
     else:

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -204,14 +204,18 @@ where
                     }
                 }
             }
-            StmtKind::Assign { targets, .. } => {
+            StmtKind::Assign { targets, value, .. } => {
                 if targets.iter().any(|target| self.name_matches(target)) {
                     self.overridden = true;
+                } else {
+                    self.visit_expr(value);
                 }
             }
-            StmtKind::AnnAssign { target, .. } => {
+            StmtKind::AnnAssign { target, value, .. } => {
                 if self.name_matches(target) {
                     self.overridden = true;
+                } else if let Some(expr) = value {
+                    self.visit_expr(expr);
                 }
             }
             _ => visitor::walk_stmt(self, stmt),

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B031_B031.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B031_B031.py.snap
@@ -106,10 +106,38 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 86
+    row: 82
+    column: 37
+  end_location:
+    row: 82
+    column: 50
+  fix:
+    edits: []
+  parent: ~
+- kind:
+    name: ReuseOfGroupbyGenerator
+    body: "Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 94
+    column: 64
+  end_location:
+    row: 94
+    column: 77
+  fix:
+    edits: []
+  parent: ~
+- kind:
+    name: ReuseOfGroupbyGenerator
+    body: "Using the generator returned from `itertools.groupby()` more than once will do nothing on the second usage"
+    suggestion: ~
+    fixable: false
+  location:
+    row: 101
     column: 36
   end_location:
-    row: 86
+    row: 101
     column: 49
   fix:
     edits: []
@@ -120,10 +148,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 93
+    row: 108
     column: 40
   end_location:
-    row: 93
+    row: 108
     column: 53
   fix:
     edits: []
@@ -134,10 +162,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 95
+    row: 110
     column: 40
   end_location:
-    row: 95
+    row: 110
     column: 53
   fix:
     edits: []
@@ -148,10 +176,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 97
+    row: 112
     column: 40
   end_location:
-    row: 97
+    row: 112
     column: 53
   fix:
     edits: []
@@ -162,10 +190,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 98
+    row: 113
     column: 36
   end_location:
-    row: 98
+    row: 113
     column: 49
   fix:
     edits: []
@@ -176,10 +204,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 105
+    row: 120
     column: 48
   end_location:
-    row: 105
+    row: 120
     column: 61
   fix:
     edits: []
@@ -190,10 +218,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 111
+    row: 126
     column: 32
   end_location:
-    row: 111
+    row: 126
     column: 45
   fix:
     edits: []
@@ -204,10 +232,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 120
+    row: 135
     column: 48
   end_location:
-    row: 120
+    row: 135
     column: 61
   fix:
     edits: []
@@ -218,10 +246,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 122
+    row: 137
     column: 48
   end_location:
-    row: 122
+    row: 137
     column: 61
   fix:
     edits: []
@@ -232,10 +260,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 125
+    row: 140
     column: 40
   end_location:
-    row: 125
+    row: 140
     column: 53
   fix:
     edits: []
@@ -246,10 +274,10 @@ expression: diagnostics
     suggestion: ~
     fixable: false
   location:
-    row: 129
+    row: 144
     column: 32
   end_location:
-    row: 129
+    row: 144
     column: 45
   fix:
     edits: []


### PR DESCRIPTION
As mentioned in the issue comment, the first commit fixes the false negative by visiting the right hand side of an assignment statement. The second commit fixes the actual bug by visiting the comprehension nodes.

fixes: #3885 