### PR TITLE
Order `Edit`s by `Location`s

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -5104,7 +5104,7 @@ impl<'a> Checker<'a> {
                             self.stylist,
                         ) {
                             Ok(fix) => {
-                                if fix.content.is_empty() || fix.content == "pass" {
+                                if fix.is_deletion() || fix.content() == Some("pass") {
                                     self.deletions.insert(*defined_by);
                                 }
                                 Some(fix)

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -73,7 +73,7 @@ impl Serialize for ExpandedEdits<'_> {
 
         for edit in self.edits {
             let value = json!({
-                "content": edit.content(),
+                "content": edit.content().unwrap_or_default(),
                 "location": edit.location(),
                 "end_location": edit.end_location()
             });

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -73,9 +73,9 @@ impl Serialize for ExpandedEdits<'_> {
 
         for edit in self.edits {
             let value = json!({
-                "content": edit.content,
-                "location": edit.location,
-                "end_location": edit.end_location
+                "content": edit.content(),
+                "location": edit.location(),
+                "end_location": edit.end_location()
             });
 
             s.serialize_element(&value)?;

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -25,7 +25,7 @@ expression: content
       "message": "Remove assignment to unused variable `x`",
       "edits": [
         {
-          "content": "",
+          "content": null,
           "location": {
             "row": 6,
             "column": 4

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -25,7 +25,7 @@ expression: content
       "message": "Remove assignment to unused variable `x`",
       "edits": [
         {
-          "content": null,
+          "content": "",
           "location": {
             "row": 6,
             "column": 4

--- a/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: CommentedOutCode
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 3
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: CommentedOutCode
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 4
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: CommentedOutCode
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: CommentedOutCode
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 13
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_annotations/snapshots/ruff__rules__flake8_annotations__tests__mypy_init_return.snap
+++ b/crates/ruff/src/rules/flake8_annotations/snapshots/ruff__rules__flake8_annotations__tests__mypy_init_return.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> None"
-        location:
+      - location:
           row: 5
           column: 22
         end_location:
           row: 5
           column: 22
+        content: " -> None"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> None"
-        location:
+      - location:
           row: 11
           column: 27
         end_location:
           row: 11
           column: 27
+        content: " -> None"
   parent: ~
 - kind:
     name: MissingReturnTypePrivateFunction
@@ -71,12 +71,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> None"
-        location:
+      - location:
           row: 47
           column: 28
         end_location:
           row: 47
           column: 28
+        content: " -> None"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_annotations/snapshots/ruff__rules__flake8_annotations__tests__simple_magic_methods.snap
+++ b/crates/ruff/src/rules/flake8_annotations/snapshots/ruff__rules__flake8_annotations__tests__simple_magic_methods.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: " -> str"
-        location:
+      - location:
           row: 2
           column: 21
         end_location:
           row: 2
           column: 21
+        content: " -> str"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> str"
-        location:
+      - location:
           row: 5
           column: 22
         end_location:
           row: 5
           column: 22
+        content: " -> str"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: " -> int"
-        location:
+      - location:
           row: 8
           column: 21
         end_location:
           row: 8
           column: 21
+        content: " -> int"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: " -> int"
-        location:
+      - location:
           row: 11
           column: 29
         end_location:
           row: 11
           column: 29
+        content: " -> int"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> None"
-        location:
+      - location:
           row: 14
           column: 22
         end_location:
           row: 14
           column: 22
+        content: " -> None"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: " -> None"
-        location:
+      - location:
           row: 17
           column: 21
         end_location:
           row: 17
           column: 21
+        content: " -> None"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: " -> bool"
-        location:
+      - location:
           row: 20
           column: 22
         end_location:
           row: 20
           column: 22
+        content: " -> bool"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: " -> bytes"
-        location:
+      - location:
           row: 23
           column: 23
         end_location:
           row: 23
           column: 23
+        content: " -> bytes"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: " -> str"
-        location:
+      - location:
           row: 26
           column: 37
         end_location:
           row: 26
           column: 37
+        content: " -> str"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: " -> bool"
-        location:
+      - location:
           row: 29
           column: 32
         end_location:
           row: 29
           column: 32
+        content: " -> bool"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: " -> complex"
-        location:
+      - location:
           row: 32
           column: 25
         end_location:
           row: 32
           column: 25
+        content: " -> complex"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: " -> int"
-        location:
+      - location:
           row: 35
           column: 21
         end_location:
           row: 35
           column: 21
+        content: " -> int"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: " -> float"
-        location:
+      - location:
           row: 38
           column: 23
         end_location:
           row: 38
           column: 23
+        content: " -> float"
   parent: ~
 - kind:
     name: MissingReturnTypeSpecialMethod
@@ -288,12 +288,12 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: " -> int"
-        location:
+      - location:
           row: 41
           column: 23
         end_location:
           row: 41
           column: 23
+        content: " -> int"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
@@ -29,13 +29,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: _k
-        location:
+      - location:
           row: 18
           column: 12
         end_location:
           row: 18
           column: 13
+        content: _k
   parent: ~
 - kind:
     name: UnusedLoopControlVariable
@@ -64,13 +64,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: _k
-        location:
+      - location:
           row: 30
           column: 12
         end_location:
           row: 30
           column: 13
+        content: _k
   parent: ~
 - kind:
     name: UnusedLoopControlVariable
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: _bar
-        location:
+      - location:
           row: 52
           column: 13
         end_location:
           row: 52
           column: 16
+        content: _bar
   parent: ~
 - kind:
     name: UnusedLoopControlVariable
@@ -176,13 +176,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: _bar
-        location:
+      - location:
           row: 68
           column: 13
         end_location:
           row: 68
           column: 16
+        content: _bar
   parent: ~
 - kind:
     name: UnusedLoopControlVariable
@@ -197,13 +197,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: _bar
-        location:
+      - location:
           row: 77
           column: 13
         end_location:
           row: 77
           column: 16
+        content: _bar
   parent: ~
 - kind:
     name: UnusedLoopControlVariable

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B009_B009_B010.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: foo.bar
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 19
           column: 19
+        content: foo.bar
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: foo._123abc
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 23
+        content: foo._123abc
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: foo.__123abc__
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 21
           column: 26
+        content: foo.__123abc__
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: foo.abc123
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 22
           column: 22
+        content: foo.abc123
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: foo.abc123
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 23
           column: 23
+        content: foo.abc123
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: x.bar
-        location:
+      - location:
           row: 24
           column: 14
         end_location:
           row: 24
           column: 31
+        content: x.bar
   parent: ~
 - kind:
     name: GetAttrWithConstant
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: x.bar
-        location:
+      - location:
           row: 25
           column: 3
         end_location:
           row: 25
           column: 20
+        content: x.bar
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B010_B009_B010.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: foo.bar = None
-        location:
+      - location:
           row: 40
           column: 0
         end_location:
           row: 40
           column: 25
+        content: foo.bar = None
   parent: ~
 - kind:
     name: SetAttrWithConstant
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: foo._123abc = None
-        location:
+      - location:
           row: 41
           column: 0
         end_location:
           row: 41
           column: 29
+        content: foo._123abc = None
   parent: ~
 - kind:
     name: SetAttrWithConstant
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: foo.__123abc__ = None
-        location:
+      - location:
           row: 42
           column: 0
         end_location:
           row: 42
           column: 32
+        content: foo.__123abc__ = None
   parent: ~
 - kind:
     name: SetAttrWithConstant
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: foo.abc123 = None
-        location:
+      - location:
           row: 43
           column: 0
         end_location:
           row: 43
           column: 28
+        content: foo.abc123 = None
   parent: ~
 - kind:
     name: SetAttrWithConstant
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: foo.abc123 = None
-        location:
+      - location:
           row: 44
           column: 0
         end_location:
           row: 44
           column: 29
+        content: foo.abc123 = None
   parent: ~
 - kind:
     name: SetAttrWithConstant
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: foo.bar.baz = None
-        location:
+      - location:
           row: 45
           column: 0
         end_location:
           row: 45
           column: 30
+        content: foo.bar.baz = None
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B011_B011.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B011_B011.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: raise AssertionError()
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 12
+        content: raise AssertionError()
   parent: ~
 - kind:
     name: AssertFalse
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "raise AssertionError(\"message\")"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 23
+        content: "raise AssertionError(\"message\")"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B013_B013.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B013_B013.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ValueError
-        location:
+      - location:
           row: 3
           column: 7
         end_location:
           row: 3
           column: 20
+        content: ValueError
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B014_B014.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B014_B014.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 17
           column: 7
         end_location:
           row: 17
           column: 25
+        content: OSError
   parent: ~
 - kind:
     name: DuplicateHandlerException
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: MyError
-        location:
+      - location:
           row: 28
           column: 7
         end_location:
           row: 28
           column: 25
+        content: MyError
   parent: ~
 - kind:
     name: DuplicateHandlerException
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: re.error
-        location:
+      - location:
           row: 49
           column: 7
         end_location:
           row: 49
           column: 27
+        content: re.error
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_commas/snapshots/ruff__rules__flake8_commas__tests__COM81.py.snap
+++ b/crates/ruff/src/rules/flake8_commas/snapshots/ruff__rules__flake8_commas__tests__COM81.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "'test',"
-        location:
+      - location:
           row: 4
           column: 11
         end_location:
           row: 4
           column: 17
+        content: "'test',"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3,"
-        location:
+      - location:
           row: 10
           column: 4
         end_location:
           row: 10
           column: 5
+        content: "3,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3,"
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 16
           column: 5
+        content: "3,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3,"
-        location:
+      - location:
           row: 23
           column: 4
         end_location:
           row: 23
           column: 5
+        content: "3,"
   parent: ~
 - kind:
     name: TrailingCommaOnBareTuple
@@ -197,13 +197,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "bar,"
-        location:
+      - location:
           row: 70
           column: 4
         end_location:
           row: 70
           column: 7
+        content: "bar,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -218,13 +218,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "bar,"
-        location:
+      - location:
           row: 78
           column: 4
         end_location:
           row: 78
           column: 7
+        content: "bar,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -239,13 +239,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "bar,"
-        location:
+      - location:
           row: 86
           column: 4
         end_location:
           row: 86
           column: 7
+        content: "bar,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -260,13 +260,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "y,"
-        location:
+      - location:
           row: 152
           column: 4
         end_location:
           row: 152
           column: 5
+        content: "y,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -281,13 +281,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "Anyway,"
-        location:
+      - location:
           row: 158
           column: 4
         end_location:
           row: 158
           column: 10
+        content: "Anyway,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -302,13 +302,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "123,"
-        location:
+      - location:
           row: 293
           column: 11
         end_location:
           row: 293
           column: 14
+        content: "123,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -323,13 +323,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "2,"
-        location:
+      - location:
           row: 304
           column: 12
         end_location:
           row: 304
           column: 13
+        content: "2,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -344,13 +344,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "3,"
-        location:
+      - location:
           row: 310
           column: 12
         end_location:
           row: 310
           column: 13
+        content: "3,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -365,13 +365,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "3,"
-        location:
+      - location:
           row: 316
           column: 8
         end_location:
           row: 316
           column: 9
+        content: "3,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -386,13 +386,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "123,"
-        location:
+      - location:
           row: 322
           column: 11
         end_location:
           row: 322
           column: 14
+        content: "123,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -407,13 +407,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\"not good\","
-        location:
+      - location:
           row: 368
           column: 4
         end_location:
           row: 368
           column: 14
+        content: "\"not good\","
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -428,13 +428,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\"not good\","
-        location:
+      - location:
           row: 375
           column: 4
         end_location:
           row: 375
           column: 14
+        content: "\"not good\","
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -449,13 +449,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\"not fine\","
-        location:
+      - location:
           row: 404
           column: 4
         end_location:
           row: 404
           column: 14
+        content: "\"not fine\","
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -470,13 +470,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\"not fine\","
-        location:
+      - location:
           row: 432
           column: 4
         end_location:
           row: 432
           column: 14
+        content: "\"not fine\","
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -491,13 +491,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 485
           column: 20
         end_location:
           row: 485
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -512,13 +512,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 487
           column: 12
         end_location:
           row: 487
           column: 13
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -533,13 +533,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 489
           column: 17
         end_location:
           row: 489
           column: 18
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -554,13 +554,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 494
           column: 5
         end_location:
           row: 494
           column: 6
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -575,13 +575,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 496
           column: 20
         end_location:
           row: 496
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -596,13 +596,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 498
           column: 12
         end_location:
           row: 498
           column: 13
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -617,13 +617,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 500
           column: 17
         end_location:
           row: 500
           column: 18
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -638,13 +638,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 505
           column: 5
         end_location:
           row: 505
           column: 6
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -659,13 +659,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 511
           column: 9
         end_location:
           row: 511
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: ProhibitedTrailingComma
@@ -680,13 +680,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 513
           column: 8
         end_location:
           row: 513
           column: 9
+        content: ~
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -701,13 +701,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "kwargs,"
-        location:
+      - location:
           row: 519
           column: 6
         end_location:
           row: 519
           column: 12
+        content: "kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -722,13 +722,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "args,"
-        location:
+      - location:
           row: 526
           column: 5
         end_location:
           row: 526
           column: 9
+        content: "args,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -743,13 +743,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "extra_kwarg,"
-        location:
+      - location:
           row: 534
           column: 4
         end_location:
           row: 534
           column: 15
+        content: "extra_kwarg,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -764,13 +764,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "kwargs,"
-        location:
+      - location:
           row: 541
           column: 6
         end_location:
           row: 541
           column: 12
+        content: "kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -785,13 +785,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "not_called_kwargs,"
-        location:
+      - location:
           row: 547
           column: 6
         end_location:
           row: 547
           column: 23
+        content: "not_called_kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -806,13 +806,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "kwarg_only,"
-        location:
+      - location:
           row: 554
           column: 4
         end_location:
           row: 554
           column: 14
+        content: "kwarg_only,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -827,13 +827,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "kwargs,"
-        location:
+      - location:
           row: 561
           column: 6
         end_location:
           row: 561
           column: 12
+        content: "kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -848,13 +848,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "kwargs,"
-        location:
+      - location:
           row: 565
           column: 6
         end_location:
           row: 565
           column: 12
+        content: "kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -869,13 +869,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "args,"
-        location:
+      - location:
           row: 573
           column: 5
         end_location:
           row: 573
           column: 9
+        content: "args,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -890,13 +890,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "args,"
-        location:
+      - location:
           row: 577
           column: 5
         end_location:
           row: 577
           column: 9
+        content: "args,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -911,13 +911,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "args,"
-        location:
+      - location:
           row: 583
           column: 5
         end_location:
           row: 583
           column: 9
+        content: "args,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -932,13 +932,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "kwargs,"
-        location:
+      - location:
           row: 590
           column: 6
         end_location:
           row: 590
           column: 12
+        content: "kwargs,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -953,13 +953,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "kwarg_only,"
-        location:
+      - location:
           row: 598
           column: 4
         end_location:
           row: 598
           column: 14
+        content: "kwarg_only,"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -974,13 +974,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "},"
-        location:
+      - location:
           row: 627
           column: 18
         end_location:
           row: 627
           column: 19
+        content: "},"
   parent: ~
 - kind:
     name: MissingTrailingComma
@@ -995,12 +995,12 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "),"
-        location:
+      - location:
           row: 632
           column: 40
         end_location:
           row: 632
           column: 41
+        content: "),"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C400_C400.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C400_C400.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "[x for x in range(3)]"
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 29
+        content: "[x for x in range(3)]"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorList
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "[\n    x for x in range(3)\n]"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 4
           column: 1
+        content: "[\n    x for x in range(3)\n]"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C401_C401.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C401_C401.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "{x for x in range(3)}"
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 28
+        content: "{x for x in range(3)}"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorSet
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "{\n    x for x in range(3)\n}"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 4
           column: 1
+        content: "{\n    x for x in range(3)\n}"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorSet
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: " {a if a < 6 else 0  for a in range(3)} "
-        location:
+      - location:
           row: 5
           column: 7
         end_location:
           row: 5
           column: 48
+        content: " {a if a < 6 else 0  for a in range(3)} "
   parent: ~
 - kind:
     name: UnnecessaryGeneratorSet
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 57
   fix:
     edits:
-      - content: "{a if a < 6 else 0  for a in range(3)}"
-        location:
+      - location:
           row: 6
           column: 16
         end_location:
           row: 6
           column: 57
+        content: "{a if a < 6 else 0  for a in range(3)}"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorSet
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: " {a for a in range(3)} "
-        location:
+      - location:
           row: 7
           column: 15
         end_location:
           row: 7
           column: 39
+        content: " {a for a in range(3)} "
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C402_C402.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C402_C402.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "{x: x for x in range(3)}"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 30
+        content: "{x: x for x in range(3)}"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorDict
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "{\n    x: x for x in range(3)\n}"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 4
           column: 1
+        content: "{\n    x: x for x in range(3)\n}"
   parent: ~
 - kind:
     name: UnnecessaryGeneratorDict
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: " {x: x for x in range(3)} "
-        location:
+      - location:
           row: 6
           column: 7
         end_location:
           row: 6
           column: 37
+        content: " {x: x for x in range(3)} "
   parent: ~
 - kind:
     name: UnnecessaryGeneratorDict
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: " {x: x for x in range(3)} "
-        location:
+      - location:
           row: 7
           column: 15
         end_location:
           row: 7
           column: 45
+        content: " {x: x for x in range(3)} "
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C403_C403.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C403_C403.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "{x for x in range(3)}"
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 30
+        content: "{x for x in range(3)}"
   parent: ~
 - kind:
     name: UnnecessaryListComprehensionSet
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "{\n    x for x in range(3)\n}"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 4
           column: 1
+        content: "{\n    x for x in range(3)\n}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C404_C404.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C404_C404.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "{i: i for i in range(3)}"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 32
+        content: "{i: i for i in range(3)}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C405_C405.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C405_C405.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "{1, 2}"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 11
+        content: "{1, 2}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "{1, 2}"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 11
+        content: "{1, 2}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: set()
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 7
+        content: set()
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: set()
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 7
+        content: set()
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "{1}"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 9
+        content: "{1}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 2
   fix:
     edits:
-      - content: "{\n    1,\n}"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 9
           column: 2
+        content: "{\n    1,\n}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 2
   fix:
     edits:
-      - content: "{\n    1,\n}"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 12
           column: 2
+        content: "{\n    1,\n}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "{1}"
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 15
           column: 1
+        content: "{1}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralSet
@@ -183,12 +183,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "{1,}"
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 18
           column: 1
+        content: "{1,}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C406_C406.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C406_C406.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "{1: 2}"
-        location:
+      - location:
           row: 1
           column: 5
         end_location:
           row: 1
           column: 19
+        content: "{1: 2}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralDict
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "{1: 2,}"
-        location:
+      - location:
           row: 2
           column: 5
         end_location:
           row: 2
           column: 20
+        content: "{1: 2,}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralDict
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "{}"
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 13
+        content: "{}"
   parent: ~
 - kind:
     name: UnnecessaryLiteralDict
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "{}"
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 4
           column: 13
+        content: "{}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 11
+        content: ()
   parent: ~
 - kind:
     name: UnnecessaryCollectionCall
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "[]"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 10
+        content: "[]"
   parent: ~
 - kind:
     name: UnnecessaryCollectionCall
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "{}"
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 11
+        content: "{}"
   parent: ~
 - kind:
     name: UnnecessaryCollectionCall
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "{\"a\": 1}"
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 4
           column: 14
+        content: "{\"a\": 1}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C408_C408.py_allow_dict_calls_with_keyword_arguments.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 11
+        content: ()
   parent: ~
 - kind:
     name: UnnecessaryCollectionCall
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "[]"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 10
+        content: "[]"
   parent: ~
 - kind:
     name: UnnecessaryCollectionCall
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "{}"
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 11
+        content: "{}"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C409_C409.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C409_C409.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 1
           column: 5
         end_location:
           row: 1
           column: 14
+        content: ()
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinTupleCall
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "(1, 2)"
-        location:
+      - location:
           row: 2
           column: 5
         end_location:
           row: 2
           column: 18
+        content: "(1, 2)"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinTupleCall
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "(1, 2)"
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 18
+        content: "(1, 2)"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinTupleCall
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 2
   fix:
     edits:
-      - content: "(\n    1,\n    2\n)"
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 7
           column: 2
+        content: "(\n    1,\n    2\n)"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinTupleCall
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "(1, 2)"
-        location:
+      - location:
           row: 8
           column: 5
         end_location:
           row: 10
           column: 1
+        content: "(1, 2)"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C410_C410.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C410_C410.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "[1, 2]"
-        location:
+      - location:
           row: 1
           column: 5
         end_location:
           row: 1
           column: 17
+        content: "[1, 2]"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinListCall
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "[1, 2]"
-        location:
+      - location:
           row: 2
           column: 5
         end_location:
           row: 2
           column: 17
+        content: "[1, 2]"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinListCall
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "[]"
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 13
+        content: "[]"
   parent: ~
 - kind:
     name: UnnecessaryLiteralWithinListCall
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "[]"
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 4
           column: 13
+        content: "[]"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C411_C411.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C411_C411.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "[i for i in x]"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 20
+        content: "[i for i in x]"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: sorted(x)
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 15
+        content: sorted(x)
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "sorted(x, reverse=True)"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 19
+        content: "sorted(x, reverse=True)"
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "sorted(x, key=lambda e: e, reverse=True)"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 36
+        content: "sorted(x, key=lambda e: e, reverse=True)"
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "sorted(x, reverse=False)"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 33
+        content: "sorted(x, reverse=False)"
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "sorted(x, key=lambda e: e, reverse=False)"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 50
+        content: "sorted(x, key=lambda e: e, reverse=False)"
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "sorted(x, reverse=False, key=lambda e: e)"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 50
+        content: "sorted(x, reverse=False, key=lambda e: e)"
   parent: ~
 - kind:
     name: UnnecessaryCallAroundSorted
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "sorted(x, reverse=True)"
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 34
+        content: "sorted(x, reverse=True)"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C414_C414.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C414_C414.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: list(x)
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 13
+        content: list(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list(x)
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 14
+        content: list(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: tuple(x)
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 14
+        content: tuple(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: tuple(x)
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 15
+        content: tuple(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 11
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 12
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 13
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 14
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "set(x, )"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 31
+        content: "set(x, )"
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 16
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: sorted(x)
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 12
           column: 15
+        content: sorted(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: sorted(x)
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 13
           column: 16
+        content: sorted(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: sorted(x)
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 14
           column: 17
+        content: sorted(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "sorted(x, )"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 34
+        content: "sorted(x, )"
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: sorted(x)
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 16
           column: 19
+        content: sorted(x)
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "sorted(x, key=lambda y: y)"
-        location:
+      - location:
           row: 17
           column: 0
         end_location:
           row: 17
           column: 32
+        content: "sorted(x, key=lambda y: y)"
   parent: ~
 - kind:
     name: UnnecessaryDoubleCastOrProcess
@@ -351,12 +351,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "tuple(\n    [x, 3, \"hell\"\\\n        \"o\"]\n    )"
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 23
           column: 1
+        content: "tuple(\n    [x, 3, \"hell\"\\\n        \"o\"]\n    )"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C416_C416.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C416_C416.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list(x)
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 14
+        content: list(x)
   parent: ~
 - kind:
     name: UnnecessaryComprehension
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: set(x)
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 14
+        content: set(x)
   parent: ~
 - kind:
     name: UnnecessaryComprehension
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: dict(y)
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 20
+        content: dict(y)
   parent: ~
 - kind:
     name: UnnecessaryComprehension
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: dict(d.items())
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 28
+        content: dict(d.items())
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: (x + 1 for x in nums)
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 26
+        content: (x + 1 for x in nums)
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: (str(x) for x in nums)
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 27
+        content: (str(x) for x in nums)
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "[x * 2 for x in nums]"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 32
+        content: "[x * 2 for x in nums]"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "{x % 2 == 0 for x in nums}"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 36
+        content: "{x % 2 == 0 for x in nums}"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "{v: v**2 for v in nums}"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 36
+        content: "{v: v**2 for v in nums}"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "(\"const\" for _ in nums)"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 26
+        content: "(\"const\" for _ in nums)"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: (3.0 for _ in nums)
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 24
+        content: (3.0 for _ in nums)
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 63
   fix:
     edits:
-      - content: "(x in nums and \"1\" or \"0\" for x in range(123))"
-        location:
+      - location:
           row: 10
           column: 12
         end_location:
           row: 10
           column: 63
+        content: "(x in nums and \"1\" or \"0\" for x in range(123))"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "(isinstance(v, dict) for v in nums)"
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 11
           column: 44
+        content: "(isinstance(v, dict) for v in nums)"
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: (v for v in nums)
-        location:
+      - location:
           row: 12
           column: 13
         end_location:
           row: 12
           column: 35
+        content: (v for v in nums)
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: " {x % 2 == 0 for x in nums} "
-        location:
+      - location:
           row: 15
           column: 7
         end_location:
           row: 15
           column: 43
+        content: " {x % 2 == 0 for x in nums} "
   parent: ~
 - kind:
     name: UnnecessaryMap
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: " {v: v**2 for v in nums} "
-        location:
+      - location:
           row: 16
           column: 7
         end_location:
           row: 16
           column: 43
+        content: " {v: v**2 for v in nums} "
   parent: ~
 - kind:
     name: UnnecessaryMap

--- a/crates/ruff/src/rules/flake8_executable/snapshots/ruff__rules__flake8_executable__tests__EXE004_1.py.snap
+++ b/crates/ruff/src/rules/flake8_executable/snapshots/ruff__rules__flake8_executable__tests__EXE004_1.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 4
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G010.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G010.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: warning
-        location:
+      - location:
           row: 4
           column: 8
         end_location:
           row: 4
           column: 12
+        content: warning
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE790_PIE790.py.snap
+++ b/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE790_PIE790.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 5
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 10
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 4
         end_location:
           row: 14
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 22
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 29
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 35
           column: 0
         end_location:
           row: 36
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 42
           column: 0
         end_location:
           row: 43
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 50
           column: 0
         end_location:
           row: 51
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 58
           column: 0
         end_location:
           row: 59
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 65
           column: 0
         end_location:
           row: 66
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 74
           column: 0
         end_location:
           row: 75
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 79
           column: 0
         end_location:
           row: 80
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 83
           column: 0
         end_location:
           row: 84
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 87
           column: 0
         end_location:
           row: 88
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 92
           column: 0
         end_location:
           row: 93
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 96
           column: 0
         end_location:
           row: 97
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryPass
@@ -351,12 +351,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 101
           column: 4
         end_location:
           row: 101
           column: 10
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE794_PIE794.py.snap
+++ b/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE794_PIE794.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 5
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: DuplicateClassFieldDefinition
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 14
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: DuplicateClassFieldDefinition
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 24
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: DuplicateClassFieldDefinition
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 40
           column: 0
         end_location:
           row: 41
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE802_PIE802.py.snap
+++ b/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE802_PIE802.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: any(x.id for x in bar)
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 24
+        content: any(x.id for x in bar)
   parent: ~
 - kind:
     name: UnnecessaryComprehensionAnyAll
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: all(x.id for x in bar)
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 24
+        content: all(x.id for x in bar)
   parent: ~
 - kind:
     name: UnnecessaryComprehensionAnyAll
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "any(  # first comment\n    x.id for x in bar  # second comment\n)"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 6
           column: 1
+        content: "any(  # first comment\n    x.id for x in bar  # second comment\n)"
   parent: ~
 - kind:
     name: UnnecessaryComprehensionAnyAll
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "all(  # first comment\n    x.id for x in bar  # second comment\n)"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 9
           column: 1
+        content: "all(  # first comment\n    x.id for x in bar  # second comment\n)"
   parent: ~
 - kind:
     name: UnnecessaryComprehensionAnyAll

--- a/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE807_PIE807.py.snap
+++ b/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE807_PIE807.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 3
           column: 43
         end_location:
           row: 3
           column: 53
+        content: list
   parent: ~
 - kind:
     name: ReimplementedListBuiltin
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 7
           column: 35
         end_location:
           row: 7
           column: 45
+        content: list
   parent: ~
 - kind:
     name: ReimplementedListBuiltin
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 11
           column: 27
         end_location:
           row: 11
           column: 37
+        content: list
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE810_PIE810.py.snap
+++ b/crates/ruff/src/rules/flake8_pie/snapshots/ruff__rules__flake8_pie__tests__PIE810_PIE810.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "obj.startswith((\"foo\", \"bar\"))"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 46
+        content: "obj.startswith((\"foo\", \"bar\"))"
   parent: ~
 - kind:
     name: MultipleStartsEndsWith
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: "obj.endswith((\"foo\", \"bar\"))"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 42
+        content: "obj.endswith((\"foo\", \"bar\"))"
   parent: ~
 - kind:
     name: MultipleStartsEndsWith
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: "obj.startswith((foo, bar))"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 42
+        content: "obj.startswith((foo, bar))"
   parent: ~
 - kind:
     name: MultipleStartsEndsWith
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "obj.startswith((foo, \"foo\"))"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 44
+        content: "obj.startswith((foo, \"foo\"))"
   parent: ~
 - kind:
     name: MultipleStartsEndsWith
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 65
   fix:
     edits:
-      - content: "obj.endswith(foo) or obj.startswith((foo, \"foo\"))"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 65
+        content: "obj.endswith(foo) or obj.startswith((foo, \"foo\"))"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -45,7 +45,7 @@ pub fn pass_in_class_body<'a>(checker: &mut Checker<'a>, parent: &'a Stmt, body:
                     checker.stylist,
                 ) {
                     Ok(fix) => {
-                        if fix.content.is_empty() || fix.content == "pass" {
+                        if fix.is_deletion() || fix.content() == Some("pass") {
                             checker.deletions.insert(RefEquality(stmt));
                         }
                         diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI011_PYI011.pyi.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 10
           column: 13
         end_location:
           row: 10
           column: 23
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 38
           column: 8
         end_location:
           row: 41
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 46
           column: 8
         end_location:
           row: 58
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 63
           column: 8
         end_location:
           row: 66
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 71
           column: 8
         end_location:
           row: 73
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 78
           column: 8
         end_location:
           row: 80
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 85
           column: 8
         end_location:
           row: 87
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 90
           column: 13
         end_location:
           row: 91
           column: 11
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 94
           column: 13
         end_location:
           row: 95
           column: 12
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 98
           column: 16
         end_location:
           row: 99
           column: 7
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 102
           column: 13
         end_location:
           row: 103
           column: 7
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 106
           column: 17
         end_location:
           row: 107
           column: 8
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 110
           column: 17
         end_location:
           row: 111
           column: 10
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 138
           column: 15
         end_location:
           row: 138
           column: 18
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 141
           column: 15
         end_location:
           row: 141
           column: 21
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 147
           column: 15
         end_location:
           row: 147
           column: 24
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 150
           column: 17
         end_location:
           row: 151
           column: 8
+        content: "..."
   parent: ~
 - kind:
     name: TypedArgumentDefaultInStub
@@ -372,12 +372,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 159
           column: 13
         end_location:
           row: 160
           column: 8
+        content: "..."
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI012_PYI012.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI012_PYI012.pyi.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PassInClassBody
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 9
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PassInClassBody
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PassInClassBody
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 21
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PassInClassBody
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 24
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PassInClassBody
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 29
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI014_PYI014.pyi.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 3
           column: 6
         end_location:
           row: 3
           column: 16
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 29
           column: 6
         end_location:
           row: 32
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 35
           column: 6
         end_location:
           row: 47
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 50
           column: 6
         end_location:
           row: 53
           column: 5
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 56
           column: 6
         end_location:
           row: 56
           column: 18
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 59
           column: 6
         end_location:
           row: 59
           column: 21
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 61
           column: 10
         end_location:
           row: 61
           column: 45
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 63
           column: 6
         end_location:
           row: 63
           column: 19
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 66
           column: 6
         end_location:
           row: 66
           column: 21
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 69
           column: 6
         end_location:
           row: 69
           column: 15
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 72
           column: 6
         end_location:
           row: 72
           column: 11
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 75
           column: 6
         end_location:
           row: 75
           column: 13
+        content: "..."
   parent: ~
 - kind:
     name: ArgumentDefaultInStub
@@ -267,12 +267,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 78
           column: 6
         end_location:
           row: 78
           column: 19
+        content: "..."
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 57
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 44
           column: 22
         end_location:
           row: 44
           column: 57
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 45
           column: 22
         end_location:
           row: 45
           column: 34
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 46
           column: 22
         end_location:
           row: 46
           column: 37
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 47
           column: 25
         end_location:
           row: 47
           column: 35
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 69
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 48
           column: 46
         end_location:
           row: 48
           column: 69
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 49
           column: 30
         end_location:
           row: 49
           column: 53
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 50
           column: 36
         end_location:
           row: 50
           column: 47
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 52
           column: 27
         end_location:
           row: 52
           column: 43
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 53
           column: 10
         end_location:
           row: 53
           column: 23
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 54
           column: 10
         end_location:
           row: 54
           column: 25
+        content: "..."
   parent: ~
 - kind:
     name: AssignmentDefaultInStub
@@ -225,12 +225,12 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "..."
-        location:
+      - location:
           row: 55
           column: 10
         end_location:
           row: 55
           column: 15
+        content: "..."
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_default.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_default.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 9
           column: 15
         end_location:
           row: 9
           column: 15
+        content: ()
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 34
           column: 8
         end_location:
           row: 34
           column: 8
+        content: ()
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 59
           column: 8
         end_location:
           row: 59
           column: 8
+        content: ()
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_no_parentheses.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_no_parentheses.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 15
         end_location:
           row: 14
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 24
           column: 15
         end_location:
           row: 26
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 39
           column: 8
         end_location:
           row: 39
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 49
           column: 8
         end_location:
           row: 51
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 64
           column: 8
         end_location:
           row: 64
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: PytestFixtureIncorrectParenthesesStyle
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 74
           column: 8
         end_location:
           row: 76
           column: 1
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT003.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT003.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 16
         end_location:
           row: 14
           column: 32
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 16
         end_location:
           row: 19
           column: 34
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 24
           column: 33
         end_location:
           row: 24
           column: 51
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 29
           column: 35
         end_location:
           row: 29
           column: 53
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 37
           column: 28
         end_location:
           row: 37
           column: 46
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 43
           column: 4
         end_location:
           row: 44
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 51
           column: 21
         end_location:
           row: 52
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: PytestExtraneousScopeFunction
@@ -162,12 +162,12 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 66
           column: 4
         end_location:
           row: 70
           column: 4
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "\"param1,param2\""
-        location:
+      - location:
           row: 24
           column: 25
         end_location:
           row: 24
           column: 45
+        content: "\"param1,param2\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 29
           column: 25
         end_location:
           row: 29
           column: 36
+        content: "\"param1\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "\"param1,param2\""
-        location:
+      - location:
           row: 34
           column: 25
         end_location:
           row: 34
           column: 45
+        content: "\"param1,param2\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 39
           column: 25
         end_location:
           row: 39
           column: 35
+        content: "\"param1\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_default.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_default.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "(\"param1\", \"param2\")"
-        location:
+      - location:
           row: 9
           column: 25
         end_location:
           row: 9
           column: 40
+        content: "(\"param1\", \"param2\")"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: "(\"param1\", \"param2\")"
-        location:
+      - location:
           row: 14
           column: 25
         end_location:
           row: 14
           column: 56
+        content: "(\"param1\", \"param2\")"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "(\"param1\", \"param2\")"
-        location:
+      - location:
           row: 19
           column: 25
         end_location:
           row: 19
           column: 40
+        content: "(\"param1\", \"param2\")"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 29
           column: 25
         end_location:
           row: 29
           column: 36
+        content: "\"param1\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "(\"param1\", \"param2\")"
-        location:
+      - location:
           row: 34
           column: 25
         end_location:
           row: 34
           column: 45
+        content: "(\"param1\", \"param2\")"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 39
           column: 25
         end_location:
           row: 39
           column: 35
+        content: "\"param1\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "(some_expr, another_expr)"
-        location:
+      - location:
           row: 44
           column: 25
         end_location:
           row: 44
           column: 50
+        content: "(some_expr, another_expr)"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -162,12 +162,12 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "(some_expr, \"param2\")"
-        location:
+      - location:
           row: 49
           column: 25
         end_location:
           row: 49
           column: 46
+        content: "(some_expr, \"param2\")"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_list.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_list.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "[\"param1\", \"param2\"]"
-        location:
+      - location:
           row: 9
           column: 25
         end_location:
           row: 9
           column: 40
+        content: "[\"param1\", \"param2\"]"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: "[\"param1\", \"param2\"]"
-        location:
+      - location:
           row: 14
           column: 25
         end_location:
           row: 14
           column: 56
+        content: "[\"param1\", \"param2\"]"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "[\"param1\", \"param2\"]"
-        location:
+      - location:
           row: 19
           column: 25
         end_location:
           row: 19
           column: 40
+        content: "[\"param1\", \"param2\"]"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "[\"param1\", \"param2\"]"
-        location:
+      - location:
           row: 24
           column: 25
         end_location:
           row: 24
           column: 45
+        content: "[\"param1\", \"param2\"]"
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 29
           column: 25
         end_location:
           row: 29
           column: 36
+        content: "\"param1\""
   parent: ~
 - kind:
     name: PytestParametrizeNamesWrongType
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "\"param1\""
-        location:
+      - location:
           row: 39
           column: 25
         end_location:
           row: 39
           column: 35
+        content: "\"param1\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: assert expr
-        location:
+      - location:
           row: 11
           column: 8
         end_location:
           row: 11
           column: 29
+        content: assert expr
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: assert expr
-        location:
+      - location:
           row: 12
           column: 8
         end_location:
           row: 12
           column: 34
+        content: assert expr
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "assert expr, msg"
-        location:
+      - location:
           row: 13
           column: 8
         end_location:
           row: 13
           column: 34
+        content: "assert expr, msg"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "assert expr, msg"
-        location:
+      - location:
           row: 14
           column: 8
         end_location:
           row: 14
           column: 43
+        content: "assert expr, msg"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "assert expr, msg"
-        location:
+      - location:
           row: 15
           column: 8
         end_location:
           row: 15
           column: 43
+        content: "assert expr, msg"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -218,13 +218,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: assert not True
-        location:
+      - location:
           row: 28
           column: 8
         end_location:
           row: 28
           column: 30
+        content: assert not True
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -239,13 +239,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: assert 1 == 2
-        location:
+      - location:
           row: 31
           column: 8
         end_location:
           row: 31
           column: 30
+        content: assert 1 == 2
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -260,13 +260,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: assert 1 != 1
-        location:
+      - location:
           row: 34
           column: 8
         end_location:
           row: 34
           column: 33
+        content: assert 1 != 1
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -281,13 +281,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: assert 1 > 2
-        location:
+      - location:
           row: 37
           column: 8
         end_location:
           row: 37
           column: 32
+        content: assert 1 > 2
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -302,13 +302,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: assert 1 >= 2
-        location:
+      - location:
           row: 40
           column: 8
         end_location:
           row: 40
           column: 37
+        content: assert 1 >= 2
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -323,13 +323,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: assert 2 < 1
-        location:
+      - location:
           row: 43
           column: 8
         end_location:
           row: 43
           column: 29
+        content: assert 2 < 1
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -344,13 +344,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: assert 1 <= 2
-        location:
+      - location:
           row: 46
           column: 8
         end_location:
           row: 46
           column: 34
+        content: assert 1 <= 2
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -365,13 +365,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "assert 1 in [2, 3]"
-        location:
+      - location:
           row: 49
           column: 8
         end_location:
           row: 49
           column: 32
+        content: "assert 1 in [2, 3]"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -386,13 +386,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "assert 2 not in [2, 3]"
-        location:
+      - location:
           row: 52
           column: 8
         end_location:
           row: 52
           column: 35
+        content: "assert 2 not in [2, 3]"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -407,13 +407,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: assert 0 is None
-        location:
+      - location:
           row: 55
           column: 8
         end_location:
           row: 55
           column: 28
+        content: assert 0 is None
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -428,13 +428,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: assert 0 is not None
-        location:
+      - location:
           row: 58
           column: 8
         end_location:
           row: 58
           column: 31
+        content: assert 0 is not None
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -449,13 +449,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "assert [] is []"
-        location:
+      - location:
           row: 61
           column: 8
         end_location:
           row: 61
           column: 29
+        content: "assert [] is []"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -470,13 +470,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: assert 1 is not 1
-        location:
+      - location:
           row: 64
           column: 8
         end_location:
           row: 64
           column: 30
+        content: assert 1 is not 1
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -491,13 +491,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "assert isinstance(1, str)"
-        location:
+      - location:
           row: 67
           column: 8
         end_location:
           row: 67
           column: 37
+        content: "assert isinstance(1, str)"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -512,13 +512,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "assert not isinstance(1, int)"
-        location:
+      - location:
           row: 70
           column: 8
         end_location:
           row: 70
           column: 40
+        content: "assert not isinstance(1, int)"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -533,13 +533,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "assert re.search(\"def\", \"abc\")"
-        location:
+      - location:
           row: 73
           column: 8
         end_location:
           row: 73
           column: 39
+        content: "assert re.search(\"def\", \"abc\")"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -554,13 +554,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "assert not re.search(\"abc\", \"abc\")"
-        location:
+      - location:
           row: 76
           column: 8
         end_location:
           row: 76
           column: 42
+        content: "assert not re.search(\"abc\", \"abc\")"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -575,13 +575,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "assert re.search(\"def\", \"abc\")"
-        location:
+      - location:
           row: 79
           column: 8
         end_location:
           row: 79
           column: 47
+        content: "assert re.search(\"def\", \"abc\")"
   parent: ~
 - kind:
     name: PytestUnittestAssertion
@@ -596,12 +596,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "assert not re.search(\"abc\", \"abc\")"
-        location:
+      - location:
           row: 82
           column: 8
         end_location:
           row: 82
           column: 42
+        content: "assert not re.search(\"abc\", \"abc\")"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: "    assert something\n    assert something_else\n"
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 15
           column: 0
+        content: "    assert something\n    assert something_else\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 59
   fix:
     edits:
-      - content: "    assert something and something_else\n    assert something_third\n"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 16
           column: 0
+        content: "    assert something and something_else\n    assert something_third\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "    assert something\n    assert not something_else\n"
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 0
+        content: "    assert something\n    assert not something_else\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 60
   fix:
     edits:
-      - content: "    assert something\n    assert (something_else or something_third)\n"
-        location:
+      - location:
           row: 17
           column: 0
         end_location:
           row: 18
           column: 0
+        content: "    assert something\n    assert (something_else or something_third)\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "    assert not something\n    assert something_else\n"
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 19
           column: 0
+        content: "    assert not something\n    assert something_else\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "    assert not something\n    assert not something_else\n"
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 20
           column: 0
+        content: "    assert not something\n    assert not something_else\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 63
   fix:
     edits:
-      - content: "    assert not something or something_else\n    assert not something_third\n"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 21
           column: 0
+        content: "    assert not something or something_else\n    assert not something_third\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    assert something\n    assert something_else == \"\"\"error\n    message\n    \"\"\"\n"
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 24
           column: 0
+        content: "    assert something\n    assert something_else == \"\"\"error\n    message\n    \"\"\"\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "    assert not a\n    assert (b or c)\n"
-        location:
+      - location:
           row: 26
           column: 0
         end_location:
           row: 27
           column: 0
+        content: "    assert not a\n    assert (b or c)\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "    assert not a\n    assert (b and c)\n"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 28
           column: 0
+        content: "    assert not a\n    assert (b and c)\n"
   parent: ~
 - kind:
     name: PytestCompositeAssertion

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT022.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT022.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: return
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 17
           column: 9
+        content: return
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT023_default.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT023_default.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 12
           column: 16
         end_location:
           row: 12
           column: 16
+        content: ()
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 17
           column: 16
         end_location:
           row: 17
           column: 16
+        content: ()
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 24
           column: 20
         end_location:
           row: 24
           column: 20
+        content: ()
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 30
           column: 20
         end_location:
           row: 30
           column: 20
+        content: ()
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ()
-        location:
+      - location:
           row: 38
           column: 24
         end_location:
           row: 38
           column: 24
+        content: ()
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT023_no_parentheses.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT023_no_parentheses.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 46
           column: 16
         end_location:
           row: 46
           column: 18
+        content: ~
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 51
           column: 16
         end_location:
           row: 51
           column: 18
+        content: ~
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 58
           column: 20
         end_location:
           row: 58
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 64
           column: 20
         end_location:
           row: 64
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: PytestIncorrectMarkParenthesesStyle
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 72
           column: 24
         end_location:
           row: 72
           column: 26
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT024.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT024.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 15
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PytestUnnecessaryAsyncioMarkOnFixture
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 21
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PytestUnnecessaryAsyncioMarkOnFixture
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 28
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PytestUnnecessaryAsyncioMarkOnFixture
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 33
           column: 0
         end_location:
           row: 34
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT025.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT025.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 10
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: PytestErroneousUseFixturesOnFixture
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT026.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT026.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 19
           column: 26
+        content: ~
   parent: ~
 - kind:
     name: PytestUseFixturesWithoutParameters
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 24
           column: 24
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\nthis is not a docstring\n'''"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 7
           column: 3
+        content: "'''\nthis is not a docstring\n'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "'''\n    this is not a docstring\n    '''"
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 18
           column: 7
+        content: "'''\n    this is not a docstring\n    '''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "'''\n        definitely not a docstring'''"
-        location:
+      - location:
           row: 21
           column: 20
         end_location:
           row: 22
           column: 37
+        content: "'''\n        definitely not a docstring'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "'''\n        this is not a docstring\n        '''"
-        location:
+      - location:
           row: 30
           column: 8
         end_location:
           row: 32
           column: 11
+        content: "'''\n        this is not a docstring\n        '''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "'''\n            Looks like a docstring, but in reality it isn't - only modules, classes and functions\n            '''"
-        location:
+      - location:
           row: 35
           column: 12
         end_location:
           row: 37
           column: 15
+        content: "'''\n            Looks like a docstring, but in reality it isn't - only modules, classes and functions\n            '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_class.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_class.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "''' Not a docstring '''"
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 27
+        content: "''' Not a docstring '''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "'''not a docstring'''"
-        location:
+      - location:
           row: 5
           column: 22
         end_location:
           row: 5
           column: 43
+        content: "'''not a docstring'''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_function.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_function.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "''' not a docstring'''"
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 26
+        content: "''' not a docstring'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "''' not a docstring'''"
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 11
           column: 26
+        content: "''' not a docstring'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\n    not a\n'''"
-        location:
+      - location:
           row: 15
           column: 38
         end_location:
           row: 17
           column: 3
+        content: "'''\n    not a\n'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "'''docstring'''"
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 17
           column: 19
+        content: "'''docstring'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "''' not a docstring '''"
-        location:
+      - location:
           row: 22
           column: 4
         end_location:
           row: 22
           column: 27
+        content: "''' not a docstring '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_module_multiline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_module_multiline.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\nthis is not a docstring\n'''"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 6
           column: 3
+        content: "'''\nthis is not a docstring\n'''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\nthis is not a docstring\n'''"
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 11
           column: 3
+        content: "'''\nthis is not a docstring\n'''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_module_singleline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_doubles_module_singleline.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "''' this is not a docstring '''"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 31
+        content: "''' this is not a docstring '''"
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "''' this is not a docstring '''"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 31
+        content: "''' this is not a docstring '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\nSingle quotes multiline module docstring\n\"\"\""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 3
+        content: "\"\"\"\nSingle quotes multiline module docstring\n\"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\"\"\n    Single quotes multiline class docstring\n    \"\"\""
-        location:
+      - location:
           row: 14
           column: 4
         end_location:
           row: 16
           column: 7
+        content: "\"\"\"\n    Single quotes multiline class docstring\n    \"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\"\"\"\n        Single quotes multiline function docstring\n        \"\"\""
-        location:
+      - location:
           row: 26
           column: 8
         end_location:
           row: 28
           column: 11
+        content: "\"\"\"\n        Single quotes multiline function docstring\n        \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_class.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_class.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: "\"\"\" Double quotes single line class docstring \"\"\""
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 53
+        content: "\"\"\" Double quotes single line class docstring \"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 57
   fix:
     edits:
-      - content: "\"\"\" Double quotes single line method docstring\"\"\""
-        location:
+      - location:
           row: 6
           column: 8
         end_location:
           row: 6
           column: 57
+        content: "\"\"\" Double quotes single line method docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: "\"\"\" inline docstring \"\"\""
-        location:
+      - location:
           row: 9
           column: 28
         end_location:
           row: 9
           column: 52
+        content: "\"\"\" inline docstring \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_function.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_function.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: "\"\"\"function without params, single line docstring\"\"\""
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 56
+        content: "\"\"\"function without params, single line docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\"\"\n        function without params, multiline docstring\n    \"\"\""
-        location:
+      - location:
           row: 8
           column: 4
         end_location:
           row: 10
           column: 7
+        content: "\"\"\"\n        function without params, multiline docstring\n    \"\"\""
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"Single line docstring\""
-        location:
+      - location:
           row: 27
           column: 4
         end_location:
           row: 27
           column: 27
+        content: "\"Single line docstring\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_module_multiline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_module_multiline.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\nDouble quotes multiline module docstring\n\"\"\""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 3
+        content: "\"\"\"\nDouble quotes multiline module docstring\n\"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_module_singleline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_doubles_over_docstring_singles_module_singleline.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "\"\"\" Double quotes singleline module docstring \"\"\""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 49
+        content: "\"\"\" Double quotes singleline module docstring \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\nDouble quotes multiline module docstring\n'''"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 3
+        content: "'''\nDouble quotes multiline module docstring\n'''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "'''\n    Double quotes multiline class docstring\n    '''"
-        location:
+      - location:
           row: 12
           column: 4
         end_location:
           row: 14
           column: 7
+        content: "'''\n    Double quotes multiline class docstring\n    '''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "'''\n        Double quotes multiline function docstring\n        '''"
-        location:
+      - location:
           row: 24
           column: 8
         end_location:
           row: 26
           column: 11
+        content: "'''\n        Double quotes multiline function docstring\n        '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_class.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_class.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: "''' Double quotes single line class docstring '''"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 53
+        content: "''' Double quotes single line class docstring '''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 57
   fix:
     edits:
-      - content: "''' Double quotes single line method docstring'''"
-        location:
+      - location:
           row: 6
           column: 8
         end_location:
           row: 6
           column: 57
+        content: "''' Double quotes single line method docstring'''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: "''' inline docstring '''"
-        location:
+      - location:
           row: 9
           column: 28
         end_location:
           row: 9
           column: 52
+        content: "''' inline docstring '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_function.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_function.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: "'''function without params, single line docstring'''"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 56
+        content: "'''function without params, single line docstring'''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "'''\n        function without params, multiline docstring\n    '''"
-        location:
+      - location:
           row: 8
           column: 4
         end_location:
           row: 10
           column: 7
+        content: "'''\n        function without params, multiline docstring\n    '''"
   parent: ~
 - kind:
     name: BadQuotesDocstring
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "'Single line docstring'"
-        location:
+      - location:
           row: 27
           column: 4
         end_location:
           row: 27
           column: 27
+        content: "'Single line docstring'"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_module_multiline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_module_multiline.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "'''\nDouble quotes multiline module docstring\n'''"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 3
+        content: "'''\nDouble quotes multiline module docstring\n'''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_module_singleline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_doubles_module_singleline.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "''' Double quotes singleline module docstring '''"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 49
+        content: "''' Double quotes singleline module docstring '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\nthis is not a docstring\n\"\"\""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 7
           column: 3
+        content: "\"\"\"\nthis is not a docstring\n\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\n    class params \\t not a docstring\n\"\"\""
-        location:
+      - location:
           row: 11
           column: 20
         end_location:
           row: 13
           column: 3
+        content: "\"\"\"\n    class params \\t not a docstring\n\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\"\"\n    this is not a docstring\n    \"\"\""
-        location:
+      - location:
           row: 18
           column: 4
         end_location:
           row: 20
           column: 7
+        content: "\"\"\"\n    this is not a docstring\n    \"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "\"\"\"\n        definitely not a docstring\"\"\""
-        location:
+      - location:
           row: 23
           column: 20
         end_location:
           row: 24
           column: 37
+        content: "\"\"\"\n        definitely not a docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\"\"\"\n        this is not a docstring\n        \"\"\""
-        location:
+      - location:
           row: 32
           column: 8
         end_location:
           row: 34
           column: 11
+        content: "\"\"\"\n        this is not a docstring\n        \"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "\"\"\"\n            Looks like a docstring, but in reality it isn't - only modules, classes and functions\n            \"\"\""
-        location:
+      - location:
           row: 37
           column: 12
         end_location:
           row: 39
           column: 15
+        content: "\"\"\"\n            Looks like a docstring, but in reality it isn't - only modules, classes and functions\n            \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_class.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_class.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"\"\" Not a docstring \"\"\""
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 27
+        content: "\"\"\" Not a docstring \"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "\"\"\"not a docstring\"\"\""
-        location:
+      - location:
           row: 5
           column: 22
         end_location:
           row: 5
           column: 43
+        content: "\"\"\"not a docstring\"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_function.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_function.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"\"\" not a docstring\"\"\""
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 26
+        content: "\"\"\" not a docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"\"\" not a docstring\"\"\""
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 11
           column: 26
+        content: "\"\"\" not a docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\n    not a\n\"\"\""
-        location:
+      - location:
           row: 15
           column: 38
         end_location:
           row: 17
           column: 3
+        content: "\"\"\"\n    not a\n\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\"\"\"docstring\"\"\""
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 17
           column: 19
+        content: "\"\"\"docstring\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"\"\" not a docstring \"\"\""
-        location:
+      - location:
           row: 22
           column: 4
         end_location:
           row: 22
           column: 27
+        content: "\"\"\" not a docstring \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_module_multiline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_module_multiline.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\nthis is not a docstring\n\"\"\""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 6
           column: 3
+        content: "\"\"\"\nthis is not a docstring\n\"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\"\"\"\nthis is not a docstring\n\"\"\""
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 11
           column: 3
+        content: "\"\"\"\nthis is not a docstring\n\"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_module_singleline.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_docstring_singles_over_docstring_singles_module_singleline.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "\"\"\" this is not a docstring \"\"\""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 31
+        content: "\"\"\" this is not a docstring \"\"\""
   parent: ~
 - kind:
     name: BadQuotesMultilineString
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "\"\"\" this is not a docstring \"\"\""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 31
+        content: "\"\"\" this is not a docstring \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "\"single quote string\""
-        location:
+      - location:
           row: 1
           column: 24
         end_location:
           row: 1
           column: 45
+        content: "\"single quote string\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "u\"double quote string\""
-        location:
+      - location:
           row: 2
           column: 24
         end_location:
           row: 2
           column: 46
+        content: "u\"double quote string\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "f\"double quote string\""
-        location:
+      - location:
           row: 3
           column: 24
         end_location:
           row: 3
           column: 46
+        content: "f\"double quote string\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_escaped.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_escaped.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: "'This is a \"string\"'"
-        location:
+      - location:
           row: 1
           column: 25
         end_location:
           row: 1
           column: 47
+        content: "'This is a \"string\"'"
   parent: ~
 - kind:
     name: AvoidableEscapedQuote
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "'\"string\"'"
-        location:
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 16
+        content: "'\"string\"'"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_implicit.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_implicit.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"This\""
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 10
+        content: "\"This\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "\"is\""
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 8
+        content: "\"is\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "\"not\""
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 9
+        content: "\"not\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"This\""
-        location:
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 10
+        content: "\"This\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "\"is\""
-        location:
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: "\"is\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "\"not\""
-        location:
+      - location:
           row: 10
           column: 4
         end_location:
           row: 10
           column: 9
+        content: "\"not\""
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "\"But this needs to be changed\""
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 27
           column: 30
+        content: "\"But this needs to be changed\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_multiline_string.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_doubles_over_singles_multiline_string.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "\"\"\" This 'should'\nbe\n'linted' \"\"\""
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 3
           column: 12
+        content: "\"\"\" This 'should'\nbe\n'linted' \"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "'double quote string'"
-        location:
+      - location:
           row: 1
           column: 24
         end_location:
           row: 1
           column: 45
+        content: "'double quote string'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "u'double quote string'"
-        location:
+      - location:
           row: 2
           column: 24
         end_location:
           row: 2
           column: 46
+        content: "u'double quote string'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "f'double quote string'"
-        location:
+      - location:
           row: 3
           column: 24
         end_location:
           row: 3
           column: 46
+        content: "f'double quote string'"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_escaped.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_escaped.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: "\"This is a 'string'\""
-        location:
+      - location:
           row: 1
           column: 25
         end_location:
           row: 1
           column: 47
+        content: "\"This is a 'string'\""
   parent: ~
 - kind:
     name: AvoidableEscapedQuote
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: "\"This is \\\\ a \\\\'string'\""
-        location:
+      - location:
           row: 2
           column: 25
         end_location:
           row: 2
           column: 52
+        content: "\"This is \\\\ a \\\\'string'\""
   parent: ~
 - kind:
     name: AvoidableEscapedQuote
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\"'string'\""
-        location:
+      - location:
           row: 10
           column: 4
         end_location:
           row: 10
           column: 16
+        content: "\"'string'\""
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_implicit.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_implicit.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "'This'"
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 10
+        content: "'This'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "'is'"
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 8
+        content: "'is'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "'not'"
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 9
+        content: "'not'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "'This'"
-        location:
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 10
+        content: "'This'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "'is'"
-        location:
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: "'is'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "'not'"
-        location:
+      - location:
           row: 10
           column: 4
         end_location:
           row: 10
           column: 9
+        content: "'not'"
   parent: ~
 - kind:
     name: BadQuotesInlineString
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "'But this needs to be changed'"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 27
           column: 30
+        content: "'But this needs to be changed'"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_multiline_string.py.snap
+++ b/crates/ruff/src/rules/flake8_quotes/snapshots/ruff__rules__flake8_quotes__tests__require_singles_over_doubles_multiline_string.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "''' This \"should\"\nbe\n\"linted\" '''"
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 3
           column: 12
+        content: "''' This \"should\"\nbe\n\"linted\" '''"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
+++ b/crates/ruff/src/rules/flake8_raise/snapshots/ruff__rules__flake8_raise__tests__unnecessary-paren-on-raise-exception_RSE102.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 20
         end_location:
           row: 5
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryParenOnRaiseException
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 15
         end_location:
           row: 13
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryParenOnRaiseException
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 15
         end_location:
           row: 16
           column: 18
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryParenOnRaiseException
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 15
         end_location:
           row: 20
           column: 6
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryParenOnRaiseException
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 23
           column: 15
         end_location:
           row: 25
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryParenOnRaiseException
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 28
           column: 15
         end_location:
           row: 30
           column: 1
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET501_RET501.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET501_RET501.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: return
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 15
+        content: return
   parent: ~
 - kind:
     name: UnnecessaryReturnNone
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: return
-        location:
+      - location:
           row: 14
           column: 8
         end_location:
           row: 14
           column: 19
+        content: return
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET502_RET502.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET502_RET502.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: return None
-        location:
+      - location:
           row: 3
           column: 8
         end_location:
           row: 3
           column: 14
+        content: return None
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET503_RET503.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET503_RET503.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 21
           column: 16
         end_location:
           row: 21
           column: 16
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 27
           column: 24
         end_location:
           row: 27
           column: 24
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 36
           column: 20
         end_location:
           row: 36
           column: 20
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 43
           column: 20
         end_location:
           row: 43
           column: 20
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 52
           column: 24
         end_location:
           row: 52
           column: 24
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 59
           column: 31
         end_location:
           row: 59
           column: 31
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 66
           column: 30
         end_location:
           row: 66
           column: 30
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 85
           column: 14
         end_location:
           row: 85
           column: 14
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 116
           column: 16
         end_location:
           row: 116
           column: 16
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 126
           column: 19
         end_location:
           row: 126
           column: 19
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 133
           column: 16
         end_location:
           row: 133
           column: 16
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 143
           column: 19
         end_location:
           row: 143
           column: 19
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\n    return None"
-        location:
+      - location:
           row: 275
           column: 20
         end_location:
           row: 275
           column: 20
+        content: "\n    return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\n            return None"
-        location:
+      - location:
           row: 291
           column: 28
         end_location:
           row: 291
           column: 28
+        content: "\n            return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 301
           column: 21
         end_location:
           row: 301
           column: 21
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 306
           column: 21
         end_location:
           row: 306
           column: 21
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 311
           column: 37
         end_location:
           row: 311
           column: 37
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 316
           column: 24
         end_location:
           row: 316
           column: 24
+        content: "\n        return None"
   parent: ~
 - kind:
     name: ImplicitReturn
@@ -393,12 +393,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n        return None"
-        location:
+      - location:
           row: 322
           column: 33
         end_location:
           row: 322
           column: 33
+        content: "\n        return None"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -299,7 +299,8 @@ pub fn nested_if_statements(
         match fix_if::fix_nested_if_statements(checker.locator, checker.stylist, stmt) {
             Ok(fix) => {
                 if fix
-                    .content
+                    .content()
+                    .unwrap_or_default()
                     .universal_newlines()
                     .all(|line| line.width() <= checker.settings.line_length)
                 {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -116,7 +116,8 @@ pub fn multiple_with_statements(
             ) {
                 Ok(fix) => {
                     if fix
-                        .content
+                        .content()
+                        .unwrap_or_default()
                         .universal_newlines()
                         .all(|line| line.width() <= checker.settings.line_length)
                     {

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM101_SIM101.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "isinstance(a, (int, float))"
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 45
+        content: "isinstance(a, (int, float))"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: "isinstance(a, (int, float, bool))"
-        location:
+      - location:
           row: 4
           column: 3
         end_location:
           row: 4
           column: 53
+        content: "isinstance(a, (int, float, bool))"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 68
   fix:
     edits:
-      - content: "isinstance(a, (int, float)) or isinstance(b, bool)"
-        location:
+      - location:
           row: 7
           column: 3
         end_location:
           row: 7
           column: 68
+        content: "isinstance(a, (int, float)) or isinstance(b, bool)"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 68
   fix:
     edits:
-      - content: "isinstance(a, (int, float)) or isinstance(b, bool)"
-        location:
+      - location:
           row: 10
           column: 3
         end_location:
           row: 10
           column: 68
+        content: "isinstance(a, (int, float)) or isinstance(b, bool)"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 68
   fix:
     edits:
-      - content: "isinstance(a, (int, float)) or isinstance(b, bool)"
-        location:
+      - location:
           row: 13
           column: 3
         end_location:
           row: 13
           column: 68
+        content: "isinstance(a, (int, float)) or isinstance(b, bool)"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "isinstance(a, (int, float))"
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 16
           column: 46
+        content: "isinstance(a, (int, float))"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "isinstance(a.b, (int, float))"
-        location:
+      - location:
           row: 19
           column: 3
         end_location:
           row: 19
           column: 49
+        content: "isinstance(a.b, (int, float))"
   parent: ~
 - kind:
     name: DuplicateIsinstanceCall

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM102_SIM102.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "if a and b:\n    c\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "if a and b:\n    c\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "if a and b:\n    if c:\n        d\n"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 11
           column: 0
+        content: "if a and b:\n    if c:\n        d\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "elif b and c:\n    d\n"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 18
           column: 0
+        content: "elif b and c:\n    d\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -92,13 +92,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "if a and b:\n    # Fixable due to placement of this comment.\n    c\n"
-        location:
+      - location:
           row: 26
           column: 0
         end_location:
           row: 30
           column: 0
+        content: "if a and b:\n    # Fixable due to placement of this comment.\n    c\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -113,13 +113,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "    if y > 0 and z > 0:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
-        location:
+      - location:
           row: 51
           column: 0
         end_location:
           row: 64
           column: 0
+        content: "    if y > 0 and z > 0:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -134,13 +134,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "if x > 0 and y > 0:\n    \"\"\"this\nis valid\"\"\"\n\n    \"\"\"the indentation on\n        this line is significant\"\"\"\n\n    \"this is\" \\\n\"allowed too\"\n\n    (\"so is\"\n\"this for some reason\")\n"
-        location:
+      - location:
           row: 67
           column: 0
         end_location:
           row: 80
           column: 0
+        content: "if x > 0 and y > 0:\n    \"\"\"this\nis valid\"\"\"\n\n    \"\"\"the indentation on\n        this line is significant\"\"\"\n\n    \"this is\" \\\n\"allowed too\"\n\n    (\"so is\"\n\"this for some reason\")\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -155,13 +155,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "    if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n        \"multiprocessing.\"\n    )):\n        print(\"Bad module!\")\n"
-        location:
+      - location:
           row: 83
           column: 0
         end_location:
           row: 88
           column: 0
+        content: "    if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n        \"multiprocessing.\"\n    )):\n        print(\"Bad module!\")\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -176,13 +176,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n    \"multiprocessing.\"\n)):\n    print(\"Bad module!\")\n"
-        location:
+      - location:
           row: 90
           column: 0
         end_location:
           row: 95
           column: 0
+        content: "if node.module and (node.module == \"multiprocessing\" or node.module.startswith(\n    \"multiprocessing.\"\n)):\n    print(\"Bad module!\")\n"
   parent: ~
 - kind:
     name: CollapsibleIf
@@ -197,12 +197,12 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "    if b and c:\n        print(\"foo\")\n"
-        location:
+      - location:
           row: 117
           column: 0
         end_location:
           row: 120
           column: 0
+        content: "    if b and c:\n        print(\"foo\")\n"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM103_SIM103.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return bool(a)
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 6
           column: 20
+        content: return bool(a)
   parent: ~
 - kind:
     name: NeedlessBool
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return a == b
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 14
           column: 20
+        content: return a == b
   parent: ~
 - kind:
     name: NeedlessBool
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return bool(b)
-        location:
+      - location:
           row: 21
           column: 4
         end_location:
           row: 24
           column: 20
+        content: return bool(b)
   parent: ~
 - kind:
     name: NeedlessBool
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return bool(b)
-        location:
+      - location:
           row: 32
           column: 8
         end_location:
           row: 35
           column: 24
+        content: return bool(b)
   parent: ~
 - kind:
     name: NeedlessBool

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM105_SIM105.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM105_SIM105.py.snap
@@ -15,27 +15,27 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import contextlib\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: with contextlib.suppress(ValueError)
-        location:
+        content: "import contextlib\n"
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 3
-      - content: ""
-        location:
+        content: with contextlib.suppress(ValueError)
+      - location:
           row: 6
           column: 0
         end_location:
           row: 7
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: SuppressibleException
@@ -50,27 +50,27 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import contextlib\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: "with contextlib.suppress(ValueError, OSError)"
-        location:
+        content: "import contextlib\n"
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 3
-      - content: ""
-        location:
+        content: "with contextlib.suppress(ValueError, OSError)"
+      - location:
           row: 11
           column: 0
         end_location:
           row: 12
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: SuppressibleException
@@ -85,27 +85,27 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import contextlib\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: with contextlib.suppress(Exception)
-        location:
+        content: "import contextlib\n"
+      - location:
           row: 14
           column: 0
         end_location:
           row: 14
           column: 3
-      - content: ""
-        location:
+        content: with contextlib.suppress(Exception)
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: SuppressibleException
@@ -120,27 +120,27 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import contextlib\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: "with contextlib.suppress(a.Error, b.Error)"
-        location:
+        content: "import contextlib\n"
+      - location:
           row: 19
           column: 0
         end_location:
           row: 19
           column: 3
-      - content: ""
-        location:
+        content: "with contextlib.suppress(a.Error, b.Error)"
+      - location:
           row: 21
           column: 0
         end_location:
           row: 22
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: SuppressibleException
@@ -155,26 +155,26 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "import contextlib\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: with contextlib.suppress(ValueError)
-        location:
+        content: "import contextlib\n"
+      - location:
           row: 64
           column: 4
         end_location:
           row: 64
           column: 7
-      - content: ""
-        location:
+        content: with contextlib.suppress(ValueError)
+      - location:
           row: 66
           column: 0
         end_location:
           row: 67
           column: 11
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM108_SIM108.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: b = c if a else d
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 5
           column: 9
+        content: b = c if a else d
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfIfExp
@@ -50,13 +50,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: b = cccccccccccccccccccccccccccccccccccc if a else ddddddddddddddddddddddddddddddddddddd
-        location:
+      - location:
           row: 82
           column: 0
         end_location:
           row: 85
           column: 45
+        content: b = cccccccccccccccccccccccccccccccccccc if a else ddddddddddddddddddddddddddddddddddddd
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfIfExp

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM109_SIM109.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "a in (b, c)"
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 19
+        content: "a in (b, c)"
   parent: ~
 - kind:
     name: CompareWithTuple
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "a in (b, c)"
-        location:
+      - location:
           row: 6
           column: 4
         end_location:
           row: 6
           column: 20
+        content: "a in (b, c)"
   parent: ~
 - kind:
     name: CompareWithTuple
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "a in (b, c) or None"
-        location:
+      - location:
           row: 10
           column: 3
         end_location:
           row: 10
           column: 27
+        content: "a in (b, c) or None"
   parent: ~
 - kind:
     name: CompareWithTuple
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "a in (b, c) or None"
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 27
+        content: "a in (b, c) or None"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 6
           column: 16
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 25
           column: 4
         end_location:
           row: 28
           column: 15
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(x.is_empty() for x in iterable)
-        location:
+      - location:
           row: 33
           column: 4
         end_location:
           row: 36
           column: 15
+        content: return all(x.is_empty() for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 55
           column: 4
         end_location:
           row: 59
           column: 20
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 64
           column: 4
         end_location:
           row: 68
           column: 19
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 73
           column: 4
         end_location:
           row: 77
           column: 20
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 83
           column: 4
         end_location:
           row: 87
           column: 19
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -190,13 +190,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 144
           column: 4
         end_location:
           row: 147
           column: 16
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -211,12 +211,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 154
           column: 4
         end_location:
           row: 157
           column: 15
+        content: return all(not check(x) for x in iterable)
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 6
           column: 16
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 25
           column: 4
         end_location:
           row: 28
           column: 15
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(x.is_empty() for x in iterable)
-        location:
+      - location:
           row: 33
           column: 4
         end_location:
           row: 36
           column: 15
+        content: return all(x.is_empty() for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 55
           column: 4
         end_location:
           row: 59
           column: 20
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 64
           column: 4
         end_location:
           row: 68
           column: 19
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 73
           column: 4
         end_location:
           row: 77
           column: 20
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 83
           column: 4
         end_location:
           row: 87
           column: 19
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -190,13 +190,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: return any(check(x) for x in iterable)
-        location:
+      - location:
           row: 144
           column: 4
         end_location:
           row: 147
           column: 16
+        content: return any(check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -211,13 +211,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(not check(x) for x in iterable)
-        location:
+      - location:
           row: 154
           column: 4
         end_location:
           row: 157
           column: 15
+        content: return all(not check(x) for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -232,13 +232,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(x in y for x in iterable)
-        location:
+      - location:
           row: 162
           column: 4
         end_location:
           row: 165
           column: 15
+        content: return all(x in y for x in iterable)
   parent: ~
 - kind:
     name: ReimplementedBuiltin
@@ -253,12 +253,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: return all(x <= y for x in iterable)
-        location:
+      - location:
           row: 170
           column: 4
         end_location:
           row: 173
           column: 15
+        content: return all(x <= y for x in iterable)
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 4
           column: 11
         end_location:
           row: 4
           column: 16
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 6
           column: 15
         end_location:
           row: 6
           column: 20
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 8
           column: 15
         end_location:
           row: 8
           column: 20
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 10
           column: 10
         end_location:
           row: 10
           column: 15
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 12
           column: 21
         end_location:
           row: 12
           column: 26
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 14
           column: 17
         end_location:
           row: 14
           column: 22
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 16
           column: 25
         end_location:
           row: 16
           column: 30
+        content: "'FOO'"
   parent: ~
 - kind:
     name: UncapitalizedEnvironmentVariables
@@ -162,12 +162,12 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "'FOO'"
-        location:
+      - location:
           row: 19
           column: 21
         end_location:
           row: 19
           column: 26
+        content: "'FOO'"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM117_SIM117.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "with A() as a, B() as b:\n    print(\"hello\")\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "with A() as a, B() as b:\n    print(\"hello\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "with A(), B():\n    with C():\n        print(\"hello\")\n"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 11
           column: 0
+        content: "with A(), B():\n    with C():\n        print(\"hello\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -71,13 +71,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "with A() as a, B() as b:\n    # Fixable due to placement of this comment.\n    print(\"hello\")\n"
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 23
           column: 0
+        content: "with A() as a, B() as b:\n    # Fixable due to placement of this comment.\n    print(\"hello\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -92,13 +92,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "    with A() as a, B() as b:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
-        location:
+      - location:
           row: 53
           column: 0
         end_location:
           row: 66
           column: 0
+        content: "    with A() as a, B() as b:\n        \"\"\"this\nis valid\"\"\"\n\n        \"\"\"the indentation on\n            this line is significant\"\"\"\n\n        \"this is\" \\\n\"allowed too\"\n\n        (\"so is\"\n\"this for some reason\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -113,13 +113,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "with (\n    A() as a,\n    B() as b,C() as c\n):\n    print(\"hello\")\n"
-        location:
+      - location:
           row: 68
           column: 0
         end_location:
           row: 74
           column: 0
+        content: "with (\n    A() as a,\n    B() as b,C() as c\n):\n    print(\"hello\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -134,13 +134,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "with (\n    A() as a, B() as b,\n    C() as c,\n):\n    print(\"hello\")\n"
-        location:
+      - location:
           row: 76
           column: 0
         end_location:
           row: 82
           column: 0
+        content: "with (\n    A() as a, B() as b,\n    C() as c,\n):\n    print(\"hello\")\n"
   parent: ~
 - kind:
     name: MultipleWithStatements
@@ -155,12 +155,12 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "with (\n    A() as a,\n    B() as b,C() as c,\n    D() as d,\n):\n    print(\"hello\")\n"
-        location:
+      - location:
           row: 84
           column: 0
         end_location:
           row: 93
           column: 0
+        content: "with (\n    A() as a,\n    B() as b,C() as c,\n    D() as d,\n):\n    print(\"hello\")\n"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM118_SIM118.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM118_SIM118.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 1
           column: 7
         end_location:
           row: 1
           column: 17
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 3
           column: 14
         end_location:
           row: 3
           column: 24
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 5
           column: 14
         end_location:
           row: 5
           column: 24
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 7
           column: 9
         end_location:
           row: 7
           column: 19
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 9
           column: 11
         end_location:
           row: 9
           column: 21
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 16
           column: 12
         end_location:
           row: 16
           column: 22
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 18
           column: 12
         end_location:
           row: 18
           column: 22
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 20
           column: 15
         end_location:
           row: 20
           column: 25
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: obj
-        location:
+      - location:
           row: 22
           column: 12
         end_location:
           row: 22
           column: 22
+        content: obj
   parent: ~
 - kind:
     name: InDictKeys
@@ -204,12 +204,12 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "(obj or {})"
-        location:
+      - location:
           row: 24
           column: 7
         end_location:
           row: 24
           column: 25
+        content: "(obj or {})"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM201_SIM201.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM201_SIM201.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: a != b
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 13
+        content: a != b
   parent: ~
 - kind:
     name: NegateEqualOp
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: a != b + c
-        location:
+      - location:
           row: 6
           column: 3
         end_location:
           row: 6
           column: 19
+        content: a != b + c
   parent: ~
 - kind:
     name: NegateEqualOp
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: a + b != c
-        location:
+      - location:
           row: 10
           column: 3
         end_location:
           row: 10
           column: 19
+        content: a + b != c
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM202_SIM202.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: a == b
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 13
+        content: a == b
   parent: ~
 - kind:
     name: NegateNotEqualOp
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: a == b + c
-        location:
+      - location:
           row: 6
           column: 3
         end_location:
           row: 6
           column: 19
+        content: a == b + c
   parent: ~
 - kind:
     name: NegateNotEqualOp
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: a + b == c
-        location:
+      - location:
           row: 10
           column: 3
         end_location:
           row: 10
           column: 19
+        content: a + b == c
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM208_SIM208.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: a
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 14
+        content: a
   parent: ~
 - kind:
     name: DoubleNegation
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: a == b
-        location:
+      - location:
           row: 4
           column: 3
         end_location:
           row: 4
           column: 21
+        content: a == b
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: bool(b)
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 24
+        content: bool(b)
   parent: ~
 - kind:
     name: IfExprWithTrueFalse
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: b != c
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 29
+        content: b != c
   parent: ~
 - kind:
     name: IfExprWithTrueFalse
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: bool(b + c)
-        location:
+      - location:
           row: 5
           column: 4
         end_location:
           row: 5
           column: 28
+        content: bool(b + c)
   parent: ~
 - kind:
     name: IfExprWithTrueFalse

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM211_SIM211.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM211_SIM211.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: not b
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 24
+        content: not b
   parent: ~
 - kind:
     name: IfExprWithFalseTrue
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: not b != c
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 29
+        content: not b != c
   parent: ~
 - kind:
     name: IfExprWithFalseTrue
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: not b + c
-        location:
+      - location:
           row: 5
           column: 4
         end_location:
           row: 5
           column: 28
+        content: not b + c
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM212_SIM212.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM212_SIM212.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: a if a else b
-        location:
+      - location:
           row: 1
           column: 4
         end_location:
           row: 1
           column: 21
+        content: a if a else b
   parent: ~
 - kind:
     name: IfExprWithTwistedArms
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: a if a else b + c
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 25
+        content: a if a else b + c
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM220_SIM220.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM220_SIM220.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 14
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndNotExpr
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 15
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndNotExpr
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 15
+        content: "False"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM221_SIM221.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 13
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrNotExpr
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 14
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrNotExpr
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 14
+        content: "True"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 12
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrTrue
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 4
           column: 3
         end_location:
           row: 4
           column: 19
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrTrue
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 7
           column: 9
         end_location:
           row: 7
           column: 18
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrTrue
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 24
           column: 15
         end_location:
           row: 24
           column: 31
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrTrue
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 27
           column: 3
         end_location:
           row: 27
           column: 31
+        content: "True"
   parent: ~
 - kind:
     name: ExprOrTrue
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "True"
-        location:
+      - location:
           row: 30
           column: 3
         end_location:
           row: 30
           column: 31
+        content: "True"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 1
           column: 3
         end_location:
           row: 1
           column: 14
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndFalse
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 4
           column: 3
         end_location:
           row: 4
           column: 21
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndFalse
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 7
           column: 9
         end_location:
           row: 7
           column: 20
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndFalse
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 19
           column: 17
         end_location:
           row: 19
           column: 36
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndFalse
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 22
           column: 3
         end_location:
           row: 22
           column: 36
+        content: "False"
   parent: ~
 - kind:
     name: ExprAndFalse
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "False"
-        location:
+      - location:
           row: 25
           column: 3
         end_location:
           row: 25
           column: 36
+        content: "False"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM300_SIM300.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "compare == \"yoda\""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 17
+        content: "compare == \"yoda\""
   parent: ~
 - kind:
     name: YodaConditions
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "compare == \"yoda\""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 17
+        content: "compare == \"yoda\""
   parent: ~
 - kind:
     name: YodaConditions
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: age == 42
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 9
+        content: age == 42
   parent: ~
 - kind:
     name: YodaConditions
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "compare == (\"a\", \"b\")"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 21
+        content: "compare == (\"a\", \"b\")"
   parent: ~
 - kind:
     name: YodaConditions
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "compare >= \"yoda\""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 17
+        content: "compare >= \"yoda\""
   parent: ~
 - kind:
     name: YodaConditions
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "compare > \"yoda\""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 16
+        content: "compare > \"yoda\""
   parent: ~
 - kind:
     name: YodaConditions
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: age < 42
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 8
+        content: age < 42
   parent: ~
 - kind:
     name: YodaConditions
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: age < -42
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 9
+        content: age < -42
   parent: ~
 - kind:
     name: YodaConditions
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: age < +42
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 9
+        content: age < +42
   parent: ~
 - kind:
     name: YodaConditions
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: age == YODA
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 11
+        content: age == YODA
   parent: ~
 - kind:
     name: YodaConditions
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: age < YODA
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 12
           column: 10
+        content: age < YODA
   parent: ~
 - kind:
     name: YodaConditions
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: age <= YODA
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 13
           column: 11
+        content: age <= YODA
   parent: ~
 - kind:
     name: YodaConditions
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: age == JediOrder.YODA
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 14
           column: 21
+        content: age == JediOrder.YODA
   parent: ~
 - kind:
     name: YodaConditions
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: (number - 100) > 0
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 18
+        content: (number - 100) > 0
   parent: ~
 - kind:
     name: YodaConditions
@@ -309,12 +309,12 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: (60 * 60) < SomeClass().settings.SOME_CONSTANT_VALUE
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 16
           column: 52
+        content: (60 * 60) < SomeClass().settings.SOME_CONSTANT_VALUE
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "var = a_dict.get(key, \"default1\")"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 9
           column: 20
+        content: "var = a_dict.get(key, \"default1\")"
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfDictGet
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "var = a_dict.get(key, \"default2\")"
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 15
           column: 21
+        content: "var = a_dict.get(key, \"default2\")"
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfDictGet
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "var = a_dict.get(keys[idx], \"default\")"
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 27
           column: 19
+        content: "var = a_dict.get(keys[idx], \"default\")"
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfDictGet
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "var = dicts[idx].get(key, \"default\")"
-        location:
+      - location:
           row: 30
           column: 0
         end_location:
           row: 33
           column: 19
+        content: "var = dicts[idx].get(key, \"default\")"
   parent: ~
 - kind:
     name: IfElseBlockInsteadOfDictGet
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "vars[idx] = a_dict.get(key, \"default\")"
-        location:
+      - location:
           row: 36
           column: 0
         end_location:
           row: 39
           column: 25
+        content: "vars[idx] = a_dict.get(key, \"default\")"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "{}.get(key)"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 17
+        content: "{}.get(key)"
   parent: ~
 - kind:
     name: DictGetWithNoneDefault
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "{}.get(\"key\")"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 19
+        content: "{}.get(\"key\")"
   parent: ~
 - kind:
     name: DictGetWithNoneDefault
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "{}.get(key)"
-        location:
+      - location:
           row: 20
           column: 8
         end_location:
           row: 20
           column: 25
+        content: "{}.get(key)"
   parent: ~
 - kind:
     name: DictGetWithNoneDefault
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "{}.get(key)"
-        location:
+      - location:
           row: 24
           column: 4
         end_location:
           row: 24
           column: 21
+        content: "{}.get(key)"
   parent: ~
 - kind:
     name: DictGetWithNoneDefault
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "({}).get(key)"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 27
           column: 19
+        content: "({}).get(key)"
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
@@ -29,13 +29,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: "from my_package.sublib.protocol import commands, definitions, responses"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 55
+        content: "from my_package.sublib.protocol import commands, definitions, responses"
   parent: ~
 - kind:
     name: RelativeImports
@@ -50,13 +50,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: "from my_package.sublib.protocol import commands, definitions, responses"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 55
+        content: "from my_package.sublib.protocol import commands, definitions, responses"
   parent: ~
 - kind:
     name: RelativeImports
@@ -71,13 +71,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: "from my_package.sublib.protocol import commands, definitions, responses"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 55
+        content: "from my_package.sublib.protocol import commands, definitions, responses"
   parent: ~
 - kind:
     name: RelativeImports
@@ -92,13 +92,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: from my_package.sublib.server import example
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 28
+        content: from my_package.sublib.server import example
   parent: ~
 - kind:
     name: RelativeImports
@@ -113,13 +113,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: from my_package.sublib import server
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 21
+        content: from my_package.sublib import server
   parent: ~
 - kind:
     name: RelativeImports
@@ -134,12 +134,12 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: from my_package.sublib.protocol.UpperCaseModule import some_function
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 52
+        content: from my_package.sublib.protocol.UpperCaseModule import some_function
   parent: ~
 

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -51,7 +51,7 @@ pub fn empty_type_checking_block<'a, 'b>(
                 checker.stylist,
             ) {
                 Ok(fix) => {
-                    if fix.content.is_empty() || fix.content == "pass" {
+                    if fix.is_deletion() || fix.content() == Some("pass") {
                         checker.deletions.insert(RefEquality(stmt));
                     }
                     diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__empty-type-checking-block_TCH005.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 5
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: EmptyTypeCheckingBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 9
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: EmptyTypeCheckingBlock
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 12
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: EmptyTypeCheckingBlock
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 17
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: EmptyTypeCheckingBlock
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 23
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__1_separate_subpackage_first_and_third_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__1_separate_subpackage_first_and_third_party_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import sys\n\nimport foo\nfrom foo import bar, baz\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 9
           column: 0
+        content: "import sys\n\nimport foo\nfrom foo import bar, baz\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__2_separate_subpackage_first_and_third_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__2_separate_subpackage_first_and_third_party_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import sys\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n\nimport foo\nfrom foo import bar, baz\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 9
           column: 0
+        content: "import sys\n\nimport baz\nimport foo.bar\nimport foo.bar.baz\nfrom foo.bar import blah, blub\nfrom foo.bar.baz import something\n\nimport foo\nfrom foo import bar, baz\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__add_newline_before_comments.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__add_newline_before_comments.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\n\n# This is a comment in the same section, so we need to add one newline.\nimport sys\n\nimport numpy as np\n\n# This is a comment, but it starts a new section, so we don't need to add a newline\n# before it.\nimport leading_prefix\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 8
           column: 0
+        content: "import os\n\n# This is a comment in the same section, so we need to add one newline.\nimport sys\n\nimport numpy as np\n\n# This is a comment, but it starts a new section, so we don't need to add a newline\n# before it.\nimport leading_prefix\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__as_imports_comments.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__as_imports_comments.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from bar import (  # Comment on `bar`\n    Member,  # Comment on `Member`\n)\nfrom baz import Member as Alias  # Comment on `Alias`  # Comment on `baz`\nfrom bop import Member  # Comment on `Member`  # Comment on `bop`\nfrom foo import (  # Comment on `foo`\n    Member as Alias,  # Comment on `Alias`\n)\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 16
           column: 0
+        content: "from bar import (  # Comment on `bar`\n    Member,  # Comment on `Member`\n)\nfrom baz import Member as Alias  # Comment on `Alias`  # Comment on `baz`\nfrom bop import Member  # Comment on `Member`  # Comment on `bop`\nfrom foo import (  # Comment on `foo`\n    Member as Alias,  # Comment on `Alias`\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__closest_to_furthest_relative_imports_order.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__closest_to_furthest_relative_imports_order.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from . import c\nfrom .. import b\nfrom ... import a\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from . import c\nfrom .. import b\nfrom ... import a\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_as_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_as_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from module import CONSTANT, function\nfrom module import Class as C\nfrom module import function as f\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "from module import CONSTANT, function\nfrom module import Class as C\nfrom module import function as f\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_as_imports_combine_as_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_as_imports_combine_as_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from module import CONSTANT, Class as C, function, function as f\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "from module import CONSTANT, Class as C, function, function as f\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_import_from.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combine_import_from.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from collections import (\n    AsyncIterable,\n    Awaitable,\n    ChainMap,\n    Collection,\n    MutableMapping,\n    MutableSequence,\n)\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "from collections import (\n    AsyncIterable,\n    Awaitable,\n    ChainMap,\n    Collection,\n    MutableMapping,\n    MutableSequence,\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combined_required_imports_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__combined_required_imports_docstring.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from __future__ import annotations\n"
   parent: ~
 - kind:
     name: MissingRequiredImport
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import generator_stop\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from __future__ import generator_stop\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__comments.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__comments.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import B  # Comment 4\n\n# Comment 3a\n# Comment 3b\nimport C\nimport D\n\n# Comment 5\n# Comment 6\nfrom A import (\n    a,  # Comment 7  # Comment 9\n    b,  # Comment 10\n    c,  # Comment 8  # Comment 11\n)\nfrom D import (\n    a_long_name_to_force_multiple_lines,  # Comment 12\n    another_long_name_to_force_multiple_lines,  # Comment 13\n)\nfrom E import a  # Comment 1\nfrom F import (\n    a,  # Comment 1\n    b,\n)\n"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 34
           column: 0
+        content: "import B  # Comment 4\n\n# Comment 3a\n# Comment 3b\nimport C\nimport D\n\n# Comment 5\n# Comment 6\nfrom A import (\n    a,  # Comment 7  # Comment 9\n    b,  # Comment 10\n    c,  # Comment 8  # Comment 11\n)\nfrom D import (\n    a_long_name_to_force_multiple_lines,  # Comment 12\n    another_long_name_to_force_multiple_lines,  # Comment 13\n)\nfrom E import a  # Comment 1\nfrom F import (\n    a,  # Comment 1\n    b,\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__deduplicate_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__deduplicate_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport os as os1\nimport os as os2\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "import os\nimport os as os1\nimport os as os2\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__fit_line_length.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__fit_line_length.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    from line_with_88 import aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    from line_with_89 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_90 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_91 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_92 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_93 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 15
           column: 0
+        content: "    from line_with_88 import aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n    from line_with_89 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_90 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_91 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_92 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n    from line_with_93 import (\n        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n    )\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__fit_line_length_comment.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__fit_line_length_comment.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import a\n\n# Don't take this comment into account when determining whether the next import can fit on one line.\nfrom b import c\nfrom d import (\n    e,  # Do take this comment into account when determining whether the next import can fit on one line.\n)\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "import a\n\n# Don't take this comment into account when determining whether the next import can fit on one line.\nfrom b import c\nfrom d import (\n    e,  # Do take this comment into account when determining whether the next import can fit on one line.\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_single_line_force_single_line.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_single_line_force_single_line.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import math\nimport sys\nfrom json import detect_encoding\nfrom json import dump\nfrom json import dumps as json_dumps\nfrom json import load\nfrom json import loads as json_loads\nfrom logging.handlers import FileHandler, StreamHandler\nfrom os import path, uname\n\n# comment 6\nfrom bar import a  # comment 7\nfrom bar import b  # comment 8\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\nfrom foo3 import bar3  # comment 5\nfrom foo3 import baz3  # comment 5\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 25
           column: 0
+        content: "import math\nimport sys\nfrom json import detect_encoding\nfrom json import dump\nfrom json import dumps as json_dumps\nfrom json import load\nfrom json import loads as json_loads\nfrom logging.handlers import FileHandler, StreamHandler\nfrom os import path, uname\n\n# comment 6\nfrom bar import a  # comment 7\nfrom bar import b  # comment 8\nfrom foo import bar  # comment 3\nfrom foo2 import bar2  # comment 4\nfrom foo3 import bar3  # comment 5\nfrom foo3 import baz3  # comment 5\n\n# comment 1\n# comment 2\nfrom third_party import lib1\nfrom third_party import lib2\nfrom third_party import lib3\nfrom third_party import lib4\nfrom third_party import lib5\nfrom third_party import lib6\nfrom third_party import lib7\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_sort_within_sections.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_sort_within_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import a  # import\nimport b as b1  # import_as\nimport c.d\nimport z\nfrom a import a1  # import_from\nfrom c import *  # import_from_star\nfrom z import z1\n\nfrom ...grandparent import fn3\nfrom ..parent import *\nfrom . import my\nfrom .my import fn\nfrom .my.nested import fn2\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 14
           column: 0
+        content: "import a  # import\nimport b as b1  # import_as\nimport c.d\nimport z\nfrom a import a1  # import_from\nfrom c import *  # import_from_star\nfrom z import z1\n\nfrom ...grandparent import fn3\nfrom ..parent import *\nfrom . import my\nfrom .my import fn\nfrom .my.nested import fn2\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_sort_within_sections_force_sort_within_sections.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_sort_within_sections_force_sort_within_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import z\nfrom z import z1\nimport a  # import\nfrom a import a1  # import_from\nimport b as b1  # import_as\nfrom c import *  # import_from_star\nimport c.d\n\nfrom ...grandparent import fn3\nfrom ..parent import *\nfrom . import my\nfrom .my import fn\nfrom .my.nested import fn2\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 14
           column: 0
+        content: "import z\nfrom z import z1\nimport a  # import\nfrom a import a1  # import_from\nimport b as b1  # import_as\nfrom c import *  # import_from_star\nimport c.d\n\nfrom ...grandparent import fn3\nfrom ..parent import *\nfrom . import my\nfrom .my import fn\nfrom .my.nested import fn2\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_to_top.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_to_top.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import foo\nimport lib1\nimport lib2\nimport lib3\nimport lib3.lib4\nimport lib3.lib4.lib5\nimport lib4\nimport lib5\nimport lib6\nimport z\nfrom foo import bar\nfrom foo.lib1.bar import baz\nfrom lib1 import foo\nfrom lib1.lib2 import foo\nfrom lib2 import foo\nfrom lib3.lib4 import foo\nfrom lib3.lib4.lib5 import foo\nfrom lib4 import lib1, lib2\nfrom lib5 import lib1, lib2\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 24
           column: 0
+        content: "import foo\nimport lib1\nimport lib2\nimport lib3\nimport lib3.lib4\nimport lib3.lib4.lib5\nimport lib4\nimport lib5\nimport lib6\nimport z\nfrom foo import bar\nfrom foo.lib1.bar import baz\nfrom lib1 import foo\nfrom lib1.lib2 import foo\nfrom lib2 import foo\nfrom lib3.lib4 import foo\nfrom lib3.lib4.lib5 import foo\nfrom lib4 import lib1, lib2\nfrom lib5 import lib1, lib2\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_to_top_force_to_top.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_to_top_force_to_top.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import lib1\nimport lib3\nimport lib3.lib4\nimport lib5\nimport z\nimport foo\nimport lib2\nimport lib3.lib4.lib5\nimport lib4\nimport lib6\nfrom lib1 import foo\nfrom lib3.lib4 import foo\nfrom lib5 import lib1, lib2\nfrom foo import bar\nfrom foo.lib1.bar import baz\nfrom lib1.lib2 import foo\nfrom lib2 import foo\nfrom lib3.lib4.lib5 import foo\nfrom lib4 import lib1, lib2\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 24
           column: 0
+        content: "import lib1\nimport lib3\nimport lib3.lib4\nimport lib5\nimport z\nimport foo\nimport lib2\nimport lib3.lib4.lib5\nimport lib4\nimport lib6\nfrom lib1 import foo\nfrom lib3.lib4 import foo\nfrom lib5 import lib1, lib2\nfrom foo import bar\nfrom foo.lib1.bar import baz\nfrom lib1.lib2 import foo\nfrom lib2 import foo\nfrom lib3.lib4.lib5 import foo\nfrom lib4 import lib1, lib2\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_wrap_aliases.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_wrap_aliases.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from .a import a1 as a1\nfrom .a import a2 as a2\nfrom .b import b1 as b1\nfrom .c import c1\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from .a import a1 as a1\nfrom .a import a2 as a2\nfrom .b import b1 as b1\nfrom .c import c1\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_wrap_aliases_force_wrap_aliases.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__force_wrap_aliases_force_wrap_aliases.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from .a import (\n    a1 as a1,\n    a2 as a2,\n)\nfrom .b import b1 as b1\nfrom .c import c1\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from .a import (\n    a1 as a1,\n    a2 as a2,\n)\nfrom .b import b1 as b1\nfrom .c import c1\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__forced_separate.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__forced_separate.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from office_helper.assistants import entity_registry as er\nfrom office_helper.core import CoreState\n\nimport tests.common.foo as tcf\nfrom tests.common import async_mock_service\n\nfrom experiments.starry import *\nfrom experiments.weird import varieties\n"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 9
           column: 0
+        content: "from office_helper.assistants import entity_registry as er\nfrom office_helper.core import CoreState\n\nimport tests.common.foo as tcf\nfrom tests.common import async_mock_service\n\nfrom experiments.starry import *\nfrom experiments.weird import varieties\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__import_from_after_import.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__import_from_after_import.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nfrom collections import Collection\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "import os\nfrom collections import Collection\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__inline_comments.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__inline_comments.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from a.prometheus.metrics import (  # type:ignore[attr-defined]\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,\n)\nfrom b.prometheus.metrics import (\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,  # type:ignore[attr-defined]\n)\nfrom c.prometheus.metrics import (\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,  # type:ignore[attr-defined]\n)\nfrom d.prometheus.metrics import (  # type:ignore[attr-defined]\n    OTHER_RUNNING_TOTAL,\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,\n)\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 12
           column: 0
+        content: "from a.prometheus.metrics import (  # type:ignore[attr-defined]\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,\n)\nfrom b.prometheus.metrics import (\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,  # type:ignore[attr-defined]\n)\nfrom c.prometheus.metrics import (\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,  # type:ignore[attr-defined]\n)\nfrom d.prometheus.metrics import (  # type:ignore[attr-defined]\n    OTHER_RUNNING_TOTAL,\n    TERMINAL_CURRENTLY_RUNNING_TOTAL,\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__insert_empty_lines.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__insert_empty_lines.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import a\nimport b\n\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "import a\nimport b\n\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\n\n"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "import os\nimport sys\n\n\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\n"
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 16
           column: 0
+        content: "import os\nimport sys\n\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\n\n\n"
-        location:
+      - location:
           row: 52
           column: 0
         end_location:
           row: 54
           column: 0
+        content: "import os\n\n\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__insert_empty_lines.pyi.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__insert_empty_lines.pyi.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import a\nimport b\n\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "import a\nimport b\n\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\n"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "import os\nimport sys\n\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\n"
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 16
           column: 0
+        content: "import os\nimport sys\n\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__known_local_folder_separate_local_folder_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__known_local_folder_separate_local_folder_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\nimport leading_prefix\n\nimport ruff\nfrom . import leading_prefix\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "import os\nimport sys\n\nimport leading_prefix\n\nimport ruff\nfrom . import leading_prefix\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_class_after.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_class_after.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n\n\n\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 10
           column: 0
+        content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n\n\n\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_func_after.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_func_after.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n\n\n\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 21
           column: 0
+        content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n\n\n\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_nothing_after.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_after_imports_lines_after_imports_nothing_after.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 10
           column: 0
+        content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_between_typeslines_between_types.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__lines_between_typeslines_between_types.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nimport datetime\nimport json\n\n\nfrom binascii import hexlify\n\nimport requests\n\n\nfrom loguru import Logger\nfrom sanic import Sanic\n\nfrom . import config\nfrom .data import Data\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 17
           column: 0
+        content: "from __future__ import annotations\n\nimport datetime\nimport json\n\n\nfrom binascii import hexlify\n\nimport requests\n\n\nfrom loguru import Logger\nfrom sanic import Sanic\n\nfrom . import config\nfrom .data import Data\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__magic_trailing_comma.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__magic_trailing_comma.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from glob import (\n    escape,  # Ends with a comment, should still treat as magic trailing comma.\n    glob,\n    iglob,\n)\n\n# No magic comma, this will be rolled into one line.\nfrom os import environ, execl, execv, path\nfrom sys import (\n    argv,\n    exit,\n    stderr,\n    stdout,\n)\n\n# These will be combined, but without a trailing comma.\nfrom foo import bar, baz\n\n# These will be combined, _with_ a trailing comma.\nfrom module1 import (\n    member1,\n    member2,\n    member3,\n)\n\n# These will be combined, _with_ a trailing comma.\nfrom module2 import (\n    member1,\n    member2,\n    member3,\n)\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 39
           column: 0
+        content: "from glob import (\n    escape,  # Ends with a comment, should still treat as magic trailing comma.\n    glob,\n    iglob,\n)\n\n# No magic comma, this will be rolled into one line.\nfrom os import environ, execl, execv, path\nfrom sys import (\n    argv,\n    exit,\n    stderr,\n    stdout,\n)\n\n# These will be combined, but without a trailing comma.\nfrom foo import bar, baz\n\n# These will be combined, _with_ a trailing comma.\nfrom module1 import (\n    member1,\n    member2,\n    member3,\n)\n\n# These will be combined, _with_ a trailing comma.\nfrom module2 import (\n    member1,\n    member2,\n    member3,\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__natural_order.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__natural_order.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import numpy1\nimport numpy2\nimport numpy10\nfrom numpy import (\n    cos,\n    int8,\n    int16,\n    int32,\n    int64,\n    sin,\n    tan,\n    uint8,\n    uint16,\n    uint32,\n    uint64,\n)\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 17
           column: 0
+        content: "import numpy1\nimport numpy2\nimport numpy10\nfrom numpy import (\n    cos,\n    int8,\n    int16,\n    int32,\n    int64,\n    sin,\n    tan,\n    uint8,\n    uint16,\n    uint32,\n    uint64,\n)\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 10
           column: 0
+        content: "from __future__ import annotations\n\nfrom typing import Any\n\nfrom my_first_party import my_first_party_object\nfrom requests import Session\n\nfrom . import my_local_folder_object\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before.py_no_lines_before.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before.py_no_lines_before.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\nfrom typing import Any\nfrom my_first_party import my_first_party_object\nfrom requests import Session\nfrom . import my_local_folder_object\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 10
           column: 0
+        content: "from __future__ import annotations\nfrom typing import Any\nfrom my_first_party import my_first_party_object\nfrom requests import Session\nfrom . import my_local_folder_object\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before_with_empty_sections.py_no_lines_before_with_empty_sections.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_lines_before_with_empty_sections.py_no_lines_before_with_empty_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\nfrom typing import Any\n\nfrom . import my_local_folder_object\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from __future__ import annotations\nfrom typing import Any\n\nfrom . import my_local_folder_object\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_wrap_star.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__no_wrap_star.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from .subscription import *  # type: ignore  # some very long comment explaining why this needs a type ignore\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from .subscription import *  # type: ignore  # some very long comment explaining why this needs a type ignore\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, STDOUT, Popen\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import BASIC, CONSTANT, Apple, Class, function\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 13
           column: 0
+        content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, STDOUT, Popen\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import BASIC, CONSTANT, Apple, Class, function\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_false_order_by_type.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_false_order_by_type.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, Popen, STDOUT\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import Apple, BASIC, Class, CONSTANT, function\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 13
           column: 0
+        content: "import glob\nimport os\nimport shutil\nimport tempfile\nimport time\nfrom subprocess import PIPE, Popen, STDOUT\n\nimport BAR\nimport bar\nimport FOO\nimport foo\nimport StringIO\nfrom module import Apple, BASIC, Class, CONSTANT, function\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_classes.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_classes.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import N_CLASS, PIPE, STDOUT, Popen\n\nfrom module import BASIC, CLASS, CONSTANT, Apple, Class, function\nfrom sklearn.svm import CONST, SVC, Klass, func\nfrom torch.nn import A_CONSTANT, SELU, AClass\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "from subprocess import N_CLASS, PIPE, STDOUT, Popen\n\nfrom module import BASIC, CLASS, CONSTANT, Apple, Class, function\nfrom sklearn.svm import CONST, SVC, Klass, func\nfrom torch.nn import A_CONSTANT, SELU, AClass\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_classes_order_by_type_with_custom_classes.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_classes_order_by_type_with_custom_classes.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import PIPE, STDOUT, N_CLASS, Popen\n\nfrom module import BASIC, CONSTANT, Apple, CLASS, Class, function\nfrom sklearn.svm import CONST, Klass, SVC, func\nfrom torch.nn import A_CONSTANT, AClass, SELU\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "from subprocess import PIPE, STDOUT, N_CLASS, Popen\n\nfrom module import BASIC, CONSTANT, Apple, CLASS, Class, function\nfrom sklearn.svm import CONST, Klass, SVC, func\nfrom torch.nn import A_CONSTANT, AClass, SELU\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_constants.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_constants.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import STDOUT, A_constant, Class, First, Last, func, konst, var\n\nfrom sklearn.svm import XYZ, Const, Klass, constant, func, variable\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "from subprocess import STDOUT, A_constant, Class, First, Last, func, konst, var\n\nfrom sklearn.svm import XYZ, Const, Klass, constant, func, variable\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_constants_order_by_type_with_custom_constants.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_constants_order_by_type_with_custom_constants.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import A_constant, First, konst, Last, STDOUT, Class, func, var\n\nfrom sklearn.svm import Const, constant, XYZ, Klass, func, variable\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "from subprocess import A_constant, First, konst, Last, STDOUT, Class, func, var\n\nfrom sklearn.svm import Const, constant, XYZ, Klass, func, variable\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_variables.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_variables.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import CONSTANT, Klass, Variable, exe, utils, var_ABC\n\nfrom sklearn.svm import CONST, VAR, Class, MyVar, abc\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "from subprocess import CONSTANT, Klass, Variable, exe, utils, var_ABC\n\nfrom sklearn.svm import CONST, VAR, Class, MyVar, abc\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_variables_order_by_type_with_custom_variables.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_by_type_with_custom_variables_order_by_type_with_custom_variables.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from subprocess import CONSTANT, Klass, exe, utils, var_ABC, Variable\n\nfrom sklearn.svm import CONST, Class, abc, MyVar, VAR\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "from subprocess import CONSTANT, Klass, exe, utils, var_ABC, Variable\n\nfrom sklearn.svm import CONST, Class, abc, MyVar, VAR\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_relative_imports_by_level.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__order_relative_imports_by_level.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from ..a import a\nfrom ..b import a\nfrom .a import a\nfrom .b import a\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "from ..a import a\nfrom ..b import a\nfrom .a import a\nfrom .b import a\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_comment_order.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_comment_order.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import abc\nimport io\n\n# Old MacDonald had a farm,\n# EIEIO\n# And on his farm he had a cow,\n# EIEIO\n# With a moo-moo here and a moo-moo there\n# Here a moo, there a moo, everywhere moo-moo\n# Old MacDonald had a farm,\n# EIEIO\nfrom errno import EIO\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 12
           column: 0
+        content: "import abc\nimport io\n\n# Old MacDonald had a farm,\n# EIEIO\n# And on his farm he had a cow,\n# EIEIO\n# With a moo-moo here and a moo-moo there\n# Here a moo, there a moo, everywhere moo-moo\n# Old MacDonald had a farm,\n# EIEIO\nfrom errno import EIO\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_import_star.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_import_star.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "# Above\nfrom some_module import *  # Aside\n\n# Above\nfrom some_module import some_class  # Aside\nfrom some_other_module import *\nfrom some_other_module import some_class\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 7
           column: 0
+        content: "# Above\nfrom some_module import *  # Aside\n\n# Above\nfrom some_module import some_class  # Aside\nfrom some_other_module import *\nfrom some_other_module import some_class\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_indentation.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__preserve_indentation.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    import os\n    import sys\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "    import os\n    import sys\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    import os\n    import sys\n"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 7
           column: 0
+        content: "    import os\n    import sys\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__reorder_within_section.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__reorder_within_section.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 3
           column: 0
+        content: "import os\nimport sys\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from __future__ import annotations\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_multiline_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_multiline_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from __future__ import annotations\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_imports_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_imports_docstring.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from __future__ import annotations\n"
   parent: ~
 - kind:
     name: MissingRequiredImport
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import generator_stop\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "from __future__ import generator_stop\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_first_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_first_party_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\nimport numpy as np\n\nimport leading_prefix\nfrom leading_prefix import Class\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "import os\nimport sys\n\nimport numpy as np\n\nimport leading_prefix\nfrom leading_prefix import Class\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_future_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_future_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from __future__ import annotations\n\nimport os\nimport sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from __future__ import annotations\n\nimport os\nimport sys\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_local_folder_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_local_folder_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\nimport ruff\n\nimport leading_prefix\n\nfrom . import leading_prefix\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 6
           column: 0
+        content: "import os\nimport sys\n\nimport ruff\n\nimport leading_prefix\n\nfrom . import leading_prefix\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_third_party_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__separate_third_party_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\nimport sys\n\nimport numpy as np\nimport pandas as pd\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 5
           column: 0
+        content: "import os\nimport sys\n\nimport numpy as np\nimport pandas as pd\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__skip.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__skip.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    import abc\n    import collections\n"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 22
           column: 0
+        content: "    import abc\n    import collections\n"
   parent: ~
 - kind:
     name: UnsortedImports
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    import abc\n    import collections\n"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 29
           column: 0
+        content: "    import abc\n    import collections\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__sort_similar_imports.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__sort_similar_imports.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import A\nimport a\nimport B\nimport b\nimport x\nimport x as A\nimport x as Y\nimport x as a\nimport x as y\nfrom a import BAD as DEF\nfrom a import B, b\nfrom a import B as A\nfrom a import B as Abc\nfrom a import B as DEF\nfrom a import Boo as DEF\nfrom a import b as a\nfrom a import b as c\nfrom a import b as d\nfrom a import b as x\nfrom a import b as y\nfrom b import C, c\nfrom b import c as d\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 27
           column: 0
+        content: "import A\nimport a\nimport B\nimport b\nimport x\nimport x as A\nimport x as Y\nimport x as a\nimport x as y\nfrom a import BAD as DEF\nfrom a import B, b\nfrom a import B as A\nfrom a import B as Abc\nfrom a import B as DEF\nfrom a import Boo as DEF\nfrom a import b as a\nfrom a import b as c\nfrom a import b as d\nfrom a import b as x\nfrom a import b as y\nfrom b import C, c\nfrom b import c as d\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__split_on_trailing_comma_magic_trailing_comma.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__split_on_trailing_comma_magic_trailing_comma.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from glob import (\n    escape,  # Ends with a comment, should still treat as magic trailing comma.\n    glob,\n    iglob,\n)\n\n# No magic comma, this will be rolled into one line.\nfrom os import environ, execl, execv, path\nfrom sys import argv, exit, stderr, stdout\n\n# These will be combined, but without a trailing comma.\nfrom foo import bar, baz\n\n# These will be combined, _with_ a trailing comma.\nfrom module1 import member1, member2, member3\n\n# These will be combined, _with_ a trailing comma.\nfrom module2 import member1, member2, member3\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 39
           column: 0
+        content: "from glob import (\n    escape,  # Ends with a comment, should still treat as magic trailing comma.\n    glob,\n    iglob,\n)\n\n# No magic comma, this will be rolled into one line.\nfrom os import environ, execl, execv, path\nfrom sys import argv, exit, stderr, stdout\n\n# These will be combined, but without a trailing comma.\nfrom foo import bar, baz\n\n# These will be combined, _with_ a trailing comma.\nfrom module1 import member1, member2, member3\n\n# These will be combined, _with_ a trailing comma.\nfrom module2 import member1, member2, member3\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__star_before_others.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__star_before_others.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "from .logging import config_logging\nfrom .settings import *\nfrom .settings import ENV\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 4
           column: 0
+        content: "from .logging import config_logging\nfrom .settings import *\nfrom .settings import ENV\n"
   parent: ~
 

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__straight_required_import_docstring.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__straight_required_import_docstring.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "import os\n"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 0
+        content: "import os\n"
   parent: ~
 

--- a/crates/ruff/src/rules/numpy/snapshots/ruff__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
+++ b/crates/ruff/src/rules/numpy/snapshots/ruff__rules__numpy__tests__numpy-deprecated-type-alias_NPY001.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: bool
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 8
+        content: bool
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 7
+        content: int
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: object
-        location:
+      - location:
           row: 9
           column: 12
         end_location:
           row: 9
           column: 21
+        content: object
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 77
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 12
           column: 71
         end_location:
           row: 12
           column: 77
+        content: int
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 86
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 12
           column: 79
         end_location:
           row: 12
           column: 86
+        content: int
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: object
-        location:
+      - location:
           row: 17
           column: 10
         end_location:
           row: 17
           column: 22
+        content: object
   parent: ~
 - kind:
     name: NumpyDeprecatedTypeAlias
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 20
           column: 15
         end_location:
           row: 20
           column: 21
+        content: int
   parent: ~
 

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_PD002.py.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_PD002.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "x = "
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 0
-      - content: ""
-        location:
+        content: "x = "
+      - location:
           row: 5
           column: 20
         end_location:
           row: 5
           column: 34
+        content: ~
   parent: ~
 - kind:
     name: PandasUseOfInplaceArgument
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "x = "
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 0
-      - content: ""
-        location:
+        content: "x = "
+      - location:
           row: 7
           column: 20
         end_location:
           row: 7
           column: 34
+        content: ~
   parent: ~
 - kind:
     name: PandasUseOfInplaceArgument
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "x = "
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 0
-      - content: ""
-        location:
+        content: "x = "
+      - location:
           row: 10
           column: 4
         end_location:
           row: 11
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: PandasUseOfInplaceArgument
@@ -99,20 +99,20 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "x = "
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 16
           column: 4
-      - content: ""
-        location:
+        content: "x = "
+      - location:
           row: 17
           column: 8
         end_location:
           row: 18
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: PandasUseOfInplaceArgument
@@ -127,20 +127,20 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "x = "
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 22
           column: 0
-      - content: ""
-        location:
+        content: "x = "
+      - location:
           row: 22
           column: 30
         end_location:
           row: 22
           column: 44
+        content: ~
   parent: ~
 - kind:
     name: PandasUseOfInplaceArgument

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E211_E21.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E211_E21.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: WhitespaceBeforeParameters
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: WhitespaceBeforeParameters
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 19
         end_location:
           row: 4
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: WhitespaceBeforeParameters
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 11
         end_location:
           row: 6
           column: 12
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E231_E23.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: " "
-        location:
+      - location:
           row: 2
           column: 7
         end_location:
           row: 2
           column: 7
+        content: " "
   parent: ~
 - kind:
     name: MissingWhitespace
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: " "
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 4
           column: 5
+        content: " "
   parent: ~
 - kind:
     name: MissingWhitespace
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: " "
-        location:
+      - location:
           row: 6
           column: 10
         end_location:
           row: 6
           column: 10
+        content: " "
   parent: ~
 - kind:
     name: MissingWhitespace
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: " "
-        location:
+      - location:
           row: 19
           column: 10
         end_location:
           row: 19
           column: 10
+        content: " "
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E703_E70.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E703_E70.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 10
           column: 12
         end_location:
           row: 10
           column: 13
+        content: ~
   parent: ~
 - kind:
     name: UselessSemicolon
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 22
         end_location:
           row: 12
           column: 23
+        content: ~
   parent: ~
 - kind:
     name: UselessSemicolon
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 25
           column: 13
         end_location:
           row: 25
           column: 14
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E711_E711.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E711_E711.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: res is None
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 14
+        content: res is None
   parent: ~
 - kind:
     name: NoneComparison
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: res is not None
-        location:
+      - location:
           row: 5
           column: 3
         end_location:
           row: 5
           column: 14
+        content: res is not None
   parent: ~
 - kind:
     name: NoneComparison
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: None is res
-        location:
+      - location:
           row: 8
           column: 3
         end_location:
           row: 8
           column: 14
+        content: None is res
   parent: ~
 - kind:
     name: NoneComparison
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: None is not res
-        location:
+      - location:
           row: 11
           column: 3
         end_location:
           row: 11
           column: 14
+        content: None is not res
   parent: ~
 - kind:
     name: NoneComparison
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "res[1] is None"
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 17
+        content: "res[1] is None"
   parent: ~
 - kind:
     name: NoneComparison
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "res[1] is not None"
-        location:
+      - location:
           row: 17
           column: 3
         end_location:
           row: 17
           column: 17
+        content: "res[1] is not None"
   parent: ~
 - kind:
     name: NoneComparison
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "None is not res[1]"
-        location:
+      - location:
           row: 20
           column: 3
         end_location:
           row: 20
           column: 17
+        content: "None is not res[1]"
   parent: ~
 - kind:
     name: NoneComparison
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "None is res[1]"
-        location:
+      - location:
           row: 23
           column: 3
         end_location:
           row: 23
           column: 17
+        content: "None is res[1]"
   parent: ~
 - kind:
     name: NoneComparison
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: x is None is not None
-        location:
+      - location:
           row: 26
           column: 3
         end_location:
           row: 26
           column: 20
+        content: x is None is not None
   parent: ~
 - kind:
     name: NoneComparison
@@ -204,12 +204,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: x is None is not None
-        location:
+      - location:
           row: 26
           column: 3
         end_location:
           row: 26
           column: 20
+        content: x is None is not None
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E712_E712.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E712_E712.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: res is True
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 14
+        content: res is True
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: res is not False
-        location:
+      - location:
           row: 5
           column: 3
         end_location:
           row: 5
           column: 15
+        content: res is not False
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: True is not res
-        location:
+      - location:
           row: 8
           column: 3
         end_location:
           row: 8
           column: 14
+        content: True is not res
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: False is res
-        location:
+      - location:
           row: 11
           column: 3
         end_location:
           row: 11
           column: 15
+        content: False is res
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "res[1] is True"
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 17
+        content: "res[1] is True"
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "res[1] is not False"
-        location:
+      - location:
           row: 17
           column: 3
         end_location:
           row: 17
           column: 18
+        content: "res[1] is not False"
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: cond is True
-        location:
+      - location:
           row: 20
           column: 11
         end_location:
           row: 20
           column: 23
+        content: cond is True
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: cond is False
-        location:
+      - location:
           row: 20
           column: 35
         end_location:
           row: 20
           column: 48
+        content: cond is False
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: True is TrueElement
-        location:
+      - location:
           row: 22
           column: 3
         end_location:
           row: 22
           column: 24
+        content: True is TrueElement
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: res is True is not False
-        location:
+      - location:
           row: 25
           column: 3
         end_location:
           row: 25
           column: 23
+        content: res is True is not False
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -225,12 +225,12 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: res is True is not False
-        location:
+      - location:
           row: 25
           column: 3
         end_location:
           row: 25
           column: 23
+        content: res is True is not False
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E713_E713.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E713_E713.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: X not in Y
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 13
+        content: X not in Y
   parent: ~
 - kind:
     name: NotInTest
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: X.B not in Y
-        location:
+      - location:
           row: 5
           column: 3
         end_location:
           row: 5
           column: 15
+        content: X.B not in Y
   parent: ~
 - kind:
     name: NotInTest
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: X not in Y
-        location:
+      - location:
           row: 8
           column: 3
         end_location:
           row: 8
           column: 13
+        content: X not in Y
   parent: ~
 - kind:
     name: NotInTest
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: Y not in Z
-        location:
+      - location:
           row: 11
           column: 18
         end_location:
           row: 11
           column: 28
+        content: Y not in Z
   parent: ~
 - kind:
     name: NotInTest
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: X not in Y
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 15
+        content: X not in Y
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E714_E714.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E714_E714.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: X is not Y
-        location:
+      - location:
           row: 2
           column: 3
         end_location:
           row: 2
           column: 13
+        content: X is not Y
   parent: ~
 - kind:
     name: NotIsTest
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: X.B is not Y
-        location:
+      - location:
           row: 5
           column: 3
         end_location:
           row: 5
           column: 15
+        content: X.B is not Y
   parent: ~
 - kind:
     name: NotIsTest

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E731_E731.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E731_E731.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "def f(x):\n    return 2 * x"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 19
+        content: "def f(x):\n    return 2 * x"
   parent: ~
 - kind:
     name: LambdaAssignment
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "def f(x):\n    return 2 * x"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 19
+        content: "def f(x):\n    return 2 * x"
   parent: ~
 - kind:
     name: LambdaAssignment
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "def this(y, z):\n        return 2 * x"
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 29
+        content: "def this(y, z):\n        return 2 * x"
   parent: ~
 - kind:
     name: LambdaAssignment
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "def f():\n    return (yield 1)"
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 21
+        content: "def f():\n    return (yield 1)"
   parent: ~
 - kind:
     name: LambdaAssignment
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "def f():\n    return (yield from g())"
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 28
+        content: "def f():\n    return (yield from g())"
   parent: ~
 - kind:
     name: LambdaAssignment

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W291_W29.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W291_W29.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 5
         end_location:
           row: 4
           column: 6
+        content: ~
   parent: ~
 - kind:
     name: TrailingWhitespace
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 11
           column: 34
         end_location:
           row: 11
           column: 37
+        content: ~
   parent: ~
 - kind:
     name: TrailingWhitespace
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 5
         end_location:
           row: 13
           column: 8
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W292_W292_0.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W292_W292_0.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 2
           column: 8
         end_location:
           row: 2
           column: 8
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W293_W29.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W293_W29.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 4
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 2
           column: 10
         end_location:
           row: 2
           column: 10
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 2
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 6
           column: 1
         end_location:
           row: 6
           column: 1
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 11
           column: 6
         end_location:
           row: 11
           column: 6
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 18
           column: 6
         end_location:
           row: 18
           column: 6
+        content: "\\"
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__W605_W605_1.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 2
           column: 10
         end_location:
           row: 2
           column: 10
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 2
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 6
           column: 1
         end_location:
           row: 6
           column: 1
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 11
           column: 6
         end_location:
           row: 11
           column: 6
+        content: "\\"
   parent: ~
 - kind:
     name: InvalidEscapeSequence
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\\"
-        location:
+      - location:
           row: 18
           column: 6
         end_location:
           row: 18
           column: 6
+        content: "\\"
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__constant_literals.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__constant_literals.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 4
           column: 9
         end_location:
           row: 4
           column: 11
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 6
           column: 9
         end_location:
           row: 6
           column: 11
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 8
           column: 8
         end_location:
           row: 8
           column: 10
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 10
           column: 9
         end_location:
           row: 10
           column: 11
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 12
           column: 9
         end_location:
           row: 12
           column: 11
+        content: "=="
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: False is None
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 16
+        content: False is None
   parent: ~
 - kind:
     name: NoneComparison
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: False is None
-        location:
+      - location:
           row: 14
           column: 3
         end_location:
           row: 14
           column: 16
+        content: False is None
   parent: ~
 - kind:
     name: NoneComparison
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: None is False
-        location:
+      - location:
           row: 16
           column: 3
         end_location:
           row: 16
           column: 16
+        content: None is False
   parent: ~
 - kind:
     name: TrueFalseComparison
@@ -183,12 +183,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: None is False
-        location:
+      - location:
           row: 16
           column: 3
         end_location:
           row: 16
           column: 16
+        content: None is False
   parent: ~
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__w292_4.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__w292_4.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "<LineEnding>"
-        location:
+      - location:
           row: 1
           column: 1
         end_location:
           row: 1
           column: 1
+        content: "<LineEnding>"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\"\"Wrong.\"\"\""
-        location:
+      - location:
           row: 129
           column: 4
         end_location:
           row: 131
           column: 7
+        content: "\"\"\"Wrong.\"\"\""
   parent: ~
 - kind:
     name: FitsOnOneLine
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "\"\"\"Wrong.\"\"\""
-        location:
+      - location:
           row: 597
           column: 4
         end_location:
           row: 599
           column: 13
+        content: "\"\"\"Wrong.\"\"\""
   parent: ~
 - kind:
     name: FitsOnOneLine
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "r\"\"\"Wrong.\"\"\""
-        location:
+      - location:
           row: 606
           column: 4
         end_location:
           row: 608
           column: 7
+        content: "r\"\"\"Wrong.\"\"\""
   parent: ~
 - kind:
     name: FitsOnOneLine

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D201_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D201_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 136
           column: 0
         end_location:
           row: 137
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineBeforeFunction
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 150
           column: 0
         end_location:
           row: 151
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineBeforeFunction
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 545
           column: 0
         end_location:
           row: 546
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineBeforeFunction
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 567
           column: 0
         end_location:
           row: 568
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D202_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D202_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 143
           column: 0
         end_location:
           row: 144
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineAfterFunction
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 152
           column: 0
         end_location:
           row: 153
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineAfterFunction
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 559
           column: 0
         end_location:
           row: 560
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineAfterFunction
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 572
           column: 0
         end_location:
           row: 573
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D202_D202.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D202_D202.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 58
           column: 0
         end_location:
           row: 60
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineAfterFunction
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 69
           column: 0
         end_location:
           row: 71
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: NoBlankLineAfterFunction
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 81
           column: 0
         end_location:
           row: 82
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D203_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D203_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 161
           column: 0
         end_location:
           row: 161
           column: 0
+        content: "\n"
   parent: ~
 - kind:
     name: OneBlankLineBeforeClass
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 192
           column: 0
         end_location:
           row: 192
           column: 0
+        content: "\n"
   parent: ~
 - kind:
     name: OneBlankLineBeforeClass
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 526
           column: 0
         end_location:
           row: 526
           column: 0
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D204_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D204_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 182
           column: 0
         end_location:
           row: 182
           column: 0
+        content: "\n"
   parent: ~
 - kind:
     name: OneBlankLineAfterClass
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 193
           column: 0
         end_location:
           row: 193
           column: 0
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D205_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D205_D.py.snap
@@ -29,12 +29,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 211
           column: 0
         end_location:
           row: 213
           column: 0
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D207_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D207_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 232
           column: 0
         end_location:
           row: 232
           column: 0
+        content: "    "
   parent: ~
 - kind:
     name: UnderIndentation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 244
           column: 0
         end_location:
           row: 244
           column: 0
+        content: "    "
   parent: ~
 - kind:
     name: UnderIndentation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "                                    "
-        location:
+      - location:
           row: 440
           column: 0
         end_location:
           row: 440
           column: 4
+        content: "                                    "
   parent: ~
 - kind:
     name: UnderIndentation
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "                                    "
-        location:
+      - location:
           row: 441
           column: 0
         end_location:
           row: 441
           column: 4
+        content: "                                    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D208_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D208_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 252
           column: 0
         end_location:
           row: 252
           column: 7
+        content: "    "
   parent: ~
 - kind:
     name: OverIndentation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 264
           column: 0
         end_location:
           row: 264
           column: 8
+        content: "    "
   parent: ~
 - kind:
     name: OverIndentation
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 272
           column: 0
         end_location:
           row: 272
           column: 8
+        content: "    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D209_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D209_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\n    "
-        location:
+      - location:
           row: 283
           column: 16
         end_location:
           row: 283
           column: 16
+        content: "\n    "
   parent: ~
 - kind:
     name: NewLineAfterLastParagraph
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n    "
-        location:
+      - location:
           row: 590
           column: 16
         end_location:
           row: 590
           column: 18
+        content: "\n    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D210_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D210_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: Whitespace at the end.
-        location:
+      - location:
           row: 288
           column: 7
         end_location:
           row: 288
           column: 30
+        content: Whitespace at the end.
   parent: ~
 - kind:
     name: SurroundingWhitespace
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: Whitespace at everywhere.
-        location:
+      - location:
           row: 293
           column: 7
         end_location:
           row: 293
           column: 34
+        content: Whitespace at everywhere.
   parent: ~
 - kind:
     name: SurroundingWhitespace
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: Whitespace at the beginning.
-        location:
+      - location:
           row: 299
           column: 7
         end_location:
           row: 299
           column: 36
+        content: Whitespace at the beginning.
   parent: ~
 - kind:
     name: SurroundingWhitespace

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D211_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D211_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 169
           column: 0
         end_location:
           row: 170
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: BlankLineBeforeClass
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 180
           column: 0
         end_location:
           row: 181
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D212_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D212_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 129
           column: 7
         end_location:
           row: 130
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: MultiLineSummaryFirstLine
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 597
           column: 7
         end_location:
           row: 599
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: MultiLineSummaryFirstLine
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 624
           column: 7
         end_location:
           row: 626
           column: 4
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D213_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D213_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 200
           column: 7
         end_location:
           row: 200
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 210
           column: 7
         end_location:
           row: 210
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 220
           column: 7
         end_location:
           row: 220
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 230
           column: 7
         end_location:
           row: 230
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 3
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 240
           column: 7
         end_location:
           row: 240
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 250
           column: 7
         end_location:
           row: 250
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 260
           column: 7
         end_location:
           row: 260
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 270
           column: 7
         end_location:
           row: 270
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 281
           column: 7
         end_location:
           row: 281
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Whitespace at the beginning."
-        location:
+      - location:
           row: 299
           column: 7
         end_location:
           row: 299
           column: 36
+        content: "\n    Whitespace at the beginning."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Exclude some backslashes from D301."
-        location:
+      - location:
           row: 343
           column: 7
         end_location:
           row: 343
           column: 42
+        content: "\n    Exclude some backslashes from D301."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    First line."
-        location:
+      - location:
           row: 383
           column: 7
         end_location:
           row: 383
           column: 18
+        content: "\n    First line."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    One liner."
-        location:
+      - location:
           row: 392
           column: 7
         end_location:
           row: 392
           column: 17
+        content: "\n    One liner."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    First Line."
-        location:
+      - location:
           row: 438
           column: 39
         end_location:
           row: 438
           column: 50
+        content: "\n    First Line."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Check for a bug where the previous function caused an assertion."
-        location:
+      - location:
           row: 450
           column: 7
         end_location:
           row: 450
           column: 71
+        content: "\n    Check for a bug where the previous function caused an assertion."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    A Blah."
-        location:
+      - location:
           row: 526
           column: 7
         end_location:
           row: 526
           column: 14
+        content: "\n    A Blah."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Leading space."
-        location:
+      - location:
           row: 546
           column: 7
         end_location:
           row: 546
           column: 21
+        content: "\n    Leading space."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Leading space."
-        location:
+      - location:
           row: 555
           column: 7
         end_location:
           row: 555
           column: 21
+        content: "\n    Leading space."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Trailing and leading space."
-        location:
+      - location:
           row: 568
           column: 7
         end_location:
           row: 568
           column: 34
+        content: "\n    Trailing and leading space."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\n    Summary."
-        location:
+      - location:
           row: 588
           column: 7
         end_location:
           row: 588
           column: 15
+        content: "\n    Summary."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Wrong."
-        location:
+      - location:
           row: 606
           column: 8
         end_location:
           row: 606
           column: 14
+        content: "\n    Wrong."
   parent: ~
 - kind:
     name: MultiLineSummarySecondLine
@@ -456,12 +456,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    Wrong.\""
-        location:
+      - location:
           row: 615
           column: 7
         end_location:
           row: 615
           column: 14
+        content: "\n    Wrong.\""
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 146
           column: 0
         end_location:
           row: 146
           column: 8
+        content: "    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D215_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D215_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 159
           column: 0
         end_location:
           row: 159
           column: 9
+        content: "    "
   parent: ~
 - kind:
     name: SectionUnderlineNotOverIndented
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    "
-        location:
+      - location:
           row: 173
           column: 0
         end_location:
           row: 173
           column: 9
+        content: "    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 355
           column: 14
         end_location:
           row: 355
           column: 14
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 406
           column: 36
         end_location:
           row: 406
           column: 36
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 410
           column: 21
         end_location:
           row: 410
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 416
           column: 21
         end_location:
           row: 416
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 422
           column: 46
         end_location:
           row: 422
           column: 46
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 63
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 429
           column: 60
         end_location:
           row: 429
           column: 60
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 470
           column: 21
         end_location:
           row: 470
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 475
           column: 21
         end_location:
           row: 475
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 480
           column: 21
         end_location:
           row: 480
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 487
           column: 21
         end_location:
           row: 487
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 514
           column: 30
         end_location:
           row: 514
           column: 30
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 520
           column: 29
         end_location:
           row: 520
           column: 29
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 581
           column: 47
         end_location:
           row: 581
           column: 47
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -288,12 +288,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 615
           column: 14
         end_location:
           row: 615
           column: 14
+        content: "."
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D400.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D400_D400.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 2
           column: 35
         end_location:
           row: 2
           column: 35
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 7
           column: 37
         end_location:
           row: 7
           column: 37
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 14
           column: 28
         end_location:
           row: 14
           column: 28
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 20
           column: 37
         end_location:
           row: 20
           column: 37
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 27
           column: 28
         end_location:
           row: 27
           column: 28
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 34
           column: 48
         end_location:
           row: 34
           column: 48
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 39
           column: 36
         end_location:
           row: 39
           column: 36
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 44
           column: 38
         end_location:
           row: 44
           column: 38
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 51
           column: 28
         end_location:
           row: 51
           column: 28
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 57
           column: 38
         end_location:
           row: 57
           column: 38
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 64
           column: 28
         end_location:
           row: 64
           column: 28
+        content: "."
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 71
           column: 48
         end_location:
           row: 71
           column: 48
+        content: "."
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D403_D403.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D403_D403.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: This
-        location:
+      - location:
           row: 2
           column: 7
         end_location:
           row: 2
           column: 11
+        content: This
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D405_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D405_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: Returns
-        location:
+      - location:
           row: 19
           column: 4
         end_location:
           row: 19
           column: 11
+        content: Returns
   parent: ~
 - kind:
     name: CapitalizeSectionName
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: Short Summary
-        location:
+      - location:
           row: 218
           column: 4
         end_location:
           row: 218
           column: 17
+        content: Short Summary
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D406_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D406_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 32
           column: 11
         end_location:
           row: 32
           column: 12
+        content: ~
   parent: ~
 - kind:
     name: NewLineAfterSectionName
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 227
           column: 10
         end_location:
           row: 227
           column: 11
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D407_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    -------"
-        location:
+      - location:
           row: 44
           column: 11
         end_location:
           row: 44
           column: 11
+        content: "\n    -------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    -------"
-        location:
+      - location:
           row: 56
           column: 11
         end_location:
           row: 56
           column: 11
+        content: "\n    -------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\n    -------"
-        location:
+      - location:
           row: 67
           column: 11
         end_location:
           row: 67
           column: 11
+        content: "\n    -------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    ------"
-        location:
+      - location:
           row: 227
           column: 11
         end_location:
           row: 227
           column: 11
+        content: "\n    ------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    ----"
-        location:
+      - location:
           row: 263
           column: 9
         end_location:
           row: 263
           column: 9
+        content: "\n    ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    -------"
-        location:
+      - location:
           row: 266
           column: 12
         end_location:
           row: 266
           column: 12
+        content: "\n    -------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    ------"
-        location:
+      - location:
           row: 268
           column: 11
         end_location:
           row: 268
           column: 11
+        content: "\n    ------"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    ----"
-        location:
+      - location:
           row: 280
           column: 8
         end_location:
           row: 280
           column: 8
+        content: "\n    ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 297
           column: 13
         end_location:
           row: 297
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n    ----"
-        location:
+      - location:
           row: 312
           column: 9
         end_location:
           row: 312
           column: 9
+        content: "\n    ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 324
           column: 13
         end_location:
           row: 324
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 336
           column: 13
         end_location:
           row: 336
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 348
           column: 13
         end_location:
           row: 348
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 361
           column: 13
         end_location:
           row: 361
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 373
           column: 13
         end_location:
           row: 373
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 382
           column: 13
         end_location:
           row: 382
           column: 13
+        content: "\n        ----"
   parent: ~
 - kind:
     name: DashedUnderlineAfterSection
@@ -351,12 +351,12 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\n        ----"
-        location:
+      - location:
           row: 503
           column: 13
         end_location:
           row: 503
           column: 13
+        content: "\n        ----"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D408_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D408_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 97
           column: 0
         end_location:
           row: 98
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D409_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D409_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    -------\n"
-        location:
+      - location:
           row: 111
           column: 0
         end_location:
           row: 112
           column: 0
+        content: "    -------\n"
   parent: ~
 - kind:
     name: SectionUnderlineMatchesSectionLength
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "    -------\n"
-        location:
+      - location:
           row: 225
           column: 0
         end_location:
           row: 226
           column: 0
+        content: "    -------\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D410_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D410_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 79
           column: 11
         end_location:
           row: 79
           column: 11
+        content: "\n"
   parent: ~
 - kind:
     name: NoBlankLineAfterSection
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 226
           column: 31
         end_location:
           row: 226
           column: 31
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D411_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D411_sections.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 80
           column: 0
         end_location:
           row: 80
           column: 0
+        content: "\n"
   parent: ~
 - kind:
     name: NoBlankLineBeforeSection
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 134
           column: 0
         end_location:
           row: 134
           column: 0
+        content: "\n"
   parent: ~
 - kind:
     name: NoBlankLineBeforeSection
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\n"
-        location:
+      - location:
           row: 227
           column: 0
         end_location:
           row: 227
           column: 0
+        content: "\n"
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D412_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D412_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 220
           column: 0
         end_location:
           row: 221
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D413_sections.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D413_sections.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "\n    "
-        location:
+      - location:
           row: 67
           column: 11
         end_location:
           row: 67
           column: 11
+        content: "\n    "
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D415_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D415_D.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 355
           column: 14
         end_location:
           row: 355
           column: 14
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 406
           column: 36
         end_location:
           row: 406
           column: 36
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 410
           column: 21
         end_location:
           row: 410
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 416
           column: 21
         end_location:
           row: 416
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 422
           column: 46
         end_location:
           row: 422
           column: 46
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 63
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 429
           column: 60
         end_location:
           row: 429
           column: 60
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 470
           column: 21
         end_location:
           row: 470
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 475
           column: 21
         end_location:
           row: 475
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 480
           column: 21
         end_location:
           row: 480
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 487
           column: 21
         end_location:
           row: 487
           column: 21
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 520
           column: 29
         end_location:
           row: 520
           column: 29
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 581
           column: 47
         end_location:
           row: 581
           column: 47
+        content: "."
   parent: ~
 - kind:
     name: EndsInPunctuation
@@ -267,12 +267,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 615
           column: 14
         end_location:
           row: 615
           column: 14
+        content: "."
   parent: ~
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__d209_d400.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 72
   fix:
     edits:
-      - content: "\n    "
-        location:
+      - location:
           row: 3
           column: 69
         end_location:
           row: 3
           column: 69
+        content: "\n    "
   parent: ~
 - kind:
     name: EndsInPeriod
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 72
   fix:
     edits:
-      - content: "."
-        location:
+      - location:
           row: 3
           column: 69
         end_location:
           row: 3
           column: 69
+        content: "."
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_0.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: import os
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 20
+        content: import os
   parent: ~
 - kind:
     name: UnusedImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "from collections import (\n    Counter,\n    namedtuple,\n)"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 8
           column: 1
+        content: "from collections import (\n    Counter,\n    namedtuple,\n)"
   parent:
     row: 4
     column: 0
@@ -59,13 +59,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 13
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -80,13 +80,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 32
           column: 0
         end_location:
           row: 33
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -101,13 +101,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 33
           column: 4
         end_location:
           row: 33
           column: 20
+        content: pass
   parent: ~
 - kind:
     name: UnusedImport
@@ -122,13 +122,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 37
           column: 0
         end_location:
           row: 38
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -143,13 +143,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 52
           column: 8
         end_location:
           row: 52
           column: 21
+        content: pass
   parent: ~
 - kind:
     name: UnusedImport
@@ -164,13 +164,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 93
           column: 0
         end_location:
           row: 94
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -185,12 +185,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 94
           column: 8
         end_location:
           row: 94
           column: 16
+        content: pass
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
@@ -29,12 +29,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 16
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_11.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_11.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: from pathlib import Path
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 34
+        content: from pathlib import Path
   parent:
     row: 4
     column: 0

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_5.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_5.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 3
           column: 0
+        content: ~
   parent:
     row: 2
     column: 0
@@ -38,13 +38,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 4
           column: 0
+        content: ~
   parent:
     row: 3
     column: 0
@@ -61,13 +61,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 5
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -82,12 +82,12 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_6.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_6.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 8
           column: 0
+        content: ~
   parent:
     row: 7
     column: 0
@@ -38,13 +38,13 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 11
           column: 0
+        content: ~
   parent:
     row: 10
     column: 0
@@ -61,13 +61,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -82,12 +82,12 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 20
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_7.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_7.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "from typing import (\n    Mapping,  # noqa: F401\n    )"
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 31
           column: 1
+        content: "from typing import (\n    Mapping,  # noqa: F401\n    )"
   parent:
     row: 28
     column: 0
@@ -38,13 +38,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 66
           column: 0
         end_location:
           row: 67
           column: 0
+        content: ~
   parent:
     row: 66
     column: 0
@@ -61,13 +61,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 66
           column: 0
         end_location:
           row: 67
           column: 0
+        content: ~
   parent:
     row: 66
     column: 0

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_9.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_9.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: from foo import bar
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 24
+        content: from foo import bar
   parent:
     row: 4
     column: 0

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F504.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F504.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "{a: \"?\", }"
-        location:
+      - location:
           row: 3
           column: 16
         end_location:
           row: 3
           column: 34
+        content: "{a: \"?\", }"
   parent: ~
 - kind:
     name: PercentFormatExtraNamedArguments
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "{\"a\": 1, }"
-        location:
+      - location:
           row: 8
           column: 10
         end_location:
           row: 8
           column: 29
+        content: "{\"a\": 1, }"
   parent: ~
 - kind:
     name: PercentFormatExtraNamedArguments
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "{'a': 1, }"
-        location:
+      - location:
           row: 9
           column: 10
         end_location:
           row: 9
           column: 29
+        content: "{'a': 1, }"
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F50x.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F504_F50x.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "{'bar': 1, }"
-        location:
+      - location:
           row: 8
           column: 12
         end_location:
           row: 8
           column: 32
+        content: "{'bar': 1, }"
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F522_F522.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F522_F522.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\"{}\".format(1, )"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 21
+        content: "\"{}\".format(1, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraNamedArguments
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "\"{bar}{}\".format(1, bar=2, )"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 34
+        content: "\"{bar}{}\".format(1, bar=2, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraNamedArguments
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "\"{bar:{spam}}\".format(bar=2, spam=3, )"
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 51
+        content: "\"{bar:{spam}}\".format(bar=2, spam=3, )"
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F523_F523.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F523_F523.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "\"{0}\".format(1, )"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 18
+        content: "\"{0}\".format(1, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\"{0}\".format(2, )"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 21
+        content: "\"{0}\".format(2, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "\"{1:{0}}\".format(1, 2, )"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 25
+        content: "\"{1:{0}}\".format(1, 2, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\"{0}{2}\".format(1, )"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 21
+        content: "\"{0}{2}\".format(1, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: "\"{0.arg[1]!r:0{1['arg']}{0}}\".format(2, 3, )"
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 48
+        content: "\"{0.arg[1]!r:0{1['arg']}{0}}\".format(2, 3, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "\"{}\".format(1, )"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 17
+        content: "\"{}\".format(1, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\"{}\".format(1, )"
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 20
+        content: "\"{}\".format(1, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "\"{:{}}\".format(1, 2, )"
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 13
           column: 23
+        content: "\"{:{}}\".format(1, 2, )"
   parent: ~
 - kind:
     name: StringDotFormatExtraPositionalArguments
@@ -183,12 +183,12 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "\"{0}{1}\".format(1, 2, *args)"
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 19
           column: 31
+        content: "\"{0}{1}\".format(1, 2, *args)"
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F541_F541.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"def\""
-        location:
+      - location:
           row: 6
           column: 4
         end_location:
           row: 6
           column: 10
+        content: "\"def\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"def\""
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 10
+        content: "\"def\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"def\""
-        location:
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 10
+        content: "\"def\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "\"a\""
-        location:
+      - location:
           row: 13
           column: 4
         end_location:
           row: 13
           column: 8
+        content: "\"a\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "\"b\""
-        location:
+      - location:
           row: 14
           column: 4
         end_location:
           row: 14
           column: 8
+        content: "\"b\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "\"d\""
-        location:
+      - location:
           row: 16
           column: 5
         end_location:
           row: 16
           column: 9
+        content: "\"d\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "r\"e\""
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 17
           column: 9
+        content: "r\"e\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\""
-        location:
+      - location:
           row: 19
           column: 4
         end_location:
           row: 19
           column: 7
+        content: "\"\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\"z\""
-        location:
+      - location:
           row: 25
           column: 12
         end_location:
           row: 25
           column: 16
+        content: "\"z\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "'0.2f'"
-        location:
+      - location:
           row: 34
           column: 6
         end_location:
           row: 34
           column: 13
+        content: "'0.2f'"
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "''"
-        location:
+      - location:
           row: 35
           column: 3
         end_location:
           row: 35
           column: 6
+        content: "''"
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "\"{test}\""
-        location:
+      - location:
           row: 36
           column: 0
         end_location:
           row: 36
           column: 11
+        content: "\"{test}\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "'{ 40 }'"
-        location:
+      - location:
           row: 37
           column: 0
         end_location:
           row: 37
           column: 11
+        content: "'{ 40 }'"
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "\"{a {x}\""
-        location:
+      - location:
           row: 38
           column: 0
         end_location:
           row: 38
           column: 12
+        content: "\"{a {x}\""
   parent: ~
 - kind:
     name: FStringMissingPlaceholders
@@ -309,12 +309,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "\"{{x}}\""
-        location:
+      - location:
           row: 39
           column: 0
         end_location:
           row: 39
           column: 12
+        content: "\"{{x}}\""
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F601_F601.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F601_F601.py.snap
@@ -85,13 +85,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 17
           column: 10
         end_location:
           row: 18
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyLiteral
@@ -134,13 +134,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 24
           column: 10
         end_location:
           row: 25
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyLiteral
@@ -169,13 +169,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 30
           column: 10
         end_location:
           row: 31
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyLiteral
@@ -260,13 +260,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 44
           column: 8
         end_location:
           row: 45
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyLiteral
@@ -281,13 +281,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 49
           column: 11
         end_location:
           row: 49
           column: 19
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyLiteral
@@ -302,12 +302,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 50
           column: 19
         end_location:
           row: 50
           column: 27
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F602_F602.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F602_F602.py.snap
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 8
         end_location:
           row: 13
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyVariable
@@ -106,13 +106,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 8
         end_location:
           row: 20
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyVariable
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 25
           column: 8
         end_location:
           row: 26
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyVariable
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 34
           column: 10
         end_location:
           row: 35
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyVariable
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 44
           column: 9
         end_location:
           row: 44
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: MultiValueRepeatedKeyVariable
@@ -288,12 +288,12 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 45
           column: 15
         end_location:
           row: 45
           column: 21
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F632_F632.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F632_F632.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 1
           column: 5
         end_location:
           row: 1
           column: 7
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "!="
-        location:
+      - location:
           row: 4
           column: 7
         end_location:
           row: 4
           column: 13
+        content: "!="
   parent: ~
 - kind:
     name: IsLiteral
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "!="
-        location:
+      - location:
           row: 7
           column: 7
         end_location:
           row: 8
           column: 11
+        content: "!="
   parent: ~
 - kind:
     name: IsLiteral
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 11
           column: 9
         end_location:
           row: 11
           column: 11
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 14
           column: 14
         end_location:
           row: 14
           column: 16
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 17
           column: 16
         end_location:
           row: 17
           column: 18
+        content: "=="
   parent: ~
 - kind:
     name: IsLiteral
@@ -141,12 +141,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "=="
-        location:
+      - location:
           row: 20
           column: 15
         end_location:
           row: 20
           column: 17
+        content: "=="
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 17
         end_location:
           row: 3
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 16
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 21
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -106,13 +106,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 26
           column: 13
         end_location:
           row: 26
           column: 19
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -127,13 +127,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 51
           column: 8
         end_location:
           row: 51
           column: 13
+        content: pass
   parent: ~
 - kind:
     name: UnusedVariable
@@ -148,13 +148,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 79
           column: 21
         end_location:
           row: 79
           column: 32
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -169,13 +169,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 85
           column: 20
         end_location:
           row: 85
           column: 31
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -190,13 +190,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 102
           column: 0
         end_location:
           row: 103
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -211,13 +211,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 115
           column: 4
         end_location:
           row: 115
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
@@ -43,13 +43,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 13
         end_location:
           row: 16
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -64,13 +64,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 4
         end_location:
           row: 20
           column: 13
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 7
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 14
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 15
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 21
           column: 14
         end_location:
           row: 21
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 15
         end_location:
           row: 27
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 28
         end_location:
           row: 27
           column: 34
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 41
         end_location:
           row: 27
           column: 47
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -211,13 +211,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 33
           column: 15
         end_location:
           row: 33
           column: 25
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -232,13 +232,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 34
           column: 4
         end_location:
           row: 34
           column: 14
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -253,13 +253,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 40
           column: 21
         end_location:
           row: 40
           column: 27
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -274,13 +274,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 45
           column: 42
         end_location:
           row: 45
           column: 48
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -295,13 +295,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 50
           column: 4
         end_location:
           row: 50
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -316,13 +316,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 56
           column: 4
         end_location:
           row: 57
           column: 8
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -337,13 +337,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 61
           column: 4
         end_location:
           row: 65
           column: 5
+        content: pass
   parent: ~
 - kind:
     name: UnusedVariable
@@ -358,13 +358,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 67
           column: 0
         end_location:
           row: 69
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -379,13 +379,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 72
           column: 18
         end_location:
           row: 72
           column: 26
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -400,13 +400,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 77
           column: 19
         end_location:
           row: 77
           column: 27
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -421,13 +421,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 87
           column: 4
         end_location:
           row: 87
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -442,13 +442,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 93
           column: 4
         end_location:
           row: 93
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -463,13 +463,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 93
           column: 15
         end_location:
           row: 93
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -484,13 +484,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 97
           column: 4
         end_location:
           row: 97
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -505,13 +505,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 101
           column: 13
         end_location:
           row: 101
           column: 24
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -526,13 +526,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 105
           column: 4
         end_location:
           row: 105
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -547,12 +547,12 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 105
           column: 15
         end_location:
           row: 105
           column: 20
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F901_F901.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F901_F901.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: NotImplementedError
-        location:
+      - location:
           row: 2
           column: 10
         end_location:
           row: 2
           column: 24
+        content: NotImplementedError
   parent: ~
 - kind:
     name: RaiseNotImplemented
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: NotImplementedError
-        location:
+      - location:
           row: 6
           column: 10
         end_location:
           row: 6
           column: 24
+        content: NotImplementedError
   parent: ~
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 17
         end_location:
           row: 3
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 21
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -85,13 +85,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 26
           column: 13
         end_location:
           row: 26
           column: 19
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -106,13 +106,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 35
           column: 0
         end_location:
           row: 36
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -127,13 +127,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 36
           column: 0
         end_location:
           row: 37
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -148,13 +148,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 37
           column: 4
         end_location:
           row: 37
           column: 18
+        content: pass
   parent: ~
 - kind:
     name: UnusedVariable
@@ -169,13 +169,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 51
           column: 8
         end_location:
           row: 51
           column: 13
+        content: pass
   parent: ~
 - kind:
     name: UnusedVariable
@@ -190,13 +190,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 79
           column: 21
         end_location:
           row: 79
           column: 32
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -211,13 +211,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 85
           column: 20
         end_location:
           row: 85
           column: 31
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -232,13 +232,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 102
           column: 0
         end_location:
           row: 103
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -253,13 +253,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 115
           column: 4
         end_location:
           row: 115
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__future_annotations.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__future_annotations.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "from models import (\n    Fruit,\n)"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 9
           column: 1
+        content: "from models import (\n    Fruit,\n)"
   parent:
     row: 6
     column: 0

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__multi_statement_lines.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__multi_statement_lines.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 4
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 8
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 12
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 11
         end_location:
           row: 16
           column: 22
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 21
           column: 9
         end_location:
           row: 21
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 26
           column: 10
         end_location:
           row: 26
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 30
           column: 11
         end_location:
           row: 30
           column: 24
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 31
           column: 15
         end_location:
           row: 31
           column: 32
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 35
           column: 8
         end_location:
           row: 36
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 40
           column: 9
         end_location:
           row: 41
           column: 9
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 46
           column: 0
         end_location:
           row: 46
           column: 12
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -267,12 +267,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 51
           column: 0
         end_location:
           row: 51
           column: 12
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_return.rs
@@ -117,7 +117,7 @@ pub fn useless_return<'a>(
             checker.stylist,
         ) {
             Ok(fix) => {
-                if fix.content.is_empty() || fix.content == "pass" {
+                if fix.is_deletion() || fix.content() == Some("pass") {
                     checker.deletions.insert(RefEquality(last_stmt));
                 }
                 diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLC0414_import_aliasing.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLC0414_import_aliasing.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: collections
-        location:
+      - location:
           row: 6
           column: 7
         end_location:
           row: 6
           column: 33
+        content: collections
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: OrderedDict
-        location:
+      - location:
           row: 7
           column: 24
         end_location:
           row: 7
           column: 50
+        content: OrderedDict
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: bar
-        location:
+      - location:
           row: 16
           column: 14
         end_location:
           row: 16
           column: 24
+        content: bar
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: bar
-        location:
+      - location:
           row: 19
           column: 18
         end_location:
           row: 19
           column: 28
+        content: bar
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 38
   fix:
     edits:
-      - content: foobar
-        location:
+      - location:
           row: 20
           column: 22
         end_location:
           row: 20
           column: 38
+        content: foobar
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: foo
-        location:
+      - location:
           row: 22
           column: 14
         end_location:
           row: 22
           column: 24
+        content: foo
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 38
   fix:
     edits:
-      - content: foo2
-        location:
+      - location:
           row: 23
           column: 26
         end_location:
           row: 23
           column: 38
+        content: foo2
   parent: ~
 - kind:
     name: UselessImportAlias
@@ -162,12 +162,12 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: foobar
-        location:
+      - location:
           row: 25
           column: 20
         end_location:
           row: 25
           column: 36
+        content: foobar
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2510_invalid_characters.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2510_invalid_characters.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "\\b"
-        location:
+      - location:
           row: 15
           column: 5
         end_location:
           row: 15
           column: 6
+        content: "\\b"
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2512_invalid_characters.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2512_invalid_characters.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "\\x1A"
-        location:
+      - location:
           row: 21
           column: 11
         end_location:
           row: 21
           column: 12
+        content: "\\x1A"
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2513_invalid_characters.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2513_invalid_characters.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "\\x1B"
-        location:
+      - location:
           row: 25
           column: 15
         end_location:
           row: 25
           column: 16
+        content: "\\x1B"
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2514_invalid_characters.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2514_invalid_characters.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "\\0"
-        location:
+      - location:
           row: 30
           column: 4
         end_location:
           row: 30
           column: 5
+        content: "\\0"
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2515_invalid_characters.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLE2515_invalid_characters.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "\\u200b"
-        location:
+      - location:
           row: 34
           column: 12
         end_location:
           row: 34
           column: 13
+        content: "\\u200b"
   parent: ~
 - kind:
     name: InvalidCharacterZeroWidthSpace
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "\\u200b"
-        location:
+      - location:
           row: 38
           column: 35
         end_location:
           row: 38
           column: 36
+        content: "\\u200b"
   parent: ~
 - kind:
     name: InvalidCharacterZeroWidthSpace
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 60
   fix:
     edits:
-      - content: "\\u200b"
-        location:
+      - location:
           row: 39
           column: 59
         end_location:
           row: 39
           column: 60
+        content: "\\u200b"
   parent: ~
 - kind:
     name: InvalidCharacterZeroWidthSpace
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 61
   fix:
     edits:
-      - content: "\\u200b"
-        location:
+      - location:
           row: 39
           column: 60
         end_location:
           row: 39
           column: 61
+        content: "\\u200b"
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0402_import_aliasing.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0402_import_aliasing.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: from os import path
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 22
+        content: from os import path
   parent: ~
 - kind:
     name: ManualFromImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: from foo.bar import foobar
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 31
+        content: from foo.bar import foobar
   parent: ~
 - kind:
     name: ManualFromImport

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1711_useless_return.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1711_useless_return.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 7
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UselessReturn
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 12
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UselessReturn
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UselessReturn
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 23
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UselessReturn
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 50
           column: 0
         end_location:
           row: 51
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UselessReturn
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 60
           column: 0
         end_location:
           row: 61
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_0.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_0.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 4
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 4
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 6
           column: 4
         end_location:
           row: 6
           column: 8
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -99,19 +99,19 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 8
+        content: sys.exit
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: import sys
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 10
-      - content: sys.exit
-        location:
+        content: import sys
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 4
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: import sys
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 10
-      - content: sys.exit
-        location:
+        content: import sys
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 4
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: import sys
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 10
-      - content: sys.exit
-        location:
+        content: import sys
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 8
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -99,20 +99,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: import sys
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 10
-      - content: sys.exit
-        location:
+        content: import sys
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_2.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_2.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: import sys as sys2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 18
-      - content: sys2.exit
-        location:
+        content: import sys as sys2
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 4
+        content: sys2.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: import sys as sys2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 18
-      - content: sys2.exit
-        location:
+        content: import sys as sys2
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 4
+        content: sys2.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: import sys as sys2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 18
-      - content: sys2.exit
-        location:
+        content: import sys as sys2
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 8
+        content: sys2.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -99,19 +99,19 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: import sys as sys2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 18
-      - content: sys2.exit
-        location:
+        content: import sys as sys2
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: sys2.exit
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: from sys import exit
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 20
-      - content: exit
-        location:
+        content: from sys import exit
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 4
+        content: exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: from sys import exit
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 20
-      - content: exit
-        location:
+        content: from sys import exit
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: exit
   parent: ~
 - kind:
     name: SysExitAlias

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_4.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_4.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: from sys import exit as exit2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 29
-      - content: exit2
-        location:
+        content: from sys import exit as exit2
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 4
+        content: exit2
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: from sys import exit as exit2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 29
-      - content: exit2
-        location:
+        content: from sys import exit as exit2
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 4
+        content: exit2
   parent: ~
 - kind:
     name: SysExitAlias
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: from sys import exit as exit2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 29
-      - content: exit2
-        location:
+        content: from sys import exit as exit2
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 8
+        content: exit2
   parent: ~
 - kind:
     name: SysExitAlias
@@ -99,19 +99,19 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: from sys import exit as exit2
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 29
-      - content: exit2
-        location:
+        content: from sys import exit as exit2
+      - location:
           row: 9
           column: 4
         end_location:
           row: 9
           column: 8
+        content: exit2
   parent: ~
 

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_6.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_6.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 4
+        content: sys.exit
   parent: ~
 - kind:
     name: SysExitAlias
@@ -43,19 +43,19 @@ expression: diagnostics
     column: 4
   fix:
     edits:
-      - content: "import sys\n"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 0
-      - content: sys.exit
-        location:
+        content: "import sys\n"
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 4
+        content: sys.exit
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -122,7 +122,7 @@ pub fn unnecessary_builtin_import(
             checker.stylist,
         ) {
             Ok(fix) => {
-                if fix.content.is_empty() || fix.content == "pass" {
+                if fix.is_deletion() || fix.content() == Some("pass") {
                     checker.deletions.insert(*defined_by);
                 }
                 diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -102,7 +102,7 @@ pub fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, names: &[Lo
             checker.stylist,
         ) {
             Ok(fix) => {
-                if fix.content.is_empty() || fix.content == "pass" {
+                if fix.is_deletion() || fix.content() == Some("pass") {
                     checker.deletions.insert(*defined_by);
                 }
                 diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -61,7 +61,7 @@ pub fn useless_metaclass_type(checker: &mut Checker, stmt: &Stmt, value: &Expr, 
             checker.stylist,
         ) {
             Ok(fix) => {
-                if fix.content.is_empty() || fix.content == "pass" {
+                if fix.is_deletion() || fix.content() == Some("pass") {
                     checker.deletions.insert(*defined_by);
                 }
                 diagnostic.set_fix(fix);

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP001.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP001.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 24
+        content: pass
   parent: ~
 - kind:
     name: UselessMetaclassType
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 7
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP003.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP003.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 8
+        content: str
   parent: ~
 - kind:
     name: TypeOfPrimitive
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: bytes
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 9
+        content: bytes
   parent: ~
 - kind:
     name: TypeOfPrimitive
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 7
+        content: int
   parent: ~
 - kind:
     name: TypeOfPrimitive
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: float
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 9
+        content: float
   parent: ~
 - kind:
     name: TypeOfPrimitive
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: complex
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 8
+        content: complex
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP004.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP004.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 7
         end_location:
           row: 5
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 9
           column: 7
         end_location:
           row: 11
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 15
           column: 7
         end_location:
           row: 18
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 22
           column: 7
         end_location:
           row: 25
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 29
           column: 7
         end_location:
           row: 32
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 36
           column: 7
         end_location:
           row: 39
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 43
           column: 7
         end_location:
           row: 47
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 51
           column: 7
         end_location:
           row: 55
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 59
           column: 7
         end_location:
           row: 63
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 67
           column: 7
         end_location:
           row: 71
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 75
           column: 9
         end_location:
           row: 75
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 79
           column: 8
         end_location:
           row: 79
           column: 16
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 84
           column: 4
         end_location:
           row: 85
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 91
           column: 5
         end_location:
           row: 92
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 98
           column: 4
         end_location:
           row: 99
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 107
           column: 5
         end_location:
           row: 108
           column: 10
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 114
           column: 11
         end_location:
           row: 114
           column: 19
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 118
           column: 7
         end_location:
           row: 120
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 124
           column: 7
         end_location:
           row: 126
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UselessObjectInheritance
@@ -414,12 +414,12 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 130
           column: 7
         end_location:
           row: 133
           column: 1
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP005.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP005.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: self.assertEqual
-        location:
+      - location:
           row: 6
           column: 8
         end_location:
           row: 6
           column: 25
+        content: self.assertEqual
   parent: ~
 - kind:
     name: DeprecatedUnittestAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: self.assertEqual
-        location:
+      - location:
           row: 7
           column: 8
         end_location:
           row: 7
           column: 25
+        content: self.assertEqual
   parent: ~
 - kind:
     name: DeprecatedUnittestAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: self.assertAlmostEqual
-        location:
+      - location:
           row: 9
           column: 8
         end_location:
           row: 9
           column: 34
+        content: self.assertAlmostEqual
   parent: ~
 - kind:
     name: DeprecatedUnittestAlias
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: self.assertNotRegex
-        location:
+      - location:
           row: 10
           column: 8
         end_location:
           row: 10
           column: 35
+        content: self.assertNotRegex
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 4
           column: 9
         end_location:
           row: 4
           column: 20
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 11
           column: 9
         end_location:
           row: 11
           column: 13
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 18
           column: 9
         end_location:
           row: 18
           column: 15
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 25
           column: 9
         end_location:
           row: 25
           column: 14
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 29
           column: 10
         end_location:
           row: 29
           column: 14
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 33
           column: 11
         end_location:
           row: 33
           column: 15
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 37
           column: 10
         end_location:
           row: 37
           column: 14
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 41
           column: 12
         end_location:
           row: 41
           column: 16
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -197,13 +197,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 49
           column: 10
         end_location:
           row: 49
           column: 14
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -218,13 +218,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 49
           column: 16
         end_location:
           row: 49
           column: 20
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -239,13 +239,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 53
           column: 10
         end_location:
           row: 53
           column: 14
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: str | None
-        location:
+      - location:
           row: 6
           column: 9
         end_location:
           row: 6
           column: 22
+        content: str | None
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: str | None
-        location:
+      - location:
           row: 10
           column: 9
         end_location:
           row: 10
           column: 29
+        content: str | None
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "str | int | Union[float, bytes]"
-        location:
+      - location:
           row: 14
           column: 9
         end_location:
           row: 14
           column: 45
+        content: "str | int | Union[float, bytes]"
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: float | bytes
-        location:
+      - location:
           row: 14
           column: 25
         end_location:
           row: 14
           column: 44
+        content: float | bytes
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: str | int
-        location:
+      - location:
           row: 18
           column: 9
         end_location:
           row: 18
           column: 31
+        content: str | int
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: str | int
-        location:
+      - location:
           row: 22
           column: 9
         end_location:
           row: 22
           column: 33
+        content: str | int
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "(str, int) | float"
-        location:
+      - location:
           row: 26
           column: 9
         end_location:
           row: 26
           column: 40
+        content: "(str, int) | float"
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "str | int | Union[float, bytes]"
-        location:
+      - location:
           row: 30
           column: 10
         end_location:
           row: 30
           column: 46
+        content: "str | int | Union[float, bytes]"
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: float | bytes
-        location:
+      - location:
           row: 30
           column: 26
         end_location:
           row: 30
           column: 45
+        content: float | bytes
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: str | int
-        location:
+      - location:
           row: 34
           column: 10
         end_location:
           row: 34
           column: 32
+        content: str | int
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: str | None
-        location:
+      - location:
           row: 47
           column: 7
         end_location:
           row: 47
           column: 20
+        content: str | None
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: str | int
-        location:
+      - location:
           row: 52
           column: 7
         end_location:
           row: 52
           column: 22
+        content: str | int
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP008.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP008.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: super()
-        location:
+      - location:
           row: 17
           column: 17
         end_location:
           row: 17
           column: 35
+        content: super()
   parent: ~
 - kind:
     name: SuperCallWithParameters
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: super()
-        location:
+      - location:
           row: 18
           column: 8
         end_location:
           row: 18
           column: 26
+        content: super()
   parent: ~
 - kind:
     name: SuperCallWithParameters
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: super()
-        location:
+      - location:
           row: 19
           column: 8
         end_location:
           row: 22
           column: 9
+        content: super()
   parent: ~
 - kind:
     name: SuperCallWithParameters
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: super()
-        location:
+      - location:
           row: 36
           column: 8
         end_location:
           row: 36
           column: 28
+        content: super()
   parent: ~
 - kind:
     name: SuperCallWithParameters
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: super()
-        location:
+      - location:
           row: 50
           column: 12
         end_location:
           row: 50
           column: 32
+        content: super()
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP009_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP009_0.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP009_1.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP009_1.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 0
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 3
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP010.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP010.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 3
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 4
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 5
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: from __future__ import invalid_module
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 49
+        content: from __future__ import invalid_module
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 10
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 10
           column: 4
         end_location:
           row: 10
           column: 37
+        content: pass
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 14
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryFutureImport
@@ -204,12 +204,12 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: from __future__ import invalid_module
-        location:
+      - location:
           row: 14
           column: 4
         end_location:
           row: 14
           column: 53
+        content: from __future__ import invalid_module
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP011.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP011.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: functools.lru_cache
-        location:
+      - location:
           row: 5
           column: 1
         end_location:
           row: 5
           column: 22
+        content: functools.lru_cache
   parent: ~
 - kind:
     name: LRUCacheWithoutParameters
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: lru_cache
-        location:
+      - location:
           row: 10
           column: 1
         end_location:
           row: 10
           column: 12
+        content: lru_cache
   parent: ~
 - kind:
     name: LRUCacheWithoutParameters
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: functools.lru_cache
-        location:
+      - location:
           row: 16
           column: 1
         end_location:
           row: 16
           column: 22
+        content: functools.lru_cache
   parent: ~
 - kind:
     name: LRUCacheWithoutParameters
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: functools.lru_cache
-        location:
+      - location:
           row: 21
           column: 1
         end_location:
           row: 21
           column: 22
+        content: functools.lru_cache
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP012.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP012.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 21
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 18
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 14
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 20
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 22
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 30
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "b\"\"\"\nLorem\n\nIpsum\n\"\"\""
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 14
           column: 1
+        content: "b\"\"\"\nLorem\n\nIpsum\n\"\"\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "b\"Lorem \"\n    b\"Ipsum\""
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 17
           column: 20
+        content: "b\"Lorem \"\n    b\"Ipsum\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "b\"Lorem \"  # Comment\n    b\"Ipsum\""
-        location:
+      - location:
           row: 20
           column: 4
         end_location:
           row: 21
           column: 20
+        content: "b\"Lorem \"  # Comment\n    b\"Ipsum\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "b\"Lorem \" b\"Ipsum\""
-        location:
+      - location:
           row: 24
           column: 4
         end_location:
           row: 24
           column: 29
+        content: "b\"Lorem \" b\"Ipsum\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 32
           column: 19
         end_location:
           row: 32
           column: 26
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 36
           column: 20
         end_location:
           row: 38
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 53
           column: 23
         end_location:
           row: 53
           column: 30
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 55
           column: 23
         end_location:
           row: 55
           column: 38
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "br\"foo\\o\""
-        location:
+      - location:
           row: 57
           column: 0
         end_location:
           row: 57
           column: 24
+        content: "br\"foo\\o\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 58
           column: 0
         end_location:
           row: 58
           column: 22
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "bR\"foo\\o\""
-        location:
+      - location:
           row: 59
           column: 0
         end_location:
           row: 59
           column: 24
+        content: "bR\"foo\\o\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 60
           column: 0
         end_location:
           row: 60
           column: 22
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: UnnecessaryEncodeUTF8
@@ -393,12 +393,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 61
           column: 6
         end_location:
           row: 61
           column: 20
+        content: "b\"foo\""
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP013.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP013.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: int\n    b: str"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 50
+        content: "class MyType(TypedDict):\n    a: int\n    b: str"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 48
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: int\n    b: str"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 48
+        content: "class MyType(TypedDict):\n    a: int\n    b: str"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: int\n    b: str"
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 42
+        content: "class MyType(TypedDict):\n    a: int\n    b: str"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    pass"
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 14
           column: 28
+        content: "class MyType(TypedDict):\n    pass"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: \"hello\""
-        location:
+      - location:
           row: 17
           column: 0
         end_location:
           row: 17
           column: 44
+        content: "class MyType(TypedDict):\n    a: \"hello\""
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: \"hello\""
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 18
           column: 39
+        content: "class MyType(TypedDict):\n    a: \"hello\""
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 54
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    a: NotRequired[dict]"
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 21
           column: 54
+        content: "class MyType(TypedDict):\n    a: NotRequired[dict]"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 63
   fix:
     edits:
-      - content: "class MyType(TypedDict, total=False):\n    x: int\n    y: int"
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 24
           column: 63
+        content: "class MyType(TypedDict, total=False):\n    x: int\n    y: int"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    key: Literal[\"value\"]"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 27
           column: 55
+        content: "class MyType(TypedDict):\n    key: Literal[\"value\"]"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "class MyType(typing.TypedDict):\n    key: int"
-        location:
+      - location:
           row: 30
           column: 0
         end_location:
           row: 30
           column: 49
+        content: "class MyType(typing.TypedDict):\n    key: int"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    pass"
-        location:
+      - location:
           row: 40
           column: 0
         end_location:
           row: 40
           column: 32
+        content: "class MyType(TypedDict):\n    pass"
   parent: ~
 - kind:
     name: ConvertTypedDictFunctionalToClass
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "class MyType(TypedDict):\n    pass"
-        location:
+      - location:
           row: 43
           column: 0
         end_location:
           row: 43
           column: 36
+        content: "class MyType(TypedDict):\n    pass"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP014.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 67
   fix:
     edits:
-      - content: "class MyType(NamedTuple):\n    a: int\n    b: tuple[str, ...]"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 67
+        content: "class MyType(NamedTuple):\n    a: int\n    b: tuple[str, ...]"
   parent: ~
 - kind:
     name: ConvertNamedTupleFunctionalToClass
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "class MyType(NamedTuple):\n    a: int\n    b: str = \"foo\"\n    c: list[bool] = [True]"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 12
           column: 1
+        content: "class MyType(NamedTuple):\n    a: int\n    b: str = \"foo\"\n    c: list[bool] = [True]"
   parent: ~
 - kind:
     name: ConvertNamedTupleFunctionalToClass
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 62
   fix:
     edits:
-      - content: "class MyType(typing.NamedTuple):\n    a: int\n    b: str"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 62
+        content: "class MyType(typing.NamedTuple):\n    a: int\n    b: str"
   parent: ~
 - kind:
     name: ConvertNamedTupleFunctionalToClass
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "class MyType(typing.NamedTuple):\n    pass"
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 28
           column: 36
+        content: "class MyType(typing.NamedTuple):\n    pass"
   parent: ~
 - kind:
     name: ConvertNamedTupleFunctionalToClass
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "class MyType(typing.NamedTuple):\n    pass"
-        location:
+      - location:
           row: 31
           column: 0
         end_location:
           row: 31
           column: 40
+        content: "class MyType(typing.NamedTuple):\n    pass"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP015.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP015.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 10
         end_location:
           row: 1
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 10
         end_location:
           row: 2
           column: 16
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 3
           column: 12
         end_location:
           row: 3
           column: 16
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 4
           column: 12
         end_location:
           row: 4
           column: 17
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 10
         end_location:
           row: 5
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 10
         end_location:
           row: 6
           column: 16
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 8
         end_location:
           row: 7
           column: 13
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "\"w\""
-        location:
+      - location:
           row: 8
           column: 10
         end_location:
           row: 8
           column: 14
+        content: "\"w\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 10
           column: 15
         end_location:
           row: 10
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 15
         end_location:
           row: 12
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 14
           column: 17
         end_location:
           row: 14
           column: 21
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 16
           column: 17
         end_location:
           row: 16
           column: 22
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 18
           column: 15
         end_location:
           row: 18
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 15
         end_location:
           row: 20
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 22
           column: 15
         end_location:
           row: 22
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"w\""
-        location:
+      - location:
           row: 24
           column: 17
         end_location:
           row: 24
           column: 21
+        content: "\"w\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 21
         end_location:
           row: 27
           column: 26
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 28
           column: 23
         end_location:
           row: 28
           column: 27
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 30
           column: 26
         end_location:
           row: 30
           column: 31
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 32
           column: 28
         end_location:
           row: 32
           column: 32
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 35
           column: 15
         end_location:
           row: 35
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 35
           column: 39
         end_location:
           row: 35
           column: 44
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 37
           column: 17
         end_location:
           row: 37
           column: 21
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 37
           column: 42
         end_location:
           row: 37
           column: 46
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -519,13 +519,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 40
           column: 10
         end_location:
           row: 40
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -540,13 +540,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 41
           column: 15
         end_location:
           row: 41
           column: 25
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -561,13 +561,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 42
           column: 5
         end_location:
           row: 42
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -582,13 +582,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 44
           column: 15
         end_location:
           row: 44
           column: 25
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -603,13 +603,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 46
           column: 20
         end_location:
           row: 46
           column: 30
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -624,13 +624,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 48
           column: 10
         end_location:
           row: 48
           column: 20
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -645,13 +645,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 51
           column: 17
         end_location:
           row: 51
           column: 21
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -666,13 +666,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 52
           column: 22
         end_location:
           row: 52
           column: 26
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -687,13 +687,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 53
           column: 10
         end_location:
           row: 53
           column: 14
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -708,13 +708,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 55
           column: 22
         end_location:
           row: 55
           column: 26
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -729,13 +729,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 57
           column: 27
         end_location:
           row: 57
           column: 31
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -750,13 +750,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 59
           column: 15
         end_location:
           row: 59
           column: 19
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -771,13 +771,13 @@ expression: diagnostics
     column: 110
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 62
           column: 15
         end_location:
           row: 62
           column: 25
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -792,13 +792,13 @@ expression: diagnostics
     column: 110
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 63
           column: 99
         end_location:
           row: 63
           column: 109
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -813,13 +813,13 @@ expression: diagnostics
     column: 110
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 64
           column: 58
         end_location:
           row: 64
           column: 68
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -834,13 +834,13 @@ expression: diagnostics
     column: 110
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 65
           column: 5
         end_location:
           row: 65
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -855,13 +855,13 @@ expression: diagnostics
     column: 111
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 67
           column: 22
         end_location:
           row: 67
           column: 26
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -876,13 +876,13 @@ expression: diagnostics
     column: 111
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 68
           column: 106
         end_location:
           row: 68
           column: 110
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -897,13 +897,13 @@ expression: diagnostics
     column: 111
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 69
           column: 65
         end_location:
           row: 69
           column: 69
+        content: "\"rb\""
   parent: ~
 - kind:
     name: RedundantOpenModes
@@ -918,12 +918,12 @@ expression: diagnostics
     column: 111
   fix:
     edits:
-      - content: "\"rb\""
-        location:
+      - location:
           row: 70
           column: 10
         end_location:
           row: 70
           column: 14
+        content: "\"rb\""
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP018.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP018.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "\"\""
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 5
+        content: "\"\""
   parent: ~
 - kind:
     name: NativeLiterals
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 10
   fix:
     edits:
-      - content: "\"foo\""
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 21
           column: 10
+        content: "\"foo\""
   parent: ~
 - kind:
     name: NativeLiterals
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "\"\"\"\nfoo\"\"\""
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 23
           column: 7
+        content: "\"\"\"\nfoo\"\"\""
   parent: ~
 - kind:
     name: NativeLiterals
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "b\"\""
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 24
           column: 7
+        content: "b\"\""
   parent: ~
 - kind:
     name: NativeLiterals
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "b\"foo\""
-        location:
+      - location:
           row: 25
           column: 0
         end_location:
           row: 25
           column: 13
+        content: "b\"foo\""
   parent: ~
 - kind:
     name: NativeLiterals
@@ -120,12 +120,12 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: "b\"\"\"\nfoo\"\"\""
-        location:
+      - location:
           row: 26
           column: 0
         end_location:
           row: 27
           column: 7
+        content: "b\"\"\"\nfoo\"\"\""
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP019.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP019.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 7
           column: 21
         end_location:
           row: 7
           column: 25
+        content: str
   parent: ~
 - kind:
     name: TypingTextStrAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 11
           column: 28
         end_location:
           row: 11
           column: 39
+        content: str
   parent: ~
 - kind:
     name: TypingTextStrAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 15
           column: 27
         end_location:
           row: 15
           column: 37
+        content: str
   parent: ~
 - kind:
     name: TypingTextStrAlias
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 19
           column: 28
         end_location:
           row: 19
           column: 35
+        content: str
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP020.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP020.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 55
   fix:
     edits:
-      - content: open
-        location:
+      - location:
           row: 3
           column: 5
         end_location:
           row: 3
           column: 12
+        content: open
   parent: ~
 - kind:
     name: OpenAlias

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP021.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP021.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: text
-        location:
+      - location:
           row: 6
           column: 24
         end_location:
           row: 6
           column: 42
+        content: text
   parent: ~
 - kind:
     name: ReplaceUniversalNewlines
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: text
-        location:
+      - location:
           row: 7
           column: 22
         end_location:
           row: 7
           column: 40
+        content: text
   parent: ~
 - kind:
     name: ReplaceUniversalNewlines
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: text
-        location:
+      - location:
           row: 9
           column: 13
         end_location:
           row: 9
           column: 31
+        content: text
   parent: ~
 - kind:
     name: ReplaceUniversalNewlines
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: text
-        location:
+      - location:
           row: 10
           column: 21
         end_location:
           row: 10
           column: 39
+        content: text
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP022.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP022.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 69
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 4
           column: 22
         end_location:
           row: 4
           column: 44
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 4
           column: 44
         end_location:
           row: 4
           column: 68
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 80
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 6
           column: 33
         end_location:
           row: 6
           column: 55
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 6
           column: 55
         end_location:
           row: 6
           column: 79
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -71,20 +71,20 @@ expression: diagnostics
     column: 86
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 8
           column: 24
         end_location:
           row: 8
           column: 46
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 8
           column: 60
         end_location:
           row: 8
           column: 85
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -99,20 +99,20 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 11
           column: 13
         end_location:
           row: 11
           column: 35
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 11
           column: 47
         end_location:
           row: 11
           column: 71
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -127,20 +127,20 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 15
           column: 13
         end_location:
           row: 15
           column: 35
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 15
           column: 47
         end_location:
           row: 15
           column: 71
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -155,20 +155,20 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 20
           column: 4
         end_location:
           row: 20
           column: 26
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 22
           column: 4
         end_location:
           row: 23
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: ReplaceStdoutStderr
@@ -183,19 +183,19 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: capture_output=True
-        location:
+      - location:
           row: 31
           column: 8
         end_location:
           row: 31
           column: 30
-      - content: ""
-        location:
+        content: capture_output=True
+      - location:
           row: 33
           column: 8
         end_location:
           row: 34
           column: 8
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP023.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP023.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 59
   fix:
     edits:
-      - content: "from xml.etree.ElementTree import XML, Element, SubElement"
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 59
+        content: "from xml.etree.ElementTree import XML, Element, SubElement"
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: xml.etree.ElementTree as ET
-        location:
+      - location:
           row: 3
           column: 7
         end_location:
           row: 3
           column: 35
+        content: xml.etree.ElementTree as ET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: from   xml.etree.ElementTree    import  XML
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 44
+        content: from   xml.etree.ElementTree    import  XML
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: xml.etree.ElementTree       as      ET
-        location:
+      - location:
           row: 7
           column: 10
         end_location:
           row: 7
           column: 49
+        content: xml.etree.ElementTree       as      ET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "from xml.etree.ElementTree import (\n    XML,\n    Element,\n    SubElement,\n)"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 14
           column: 1
+        content: "from xml.etree.ElementTree import (\n    XML,\n    Element,\n    SubElement,\n)"
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: xml.etree.ElementTree as ET
-        location:
+      - location:
           row: 16
           column: 11
         end_location:
           row: 16
           column: 39
+        content: xml.etree.ElementTree as ET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: ElementTree as CET
-        location:
+      - location:
           row: 17
           column: 26
         end_location:
           row: 17
           column: 45
+        content: ElementTree as CET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: ElementTree as ET
-        location:
+      - location:
           row: 19
           column: 22
         end_location:
           row: 19
           column: 40
+        content: ElementTree as ET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: xml.etree.ElementTree as ET
-        location:
+      - location:
           row: 21
           column: 19
         end_location:
           row: 21
           column: 47
+        content: xml.etree.ElementTree as ET
   parent: ~
 - kind:
     name: DeprecatedCElementTree
@@ -204,12 +204,12 @@ expression: diagnostics
     column: 59
   fix:
     edits:
-      - content: xml.etree.ElementTree as ET
-        location:
+      - location:
           row: 24
           column: 31
         end_location:
           row: 24
           column: 59
+        content: xml.etree.ElementTree as ET
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 6
           column: 7
         end_location:
           row: 6
           column: 23
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 11
           column: 7
         end_location:
           row: 11
           column: 14
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 16
           column: 7
         end_location:
           row: 16
           column: 19
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 21
           column: 7
         end_location:
           row: 21
           column: 17
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 26
           column: 7
         end_location:
           row: 26
           column: 19
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 31
           column: 7
         end_location:
           row: 31
           column: 19
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 36
           column: 7
         end_location:
           row: 36
           column: 12
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 43
           column: 7
         end_location:
           row: 43
           column: 17
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 47
           column: 7
         end_location:
           row: 47
           column: 20
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 57
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 51
           column: 7
         end_location:
           row: 51
           column: 57
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "(KeyError, OSError)"
-        location:
+      - location:
           row: 58
           column: 7
         end_location:
           row: 58
           column: 35
+        content: "(KeyError, OSError)"
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "(OSError, error)"
-        location:
+      - location:
           row: 65
           column: 7
         end_location:
           row: 65
           column: 23
+        content: "(OSError, error)"
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -267,12 +267,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 87
           column: 7
         end_location:
           row: 87
           column: 19
+        content: OSError
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_1.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_1.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 5
           column: 7
         end_location:
           row: 5
           column: 37
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "(OSError, KeyError)"
-        location:
+      - location:
           row: 7
           column: 7
         end_location:
           row: 7
           column: 40
+        content: "(OSError, KeyError)"
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 12
           column: 7
         end_location:
           row: 16
           column: 1
+        content: OSError
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_2.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 10
           column: 6
         end_location:
           row: 10
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 11
           column: 6
         end_location:
           row: 11
           column: 16
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 12
           column: 6
         end_location:
           row: 12
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 14
           column: 6
         end_location:
           row: 14
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 15
           column: 6
         end_location:
           row: 15
           column: 16
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 16
           column: 6
         end_location:
           row: 16
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 18
           column: 6
         end_location:
           row: 18
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 25
           column: 6
         end_location:
           row: 25
           column: 11
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 28
           column: 6
         end_location:
           row: 28
           column: 11
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 31
           column: 6
         end_location:
           row: 31
           column: 11
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 34
           column: 6
         end_location:
           row: 34
           column: 22
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 35
           column: 6
         end_location:
           row: 35
           column: 13
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 36
           column: 6
         end_location:
           row: 36
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 38
           column: 6
         end_location:
           row: 38
           column: 22
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 39
           column: 6
         end_location:
           row: 39
           column: 13
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 40
           column: 6
         end_location:
           row: 40
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 42
           column: 6
         end_location:
           row: 42
           column: 22
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 48
           column: 6
         end_location:
           row: 48
           column: 18
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 49
           column: 6
         end_location:
           row: 49
           column: 22
+        content: OSError
   parent: ~
 - kind:
     name: OSErrorAlias
@@ -414,12 +414,12 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: OSError
-        location:
+      - location:
           row: 50
           column: 6
         end_location:
           row: 50
           column: 13
+        content: OSError
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_4.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP024_4.py.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "(OSError, exceptions.OperationalError)"
-        location:
+      - location:
           row: 9
           column: 7
         end_location:
           row: 9
           column: 50
+        content: "(OSError, exceptions.OperationalError)"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP025.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP025.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 2
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 1
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 6
         end_location:
           row: 6
           column: 7
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 8
           column: 6
         end_location:
           row: 8
           column: 7
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 4
         end_location:
           row: 12
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 14
         end_location:
           row: 12
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 26
         end_location:
           row: 12
           column: 27
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 12
           column: 38
         end_location:
           row: 12
           column: 39
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 4
         end_location:
           row: 16
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 17
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 18
           column: 4
         end_location:
           row: 18
           column: 5
+        content: ~
   parent: ~
 - kind:
     name: UnicodeKindPrefix
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 4
         end_location:
           row: 19
           column: 5
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP026.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP026.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: from unittest import mock
-        location:
+      - location:
           row: 3
           column: 4
         end_location:
           row: 3
           column: 15
+        content: from unittest import mock
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "import sys\n    from unittest import mock"
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 7
           column: 20
+        content: "import sys\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: from unittest.mock import *
-        location:
+      - location:
           row: 11
           column: 4
         end_location:
           row: 11
           column: 22
+        content: from unittest.mock import *
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: from unittest import mock
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 14
           column: 16
+        content: from unittest import mock
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "import contextlib, sys\nfrom unittest import mock"
-        location:
+      - location:
           row: 17
           column: 0
         end_location:
           row: 17
           column: 28
+        content: "import contextlib, sys\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "import sys\nfrom unittest import mock"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 16
+        content: "import sys\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: from unittest import mock
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 24
           column: 21
+        content: from unittest import mock
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "from unittest.mock import (\n    a,\n    b,\n    c,\n)\nfrom unittest import mock"
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 32
           column: 1
+        content: "from unittest.mock import (\n    a,\n    b,\n    c,\n)\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "from unittest.mock import (\n    a,\n    b,\n    c,\n)\nfrom unittest import mock"
-        location:
+      - location:
           row: 33
           column: 0
         end_location:
           row: 38
           column: 1
+        content: "from unittest.mock import (\n    a,\n    b,\n    c,\n)\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "from unittest.mock import (\n    a,\n    b,\n    c\n)\nfrom unittest import mock"
-        location:
+      - location:
           row: 41
           column: 0
         end_location:
           row: 46
           column: 1
+        content: "from unittest.mock import (\n    a,\n    b,\n    c\n)\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "from unittest.mock import (\n    a,\n    b,\n    c\n)\nfrom unittest import mock"
-        location:
+      - location:
           row: 47
           column: 0
         end_location:
           row: 52
           column: 1
+        content: "from unittest.mock import (\n    a,\n    b,\n    c\n)\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "from unittest.mock import a, b, c\nfrom unittest import mock"
-        location:
+      - location:
           row: 53
           column: 0
         end_location:
           row: 53
           column: 30
+        content: "from unittest.mock import a, b, c\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "from unittest.mock import a, b, c\nfrom unittest import mock"
-        location:
+      - location:
           row: 54
           column: 0
         end_location:
           row: 54
           column: 30
+        content: "from unittest.mock import a, b, c\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "from unittest.mock import (\n            a,\n            b,\n            c\n        )\n        from unittest import mock"
-        location:
+      - location:
           row: 58
           column: 8
         end_location:
           row: 63
           column: 9
+        content: "from unittest.mock import (\n            a,\n            b,\n            c\n        )\n        from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: "from unittest import mock\nfrom unittest import mock"
-        location:
+      - location:
           row: 69
           column: 0
         end_location:
           row: 69
           column: 17
+        content: "from unittest import mock\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "from unittest import mock\nfrom unittest import mock"
-        location:
+      - location:
           row: 69
           column: 0
         end_location:
           row: 69
           column: 17
+        content: "from unittest import mock\nfrom unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: from unittest import mock as foo
-        location:
+      - location:
           row: 72
           column: 0
         end_location:
           row: 72
           column: 18
+        content: from unittest import mock as foo
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: from unittest import mock as foo
-        location:
+      - location:
           row: 75
           column: 0
         end_location:
           row: 75
           column: 28
+        content: from unittest import mock as foo
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 79
           column: 4
         end_location:
           row: 79
           column: 41
+        content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 79
           column: 4
         end_location:
           row: 79
           column: 41
+        content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 79
           column: 4
         end_location:
           row: 79
           column: 41
+        content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 82
           column: 4
         end_location:
           row: 82
           column: 45
+        content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 82
           column: 4
         end_location:
           row: 82
           column: 45
+        content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 82
           column: 4
         end_location:
           row: 82
           column: 45
+        content: "import os\n    from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -519,13 +519,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
-        location:
+      - location:
           row: 86
           column: 4
         end_location:
           row: 86
           column: 51
+        content: "from unittest import mock as foo\n    from unittest import mock as bar\n    from unittest import mock"
   parent: ~
 - kind:
     name: DeprecatedMockImport
@@ -540,12 +540,12 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: mock
-        location:
+      - location:
           row: 93
           column: 4
         end_location:
           row: 93
           column: 13
+        content: mock
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP027.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP027.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 38
   fix:
     edits:
-      - content: (fn(x) for x in items)
-        location:
+      - location:
           row: 2
           column: 16
         end_location:
           row: 2
           column: 38
+        content: (fn(x) for x in items)
   parent: ~
 - kind:
     name: UnpackedListComprehension
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: (fn(x) for x in items)
-        location:
+      - location:
           row: 4
           column: 15
         end_location:
           row: 4
           column: 37
+        content: (fn(x) for x in items)
   parent: ~
 - kind:
     name: UnpackedListComprehension
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: (fn(x) for x in items)
-        location:
+      - location:
           row: 6
           column: 25
         end_location:
           row: 6
           column: 47
+        content: (fn(x) for x in items)
   parent: ~
 - kind:
     name: UnpackedListComprehension
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "([i for i in fn(x)] for x in items)"
-        location:
+      - location:
           row: 8
           column: 16
         end_location:
           row: 8
           column: 51
+        content: "([i for i in fn(x)] for x in items)"
   parent: ~
 - kind:
     name: UnpackedListComprehension
@@ -99,12 +99,12 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "(\n    fn(x)\n    for x in items\n)"
-        location:
+      - location:
           row: 10
           column: 16
         end_location:
           row: 13
           column: 1
+        content: "(\n    fn(x)\n    for x in items\n)"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP028_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP028_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: yield from y
-        location:
+      - location:
           row: 2
           column: 4
         end_location:
           row: 3
           column: 15
+        content: yield from y
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: yield from z
-        location:
+      - location:
           row: 7
           column: 4
         end_location:
           row: 8
           column: 20
+        content: yield from z
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "yield from [1, 2, 3]"
-        location:
+      - location:
           row: 12
           column: 4
         end_location:
           row: 13
           column: 15
+        content: "yield from [1, 2, 3]"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "yield from {x for x in y}"
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 18
           column: 15
+        content: "yield from {x for x in y}"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "yield from (1, 2, 3)"
-        location:
+      - location:
           row: 22
           column: 4
         end_location:
           row: 23
           column: 15
+        content: "yield from (1, 2, 3)"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "yield from {3: \"x\", 6: \"y\"}"
-        location:
+      - location:
           row: 27
           column: 4
         end_location:
           row: 28
           column: 18
+        content: "yield from {3: \"x\", 6: \"y\"}"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "yield from {  # Comment three\\n'\n        3: \"x\",  # Comment four\\n'\n        # Comment five\\n'\n        6: \"y\",  # Comment six\\n'\n    }"
-        location:
+      - location:
           row: 33
           column: 4
         end_location:
           row: 39
           column: 18
+        content: "yield from {  # Comment three\\n'\n        3: \"x\",  # Comment four\\n'\n        # Comment five\\n'\n        6: \"y\",  # Comment six\\n'\n    }"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "yield from [{3: (3, [44, \"long ss\"]), 6: \"y\"}]"
-        location:
+      - location:
           row: 44
           column: 4
         end_location:
           row: 45
           column: 18
+        content: "yield from [{3: (3, [44, \"long ss\"]), 6: \"y\"}]"
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: yield from z()
-        location:
+      - location:
           row: 49
           column: 4
         end_location:
           row: 50
           column: 18
+        content: yield from z()
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: yield from z()
-        location:
+      - location:
           row: 55
           column: 8
         end_location:
           row: 57
           column: 22
+        content: yield from z()
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: yield from x
-        location:
+      - location:
           row: 67
           column: 4
         end_location:
           row: 68
           column: 15
+        content: yield from x
   parent: ~
 - kind:
     name: YieldInForLoop
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: yield from z()
-        location:
+      - location:
           row: 72
           column: 4
         end_location:
           row: 73
           column: 18
+        content: yield from z()
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP029.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP029.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnnecessaryBuiltinImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: from builtins import compile
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 42
+        content: from builtins import compile
   parent: ~
 - kind:
     name: UnnecessaryBuiltinImport
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: from six.moves import zip_longest
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 46
+        content: from six.moves import zip_longest
   parent: ~
 - kind:
     name: UnnecessaryBuiltinImport
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 6
           column: 0
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "\"{}\" \"{}\" \"{}\".format(1, 2, 3)"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 3
           column: 33
+        content: "\"{}\" \"{}\" \"{}\".format(1, 2, 3)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "\"a {} complicated {} string with {} {}\".format(\n    \"fourth\", \"second\", \"first\", \"third\"\n)"
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 7
           column: 1
+        content: "\"a {} complicated {} string with {} {}\".format(\n    \"fourth\", \"second\", \"first\", \"third\"\n)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "'{}'.format(1)"
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 15
+        content: "'{}'.format(1)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "'{:x}'.format(30)"
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 18
+        content: "'{:x}'.format(30)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "'{}'.format(1)"
-        location:
+      - location:
           row: 13
           column: 4
         end_location:
           row: 13
           column: 19
+        content: "'{}'.format(1)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "'''{}\\n{}\\n'''.format(1, 2)"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 29
+        content: "'''{}\\n{}\\n'''.format(1, 2)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"foo {}\" \\\n    \"bar {}\".format(1, 2)"
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 18
           column: 26
+        content: "\"foo {}\" \\\n    \"bar {}\".format(1, 2)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "(\"{}\").format(1)"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 17
+        content: "(\"{}\").format(1)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"\\N{snowman} {}\".format(1)"
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 22
           column: 27
+        content: "\"\\N{snowman} {}\".format(1)"
   parent: ~
 - kind:
     name: FormatLiterals

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\"{}\".format(*args)"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 19
+        content: "\"{}\".format(*args)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"{}\".format(**kwargs)"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 22
+        content: "\"{}\".format(**kwargs)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "\"{}_{}\".format(*args)"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 23
+        content: "\"{}_{}\".format(*args)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"{}_{}\".format(1, *args)"
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 12
           column: 26
+        content: "\"{}_{}\".format(1, *args)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -113,13 +113,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"{}_{}\".format(*args, 1)"
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 16
           column: 26
+        content: "\"{}_{}\".format(*args, 1)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -134,13 +134,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "\"{}_{}\".format(1, 2, *args)"
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 18
           column: 29
+        content: "\"{}_{}\".format(1, 2, *args)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -155,13 +155,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "\"{}_{}\".format(*args, 1, 2)"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 29
+        content: "\"{}_{}\".format(*args, 1, 2)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -176,13 +176,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "\"{}_{}_{}\".format(1, **kwargs)"
-        location:
+      - location:
           row: 22
           column: 0
         end_location:
           row: 22
           column: 33
+        content: "\"{}_{}_{}\".format(1, **kwargs)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -197,13 +197,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "\"{}_{}_{}\".format(1, 2, **kwargs)"
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 24
           column: 36
+        content: "\"{}_{}_{}\".format(1, 2, **kwargs)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -218,13 +218,13 @@ expression: diagnostics
     column: 39
   fix:
     edits:
-      - content: "\"{}_{}_{}\".format(1, 2, 3, **kwargs)"
-        location:
+      - location:
           row: 26
           column: 0
         end_location:
           row: 26
           column: 39
+        content: "\"{}_{}_{}\".format(1, 2, 3, **kwargs)"
   parent: ~
 - kind:
     name: FormatLiterals
@@ -239,12 +239,12 @@ expression: diagnostics
     column: 46
   fix:
     edits:
-      - content: "\"{}_{}_{}\".format(1, 2, 3, *args, **kwargs)"
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 28
           column: 46
+        content: "\"{}_{}_{}\".format(1, 2, 3, *args, **kwargs)"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP031_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP031_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "'{} {}'.format(a, b)"
-        location:
+      - location:
           row: 4
           column: 6
         end_location:
           row: 4
           column: 22
+        content: "'{} {}'.format(a, b)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "'{}{}'.format(a, b)"
-        location:
+      - location:
           row: 6
           column: 6
         end_location:
           row: 6
           column: 21
+        content: "'{}{}'.format(a, b)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\"trivial\".format()"
-        location:
+      - location:
           row: 8
           column: 6
         end_location:
           row: 8
           column: 20
+        content: "\"trivial\".format()"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "\"{}\".format(\"simple\")"
-        location:
+      - location:
           row: 10
           column: 6
         end_location:
           row: 10
           column: 24
+        content: "\"{}\".format(\"simple\")"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "\"{}\".format(\"%s\" % (\"nested\",))"
-        location:
+      - location:
           row: 12
           column: 6
         end_location:
           row: 12
           column: 34
+        content: "\"{}\".format(\"%s\" % (\"nested\",))"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "\"{}\".format(\"nested\")"
-        location:
+      - location:
           row: 12
           column: 14
         end_location:
           row: 12
           column: 32
+        content: "\"{}\".format(\"nested\")"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "\"{}% percent\".format(15)"
-        location:
+      - location:
           row: 14
           column: 6
         end_location:
           row: 14
           column: 28
+        content: "\"{}% percent\".format(15)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "\"{:f}\".format(15)"
-        location:
+      - location:
           row: 16
           column: 6
         end_location:
           row: 16
           column: 18
+        content: "\"{:f}\".format(15)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\"{:.0f}\".format(15)"
-        location:
+      - location:
           row: 18
           column: 6
         end_location:
           row: 18
           column: 19
+        content: "\"{:.0f}\".format(15)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\"{:.3f}\".format(15)"
-        location:
+      - location:
           row: 20
           column: 6
         end_location:
           row: 20
           column: 20
+        content: "\"{:.3f}\".format(15)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\"{:3f}\".format(15)"
-        location:
+      - location:
           row: 22
           column: 6
         end_location:
           row: 22
           column: 19
+        content: "\"{:3f}\".format(15)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "\"{:<5f}\".format(5)"
-        location:
+      - location:
           row: 24
           column: 6
         end_location:
           row: 24
           column: 19
+        content: "\"{:<5f}\".format(5)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "\"{:9f}\".format(5)"
-        location:
+      - location:
           row: 26
           column: 6
         end_location:
           row: 26
           column: 18
+        content: "\"{:9f}\".format(5)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "\"{:#o}\".format(123)"
-        location:
+      - location:
           row: 28
           column: 6
         end_location:
           row: 28
           column: 20
+        content: "\"{:#o}\".format(123)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"brace {{}} {}\".format(1)"
-        location:
+      - location:
           row: 30
           column: 6
         end_location:
           row: 30
           column: 26
+        content: "\"brace {{}} {}\".format(1)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "\"{}\".format(\n    \"trailing comma\",\n        )"
-        location:
+      - location:
           row: 33
           column: 2
         end_location:
           row: 35
           column: 9
+        content: "\"{}\".format(\n    \"trailing comma\",\n        )"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "\"foo {} \".format(x)"
-        location:
+      - location:
           row: 38
           column: 6
         end_location:
           row: 38
           column: 22
+        content: "\"foo {} \".format(x)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"{k}\".format(k=\"v\")"
-        location:
+      - location:
           row: 40
           column: 6
         end_location:
           row: 40
           column: 26
+        content: "\"{k}\".format(k=\"v\")"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 1
   fix:
     edits:
-      - content: "\"{k}\".format(\n    k=\"v\",\n    i=\"j\",\n)"
-        location:
+      - location:
           row: 42
           column: 6
         end_location:
           row: 45
           column: 1
+        content: "\"{k}\".format(\n    k=\"v\",\n    i=\"j\",\n)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "\"{to_list}\".format(to_list=[])"
-        location:
+      - location:
           row: 47
           column: 6
         end_location:
           row: 47
           column: 37
+        content: "\"{to_list}\".format(to_list=[])"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 43
   fix:
     edits:
-      - content: "\"{k}\".format(k=\"v\", i=1, j=[])"
-        location:
+      - location:
           row: 49
           column: 6
         end_location:
           row: 49
           column: 43
+        content: "\"{k}\".format(k=\"v\", i=1, j=[])"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "\"{ab}\".format(ab=1)"
-        location:
+      - location:
           row: 51
           column: 6
         end_location:
           row: 51
           column: 29
+        content: "\"{ab}\".format(ab=1)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"{a}\".format(a=1)"
-        location:
+      - location:
           row: 53
           column: 6
         end_location:
           row: 53
           column: 27
+        content: "\"{a}\".format(a=1)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "\"foo {} \"\n    \"bar {}\".format(x, y)"
-        location:
+      - location:
           row: 56
           column: 4
         end_location:
           row: 57
           column: 21
+        content: "\"foo {} \"\n    \"bar {}\".format(x, y)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -519,13 +519,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "\"foo {foo} \"\n    \"bar {bar}\".format(foo=x, bar=y)"
-        location:
+      - location:
           row: 61
           column: 4
         end_location:
           row: 62
           column: 40
+        content: "\"foo {foo} \"\n    \"bar {bar}\".format(foo=x, bar=y)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -540,13 +540,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: "\"foo {foo} \"\n    \"bar {bar}\".format(foo=x, **bar)"
-        location:
+      - location:
           row: 67
           column: 4
         end_location:
           row: 68
           column: 37
+        content: "\"foo {foo} \"\n    \"bar {bar}\".format(foo=x, **bar)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -561,13 +561,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "\"{} \\N{snowman}\".format(a)"
-        location:
+      - location:
           row: 71
           column: 6
         end_location:
           row: 71
           column: 29
+        content: "\"{} \\N{snowman}\".format(a)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -582,13 +582,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "\"{foo} \\N{snowman}\".format(foo=1)"
-        location:
+      - location:
           row: 73
           column: 6
         end_location:
           row: 73
           column: 40
+        content: "\"{foo} \\N{snowman}\".format(foo=1)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -603,13 +603,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: "(\"foo {} \" \"bar {}\").format(x, y)"
-        location:
+      - location:
           row: 75
           column: 6
         end_location:
           row: 75
           column: 35
+        content: "(\"foo {} \" \"bar {}\").format(x, y)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -624,13 +624,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "'Hello {}'.format(\"World\")"
-        location:
+      - location:
           row: 78
           column: 6
         end_location:
           row: 78
           column: 26
+        content: "'Hello {}'.format(\"World\")"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -645,13 +645,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "'Hello {}'.format(f\"World\")"
-        location:
+      - location:
           row: 79
           column: 6
         end_location:
           row: 79
           column: 27
+        content: "'Hello {}'.format(f\"World\")"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -666,13 +666,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "'Hello {} ({})'.format(*bar)"
-        location:
+      - location:
           row: 80
           column: 6
         end_location:
           row: 80
           column: 27
+        content: "'Hello {} ({})'.format(*bar)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -687,13 +687,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "'Hello {} ({})'.format(*bar.baz)"
-        location:
+      - location:
           row: 81
           column: 6
         end_location:
           row: 81
           column: 31
+        content: "'Hello {} ({})'.format(*bar.baz)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -708,13 +708,13 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "'Hello {} ({})'.format(*bar['bop'])"
-        location:
+      - location:
           row: 82
           column: 6
         end_location:
           row: 82
           column: 34
+        content: "'Hello {} ({})'.format(*bar['bop'])"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -729,13 +729,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "'Hello {arg}'.format(**bar)"
-        location:
+      - location:
           row: 83
           column: 6
         end_location:
           row: 83
           column: 27
+        content: "'Hello {arg}'.format(**bar)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -750,13 +750,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: "'Hello {arg}'.format(**bar.baz)"
-        location:
+      - location:
           row: 84
           column: 6
         end_location:
           row: 84
           column: 31
+        content: "'Hello {arg}'.format(**bar.baz)"
   parent: ~
 - kind:
     name: PrintfStringFormatting
@@ -771,12 +771,12 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: "'Hello {arg}'.format(**bar['bop'])"
-        location:
+      - location:
           row: 85
           column: 6
         end_location:
           row: 85
           column: 34
+        content: "'Hello {arg}'.format(**bar['bop'])"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "f\"{a} {b}\""
-        location:
+      - location:
           row: 5
           column: 0
         end_location:
           row: 5
           column: 20
+        content: "f\"{a} {b}\""
   parent: ~
 - kind:
     name: FString
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "f\"{b} {a}\""
-        location:
+      - location:
           row: 7
           column: 0
         end_location:
           row: 7
           column: 22
+        content: "f\"{b} {a}\""
   parent: ~
 - kind:
     name: FString
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "f\"{z.y}\""
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 9
           column: 19
+        content: "f\"{z.y}\""
   parent: ~
 - kind:
     name: FString
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "f\"{a.x} {b.y}\""
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 11
           column: 24
+        content: "f\"{a.x} {b.y}\""
   parent: ~
 - kind:
     name: FString
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "f\"{a.b} {c.d}\""
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 13
           column: 24
+        content: "f\"{a.b} {c.d}\""
   parent: ~
 - kind:
     name: FString
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "f\"{a()}\""
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 16
+        content: "f\"{a()}\""
   parent: ~
 - kind:
     name: FString
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "f\"{a.b()}\""
-        location:
+      - location:
           row: 17
           column: 0
         end_location:
           row: 17
           column: 18
+        content: "f\"{a.b()}\""
   parent: ~
 - kind:
     name: FString
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "f\"{a.b().c()}\""
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 19
           column: 22
+        content: "f\"{a.b().c()}\""
   parent: ~
 - kind:
     name: FString
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "f\"hello {name}!\""
-        location:
+      - location:
           row: 21
           column: 0
         end_location:
           row: 21
           column: 24
+        content: "f\"hello {name}!\""
   parent: ~
 - kind:
     name: FString
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "f\"{a}{b}{c}\""
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 23
           column: 27
+        content: "f\"{a}{b}{c}\""
   parent: ~
 - kind:
     name: FString
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "f\"{0x0}\""
-        location:
+      - location:
           row: 25
           column: 0
         end_location:
           row: 25
           column: 16
+        content: "f\"{0x0}\""
   parent: ~
 - kind:
     name: FString
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "f\"{a} {b}\""
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 27
           column: 20
+        content: "f\"{a} {b}\""
   parent: ~
 - kind:
     name: FString
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "f\"\"\"{a} {b}\"\"\""
-        location:
+      - location:
           row: 29
           column: 0
         end_location:
           row: 29
           column: 24
+        content: "f\"\"\"{a} {b}\"\"\""
   parent: ~
 - kind:
     name: FString
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: "f\"foo{1}\""
-        location:
+      - location:
           row: 31
           column: 0
         end_location:
           row: 31
           column: 17
+        content: "f\"foo{1}\""
   parent: ~
 - kind:
     name: FString
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "fr\"foo{1}\""
-        location:
+      - location:
           row: 33
           column: 0
         end_location:
           row: 33
           column: 18
+        content: "fr\"foo{1}\""
   parent: ~
 - kind:
     name: FString
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "f\"{1}\""
-        location:
+      - location:
           row: 35
           column: 4
         end_location:
           row: 35
           column: 21
+        content: "f\"{1}\""
   parent: ~
 - kind:
     name: FString
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "f\"foo {x} \""
-        location:
+      - location:
           row: 37
           column: 6
         end_location:
           row: 37
           column: 25
+        content: "f\"foo {x} \""
   parent: ~
 - kind:
     name: FString
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "f\"{a[b]}\""
-        location:
+      - location:
           row: 39
           column: 0
         end_location:
           row: 39
           column: 20
+        content: "f\"{a[b]}\""
   parent: ~
 - kind:
     name: FString
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: "f\"{a.a[b]}\""
-        location:
+      - location:
           row: 41
           column: 0
         end_location:
           row: 41
           column: 22
+        content: "f\"{a.a[b]}\""
   parent: ~
 - kind:
     name: FString
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: "f\"{escaped}{{}}{y}\""
-        location:
+      - location:
           row: 43
           column: 0
         end_location:
           row: 43
           column: 29
+        content: "f\"{escaped}{{}}{y}\""
   parent: ~
 - kind:
     name: FString
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 14
   fix:
     edits:
-      - content: "f\"{a}\""
-        location:
+      - location:
           row: 45
           column: 0
         end_location:
           row: 45
           column: 14
+        content: "f\"{a}\""
   parent: ~
 - kind:
     name: FString
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "f'({a}={{0!e}})'"
-        location:
+      - location:
           row: 47
           column: 0
         end_location:
           row: 47
           column: 24
+        content: "f'({a}={{0!e}})'"
   parent: ~
 - kind:
     name: FString
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: " f\"{osname}-{version}.{release}\""
-        location:
+      - location:
           row: 92
           column: 10
         end_location:
           row: 92
           column: 53
+        content: " f\"{osname}-{version}.{release}\""
   parent: ~
 - kind:
     name: FString
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: " f\"{1}\""
-        location:
+      - location:
           row: 96
           column: 9
         end_location:
           row: 96
           column: 23
+        content: " f\"{1}\""
   parent: ~
 - kind:
     name: FString
@@ -519,12 +519,12 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: " f\"{1}\""
-        location:
+      - location:
           row: 99
           column: 6
         end_location:
           row: 99
           column: 20
+        content: " f\"{1}\""
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP033_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP033_0.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: import functools
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 16
-      - content: functools.cache
-        location:
+        content: import functools
+      - location:
           row: 4
           column: 1
         end_location:
           row: 4
           column: 34
+        content: functools.cache
   parent: ~
 - kind:
     name: LRUCacheWithMaxsizeNone
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: import functools
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 16
-      - content: functools.cache
-        location:
+        content: import functools
+      - location:
           row: 10
           column: 1
         end_location:
           row: 10
           column: 34
+        content: functools.cache
   parent: ~
 - kind:
     name: LRUCacheWithMaxsizeNone
@@ -71,19 +71,19 @@ expression: diagnostics
     column: 34
   fix:
     edits:
-      - content: import functools
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 16
-      - content: functools.cache
-        location:
+        content: import functools
+      - location:
           row: 15
           column: 1
         end_location:
           row: 15
           column: 34
+        content: functools.cache
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP033_1.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP033_1.py.snap
@@ -15,20 +15,20 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "from functools import lru_cache, cache"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 31
-      - content: cache
-        location:
+        content: "from functools import lru_cache, cache"
+      - location:
           row: 4
           column: 1
         end_location:
           row: 4
           column: 24
+        content: cache
   parent: ~
 - kind:
     name: LRUCacheWithMaxsizeNone
@@ -43,20 +43,20 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "from functools import lru_cache, cache"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 31
-      - content: cache
-        location:
+        content: "from functools import lru_cache, cache"
+      - location:
           row: 10
           column: 1
         end_location:
           row: 10
           column: 24
+        content: cache
   parent: ~
 - kind:
     name: LRUCacheWithMaxsizeNone
@@ -71,19 +71,19 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: "from functools import lru_cache, cache"
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 1
           column: 31
-      - content: cache
-        location:
+        content: "from functools import lru_cache, cache"
+      - location:
           row: 15
           column: 1
         end_location:
           row: 15
           column: 24
+        content: cache
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP034.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP034.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "\"foo\""
-        location:
+      - location:
           row: 2
           column: 6
         end_location:
           row: 2
           column: 13
+        content: "\"foo\""
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "\"hell((goodybe))o\""
-        location:
+      - location:
           row: 5
           column: 6
         end_location:
           row: 5
           column: 26
+        content: "\"hell((goodybe))o\""
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "(\"foo\")"
-        location:
+      - location:
           row: 8
           column: 6
         end_location:
           row: 8
           column: 15
+        content: "(\"foo\")"
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ((1))
-        location:
+      - location:
           row: 11
           column: 6
         end_location:
           row: 11
           column: 13
+        content: ((1))
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 25
   fix:
     edits:
-      - content: "\"foo{}\".format(1)"
-        location:
+      - location:
           row: 14
           column: 6
         end_location:
           row: 14
           column: 25
+        content: "\"foo{}\".format(1)"
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "\"foo{}\".format(1)"
-        location:
+      - location:
           row: 18
           column: 4
         end_location:
           row: 18
           column: 23
+        content: "\"foo{}\".format(1)"
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "\n        \"foo\"\n    "
-        location:
+      - location:
           row: 23
           column: 4
         end_location:
           row: 25
           column: 5
+        content: "\n        \"foo\"\n    "
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: (yield 1)
-        location:
+      - location:
           row: 30
           column: 12
         end_location:
           row: 30
           column: 23
+        content: (yield 1)
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: "\"foo{}\".format(1)"
-        location:
+      - location:
           row: 35
           column: 8
         end_location:
           row: 35
           column: 27
+        content: "\"foo{}\".format(1)"
   parent: ~
 - kind:
     name: ExtraneousParentheses
@@ -204,12 +204,12 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: x for x in range(3)
-        location:
+      - location:
           row: 39
           column: 6
         end_location:
           row: 39
           column: 27
+        content: x for x in range(3)
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP035.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: from collections.abc import Mapping
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 31
+        content: from collections.abc import Mapping
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 38
   fix:
     edits:
-      - content: from collections.abc import Mapping as MAP
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 4
           column: 38
+        content: from collections.abc import Mapping as MAP
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: "from collections.abc import Mapping, Sequence"
-        location:
+      - location:
           row: 6
           column: 0
         end_location:
           row: 6
           column: 41
+        content: "from collections.abc import Mapping, Sequence"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "from collections import Counter\nfrom collections.abc import Mapping"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 8
           column: 40
+        content: "from collections import Counter\nfrom collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: "from collections import (Counter)\nfrom collections.abc import Mapping"
-        location:
+      - location:
           row: 10
           column: 0
         end_location:
           row: 10
           column: 42
+        content: "from collections import (Counter)\nfrom collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: "from collections import (Counter)\nfrom collections.abc import Mapping"
-        location:
+      - location:
           row: 12
           column: 0
         end_location:
           row: 13
           column: 33
+        content: "from collections import (Counter)\nfrom collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "from collections import Counter\nfrom collections.abc import Mapping"
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 16
           column: 32
+        content: "from collections import Counter\nfrom collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "from collections import Counter\nfrom collections.abc import Mapping, Sequence"
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 18
           column: 50
+        content: "from collections import Counter\nfrom collections.abc import Mapping, Sequence"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "from collections import Counter\nfrom collections.abc import Mapping as mapping"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 20
           column: 51
+        content: "from collections import Counter\nfrom collections.abc import Mapping as mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "from collections import Counter\n    from collections.abc import Mapping"
-        location:
+      - location:
           row: 23
           column: 4
         end_location:
           row: 23
           column: 44
+        content: "from collections import Counter\n    from collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "from collections import Counter\n    from collections.abc import Mapping"
-        location:
+      - location:
           row: 28
           column: 4
         end_location:
           row: 28
           column: 44
+        content: "from collections import Counter\n    from collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: from collections.abc import Mapping
-        location:
+      - location:
           row: 30
           column: 9
         end_location:
           row: 30
           column: 40
+        content: from collections.abc import Mapping
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: "from collections import Counter\nfrom collections.abc import Mapping"
-        location:
+      - location:
           row: 33
           column: 0
         end_location:
           row: 33
           column: 40
+        content: "from collections import Counter\nfrom collections.abc import Mapping"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "from collections import (\n        Bad,\n        Good,\n    )\n    from collections.abc import Mapping, Callable"
-        location:
+      - location:
           row: 37
           column: 4
         end_location:
           row: 42
           column: 5
+        content: "from collections import (\n        Bad,\n        Good,\n    )\n    from collections.abc import Mapping, Callable"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 91
   fix:
     edits:
-      - content: "from typing import Match, Pattern, List, OrderedDict, AbstractSet, ContextManager\nfrom collections.abc import Callable"
-        location:
+      - location:
           row: 44
           column: 0
         end_location:
           row: 44
           column: 91
+        content: "from typing import Match, Pattern, List, OrderedDict, AbstractSet, ContextManager\nfrom collections.abc import Callable"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 91
   fix:
     edits:
-      - content: "from typing import Callable, Match, Pattern, List, AbstractSet, ContextManager\nfrom collections import OrderedDict"
-        location:
+      - location:
           row: 44
           column: 0
         end_location:
           row: 44
           column: 91
+        content: "from typing import Callable, Match, Pattern, List, AbstractSet, ContextManager\nfrom collections import OrderedDict"
   parent: ~
 - kind:
     name: DeprecatedImport
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 91
   fix:
     edits:
-      - content: "from typing import Callable, List, OrderedDict, AbstractSet, ContextManager\nfrom re import Match, Pattern"
-        location:
+      - location:
           row: 44
           column: 0
         end_location:
           row: 44
           column: 91
+        content: "from typing import Callable, List, OrderedDict, AbstractSet, ContextManager\nfrom re import Match, Pattern"
   parent: ~
 - kind:
     name: DeprecatedImport

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_0.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 6
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 14
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: "print(\"PY3!\")"
-        location:
+      - location:
           row: 16
           column: 0
         end_location:
           row: 17
           column: 19
+        content: "print(\"PY3!\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "    print(\"PY3\")"
-        location:
+      - location:
           row: 20
           column: 0
         end_location:
           row: 23
           column: 20
+        content: "    print(\"PY3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 25
           column: 0
         end_location:
           row: 27
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "def f():\n    print(\"py3\")\n    print(\"This the next\")"
-        location:
+      - location:
           row: 29
           column: 0
         end_location:
           row: 35
           column: 30
+        content: "def f():\n    print(\"py3\")\n    print(\"This the next\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 37
           column: 0
         end_location:
           row: 40
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 45
           column: 0
         end_location:
           row: 48
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 53
           column: 0
         end_location:
           row: 54
           column: 18
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 56
           column: 0
         end_location:
           row: 59
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "    print(\"py3\")"
-        location:
+      - location:
           row: 62
           column: 0
         end_location:
           row: 65
           column: 20
+        content: "    print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "print(\"py3\")"
-        location:
+      - location:
           row: 67
           column: 0
         end_location:
           row: 70
           column: 16
+        content: "print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "    yield"
-        location:
+      - location:
           row: 73
           column: 0
         end_location:
           row: 79
           column: 13
+        content: "    yield"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "    def f(py3):\n        pass"
-        location:
+      - location:
           row: 86
           column: 0
         end_location:
           row: 91
           column: 16
+        content: "    def f(py3):\n        pass"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "    3"
-        location:
+      - location:
           row: 97
           column: 0
         end_location:
           row: 100
           column: 9
+        content: "    3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: "def f():\n    print(\"py3\")\ndef g():\n    print(\"py3\")"
-        location:
+      - location:
           row: 104
           column: 0
         end_location:
           row: 113
           column: 20
+        content: "def f():\n    print(\"py3\")\ndef g():\n    print(\"py3\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "    print(3)"
-        location:
+      - location:
           row: 116
           column: 0
         end_location:
           row: 117
           column: 16
+        content: "    print(3)"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: print(3)
-        location:
+      - location:
           row: 122
           column: 4
         end_location:
           row: 122
           column: 40
+        content: print(3)
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "    print(3)"
-        location:
+      - location:
           row: 125
           column: 0
         end_location:
           row: 126
           column: 16
+        content: "    print(3)"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 9
   fix:
     edits:
-      - content: "    expected_error = [\n\"<stdin>:1:5: Generator expression must be parenthesized\",\n\"max(1 for i in range(10), key=lambda x: x+1)\",\n\"    ^\",\n    ]"
-        location:
+      - location:
           row: 130
           column: 0
         end_location:
           row: 137
           column: 9
+        content: "    expected_error = [\n\"<stdin>:1:5: Generator expression must be parenthesized\",\n\"max(1 for i in range(10), key=lambda x: x+1)\",\n\"    ^\",\n    ]"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "expected_error = [\n\"<stdin>:1:5: Generator expression must be parenthesized\",\n\"max(1 for i in range(10), key=lambda x: x+1)\",\n\"    ^\",\n]"
-        location:
+      - location:
           row: 140
           column: 0
         end_location:
           row: 147
           column: 5
+        content: "expected_error = [\n\"<stdin>:1:5: Generator expression must be parenthesized\",\n\"max(1 for i in range(10), key=lambda x: x+1)\",\n\"    ^\",\n]"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "\"\"\"this\nis valid\"\"\"\n\n\"\"\"the indentation on\n    this line is significant\"\"\"\n\n\"this is\" \\\n    \"allowed too\"\n\n(\"so is\"\n \"this for some reason\")"
-        location:
+      - location:
           row: 150
           column: 0
         end_location:
           row: 161
           column: 28
+        content: "\"\"\"this\nis valid\"\"\"\n\n\"\"\"the indentation on\n    this line is significant\"\"\"\n\n\"this is\" \\\n    \"allowed too\"\n\n(\"so is\"\n \"this for some reason\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "expected_error = \\\n    []"
-        location:
+      - location:
           row: 163
           column: 0
         end_location:
           row: 164
           column: 6
+        content: "expected_error = \\\n    []"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: "expected_error = []"
-        location:
+      - location:
           row: 166
           column: 0
         end_location:
           row: 166
           column: 49
+        content: "expected_error = []"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -519,13 +519,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "expected_error = []"
-        location:
+      - location:
           row: 168
           column: 0
         end_location:
           row: 169
           column: 23
+        content: "expected_error = []"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -540,13 +540,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: "expected_error = \\\n    []"
-        location:
+      - location:
           row: 172
           column: 4
         end_location:
           row: 173
           column: 6
+        content: "expected_error = \\\n    []"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -561,13 +561,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: "expected_error = []"
-        location:
+      - location:
           row: 176
           column: 4
         end_location:
           row: 176
           column: 53
+        content: "expected_error = []"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -582,12 +582,12 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "    expected_error = []"
-        location:
+      - location:
           row: 179
           column: 0
         end_location:
           row: 180
           column: 23
+        content: "    expected_error = []"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_1.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_1.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 6
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 8
           column: 0
         end_location:
           row: 11
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 16
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 18
           column: 0
         end_location:
           row: 21
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 26
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 28
           column: 0
         end_location:
           row: 31
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: "3"
-        location:
+      - location:
           row: 35
           column: 0
         end_location:
           row: 38
           column: 5
+        content: "3"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 42
           column: 0
         end_location:
           row: 44
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "else:\n    print(3)"
-        location:
+      - location:
           row: 49
           column: 0
         end_location:
           row: 52
           column: 12
+        content: "else:\n    print(3)"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: "else:\n    print(3)"
-        location:
+      - location:
           row: 56
           column: 0
         end_location:
           row: 57
           column: 12
+        content: "else:\n    print(3)"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "else:\n        print(3)"
-        location:
+      - location:
           row: 62
           column: 4
         end_location:
           row: 63
           column: 16
+        content: "else:\n        print(3)"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 67
           column: 0
         end_location:
           row: 69
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -267,12 +267,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: "else:\n        print(3)"
-        location:
+      - location:
           row: 75
           column: 4
         end_location:
           row: 76
           column: 16
+        content: "else:\n        print(3)"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_2.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 4
           column: 0
         end_location:
           row: 7
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 9
           column: 0
         end_location:
           row: 12
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 17
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 19
           column: 0
         end_location:
           row: 22
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 27
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 29
           column: 0
         end_location:
           row: 32
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 7
   fix:
     edits:
-      - content: 3+6
-        location:
+      - location:
           row: 34
           column: 0
         end_location:
           row: 37
           column: 7
+        content: 3+6
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 39
           column: 0
         end_location:
           row: 40
           column: 8
+        content: pass
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 42
           column: 0
         end_location:
           row: 44
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 46
           column: 4
         end_location:
           row: 47
           column: 12
+        content: pass
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 49
           column: 0
         end_location:
           row: 51
           column: 2
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -246,12 +246,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 54
           column: 0
         end_location:
           row: 57
           column: 8
+        content: pass
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_3.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_3.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "print(\"py3\")\nfor item in range(10):\n    print(f\"PY3-{item}\")"
-        location:
+      - location:
           row: 3
           column: 0
         end_location:
           row: 10
           column: 28
+        content: "print(\"py3\")\nfor item in range(10):\n    print(f\"PY3-{item}\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: "    print(\"py3\")\n    for item in range(10):\n        print(f\"PY3-{item}\")"
-        location:
+      - location:
           row: 13
           column: 0
         end_location:
           row: 20
           column: 32
+        content: "    print(\"py3\")\n    for item in range(10):\n        print(f\"PY3-{item}\")"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 50
   fix:
     edits:
-      - content: "print(\"PY3!\")"
-        location:
+      - location:
           row: 23
           column: 0
         end_location:
           row: 24
           column: 50
+        content: "print(\"PY3!\")"
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_4.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_4.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 4
           column: 4
         end_location:
           row: 5
           column: 53
+        content: pass
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 11
           column: 0
         end_location:
           row: 13
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 17
           column: 4
         end_location:
           row: 19
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 24
           column: 0
         end_location:
           row: 26
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 53
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 27
           column: 0
         end_location:
           row: 29
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 32
           column: 4
         end_location:
           row: 34
           column: 4
+        content: ~
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: "    cmd = [sys.executable, \"-m\", \"test\", \"-j0\"]"
-        location:
+      - location:
           row: 37
           column: 0
         end_location:
           row: 40
           column: 51
+        content: "    cmd = [sys.executable, \"-m\", \"test\", \"-j0\"]"
   parent: ~
 - kind:
     name: OutdatedVersionBlock
@@ -162,12 +162,12 @@ expression: diagnostics
     column: 51
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 42
           column: 4
         end_location:
           row: 44
           column: 6
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP037.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP037.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 18
           column: 13
         end_location:
           row: 18
           column: 22
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 18
           column: 27
         end_location:
           row: 18
           column: 36
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 19
           column: 7
         end_location:
           row: 19
           column: 16
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: bool
-        location:
+      - location:
           row: 22
           column: 20
         end_location:
           row: 22
           column: 26
+        content: bool
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 20
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 26
           column: 15
         end_location:
           row: 26
           column: 20
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 37
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 26
           column: 32
         end_location:
           row: 26
           column: 37
+        content: int
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 30
           column: 9
         end_location:
           row: 30
           column: 18
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 22
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 32
           column: 13
         end_location:
           row: 32
           column: 22
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 36
           column: 7
         end_location:
           row: 36
           column: 16
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 40
           column: 26
         end_location:
           row: 40
           column: 31
+        content: int
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 44
           column: 30
         end_location:
           row: 44
           column: 35
+        content: int
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 47
           column: 13
         end_location:
           row: 47
           column: 18
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 49
           column: 7
         end_location:
           row: 49
           column: 12
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 19
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 51
           column: 14
         end_location:
           row: 51
           column: 19
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 53
           column: 12
         end_location:
           row: 53
           column: 17
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 55
           column: 19
         end_location:
           row: 55
           column: 24
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 24
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 57
           column: 19
         end_location:
           row: 57
           column: 24
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 59
           column: 10
         end_location:
           row: 59
           column: 15
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -393,13 +393,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: MyClass
-        location:
+      - location:
           row: 61
           column: 18
         end_location:
           row: 61
           column: 27
+        content: MyClass
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -414,13 +414,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 63
           column: 28
         end_location:
           row: 63
           column: 33
+        content: int
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -435,13 +435,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 63
           column: 44
         end_location:
           row: 63
           column: 49
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -456,13 +456,13 @@ expression: diagnostics
     column: 33
   fix:
     edits:
-      - content: foo
-        location:
+      - location:
           row: 65
           column: 28
         end_location:
           row: 65
           column: 33
+        content: foo
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -477,13 +477,13 @@ expression: diagnostics
     column: 40
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 65
           column: 35
         end_location:
           row: 65
           column: 40
+        content: int
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -498,13 +498,13 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: bar
-        location:
+      - location:
           row: 65
           column: 44
         end_location:
           row: 65
           column: 49
+        content: bar
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -519,13 +519,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: str
-        location:
+      - location:
           row: 65
           column: 51
         end_location:
           row: 65
           column: 56
+        content: str
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -540,13 +540,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: X
-        location:
+      - location:
           row: 67
           column: 23
         end_location:
           row: 67
           column: 26
+        content: X
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -561,13 +561,13 @@ expression: diagnostics
     column: 42
   fix:
     edits:
-      - content: foo
-        location:
+      - location:
           row: 67
           column: 37
         end_location:
           row: 67
           column: 42
+        content: foo
   parent: ~
 - kind:
     name: QuotedAnnotation
@@ -582,12 +582,12 @@ expression: diagnostics
     column: 49
   fix:
     edits:
-      - content: int
-        location:
+      - location:
           row: 67
           column: 44
         end_location:
           row: 67
           column: 49
+        content: int
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP038.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP038.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: int | float
-        location:
+      - location:
           row: 1
           column: 14
         end_location:
           row: 1
           column: 26
+        content: int | float
   parent: ~
 - kind:
     name: NonPEP604Isinstance
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: int | float | str
-        location:
+      - location:
           row: 2
           column: 18
         end_location:
           row: 2
           column: 35
+        content: int | float | str
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__datetime_utc_alias_py311.snap
@@ -43,13 +43,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: datetime.UTC
-        location:
+      - location:
           row: 10
           column: 6
         end_location:
           row: 10
           column: 27
+        content: datetime.UTC
   parent: ~
 - kind:
     name: DatetimeTimezoneUTC

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 34
           column: 17
         end_location:
           row: 34
           column: 21
+        content: list
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 34
           column: 17
         end_location:
           row: 34
           column: 21
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 12
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 35
           column: 8
         end_location:
           row: 35
           column: 12
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 42
           column: 26
         end_location:
           row: 42
           column: 30
+        content: list
   parent: ~
 - kind:
     name: NonPEP585Annotation
@@ -78,12 +78,12 @@ expression: diagnostics
     column: 41
   fix:
     edits:
-      - content: list
-        location:
+      - location:
           row: 42
           column: 37
         end_location:
           row: 42
           column: 41
+        content: list
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_p37.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_p37.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: int | None
-        location:
+      - location:
           row: 40
           column: 3
         end_location:
           row: 40
           column: 16
+        content: int | None
   parent: ~
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_604_py310.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 16
   fix:
     edits:
-      - content: int | None
-        location:
+      - location:
           row: 40
           column: 3
         end_location:
           row: 40
           column: 16
+        content: int | None
   parent: ~
 - kind:
     name: NonPEP604Annotation
@@ -36,12 +36,12 @@ expression: diagnostics
     column: 47
   fix:
     edits:
-      - content: "List[int] | List[str]"
-        location:
+      - location:
           row: 42
           column: 20
         end_location:
           row: 42
           column: 47
+        content: "List[int] | List[str]"
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF005_RUF005.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF005_RUF005.py.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: "[1, 2, 3, *foo]"
-        location:
+      - location:
           row: 10
           column: 6
         end_location:
           row: 10
           column: 21
+        content: "[1, 2, 3, *foo]"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "(7, 8, 9, *zoob)"
-        location:
+      - location:
           row: 12
           column: 7
         end_location:
           row: 12
           column: 23
+        content: "(7, 8, 9, *zoob)"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "(*quux, 10, 11, 12)"
-        location:
+      - location:
           row: 13
           column: 7
         end_location:
           row: 13
           column: 26
+        content: "(*quux, 10, 11, 12)"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 26
   fix:
     edits:
-      - content: "[*spom, 13, 14, 15]"
-        location:
+      - location:
           row: 15
           column: 7
         end_location:
           row: 15
           column: 26
+        content: "[*spom, 13, 14, 15]"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 36
   fix:
     edits:
-      - content: "(\"we all say\", *yay())"
-        location:
+      - location:
           row: 16
           column: 12
         end_location:
           row: 16
           column: 36
+        content: "(\"we all say\", *yay())"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 45
   fix:
     edits:
-      - content: "(\"we all think\", *Fun().yay())"
-        location:
+      - location:
           row: 17
           column: 13
         end_location:
           row: 17
           column: 45
+        content: "(\"we all think\", *Fun().yay())"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: "(\"we all feel\", *Fun.words)"
-        location:
+      - location:
           row: 18
           column: 15
         end_location:
           row: 18
           column: 44
+        content: "(\"we all feel\", *Fun.words)"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: "[\"a\", \"b\", \"c\", *eggs]"
-        location:
+      - location:
           row: 20
           column: 8
         end_location:
           row: 20
           column: 30
+        content: "[\"a\", \"b\", \"c\", *eggs]"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 67
   fix:
     edits:
-      - content: "(\"yes\", \"no\", \"pants\", *zoob)"
-        location:
+      - location:
           row: 20
           column: 38
         end_location:
           row: 20
           column: 67
+        content: "(\"yes\", \"no\", \"pants\", *zoob)"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: "(*zoob,)"
-        location:
+      - location:
           row: 22
           column: 6
         end_location:
           row: 22
           column: 15
+        content: "(*zoob,)"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -239,13 +239,13 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "[*foo]"
-        location:
+      - location:
           row: 41
           column: 0
         end_location:
           row: 41
           column: 8
+        content: "[*foo]"
   parent: ~
 - kind:
     name: CollectionLiteralConcatenation
@@ -260,12 +260,12 @@ expression: diagnostics
     column: 8
   fix:
     edits:
-      - content: "[*foo]"
-        location:
+      - location:
           row: 44
           column: 0
         end_location:
           row: 44
           column: 8
+        content: "[*foo]"
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: B
-        location:
+      - location:
           row: 1
           column: 5
         end_location:
           row: 1
           column: 6
+        content: B
   parent: ~
 - kind:
     name: AmbiguousUnicodeCharacterDocstring
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 56
   fix:
     edits:
-      - content: )
-        location:
+      - location:
           row: 6
           column: 55
         end_location:
           row: 6
           column: 56
+        content: )
   parent: ~
 - kind:
     name: AmbiguousUnicodeCharacterComment
@@ -57,12 +57,12 @@ expression: diagnostics
     column: 62
   fix:
     edits:
-      - content: /
-        location:
+      - location:
           row: 7
           column: 61
         end_location:
           row: 7
           column: 62
+        content: /
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_0.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 9
           column: 9
         end_location:
           row: 9
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 13
           column: 9
         end_location:
           row: 13
           column: 23
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 9
         end_location:
           row: 16
           column: 29
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 35
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 9
         end_location:
           row: 19
           column: 35
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 29
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 22
           column: 9
         end_location:
           row: 22
           column: 29
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 21
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 26
           column: 9
         end_location:
           row: 26
           column: 21
+        content: ~
   parent: ~
 - kind:
     name: UnusedVariable
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 29
           column: 0
         end_location:
           row: 30
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 44
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 29
           column: 9
         end_location:
           row: 29
           column: 44
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 23
   fix:
     edits:
-      - content: "# noqa: E501"
-        location:
+      - location:
           row: 55
           column: 5
         end_location:
           row: 55
           column: 23
+        content: "# noqa: E501"
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 17
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 63
           column: 3
         end_location:
           row: 63
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 11
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 71
           column: 3
         end_location:
           row: 71
           column: 11
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 85
           column: 0
         end_location:
           row: 86
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: LineTooLong
@@ -281,12 +281,12 @@ expression: diagnostics
     column: 103
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 90
           column: 89
         end_location:
           row: 90
           column: 103
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_1.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 13
   fix:
     edits:
-      - content: "from typing import (\n        Mapping,  # noqa: F401\n        )"
-        location:
+      - location:
           row: 35
           column: 4
         end_location:
           row: 38
           column: 5
+        content: "from typing import (\n        Mapping,  # noqa: F401\n        )"
   parent:
     row: 35
     column: 4
@@ -38,13 +38,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 52
           column: 17
         end_location:
           row: 52
           column: 31
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -59,13 +59,13 @@ expression: diagnostics
     column: 31
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 59
           column: 17
         end_location:
           row: 59
           column: 31
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -80,13 +80,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 66
           column: 13
         end_location:
           row: 66
           column: 27
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -101,13 +101,13 @@ expression: diagnostics
     column: 38
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 72
           column: 24
         end_location:
           row: 72
           column: 38
+        content: ~
   parent: ~
 - kind:
     name: UnusedImport
@@ -122,13 +122,13 @@ expression: diagnostics
     column: 32
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 89
           column: 4
         end_location:
           row: 89
           column: 52
+        content: pass
   parent:
     row: 89
     column: 4
@@ -145,13 +145,13 @@ expression: diagnostics
     column: 52
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 89
           column: 4
         end_location:
           row: 89
           column: 52
+        content: pass
   parent:
     row: 89
     column: 4
@@ -168,12 +168,12 @@ expression: diagnostics
     column: 66
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 89
           column: 52
         end_location:
           row: 89
           column: 66
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_2.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 30
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 16
         end_location:
           row: 1
           column: 30
+        content: ~
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruf100_3.snap
@@ -15,13 +15,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 1
           column: 0
         end_location:
           row: 2
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -36,13 +36,13 @@ expression: diagnostics
     column: 6
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 2
           column: 0
         end_location:
           row: 2
           column: 7
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -57,13 +57,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 3
           column: 7
         end_location:
           row: 3
           column: 15
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -78,13 +78,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 4
           column: 9
         end_location:
           row: 4
           column: 16
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -99,13 +99,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 5
           column: 9
         end_location:
           row: 5
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -120,13 +120,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 6
           column: 11
         end_location:
           row: 6
           column: 16
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -141,13 +141,13 @@ expression: diagnostics
     column: 15
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 7
           column: 11
         end_location:
           row: 7
           column: 17
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -162,13 +162,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 14
           column: 0
         end_location:
           row: 15
           column: 0
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -183,13 +183,13 @@ expression: diagnostics
     column: 18
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 15
           column: 0
         end_location:
           row: 15
           column: 19
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -204,13 +204,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 16
           column: 7
         end_location:
           row: 16
           column: 27
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -225,13 +225,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 17
           column: 9
         end_location:
           row: 17
           column: 28
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -246,13 +246,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 18
           column: 9
         end_location:
           row: 18
           column: 29
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -267,13 +267,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 19
           column: 11
         end_location:
           row: 19
           column: 28
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -288,13 +288,13 @@ expression: diagnostics
     column: 27
   fix:
     edits:
-      - content: ""
-        location:
+      - location:
           row: 20
           column: 11
         end_location:
           row: 20
           column: 29
+        content: ~
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -309,13 +309,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "# noqa: F821"
-        location:
+      - location:
           row: 21
           column: 10
         end_location:
           row: 21
           column: 28
+        content: "# noqa: F821"
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -330,13 +330,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "# noqa: F821"
-        location:
+      - location:
           row: 22
           column: 10
         end_location:
           row: 22
           column: 28
+        content: "# noqa: F821"
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -351,13 +351,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "# noqa: F821"
-        location:
+      - location:
           row: 23
           column: 10
         end_location:
           row: 23
           column: 28
+        content: "# noqa: F821"
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -372,13 +372,13 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "# noqa: F821"
-        location:
+      - location:
           row: 24
           column: 10
         end_location:
           row: 24
           column: 28
+        content: "# noqa: F821"
   parent: ~
 - kind:
     name: UnusedNOQA
@@ -393,12 +393,12 @@ expression: diagnostics
     column: 28
   fix:
     edits:
-      - content: "# noqa: F821"
-        location:
+      - location:
           row: 25
           column: 10
         end_location:
           row: 25
           column: 28
+        content: "# noqa: F821"
   parent: ~
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_targeted_noqa.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__ruff_targeted_noqa.snap
@@ -15,12 +15,12 @@ expression: diagnostics
     column: 5
   fix:
     edits:
-      - content: pass
-        location:
+      - location:
           row: 8
           column: 4
         end_location:
           row: 8
           column: 9
+        content: pass
   parent: ~
 

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -96,7 +96,7 @@ fn test_stdin_json() -> Result<()> {
       "message": "Remove unused import: `os`",
       "edits": [
         {{
-          "content": null,
+          "content": "",
           "location": {{
             "row": 1,
             "column": 0

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -96,7 +96,7 @@ fn test_stdin_json() -> Result<()> {
       "message": "Remove unused import: `os`",
       "edits": [
         {{
-          "content": "",
+          "content": null,
           "location": {{
             "row": 1,
             "column": 0

--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -7,40 +7,112 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Edit {
-    /// The replacement content to insert between the start and end locations.
-    pub content: String,
     /// The start location of the edit.
-    pub location: Location,
+    location: Location,
     /// The end location of the edit.
-    pub end_location: Location,
+    end_location: Location,
+    /// The replacement content to insert between the start and end locations.
+    content: Option<Box<str>>,
 }
 
 impl Edit {
+    /// Creates an edit that deletes the content in the `start` to `end` range.
     pub const fn deletion(start: Location, end: Location) -> Self {
         Self {
-            content: String::new(),
+            content: None,
             location: start,
             end_location: end,
         }
     }
 
+    /// Creates an edit that replaces the content in the `start` to `end` range with `content`.
     pub fn replacement(content: String, start: Location, end: Location) -> Self {
         debug_assert!(!content.is_empty(), "Prefer `Fix::deletion`");
 
         Self {
-            content,
+            content: Some(Box::from(content)),
             location: start,
             end_location: end,
         }
     }
 
+    /// Creates an edit that inserts `content` at the [`Location`] `at`.
     pub fn insertion(content: String, at: Location) -> Self {
         debug_assert!(!content.is_empty(), "Insert content is empty");
 
         Self {
-            content,
+            content: Some(Box::from(content)),
             location: at,
             end_location: at,
         }
+    }
+
+    /// Returns the new content for an insertion or deletion.
+    pub fn content(&self) -> Option<&str> {
+        self.content.as_deref()
+    }
+
+    /// Returns the start location of the edit in the source document.
+    pub const fn location(&self) -> Location {
+        self.location
+    }
+
+    /// Returns the edit's end location in the source document.
+    pub const fn end_location(&self) -> Location {
+        self.end_location
+    }
+
+    fn kind(&self) -> EditOperationKind {
+        if self.content.is_none() {
+            EditOperationKind::Deletion
+        } else if self.location == self.end_location {
+            EditOperationKind::Insertion
+        } else {
+            EditOperationKind::Replacement
+        }
+    }
+
+    /// Returns `true` if this edit deletes content from the source document.
+    #[inline]
+    pub fn is_deletion(&self) -> bool {
+        self.kind().is_deletion()
+    }
+
+    /// Returns `true` if this edit inserts new content into the source document.
+    #[inline]
+    pub fn is_insertion(&self) -> bool {
+        self.kind().is_insertion()
+    }
+
+    /// Returns `true` if this edit replaces some existing content with new content.
+    #[inline]
+    pub fn is_replacement(&self) -> bool {
+        self.kind().is_replacement()
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum EditOperationKind {
+    /// Edit that inserts new content into the source document.
+    Insertion,
+
+    /// Edit that deletes content from the source document.
+    Deletion,
+
+    /// Edit that replaces content from the source document.
+    Replacement,
+}
+
+impl EditOperationKind {
+    pub const fn is_insertion(self) -> bool {
+        matches!(self, EditOperationKind::Insertion)
+    }
+
+    pub const fn is_deletion(self) -> bool {
+        matches!(self, EditOperationKind::Deletion)
+    }
+
+    pub const fn is_replacement(self) -> bool {
+        matches!(self, EditOperationKind::Replacement)
     }
 }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -28,13 +28,8 @@ impl Fix {
     }
 
     /// Return the [`Location`] of the first [`Edit`] in the [`Fix`].
-    pub fn location(&self) -> Option<Location> {
-        self.edits.iter().map(|edit| edit.location).min()
-    }
-
-    /// Return the [`Location`] of the last [`Edit`] in the [`Fix`].
-    pub fn end_location(&self) -> Option<Location> {
-        self.edits.iter().map(|edit| edit.end_location).max()
+    pub fn min_location(&self) -> Option<Location> {
+        self.edits.iter().map(Edit::location).min()
     }
 
     /// Return a slice of the [`Edit`] elements in the [`Fix`].


### PR DESCRIPTION
This PR changes the Ordering of `Edit`s from `content` > `location` > `end_location` to `location` > `end_location` > `content`. 

This is the more *natural* order in my view and has the added benefit that comparing the `content` is only necessary for edits that start and end at the same location, which should be rare. 

Changing the field order, unfortunately, changes all snapshots...  A good example why we shouldn't use the serialized `Diagnostic` in test assertions.

I used this PR as a chance to type `content` as `Option<Box<str>>` because we don't intend to modify the edit (reduces the size of every edit by 8 bytes). 
