### PR TITLE
Introduce SourceFile to avoid cloning the message filename

### DIFF
--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -373,7 +373,7 @@ fn diagnostics_to_messages(
     let file = once_cell::unsync::Lazy::new(|| {
         let mut builder = SourceFileBuilder::new(&path.to_string_lossy());
         if settings.show_source {
-            builder.set_source_code(locator.to_source_code());
+            builder.set_source_code(&locator.to_source_code());
         }
 
         builder.finish()

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::ops::Deref;
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
@@ -10,7 +11,7 @@ use rustpython_parser::ParseError;
 
 use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::imports::ImportMap;
-use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+use ruff_python_ast::source_code::{Indexer, Locator, SourceFileBuilder, Stylist};
 use ruff_python_stdlib::path::is_python_stub_file;
 
 use crate::autofix::fix_file;
@@ -353,33 +354,39 @@ pub fn lint_only(
         autofix,
     );
 
-    // Convert from diagnostics to messages.
-    let path_lossy = path.to_string_lossy();
-
-    result.map(|(messages, imports)| {
-        let source_code = if settings.show_source && !messages.is_empty() {
-            Some(locator.to_source_code_buf())
-        } else {
-            None
-        };
-
+    result.map(|(diagnostics, imports)| {
         (
-            messages
-                .into_iter()
-                .map(|diagnostic| {
-                    let lineno = diagnostic.location.row();
-                    let noqa_row = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
-                    Message::from_diagnostic(
-                        diagnostic,
-                        path_lossy.to_string(),
-                        source_code.clone(),
-                        noqa_row,
-                    )
-                })
-                .collect(),
+            diagnostics_to_messages(diagnostics, path, settings, &locator, &directives),
             imports,
         )
     })
+}
+
+/// Convert from diagnostics to messages.
+fn diagnostics_to_messages(
+    diagnostics: Vec<Diagnostic>,
+    path: &Path,
+    settings: &Settings,
+    locator: &Locator,
+    directives: &Directives,
+) -> Vec<Message> {
+    let file = once_cell::unsync::Lazy::new(|| {
+        let mut builder = SourceFileBuilder::new(&path.to_string_lossy());
+        if settings.show_source {
+            builder.set_source_code(locator.to_source_code());
+        }
+
+        builder.finish()
+    });
+
+    diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            let lineno = diagnostic.location.row();
+            let noqa_row = *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
+            Message::from_diagnostic(diagnostic, file.deref().clone(), noqa_row)
+        })
+        .collect()
 }
 
 /// Generate `Diagnostic`s from source code content, iteratively autofixing
@@ -503,31 +510,10 @@ This indicates a bug in `{}`. If you could open an issue at:
             }
         }
 
