### PR TITLE
Render code frame with context

### DIFF
--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -104,7 +104,7 @@ impl Display for DisplayGroupedMessage<'_> {
 
         writeln!(
             f,
-            "{row}{sep}{col}{col_padding}  {code_and_body}",
+            "{row}{sep}{col}{col_padding} {code_and_body}",
             sep = ":".cyan(),
             col_padding = " ".repeat(self.column_length - num_digits(message.location.column())),
             code_and_body = RuleCodeAndBody {

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -132,6 +132,7 @@ mod tests {
     pub(super) fn create_messages() -> Vec<Message> {
         let fib = r#"import os
 
+
 def fibonacci(n):
     """Compute the nth number in the Fibonacci sequence."""
     x = 1
@@ -141,7 +142,7 @@ def fibonacci(n):
         return 1
     else:
         return fibonacci(n - 1) + fibonacci(n - 2)
-        "#;
+"#;
 
         let unused_import = Diagnostic::new(
             UnusedImport {
@@ -158,11 +159,11 @@ def fibonacci(n):
             UnusedVariable {
                 name: "x".to_string(),
             },
-            Range::new(Location::new(5, 4), Location::new(5, 5)),
+            Range::new(Location::new(6, 4), Location::new(6, 5)),
         )
         .with_fix(Fix::new(vec![Edit::deletion(
-            Location::new(5, 4),
-            Location::new(5, 9),
+            Location::new(6, 4),
+            Location::new(6, 9),
         )]));
 
         let file_2 = r#"if a == 1: pass"#;

--- a/crates/ruff/src/message/snapshots/ruff__message__azure__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__azure__tests__output.snap
@@ -3,6 +3,6 @@ source: crates/ruff/src/message/azure.rs
 expression: content
 ---
 ##vso[task.logissue type=error;sourcepath=fib.py;linenumber=1;columnnumber=8;code=F401;]`os` imported but unused
-##vso[task.logissue type=error;sourcepath=fib.py;linenumber=5;columnnumber=5;code=F841;]Local variable `x` is assigned to but never used
+##vso[task.logissue type=error;sourcepath=fib.py;linenumber=6;columnnumber=5;code=F841;]Local variable `x` is assigned to but never used
 ##vso[task.logissue type=error;sourcepath=undef.py;linenumber=1;columnnumber=4;code=F821;]Undefined name `a`
 

--- a/crates/ruff/src/message/snapshots/ruff__message__github__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__github__tests__output.snap
@@ -3,6 +3,6 @@ source: crates/ruff/src/message/github.rs
 expression: content
 ---
 ::error title=Ruff (F401),file=fib.py,line=1,col=8,endLine=1,endColumn=10::fib.py:1:8: F401 `os` imported but unused
-::error title=Ruff (F841),file=fib.py,line=5,col=5,endLine=5,endColumn=6::fib.py:5:5: F841 Local variable `x` is assigned to but never used
+::error title=Ruff (F841),file=fib.py,line=6,col=5,endLine=6,endColumn=6::fib.py:6:5: F841 Local variable `x` is assigned to but never used
 ::error title=Ruff (F821),file=undef.py,line=1,col=4,endLine=1,endColumn=5::undef.py:1:4: F821 Undefined name `a`
 

--- a/crates/ruff/src/message/snapshots/ruff__message__gitlab__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__gitlab__tests__output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ruff/src/message/gitlab.rs
-expression: output
+expression: redact_fingerprint(&content)
 ---
 [
   {
@@ -22,8 +22,8 @@ expression: output
     "location": {
       "path": "fib.py",
       "lines": {
-        "begin": 5,
-        "end": 5
+        "begin": 6,
+        "end": 6
       }
     }
   },

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
@@ -10,12 +10,16 @@ fib.py:
     |
     = help: Remove unused import: `os`
 
-  5:5  F841 Local variable `x` is assigned to but never used
-    |
-  5 |     x = 1
-    |     ^ F841
-    |
-    = help: Remove assignment to unused variable `x`
+  6:5  F841 Local variable `x` is assigned to but never used
+     |
+   6 | def fibonacci(n):
+   7 |     """Compute the nth number in the Fibonacci sequence."""
+   8 |     x = 1
+     |     ^ F841
+   9 |     if n == 0:
+  10 |         return 0
+     |
+     = help: Remove assignment to unused variable `x`
 
 
 undef.py:

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
@@ -3,14 +3,14 @@ source: crates/ruff/src/message/grouped.rs
 expression: content
 ---
 fib.py:
-  1:8  F401 `os` imported but unused
+  1:8 F401 `os` imported but unused
     |
   1 | import os
     |        ^^ F401
     |
     = help: Remove unused import: `os`
 
-  6:5  F841 Local variable `x` is assigned to but never used
+  6:5 F841 Local variable `x` is assigned to but never used
      |
    6 | def fibonacci(n):
    7 |     """Compute the nth number in the Fibonacci sequence."""
@@ -23,7 +23,7 @@ fib.py:
 
 
 undef.py:
-  1:4  F821 Undefined name `a`
+  1:4 F821 Undefined name `a`
     |
   1 | if a == 1: pass
     |    ^ F821

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__fix_status.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__fix_status.snap
@@ -3,14 +3,14 @@ source: crates/ruff/src/message/grouped.rs
 expression: content
 ---
 fib.py:
-  1:8  F401 [*] `os` imported but unused
+  1:8 F401 [*] `os` imported but unused
     |
   1 | import os
     |        ^^ F401
     |
     = help: Remove unused import: `os`
 
-  6:5  F841 [*] Local variable `x` is assigned to but never used
+  6:5 F841 [*] Local variable `x` is assigned to but never used
      |
    6 | def fibonacci(n):
    7 |     """Compute the nth number in the Fibonacci sequence."""
@@ -23,7 +23,7 @@ fib.py:
 
 
 undef.py:
-  1:4  F821 Undefined name `a`
+  1:4 F821 Undefined name `a`
     |
   1 | if a == 1: pass
     |    ^ F821

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__fix_status.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__fix_status.snap
@@ -10,12 +10,16 @@ fib.py:
     |
     = help: Remove unused import: `os`
 
-  5:5  F841 [*] Local variable `x` is assigned to but never used
-    |
-  5 |     x = 1
-    |     ^ F841
-    |
-    = help: Remove assignment to unused variable `x`
+  6:5  F841 [*] Local variable `x` is assigned to but never used
+     |
+   6 | def fibonacci(n):
+   7 |     """Compute the nth number in the Fibonacci sequence."""
+   8 |     x = 1
+     |     ^ F841
+   9 |     if n == 0:
+  10 |         return 0
+     |
+     = help: Remove assignment to unused variable `x`
 
 
 undef.py:

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -27,22 +27,22 @@ expression: content
         {
           "content": "",
           "location": {
-            "row": 5,
+            "row": 6,
             "column": 4
           },
           "end_location": {
-            "row": 5,
+            "row": 6,
             "column": 9
           }
         }
       ]
     },
     "location": {
-      "row": 5,
+      "row": 6,
       "column": 5
     },
     "end_location": {
-      "row": 5,
+      "row": 6,
       "column": 6
     },
     "filename": "fib.py",

--- a/crates/ruff/src/message/snapshots/ruff__message__junit__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__junit__tests__output.snap
@@ -8,8 +8,8 @@ expression: content
         <testcase name="org.ruff.F401" classname="fib" line="1" column="8">
             <failure message="`os` imported but unused">line 1, col 8, `os` imported but unused</failure>
         </testcase>
-        <testcase name="org.ruff.F841" classname="fib" line="5" column="5">
-            <failure message="Local variable `x` is assigned to but never used">line 5, col 5, Local variable `x` is assigned to but never used</failure>
+        <testcase name="org.ruff.F841" classname="fib" line="6" column="5">
+            <failure message="Local variable `x` is assigned to but never used">line 6, col 5, Local variable `x` is assigned to but never used</failure>
         </testcase>
     </testsuite>
     <testsuite name="undef.py" tests="1" disabled="0" errors="0" failures="1" package="org.ruff">

--- a/crates/ruff/src/message/snapshots/ruff__message__pylint__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__pylint__tests__output.snap
@@ -3,6 +3,6 @@ source: crates/ruff/src/message/pylint.rs
 expression: content
 ---
 fib.py:1: [F401] `os` imported but unused
-fib.py:5: [F841] Local variable `x` is assigned to but never used
+fib.py:6: [F841] Local variable `x` is assigned to but never used
 undef.py:1: [F821] Undefined name `a`
 

--- a/crates/ruff/src/message/snapshots/ruff__message__text__tests__default.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__text__tests__default.snap
@@ -9,12 +9,16 @@ fib.py:1:8: F401 `os` imported but unused
   |
   = help: Remove unused import: `os`
 
-fib.py:5:5: F841 Local variable `x` is assigned to but never used
-  |
-5 |     x = 1
-  |     ^ F841
-  |
-  = help: Remove assignment to unused variable `x`
+fib.py:6:5: F841 Local variable `x` is assigned to but never used
+   |
+ 6 | def fibonacci(n):
+ 7 |     """Compute the nth number in the Fibonacci sequence."""
+ 8 |     x = 1
+   |     ^ F841
+ 9 |     if n == 0:
+10 |         return 0
+   |
+   = help: Remove assignment to unused variable `x`
 
 undef.py:1:4: F821 Undefined name `a`
   |

--- a/crates/ruff/src/message/snapshots/ruff__message__text__tests__fix_status.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__text__tests__fix_status.snap
@@ -9,12 +9,16 @@ fib.py:1:8: F401 [*] `os` imported but unused
   |
   = help: Remove unused import: `os`
 
-fib.py:5:5: F841 [*] Local variable `x` is assigned to but never used
-  |
-5 |     x = 1
-  |     ^ F841
-  |
-  = help: Remove assignment to unused variable `x`
+fib.py:6:5: F841 [*] Local variable `x` is assigned to but never used
+   |
+ 6 | def fibonacci(n):
+ 7 |     """Compute the nth number in the Fibonacci sequence."""
+ 8 |     x = 1
+   |     ^ F841
+ 9 |     if n == 0:
+10 |         return 0
+   |
+   = help: Remove assignment to unused variable `x`
 
 undef.py:1:4: F821 Undefined name `a`
   |

--- a/crates/ruff_python_ast/src/source_code/line_index.rs
+++ b/crates/ruff_python_ast/src/source_code/line_index.rs
@@ -100,6 +100,20 @@ impl LineIndex {
         }
     }
 
+    /// Returns the [byte offset](TextSize) of the `line`'s end.
+    /// The offset is the end of the line, up to and including the newline character ending the line (if any).
+    pub(crate) fn line_end(&self, line: OneIndexed, contents: &str) -> TextSize {
+        let row_index = line.to_zero_indexed();
+        let starts = self.line_starts();
+
+        // If start-of-line position after last line
+        if row_index.saturating_add(1) >= starts.len() {
+            contents.text_len()
+        } else {
+            starts[row_index + 1]
+        }
+    }
+
     /// Returns the [`TextRange`] of the `line` with the given index.
     /// The start points to the first character's [byte offset](TextSize), the end up to, and including
     /// the newline character ending the line (if any).

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -78,6 +78,10 @@ impl<'src, 'index> SourceCode<'src, 'index> {
         self.index.line_start(line, self.text)
     }
 
+    pub fn line_end(&self, line: OneIndexed) -> TextSize {
+        self.index.line_end(line, self.text)
+    }
+
     pub fn line_range(&self, line: OneIndexed) -> TextRange {
         self.index.line_range(line, self.text)
     }
@@ -196,6 +200,11 @@ impl SourceCodeBuf {
     #[inline]
     pub fn offset(&self, location: Location) -> TextSize {
         self.as_source_code().offset(location)
+    }
+
+    #[inline]
+    pub fn line_end(&self, line: OneIndexed) -> TextSize {
+        self.as_source_code().line_end(line)
     }
 
     #[inline]


### PR DESCRIPTION
This PR changes the `text` and `grouped` emitter to show up to two lines of context before and after the offending code. 

<pre>crates/ruff/resources/test/cpython/Tools/scripts/pysource.py:20:89: E501 Line too long (89 &gt; 88 characters)
<span style="color:#2A7BDE"><b>   |</b></span>
<span style="color:#2A7BDE"><b>20 |</b></span> __author__ = &quot;Oleg Broytmann, Georg Brandl&quot;
<span style="color:#2A7BDE"><b>21 |</b></span> 
<span style="color:#2A7BDE"><b>22 |</b></span> __all__ = [&quot;has_python_ext&quot;, &quot;looks_like_python&quot;, &quot;can_be_compiled&quot;, &quot;walk_python_files&quot;]
<span style="color:#2A7BDE"><b>   |</b></span><span style="color:#F66151"><b>                                                                                         ^</b></span> <span style="color:#F66151"><b>E501</b></span>
<span style="color:#2A7BDE"><b>   |</b></span>

crates/ruff/resources/test/cpython/Tools/scripts/pysource.py:23:1: E401 Multiple imports on one line
<span style="color:#2A7BDE"><b>   |</b></span>
<span style="color:#2A7BDE"><b>23 |</b></span> import os, re
<span style="color:#2A7BDE"><b>   |</b></span><span style="color:#F66151"><b> ^^^^^^^^^^^^^</b></span> <span style="color:#F66151"><b>E401</b></span>
<span style="color:#2A7BDE"><b>24 |</b></span> 
<span style="color:#2A7BDE"><b>25 |</b></span> binary_re = re.compile(br&apos;[\x00-\x08\x0E-\x1F\x7F]&apos;)
<span style="color:#2A7BDE"><b>   |</b></span>

crates/ruff/resources/test/cpython/Tools/scripts/pysource.py:30:13: E701 Multiple statements on one line (colon)
<span style="color:#2A7BDE"><b>   |</b></span>
<span style="color:#2A7BDE"><b>30 |</b></span> def print_debug(msg):
<span style="color:#2A7BDE"><b>31 |</b></span>     if debug: print(msg)
<span style="color:#2A7BDE"><b>   |</b></span><span style="color:#F66151"><b>             ^</b></span> <span style="color:#F66151"><b>E701</b></span>
<span style="color:#2A7BDE"><b>   |</b></span>
</pre>

## Performance

This change significantly impacts performance for projects that have many diagnostics (500k). Running ruff on cpython with all rules and `--show-source` regresses by about 50% when using a cache. I think this is fine. We can decide to limit the diagnostics to show at max 500 (or another arbitrary) number by default that users can override if they want to see more. It's also worth pointing out that the slowest part is still my terminal trying to render all diagnostics :smile: 

* `./target/release/ruff`: This version
* `./ruff-source-code`: base reference (main)

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e   ` | 37.9 ± 1.5 | 34.6 | 41.5 | 1.00 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e   ` | 37.9 ± 1.8 | 33.5 | 42.1 | 1.00 ± 0.06 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 211.2 ± 6.6 | 202.9 | 226.7 | 5.58 ± 0.28 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 214.4 ± 7.7 | 206.3 | 232.4 | 5.66 ± 0.30 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e  --select=ALL ` | 433.3 ± 7.2 | 426.7 | 449.1 | 11.44 ± 0.50 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e  --select=ALL ` | 437.9 ± 9.3 | 426.7 | 452.7 | 11.57 ± 0.52 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 757.8 ± 12.8 | 735.9 | 778.3 | 20.02 ± 0.87 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 765.9 ± 14.3 | 748.2 | 790.1 | 20.23 ± 0.89 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e   --show-source` | 86.6 ± 2.3 | 83.5 | 94.5 | 2.29 ± 0.11 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e   --show-source` | 68.0 ± 2.0 | 65.0 | 72.9 | 1.80 ± 0.09 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache  --show-source` | 254.8 ± 5.0 | 245.4 | 263.3 | 6.73 ± 0.30 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e --no-cache  --show-source` | 244.6 ± 6.7 | 237.2 | 261.4 | 6.46 ± 0.31 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e  --select=ALL --show-source` | 1549.5 ± 12.3 | 1529.1 | 1564.4 | 40.93 ± 1.67 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e  --select=ALL --show-source` | 1079.5 ± 20.9 | 1061.8 | 1134.8 | 28.51 ± 1.27 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL --show-source` | 1896.6 ± 27.4 | 1857.3 | 1934.6 | 50.09 ± 2.13 |
| `./ruff-source-code ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL --show-source` | 1439.7 ± 36.1 | 1401.9 | 1493.6 | 38.03 ± 1.80 |
