### PR TITLE
Store source code on message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ dependencies = [
  "ruff_python_semantic",
  "ruff_python_stdlib",
  "ruff_rustpython",
+ "ruff_text_size",
  "rustc-hash",
  "rustpython-common",
  "rustpython-parser",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -21,6 +21,7 @@ ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_semantic = { path = "../ruff_python_semantic" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_rustpython = { path = "../ruff_rustpython" }
+ruff_text_size = { path = "../ruff_text_size" }
 
 annotate-snippets = { version = "0.9.1", features = ["color"] }
 anyhow = { workspace = true }

--- a/crates/ruff/src/autofix/actions.rs
+++ b/crates/ruff/src/autofix/actions.rs
@@ -103,7 +103,7 @@ fn is_lone_child(child: &Stmt, parent: &Stmt, deleted: &[&Stmt]) -> Result<bool>
 /// Return the location of a trailing semicolon following a `Stmt`, if it's part
 /// of a multi-statement line.
 fn trailing_semicolon(stmt: &Stmt, locator: &Locator) -> Option<Location> {
-    let contents = locator.skip(stmt.end_location.unwrap());
+    let contents = locator.after(stmt.end_location.unwrap());
     for (row, line) in NewlineWithTrailingNewline::from(contents).enumerate() {
         let trimmed = line.trim();
         if trimmed.starts_with(';') {
@@ -126,7 +126,7 @@ fn trailing_semicolon(stmt: &Stmt, locator: &Locator) -> Option<Location> {
 /// Find the next valid break for a `Stmt` after a semicolon.
 fn next_stmt_break(semicolon: Location, locator: &Locator) -> Location {
     let start_location = Location::new(semicolon.row(), semicolon.column() + 1);
-    let contents = locator.skip(start_location);
+    let contents = locator.after(start_location);
     for (row, line) in NewlineWithTrailingNewline::from(contents).enumerate() {
         let trimmed = line.trim();
         // Skip past any continuations.
@@ -158,7 +158,7 @@ fn next_stmt_break(semicolon: Location, locator: &Locator) -> Location {
 
 /// Return `true` if a `Stmt` occurs at the end of a file.
 fn is_end_of_file(stmt: &Stmt, locator: &Locator) -> bool {
-    let contents = locator.skip(stmt.end_location.unwrap());
+    let contents = locator.after(stmt.end_location.unwrap());
     contents.is_empty()
 }
 
@@ -361,7 +361,7 @@ pub fn remove_argument(
     remove_parentheses: bool,
 ) -> Result<Edit> {
     // TODO(sbrugman): Preserve trailing comments.
-    let contents = locator.skip(call_at);
+    let contents = locator.after(call_at);
 
     let mut fix_start = None;
     let mut fix_end = None;

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -80,7 +80,7 @@ fn apply_fixes<'a>(
     }
 
     // Add the remaining content.
-    let slice = locator.skip(last_pos.unwrap_or_default());
+    let slice = locator.after(last_pos.unwrap_or_default());
     output.push_str(slice);
 
     (output, fixed)

--- a/crates/ruff/src/importer.rs
+++ b/crates/ruff/src/importer.rs
@@ -174,7 +174,7 @@ fn match_docstring_end(body: &[Stmt]) -> Option<Location> {
 /// along with a trailing newline suffix.
 fn end_of_statement_insertion(stmt: &Stmt, locator: &Locator, stylist: &Stylist) -> Insertion {
     let location = stmt.end_location.unwrap();
-    let mut tokens = lexer::lex_located(locator.skip(location), Mode::Module, location).flatten();
+    let mut tokens = lexer::lex_located(locator.after(location), Mode::Module, location).flatten();
     if let Some((.., Tok::Semi, end)) = tokens.next() {
         // If the first token after the docstring is a semicolon, insert after the semicolon as an
         // inline statement;
@@ -207,7 +207,7 @@ fn top_of_file_insertion(body: &[Stmt], locator: &Locator, stylist: &Stylist) ->
     let mut location = if let Some(location) = match_docstring_end(body) {
         // If the first token after the docstring is a semicolon, insert after the semicolon as an
         // inline statement;
-        let first_token = lexer::lex_located(locator.skip(location), Mode::Module, location)
+        let first_token = lexer::lex_located(locator.after(location), Mode::Module, location)
             .flatten()
             .next();
         if let Some((.., Tok::Semi, end)) = first_token {
@@ -222,7 +222,7 @@ fn top_of_file_insertion(body: &[Stmt], locator: &Locator, stylist: &Stylist) ->
 
     // Skip over any comments and empty lines.
     for (.., tok, end) in
-        lexer::lex_located(locator.skip(location), Mode::Module, location).flatten()
+        lexer::lex_located(locator.after(location), Mode::Module, location).flatten()
     {
         if matches!(tok, Tok::Comment(..) | Tok::Newline) {
             location = Location::new(end.row() + 1, 0);

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -1,11 +1,14 @@
 use crate::fs::relativize_path;
-use crate::message::{Emitter, EmitterContext, Message};
+use crate::message::{Emitter, EmitterContext, Location, Message};
 use crate::registry::AsRule;
 use annotate_snippets::display_list::{DisplayList, FormatOptions};
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use colored::Colorize;
 use ruff_diagnostics::DiagnosticKind;
-use std::fmt::Display;
+use ruff_python_ast::source_code::OneIndexed;
+use ruff_python_ast::types::Range;
+use ruff_text_size::TextRange;
+use std::fmt::{Display, Formatter};
 use std::io::Write;
 
 #[derive(Default)]
@@ -63,45 +66,8 @@ impl Emitter for TextEmitter {
                 }
             )?;
 
-            if let Some(source) = &message.source {
-                let suggestion = message.kind.suggestion.clone();
-                let footer = if suggestion.is_some() {
-                    vec![Annotation {
-                        id: None,
-                        label: suggestion.as_deref(),
-                        annotation_type: AnnotationType::Help,
-                    }]
-                } else {
-                    Vec::new()
-                };
-
-                let label = message.kind.rule().noqa_code().to_string();
-                let snippet = Snippet {
-                    title: None,
-                    slices: vec![Slice {
-                        source: &source.contents,
-                        line_start: message.location.row(),
-                        annotations: vec![SourceAnnotation {
-                            label: &label,
-                            annotation_type: AnnotationType::Error,
-                            range: source.range,
-                        }],
-                        // The origin (file name, line number, and column number) is already encoded
-                        // in the `label`.
-                        origin: None,
-                        fold: false,
-                    }],
-                    footer,
-                    opt: FormatOptions {
-                        #[cfg(test)]
-                        color: false,
-                        #[cfg(not(test))]
-                        color: colored::control::SHOULD_COLORIZE.should_colorize(),
-                        ..FormatOptions::default()
-                    },
-                };
-
-                writeln!(writer, "{message}\n", message = DisplayList::from(snippet))?;
+            if message.source.is_some() {
+                writeln!(writer, "{}", MessageCodeFrame { message })?;
             }
         }
 
@@ -144,6 +110,95 @@ impl Display for RuleCodeAndBody<'_> {
                 body = self.message_kind.body,
             )
         }
+    }
+}
+
+pub(super) struct MessageCodeFrame<'a> {
+    pub message: &'a Message,
+}
+
+impl Display for MessageCodeFrame<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let Message {
+            kind,
+            source,
+            location,
+            end_location,
+            ..
+        } = self.message;
+
+        if let Some(source_code) = source {
+            let suggestion = kind.suggestion.as_deref();
+            let footer = if suggestion.is_some() {
+                vec![Annotation {
+                    id: None,
+                    label: suggestion,
+                    annotation_type: AnnotationType::Help,
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let source_code_start =
+                source_code.line_start(OneIndexed::new(location.row()).unwrap());
+
+            let source_code_end = source_code.line_start(
+                OneIndexed::new(
+                    end_location
+                        .row()
+                        .saturating_add(1)
+                        .min(source_code.line_count() + 1),
+                )
+                .unwrap(),
+            );
+
+            let source_text =
+                &source_code.text()[TextRange::new(source_code_start, source_code_end)];
+
+            let content_range = source_code.text_range(Range::new(
+                // Subtract 1 because message column indices are 1 based but the index columns are 1 based.
+                Location::new(location.row(), location.column().saturating_sub(1)),
+                Location::new(end_location.row(), end_location.column().saturating_sub(1)),
+            ));
+
+            let annotation_length = &source_text[content_range - source_code_start]
+                .chars()
+                .count();
+
+            let label = kind.rule().noqa_code().to_string();
+
+            let snippet = Snippet {
+                title: None,
+                slices: vec![Slice {
+                    source: source_text,
+                    line_start: location.row(),
+                    annotations: vec![SourceAnnotation {
+                        label: &label,
+                        annotation_type: AnnotationType::Error,
+                        range: (
+                            location.column() - 1,
+                            location.column() + annotation_length - 1,
+                        ),
+                    }],
+                    // The origin (file name, line number, and column number) is already encoded
+                    // in the `label`.
+                    origin: None,
+                    fold: false,
+                }],
+                footer,
+                opt: FormatOptions {
+                    #[cfg(test)]
+                    color: false,
+                    #[cfg(not(test))]
+                    color: colored::control::SHOULD_COLORIZE.should_colorize(),
+                    ..FormatOptions::default()
+                },
+            };
+
+            writeln!(f, "{message}", message = DisplayList::from(snippet))?;
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/ruff/src/rules/flake8_return/helpers.rs
+++ b/crates/ruff/src/rules/flake8_return/helpers.rs
@@ -29,7 +29,7 @@ pub fn result_exists(returns: &[(&Stmt, Option<&Expr>)]) -> bool {
 /// This method assumes that the statement is the last statement in its body; specifically, that
 /// the statement isn't followed by a semicolon, followed by a multi-line statement.
 pub fn end_of_last_statement(stmt: &Stmt, locator: &Locator) -> Location {
-    let contents = locator.skip(stmt.end_location.unwrap());
+    let contents = locator.after(stmt.end_location.unwrap());
 
     // End-of-file, so just return the end of the statement.
     if contents.is_empty() {

--- a/crates/ruff/src/rules/isort/helpers.rs
+++ b/crates/ruff/src/rules/isort/helpers.rs
@@ -62,7 +62,7 @@ pub fn has_comment_break(stmt: &Stmt, locator: &Locator) -> bool {
     //   # Direct comment.
     //   def f(): pass
     let mut seen_blank = false;
-    for line in locator.take(stmt.location).universal_newlines().rev() {
+    for line in locator.up_to(stmt.location).universal_newlines().rev() {
         let line = line.trim();
         if seen_blank {
             if line.starts_with('#') {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -66,7 +66,7 @@ fn match_token_after<F, T>(located: &Located<T>, locator: &Locator, f: F) -> Ran
 where
     F: Fn(Tok) -> bool,
 {
-    let contents = locator.skip(located.location);
+    let contents = locator.after(located.location);
 
     // Track the bracket depth.
     let mut par_count = 0;
@@ -129,7 +129,7 @@ fn match_token<F, T>(located: &Located<T>, locator: &Locator, f: F) -> Range
 where
     F: Fn(Tok) -> bool,
 {
-    let contents = locator.skip(located.location);
+    let contents = locator.after(located.location);
 
     // Track the bracket depth.
     let mut par_count = 0;

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -142,7 +142,7 @@ pub fn remove_import_members(contents: &str, members: &[&str]) -> String {
     }
 
     // Add the remaining content.
-    let slice = locator.skip(last_pos);
+    let slice = locator.after(last_pos);
     output.push_str(slice);
     output
 }

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -118,7 +118,7 @@ pub fn lint_path(
     {
         let metadata = path.metadata()?;
         if let Some((messages, imports)) =
-            cache::get(path, package.as_ref(), &metadata, settings, autofix.into())
+            cache::get(path, package, &metadata, settings, autofix.into())
         {
             debug!("Cache hit for: {}", path.display());
             return Ok(Diagnostics::new(messages, imports));
@@ -207,14 +207,14 @@ pub fn lint_path(
 
         // Purge the cache.
         if let Some(metadata) = metadata {
-            cache::del(path, package.as_ref(), &metadata, settings, autofix.into());
+            cache::del(path, package, &metadata, settings, autofix.into());
         }
     } else {
         // Re-populate the cache.
         if let Some(metadata) = metadata {
             cache::set(
                 path,
-                package.as_ref(),
+                package,
                 &metadata,
                 settings,
                 autofix.into(),

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -897,7 +897,7 @@ pub fn match_trailing_comment<T>(located: &Located<T>, locator: &Locator) -> Opt
 
 /// Return the number of trailing empty lines following a statement.
 pub fn count_trailing_lines(stmt: &Stmt, locator: &Locator) -> usize {
-    let suffix = locator.skip(Location::new(stmt.end_location.unwrap().row() + 1, 0));
+    let suffix = locator.after(Location::new(stmt.end_location.unwrap().row() + 1, 0));
     suffix
         .lines()
         .take_while(|line| line.trim().is_empty())
@@ -906,7 +906,7 @@ pub fn count_trailing_lines(stmt: &Stmt, locator: &Locator) -> usize {
 
 /// Return the range of the first parenthesis pair after a given [`Location`].
 pub fn match_parens(start: Location, locator: &Locator) -> Option<Range> {
-    let contents = locator.skip(start);
+    let contents = locator.after(start);
     let mut fix_start = None;
     let mut fix_end = None;
     let mut count: usize = 0;

--- a/crates/ruff_python_ast/src/source_code/line_index.rs
+++ b/crates/ruff_python_ast/src/source_code/line_index.rs
@@ -83,12 +83,12 @@ impl LineIndex {
     }
 
     /// Return the number of lines in the source code.
-    pub(crate) fn lines_count(&self) -> usize {
+    pub(crate) fn line_count(&self) -> usize {
         self.line_starts().len()
     }
 
     /// Returns the [byte offset](TextSize) for the `line` with the given index.
-    fn line_start(&self, line: OneIndexed, contents: &str) -> TextSize {
+    pub(crate) fn line_start(&self, line: OneIndexed, contents: &str) -> TextSize {
         let row_index = line.to_zero_indexed();
         let starts = self.line_starts();
 
@@ -103,7 +103,7 @@ impl LineIndex {
     /// Returns the [`TextRange`] of the `line` with the given index.
     /// The start points to the first character's [byte offset](TextSize), the end up to, and including
     /// the newline character ending the line (if any).
-    fn line_range(&self, line: OneIndexed, contents: &str) -> TextRange {
+    pub(crate) fn line_range(&self, line: OneIndexed, contents: &str) -> TextRange {
         let starts = self.line_starts();
 
         if starts.len() == line.to_zero_indexed() {
@@ -173,6 +173,11 @@ impl OneIndexed {
     /// Construct a new [`OneIndexed`] from a zero-indexed value
     pub const fn from_zero_indexed(value: usize) -> Self {
         Self(ONE.saturating_add(value))
+    }
+
+    /// Returns the value as a primitive type.
+    pub const fn get(self) -> usize {
+        self.0.get()
     }
 
     /// Return the zero-indexed primitive value for this [`OneIndexed`]
@@ -306,18 +311,18 @@ mod tests {
     #[test]
     fn utf8_index() {
         let index = LineIndex::from_source_text("x = '🫣'");
-        assert_eq!(index.lines_count(), 1);
+        assert_eq!(index.line_count(), 1);
         assert_eq!(index.line_starts(), &[TextSize::from(0)]);
 
         let index = LineIndex::from_source_text("x = '🫣'\n");
-        assert_eq!(index.lines_count(), 2);
+        assert_eq!(index.line_count(), 2);
         assert_eq!(
             index.line_starts(),
             &[TextSize::from(0), TextSize::from(11)]
         );
 
         let index = LineIndex::from_source_text("x = '🫣'\ny = 2\nz = x + y\n");
-        assert_eq!(index.lines_count(), 4);
+        assert_eq!(index.line_count(), 4);
         assert_eq!(
             index.line_starts(),
             &[
@@ -329,7 +334,7 @@ mod tests {
         );
 
         let index = LineIndex::from_source_text("# 🫣\nclass Foo:\n    \"\"\".\"\"\"");
-        assert_eq!(index.lines_count(), 3);
+        assert_eq!(index.line_count(), 3);
         assert_eq!(
             index.line_starts(),
             &[TextSize::from(0), TextSize::from(7), TextSize::from(18)]
@@ -340,7 +345,7 @@ mod tests {
     fn utf8_carriage_return() {
         let contents = "x = '🫣'\ry = 3";
         let index = LineIndex::from_source_text(contents);
-        assert_eq!(index.lines_count(), 2);
+        assert_eq!(index.line_count(), 2);
         assert_eq!(
             index.line_starts(),
             &[TextSize::from(0), TextSize::from(11)]
@@ -365,7 +370,7 @@ mod tests {
     fn utf8_carriage_return_newline() {
         let contents = "x = '🫣'\r\ny = 3";
         let index = LineIndex::from_source_text(contents);
-        assert_eq!(index.lines_count(), 2);
+        assert_eq!(index.line_count(), 2);
         assert_eq!(
             index.line_starts(),
             &[TextSize::from(0), TextSize::from(12)]

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -5,12 +5,16 @@ mod locator;
 mod stylist;
 
 pub use crate::source_code::line_index::{LineIndex, OneIndexed};
+use crate::types::Range;
 pub use generator::Generator;
 pub use indexer::Indexer;
 pub use locator::Locator;
+use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser as parser;
+use rustpython_parser::ast::Location;
 use rustpython_parser::{lexer, Mode, ParseError};
 
+use std::sync::Arc;
 pub use stylist::{LineEnding, Stylist};
 
 /// Run round-trip source code generation on a given Python code.
@@ -23,3 +27,214 @@ pub fn round_trip(code: &str, source_path: &str) -> Result<String, ParseError> {
     generator.unparse_suite(&python_ast);
     Ok(generator.generate())
 }
+
+/// Gives access to the source code of a file and allows mapping between [`Location`] and byte offsets.
+#[derive(Debug)]
+pub struct SourceCode<'src, 'index> {
+    text: &'src str,
+    index: &'index LineIndex,
+}
+
+impl<'src, 'index> SourceCode<'src, 'index> {
+    pub fn new(content: &'src str, index: &'index LineIndex) -> Self {
+        Self {
+            text: content,
+            index,
+        }
+    }
+
+    /// Take the source code up to the given [`Location`].
+    pub fn up_to(&self, location: Location) -> &'src str {
+        let offset = self.index.location_offset(location, self.text);
+        &self.text[TextRange::up_to(offset)]
+    }
+
+    /// Take the source code after the given [`Location`].
+    pub fn after(&self, location: Location) -> &'src str {
+        let offset = self.index.location_offset(location, self.text);
+        &self.text[usize::from(offset)..]
+    }
+
+    /// Take the source code between the given [`Range`].
+    pub fn slice<R: Into<Range>>(&self, range: R) -> &'src str {
+        let range = self.text_range(range);
+        &self.text[range]
+    }
+
+    /// Converts a [`Location`] range to a byte offset range
+    pub fn text_range<R: Into<Range>>(&self, range: R) -> TextRange {
+        let range = range.into();
+        let start = self.index.location_offset(range.location, self.text);
+        let end = self.index.location_offset(range.end_location, self.text);
+        TextRange::new(start, end)
+    }
+
+    /// Return the byte offset of the given [`Location`].
+    pub fn offset(&self, location: Location) -> TextSize {
+        self.index.location_offset(location, self.text)
+    }
+
+    pub fn line_start(&self, line: OneIndexed) -> TextSize {
+        self.index.line_start(line, self.text)
+    }
+
+    pub fn line_range(&self, line: OneIndexed) -> TextRange {
+        self.index.line_range(line, self.text)
+    }
+
+    /// Returns a string with the lines spawning between location and end location.
+    pub fn lines(&self, range: Range) -> &'src str {
+        let start_line = self
+            .index
+            .line_range(OneIndexed::new(range.location.row()).unwrap(), self.text);
+
+        let end_line = self.index.line_range(
+            OneIndexed::new(range.end_location.row()).unwrap(),
+            self.text,
+        );
+
+        &self.text[TextRange::new(start_line.start(), end_line.end())]
+    }
+
+    /// Returns the source text of the line with the given index
+    #[inline]
+    pub fn line_text(&self, index: OneIndexed) -> &'src str {
+        let range = self.index.line_range(index, self.text);
+        &self.text[range]
+    }
+
+    pub fn text(&self) -> &'src str {
+        self.text
+    }
+
+    #[inline]
+    pub fn line_count(&self) -> usize {
+        self.index.line_count()
+    }
+
+    pub fn to_source_code_buf(&self) -> SourceCodeBuf {
+        self.to_owned()
+    }
+
+    pub fn to_owned(&self) -> SourceCodeBuf {
+        SourceCodeBuf::new(self.text, self.index.clone())
+    }
+}
+
+impl PartialEq<Self> for SourceCode<'_, '_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+    }
+}
+
+impl Eq for SourceCode<'_, '_> {}
+
+impl PartialEq<SourceCodeBuf> for SourceCode<'_, '_> {
+    fn eq(&self, other: &SourceCodeBuf) -> bool {
+        self.text == &*other.text
+    }
+}
+
+/// Gives access to the source code of a file and allows mapping between [`Location`] and byte offsets.
+///
+/// This is the owned pendant to [`SourceCode`]. Cloning only requires bumping reference counters.
+#[derive(Clone, Debug)]
+pub struct SourceCodeBuf {
+    text: Arc<str>,
+    index: LineIndex,
+}
+
+impl SourceCodeBuf {
+    pub fn new(content: &str, index: LineIndex) -> Self {
+        Self {
+            text: Arc::from(content),
+            index,
+        }
+    }
+
+    /// Creates the [`LineIndex`] for `text` and returns the [`SourceCodeBuf`].
+    pub fn from_content(text: &str) -> Self {
+        Self::new(text, LineIndex::from_source_text(text))
+    }
+
+    #[inline]
+    fn as_source_code(&self) -> SourceCode {
+        SourceCode {
+            text: &self.text,
+            index: &self.index,
+        }
+    }
+
+    /// Take the source code up to the given [`Location`].
+    pub fn up_to(&self, location: Location) -> &str {
+        self.as_source_code().up_to(location)
+    }
+
+    /// Take the source code after the given [`Location`].
+    pub fn after(&self, location: Location) -> &str {
+        self.as_source_code().after(location)
+    }
+
+    /// Take the source code between the given [`Range`].
+    #[inline]
+    pub fn slice<R: Into<Range>>(&self, range: R) -> &str {
+        self.as_source_code().slice(range)
+    }
+
+    /// Converts a [`Location`] range to a byte offset range
+    #[inline]
+    pub fn text_range<R: Into<Range>>(&self, range: R) -> TextRange {
+        self.as_source_code().text_range(range)
+    }
+
+    #[inline]
+    pub fn line_range(&self, line: OneIndexed) -> TextRange {
+        self.as_source_code().line_range(line)
+    }
+
+    /// Return the byte offset of the given [`Location`].
+    #[inline]
+    pub fn offset(&self, location: Location) -> TextSize {
+        self.as_source_code().offset(location)
+    }
+
+    #[inline]
+    pub fn line_start(&self, line: OneIndexed) -> TextSize {
+        self.as_source_code().line_start(line)
+    }
+
+    #[inline]
+    pub fn lines(&self, range: Range) -> &str {
+        self.as_source_code().lines(range)
+    }
+
+    /// Returns the source text of the line with the given index
+    #[inline]
+    pub fn line_text(&self, index: OneIndexed) -> &str {
+        self.as_source_code().line_text(index)
+    }
+
+    #[inline]
+    pub fn line_count(&self) -> usize {
+        self.index.line_count()
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+impl PartialEq<Self> for SourceCodeBuf {
+    // The same source text should have the same index
+    fn eq(&self, other: &Self) -> bool {
+        self.text == other.text
+    }
+}
+
+impl PartialEq<SourceCode<'_, '_>> for SourceCodeBuf {
+    fn eq(&self, other: &SourceCode<'_, '_>) -> bool {
+        &*self.text == other.text
+    }
+}
+
+impl Eq for SourceCodeBuf {}

--- a/crates/ruff_python_formatter/src/cst/helpers.rs
+++ b/crates/ruff_python_formatter/src/cst/helpers.rs
@@ -125,7 +125,7 @@ pub fn expand_indented_block(
 /// Return true if the `orelse` block of an `if` statement is an `elif` statement.
 pub fn is_elif(orelse: &[rustpython_parser::ast::Stmt], locator: &Locator) -> bool {
     if orelse.len() == 1 && matches!(orelse[0].node, rustpython_parser::ast::StmtKind::If { .. }) {
-        let contents = locator.skip(orelse[0].location);
+        let contents = locator.after(orelse[0].location);
         if contents.starts_with("elif") {
             return true;
         }


### PR DESCRIPTION
This PR stores the whole source text on `Message` so that it becomes possible to build up a code frame with dynamic context or show a diff for the code changes. 

The PR introduces two new data structures

* `SourceCode`: Similar to `Locator`. It stores a reference to the source text and a reference to a `LineIndex`. The difference to `Locator` is that the `LineIndex` is eagerly computed when creating the `SourceCode`
* `SourceCodeBuf`: A owned version of `SourceCode` that uses an `Arc<str>` for the source code to be cheaply cloneable. 

`SourceCode` is used by both `SourceCodeBuf` and `Locator` to implement the "resolution" logic that is shared between all three structs. 

## Serialization

The `Message` serialization in ruff's cache skips over the `source` field when serializing the messages to avoid serializing the content `n` times. Instead, the serializer computes the unique contents using the file name and stores each content only once. 

## Benchmark

This change improves/regresses the runtime of some configurations slightly.

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e   ` | 37.5 ± 1.9 | 33.6 | 40.9 | 1.00 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e   ` | 37.6 ± 1.6 | 33.9 | 40.7 | 1.00 ± 0.07 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 209.1 ± 3.2 | 201.9 | 213.5 | 5.57 ± 0.29 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 212.2 ± 5.5 | 202.7 | 223.5 | 5.65 ± 0.32 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e  --select=ALL ` | 439.5 ± 10.3 | 422.0 | 456.2 | 11.71 ± 0.64 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e  --select=ALL ` | 431.3 ± 9.4 | 410.9 | 447.3 | 11.49 ± 0.62 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 745.9 ± 14.2 | 722.4 | 768.2 | 19.87 ± 1.05 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 749.6 ± 9.4 | 738.5 | 763.2 | 19.97 ± 1.02 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e   --show-source` | 66.9 ± 2.2 | 63.7 | 73.8 | 1.78 ± 0.11 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e   --show-source` | 66.4 ± 2.2 | 63.0 | 71.7 | 1.77 ± 0.11 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache  --show-source` | 234.1 ± 4.2 | 227.4 | 240.4 | 6.24 ± 0.33 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache  --show-source` | 235.9 ± 6.0 | 229.0 | 249.0 | 6.28 ± 0.35 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e  --select=ALL --show-source` | 1047.8 ± 16.1 | 1021.9 | 1073.2 | 27.91 ± 1.45 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e  --select=ALL --show-source` | 1041.8 ± 10.1 | 1024.6 | 1056.5 | 27.75 ± 1.40 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL --show-source` | 1359.4 ± 19.6 | 1334.5 | 1386.7 | 36.21 ± 1.87 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL --show-source` | 1358.1 ± 30.6 | 1335.4 | 1435.3 | 36.17 ± 1.97 |