-        // Convert to messages.
-        let path_lossy = path.to_string_lossy();
         return Ok(FixerResult {
-            result: result.map(|(messages, imports)| {
-                let source_code = if settings.show_source && !messages.is_empty() {
-                    Some(locator.to_source_code_buf())
-                } else {
-                    None
-                };
-
+            result: result.map(|(diagnostics, imports)| {
                 (
-                    messages
-                        .into_iter()
-                        .map(|diagnostic| {
-                            let lineno = diagnostic.location.row();
-                            let noqa_row =
-                                *directives.noqa_line_for.get(&lineno).unwrap_or(&lineno);
-                            Message::from_diagnostic(
-                                diagnostic,
-                                path_lossy.to_string(),
-                                source_code.clone(),
-                                noqa_row,
-                            )
-                        })
-                        .collect(),
+                    diagnostics_to_messages(diagnostics, path, settings, &locator, &directives),
                     imports,
                 )
             }),

--- a/crates/ruff/src/message/azure.rs
+++ b/crates/ruff/src/message/azure.rs
@@ -15,7 +15,7 @@ impl Emitter for AzureEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            let (line, col) = if context.is_jupyter_notebook(&message.filename) {
+            let (line, col) = if context.is_jupyter_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 (1, 0)
@@ -27,7 +27,7 @@ impl Emitter for AzureEmitter {
                 writer,
                 "##vso[task.logissue type=error\
                         ;sourcepath={filename};linenumber={line};columnnumber={col};code={code};]{body}",
-                filename = message.filename,
+                filename = message.filename(),
                 code = message.kind.rule().noqa_code(),
                 body = message.kind.body,
             )?;

--- a/crates/ruff/src/message/github.rs
+++ b/crates/ruff/src/message/github.rs
@@ -16,7 +16,7 @@ impl Emitter for GithubEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            let (row, column) = if context.is_jupyter_notebook(&message.filename) {
+            let (row, column) = if context.is_jupyter_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 (1, 0)
@@ -29,7 +29,7 @@ impl Emitter for GithubEmitter {
                 "::error title=Ruff \
                          ({code}),file={file},line={row},col={column},endLine={end_row},endColumn={end_column}::",
                 code = message.kind.rule().noqa_code(),
-                file = message.filename,
+                file = message.filename(),
                 row = message.location.row(),
                 column = message.location.column(),
                 end_row = message.end_location.row(),
@@ -39,7 +39,7 @@ impl Emitter for GithubEmitter {
             writeln!(
                 writer,
                 "{path}:{row}:{column}: {code} {body}",
-                path = relativize_path(&message.filename),
+                path = relativize_path(&message.filename()),
                 code = message.kind.rule().noqa_code(),
                 body = message.kind.body,
             )?;

--- a/crates/ruff/src/message/github.rs
+++ b/crates/ruff/src/message/github.rs
@@ -39,7 +39,7 @@ impl Emitter for GithubEmitter {
             writeln!(
                 writer,
                 "{path}:{row}:{column}: {code} {body}",
-                path = relativize_path(&message.filename()),
+                path = relativize_path(message.filename()),
                 code = message.kind.rule().noqa_code(),
                 body = message.kind.body,
             )?;

--- a/crates/ruff/src/message/gitlab.rs
+++ b/crates/ruff/src/message/gitlab.rs
@@ -56,7 +56,7 @@ impl Serialize for SerializedMessages<'_> {
         let mut s = serializer.serialize_seq(Some(self.messages.len()))?;
 
         for message in self.messages {
-            let lines = if self.context.is_jupyter_notebook(&message.filename) {
+            let lines = if self.context.is_jupyter_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 json!({
@@ -71,8 +71,8 @@ impl Serialize for SerializedMessages<'_> {
             };
 
             let path = self.project_dir.as_ref().map_or_else(
-                || relativize_path(&message.filename),
-                |project_dir| relativize_path_to(&message.filename, project_dir),
+                || relativize_path(message.filename()),
+                |project_dir| relativize_path_to(message.filename(), project_dir),
             );
 
             let value = json!({
@@ -99,8 +99,7 @@ fn fingerprint(message: &Message) -> String {
         location,
         end_location,
         fix: _fix,
-        filename,
-        source: _source,
+        file,
         noqa_row: _noqa_row,
     } = message;
 
@@ -111,7 +110,7 @@ fn fingerprint(message: &Message) -> String {
     location.column().hash(&mut hasher);
     end_location.row().hash(&mut hasher);
     end_location.column().hash(&mut hasher);
-    filename.hash(&mut hasher);
+    file.name().hash(&mut hasher);
 
     format!("{:x}", hasher.finish())
 }

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -57,7 +57,7 @@ impl Emitter for GroupedEmitter {
                         show_fix_status: self.show_fix_status,
                         row_length,
                         column_length,
-                        jupyter_index: context.jupyter_index(&message.filename),
+                        jupyter_index: context.jupyter_index(message.filename()),
                     }
                 )?;
             }

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -49,7 +49,7 @@ impl Serialize for ExpandedMessages<'_> {
                 "fix": fix,
                 "location": message.location,
                 "end_location": message.end_location,
-                "filename": message.filename,
+                "filename": message.filename(),
                 "noqa_row": message.noqa_row
             });
 

--- a/crates/ruff/src/message/junit.rs
+++ b/crates/ruff/src/message/junit.rs
@@ -25,7 +25,7 @@ impl Emitter for JunitEmitter {
             for message in messages {
                 let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
                 status.set_message(message.kind.body.clone());
-                let (row, col) = if context.is_jupyter_notebook(&message.filename) {
+                let (row, col) = if context.is_jupyter_notebook(message.filename()) {
                     // We can't give a reasonable location for the structured formats,
                     // so we show one that's clearly a fallback
                     (1, 0)

--- a/crates/ruff/src/message/pylint.rs
+++ b/crates/ruff/src/message/pylint.rs
@@ -16,7 +16,7 @@ impl Emitter for PylintEmitter {
         context: &EmitterContext,
     ) -> anyhow::Result<()> {
         for message in messages {
-            let row = if context.is_jupyter_notebook(&message.filename) {
+            let row = if context.is_jupyter_notebook(message.filename()) {
                 // We can't give a reasonable location for the structured formats,
                 // so we show one that's clearly a fallback
                 1
@@ -27,7 +27,7 @@ impl Emitter for PylintEmitter {
             writeln!(
                 writer,
                 "{path}:{row}: [{code}] {body}",
-                path = relativize_path(&message.filename),
+                path = relativize_path(message.filename()),
                 code = message.kind.rule().noqa_code(),
                 body = message.kind.body,
             )?;

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -35,12 +35,13 @@ impl Emitter for TextEmitter {
             write!(
                 writer,
                 "{path}{sep}",
-                path = relativize_path(&message.filename).bold(),
+                path = relativize_path(message.filename()).bold(),
                 sep = ":".cyan(),
             )?;
 
             // Check if we're working on a jupyter notebook and translate positions with cell accordingly
-            let (row, col) = if let Some(jupyter_index) = context.jupyter_index(&message.filename) {
+            let (row, col) = if let Some(jupyter_index) = context.jupyter_index(message.filename())
+            {
                 write!(
                     writer,
                     "cell {cell}{sep}",
@@ -66,7 +67,7 @@ impl Emitter for TextEmitter {
                 }
             )?;
 
-            if message.source.is_some() {
+            if message.file.source_code().is_some() {
                 writeln!(writer, "{}", MessageCodeFrame { message })?;
             }
         }
@@ -121,13 +122,13 @@ impl Display for MessageCodeFrame<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let Message {
             kind,
-            source,
+            file,
             location,
             end_location,
             ..
         } = self.message;
 
-        if let Some(source_code) = source {
+        if let Some(source_code) = file.source_code() {
             let suggestion = kind.suggestion.as_deref();
             let footer = if suggestion.is_some() {
                 vec![Annotation {

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -16,6 +16,7 @@ use ruff::settings::{flags, AllSettings};
 use ruff::{fs, packaging, resolver, warn_user_once, IOError, Range};
 use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::imports::ImportMap;
+use ruff_python_ast::source_code::SourceFileBuilder;
 
 use crate::args::Overrides;
 use crate::cache;
@@ -116,14 +117,15 @@ pub fn run(
                     );
                     let settings = resolver.resolve(path, pyproject_strategy);
                     if settings.rules.enabled(Rule::IOError) {
+                        let file = SourceFileBuilder::new(&path.to_string_lossy()).finish();
+
                         Diagnostics::new(
                             vec![Message::from_diagnostic(
                                 Diagnostic::new(
                                     IOError { message },
                                     Range::new(Location::default(), Location::default()),
                                 ),
-                                format!("{}", path.display()),
-                                None,
+                                file,
                                 1,
                             )],
                             ImportMap::default(),

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -18,6 +18,7 @@ use ruff::linter::{lint_fix, lint_only, FixTable, FixerResult, LinterResult};
 use ruff::message::Message;
 use ruff::settings::{flags, AllSettings, Settings};
 use ruff_python_ast::imports::ImportMap;
+use ruff_python_ast::source_code::SourceFileBuilder;
 
 use crate::cache;
 
@@ -85,8 +86,7 @@ fn load_jupyter_notebook(path: &Path) -> Result<(String, JupyterIndex), Box<Diag
             return Err(Box::new(Diagnostics {
                 messages: vec![Message::from_diagnostic(
                     *diagnostic,
-                    path.to_string_lossy().to_string(),
-                    None,
+                    SourceFileBuilder::new(&path.to_string_lossy()).finish(),
                     1,
                 )],
                 ..Diagnostics::default()

--- a/crates/ruff_python_ast/src/source_code/locator.rs
+++ b/crates/ruff_python_ast/src/source_code/locator.rs
@@ -1,7 +1,7 @@
 //! Struct used to efficiently slice source code at (row, column) Locations.
 
 use crate::source_code::line_index::LineIndex;
-use crate::source_code::{SourceCode, SourceCodeBuf};
+use crate::source_code::SourceCode;
 use once_cell::unsync::OnceCell;
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::Location;
@@ -26,40 +26,36 @@ impl<'a> Locator<'a> {
             .get_or_init(|| LineIndex::from_source_text(self.contents))
     }
 
-    fn source_code(&self) -> SourceCode<'a, '_> {
+    #[inline]
+    pub fn to_source_code(&self) -> SourceCode<'a, '_> {
         SourceCode {
             index: self.get_or_init_index(),
             text: self.contents,
         }
     }
 
-    #[inline]
-    pub fn to_source_code_buf(&self) -> SourceCodeBuf {
-        self.source_code().to_owned()
-    }
-
     /// Take the source code up to the given [`Location`].
     #[inline]
     pub fn up_to(&self, location: Location) -> &'a str {
-        self.source_code().up_to(location)
+        self.to_source_code().up_to(location)
     }
 
     /// Take the source code after the given [`Location`].
     #[inline]
     pub fn after(&self, location: Location) -> &'a str {
-        self.source_code().after(location)
+        self.to_source_code().after(location)
     }
 
     /// Take the source code between the given [`Range`].
     #[inline]
     pub fn slice<R: Into<Range>>(&self, range: R) -> &'a str {
-        self.source_code().slice(range)
+        self.to_source_code().slice(range)
     }
 
     /// Return the byte offset of the given [`Location`].
     #[inline]
     pub fn offset(&self, location: Location) -> TextSize {
-        self.source_code().offset(location)
+        self.to_source_code().offset(location)
     }
 
     /// Return the underlying source code.

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -14,7 +14,6 @@ use rustpython_parser as parser;
 use rustpython_parser::ast::Location;
 use rustpython_parser::{lexer, Mode, ParseError};
 use std::fmt::{Debug, Formatter};
-use std::ops::Deref;
 
 use std::sync::Arc;
 pub use stylist::{LineEnding, Stylist};
@@ -155,13 +154,13 @@ impl SourceFileBuilder {
     /// Consumes `self` and returns a builder for a file with the source text and the [`LineIndex`] copied
     /// from `source`.
     #[must_use]
-    pub fn source_code(mut self, source: SourceCode) -> Self {
+    pub fn source_code(mut self, source: &SourceCode) -> Self {
         self.set_source_code(source);
         self
     }
 
     /// Copies the source text and [`LineIndex`] from `source`.
-    pub fn set_source_code(&mut self, source: SourceCode) {
+    pub fn set_source_code(&mut self, source: &SourceCode) {
         self.code = Some(FileSourceCode {
             text: Box::from(source.text()),
             index: source.index.clone(),
@@ -171,7 +170,7 @@ impl SourceFileBuilder {
     /// Consumes `self` and returns a builder for a file with the source text `text`. Builds the [`LineIndex`] from `text`.
     #[must_use]
     pub fn source_text(self, text: &str) -> Self {
-        self.source_code(SourceCode::new(text, &LineIndex::from_source_text(text)))
+        self.source_code(&SourceCode::new(text, &LineIndex::from_source_text(text)))
     }
 
     /// Consumes `self` and returns a builder for a file with the source text `text`. Builds the [`LineIndex`] from `text`.
@@ -233,10 +232,10 @@ impl SourceFile {
         })
     }
 
-    /// Returns `Some` with the source text if set, or `None.
+    /// Returns `Some` with the source text if set, or `None`.
     #[inline]
     pub fn source_text(&self) -> Option<&str> {
-        self.inner.code.as_ref().map(|code| code.text.deref())
+        self.inner.code.as_ref().map(|code| &*code.text)
     }
 }
 

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -13,6 +13,8 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser as parser;
 use rustpython_parser::ast::Location;
 use rustpython_parser::{lexer, Mode, ParseError};
+use std::fmt::{Debug, Formatter};
+use std::ops::Deref;
 
 use std::sync::Arc;
 pub use stylist::{LineEnding, Stylist};
@@ -107,21 +109,15 @@ impl<'src, 'index> SourceCode<'src, 'index> {
         &self.text[range]
     }
 
+    /// Returns the source text
     pub fn text(&self) -> &'src str {
         self.text
     }
 
+    /// Returns the number of lines
     #[inline]
     pub fn line_count(&self) -> usize {
         self.index.line_count()
-    }
-
-    pub fn to_source_code_buf(&self) -> SourceCodeBuf {
-        self.to_owned()
-    }
-
-    pub fn to_owned(&self) -> SourceCodeBuf {
-        SourceCodeBuf::new(self.text, self.index.clone())
     }
 }
 
@@ -133,117 +129,133 @@ impl PartialEq<Self> for SourceCode<'_, '_> {
 
 impl Eq for SourceCode<'_, '_> {}
 
-impl PartialEq<SourceCodeBuf> for SourceCode<'_, '_> {
-    fn eq(&self, other: &SourceCodeBuf) -> bool {
-        self.text == &*other.text
+/// A Builder for constructing a [`SourceFile`]
+pub struct SourceFileBuilder {
+    name: Box<str>,
+    code: Option<FileSourceCode>,
+}
+
+impl SourceFileBuilder {
+    /// Creates a new builder for a file named `name`.
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: Box::from(name),
+            code: None,
+        }
+    }
+
+    /// Creates a enw builder for a file named `name`
+    pub fn from_string(name: String) -> Self {
+        Self {
+            name: Box::from(name),
+            code: None,
+        }
+    }
+
+    /// Consumes `self` and returns a builder for a file with the source text and the [`LineIndex`] copied
+    /// from `source`.
+    #[must_use]
+    pub fn source_code(mut self, source: SourceCode) -> Self {
+        self.set_source_code(source);
+        self
+    }
+
+    /// Copies the source text and [`LineIndex`] from `source`.
+    pub fn set_source_code(&mut self, source: SourceCode) {
+        self.code = Some(FileSourceCode {
+            text: Box::from(source.text()),
+            index: source.index.clone(),
+        });
+    }
+
+    /// Consumes `self` and returns a builder for a file with the source text `text`. Builds the [`LineIndex`] from `text`.
+    #[must_use]
+    pub fn source_text(self, text: &str) -> Self {
+        self.source_code(SourceCode::new(text, &LineIndex::from_source_text(text)))
+    }
+
+    /// Consumes `self` and returns a builder for a file with the source text `text`. Builds the [`LineIndex`] from `text`.
+    #[must_use]
+    pub fn source_text_string(mut self, text: String) -> Self {
+        self.set_source_text_string(text);
+        self
+    }
+
+    /// Copies the source text `text` and builds the [`LineIndex`] from `text`.
+    pub fn set_source_text_string(&mut self, text: String) {
+        self.code = Some(FileSourceCode {
+            index: LineIndex::from_source_text(&text),
+            text: Box::from(text),
+        });
+    }
+
+    /// Consumes `self` and returns the [`SourceFile`].
+    pub fn finish(self) -> SourceFile {
+        SourceFile {
+            inner: Arc::new(SourceFileInner {
+                name: self.name,
+                code: self.code,
+            }),
+        }
     }
 }
 
-/// Gives access to the source code of a file and allows mapping between [`Location`] and byte offsets.
+/// A source file that is identified by its name. Optionally stores the source code and [`LineIndex`].
 ///
-/// This is the owned pendant to [`SourceCode`]. Cloning only requires bumping reference counters.
-#[derive(Clone, Debug)]
-pub struct SourceCodeBuf {
-    text: Arc<str>,
+/// Cloning a [`SourceFile`] is cheap, because it only requires bumping a reference count.
+#[derive(Clone, Eq, PartialEq)]
+pub struct SourceFile {
+    inner: Arc<SourceFileInner>,
+}
+
+impl Debug for SourceFile {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SourceFile")
+            .field("name", &self.name())
+            .field("code", &self.source_code())
+            .finish()
+    }
+}
+
+impl SourceFile {
+    /// Returns the name of the source file (filename).
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Returns `Some` with the source code if set, or `None`.
+    #[inline]
+    pub fn source_code(&self) -> Option<SourceCode> {
+        self.inner.code.as_ref().map(|code| SourceCode {
+            text: &code.text,
+            index: &code.index,
+        })
+    }
+
+    /// Returns `Some` with the source text if set, or `None.
+    #[inline]
+    pub fn source_text(&self) -> Option<&str> {
+        self.inner.code.as_ref().map(|code| code.text.deref())
+    }
+}
+
+#[derive(Eq, PartialEq)]
+struct SourceFileInner {
+    name: Box<str>,
+    code: Option<FileSourceCode>,
+}
+
+struct FileSourceCode {
+    text: Box<str>,
     index: LineIndex,
 }
 
-impl SourceCodeBuf {
-    pub fn new(content: &str, index: LineIndex) -> Self {
-        Self {
-            text: Arc::from(content),
-            index,
-        }
-    }
-
-    /// Creates the [`LineIndex`] for `text` and returns the [`SourceCodeBuf`].
-    pub fn from_content(text: &str) -> Self {
-        Self::new(text, LineIndex::from_source_text(text))
-    }
-
-    #[inline]
-    fn as_source_code(&self) -> SourceCode {
-        SourceCode {
-            text: &self.text,
-            index: &self.index,
-        }
-    }
-
-    /// Take the source code up to the given [`Location`].
-    pub fn up_to(&self, location: Location) -> &str {
-        self.as_source_code().up_to(location)
-    }
-
-    /// Take the source code after the given [`Location`].
-    pub fn after(&self, location: Location) -> &str {
-        self.as_source_code().after(location)
-    }
-
-    /// Take the source code between the given [`Range`].
-    #[inline]
-    pub fn slice<R: Into<Range>>(&self, range: R) -> &str {
-        self.as_source_code().slice(range)
-    }
-
-    /// Converts a [`Location`] range to a byte offset range
-    #[inline]
-    pub fn text_range<R: Into<Range>>(&self, range: R) -> TextRange {
-        self.as_source_code().text_range(range)
-    }
-
-    #[inline]
-    pub fn line_range(&self, line: OneIndexed) -> TextRange {
-        self.as_source_code().line_range(line)
-    }
-
-    /// Return the byte offset of the given [`Location`].
-    #[inline]
-    pub fn offset(&self, location: Location) -> TextSize {
-        self.as_source_code().offset(location)
-    }
-
-    #[inline]
-    pub fn line_end(&self, line: OneIndexed) -> TextSize {
-        self.as_source_code().line_end(line)
-    }
-
-    #[inline]
-    pub fn line_start(&self, line: OneIndexed) -> TextSize {
-        self.as_source_code().line_start(line)
-    }
-
-    #[inline]
-    pub fn lines(&self, range: Range) -> &str {
-        self.as_source_code().lines(range)
-    }
-
-    /// Returns the source text of the line with the given index
-    #[inline]
-    pub fn line_text(&self, index: OneIndexed) -> &str {
-        self.as_source_code().line_text(index)
-    }
-
-    #[inline]
-    pub fn line_count(&self) -> usize {
-        self.index.line_count()
-    }
-
-    pub fn text(&self) -> &str {
-        &self.text
-    }
-}
-
-impl PartialEq<Self> for SourceCodeBuf {
-    // The same source text should have the same index
+impl PartialEq for FileSourceCode {
     fn eq(&self, other: &Self) -> bool {
+        // It should be safe to assume that the index for two source files are identical
         self.text == other.text
     }
 }
 
-impl PartialEq<SourceCode<'_, '_>> for SourceCodeBuf {
-    fn eq(&self, other: &SourceCode<'_, '_>) -> bool {
-        &*self.text == other.text
-    }
-}
-
-impl Eq for SourceCodeBuf {}
+impl Eq for FileSourceCode {}


### PR DESCRIPTION
This PR introduces a new `SourceFile` type that replaces `SourceCodeBuf`. It stores the filename and, optionally, the content of the file. `SourceFile` uses an `Arc` internally to make it cheap to clone. 

This change was [proposed](https://github.com/charliermarsh/ruff/pull/3897#discussion_r1160290415) by @charliermarsh to avoid allocating a `String` with the `filename` for every `Message`. 

## Performance

This change significantly improves performance for projects with many diagnostics as we can see from the benchmarks that use `--select ALL`. For example, checking all rules with caching enabled improves from 470ms to 406ms

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./ruff-source-file <cpython_path> -e   ` | 40.1 ± 2.4 | 35.4 | 45.4 | 1.00 |
| `./ruff-main <cpython_path> -e   ` | 41.8 ± 2.6 | 37.4 | 47.6 | 1.04 ± 0.09 |
| `./ruff-source-file <cpython_path> -e --no-cache  ` | 221.9 ± 8.2 | 211.2 | 236.9 | 5.53 ± 0.39 |
| `./ruff-main <cpython_path> -e --no-cache  ` | 221.5 ± 4.3 | 211.7 | 226.3 | 5.52 ± 0.35 |
| `./ruff-source-file <cpython_path> -e  --select=ALL ` | 405.8 ± 10.1 | 391.0 | 427.4 | 10.11 ± 0.66 |
| `./ruff-main <cpython_path> -e  --select=ALL ` | 469.5 ± 8.6 | 451.0 | 482.2 | 11.69 ± 0.74 |
| `./ruff-source-file <cpython_path> -e --no-cache --select=ALL ` | 739.1 ± 17.6 | 714.8 | 770.5 | 18.41 ± 1.20 |
| `./ruff-main <cpython_path> -e --no-cache --select=ALL ` | 796.1 ± 13.2 | 780.0 | 820.7 | 19.83 ± 1.25 |
| `./ruff-source-file <cpython_path> -e   --show-source` | 85.9 ± 3.7 | 80.0 | 93.1 | 2.14 ± 0.16 |
| `./ruff-main <cpython_path> -e   --show-source` | 87.5 ± 2.9 | 82.5 | 93.2 | 2.18 ± 0.15 |
| `./ruff-source-file <cpython_path> -e --no-cache  --show-source` | 262.4 ± 6.0 | 253.2 | 272.0 | 6.54 ± 0.42 |
| `./ruff-main <cpython_path> -e --no-cache  --show-source` | 267.3 ± 7.4 | 255.7 | 279.7 | 6.66 ± 0.44 |
| `./ruff-source-file <cpython_path> -e  --select=ALL --show-source` | 1480.3 ± 22.2 | 1453.7 | 1516.0 | 36.87 ± 2.30 |
| `./ruff-main <cpython_path> -e  --select=ALL --show-source` | 1551.0 ± 24.1 | 1499.7 | 1590.7 | 38.63 ± 2.42 |
| `./ruff-source-file <cpython_path> -e --no-cache --select=ALL --show-source` | 1791.8 ± 25.6 | 1759.3 | 1845.3 | 44.63 ± 2.78 |
| `./ruff-main <cpython_path> -e --no-cache --select=ALL --show-source` | 1851.4 ± 23.0 | 1816.1 | 1887.9 | 46.11 ± 2.86 |

## Memory Usage

Memory usage reduced from ~813MB to ~686MB when running all rules without showing the source code. 