### PR TITLE
Do not skip analysis if `*args` present for `F523`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F523.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F523.py
@@ -11,3 +11,9 @@
 "{}".format(1, 2, 3)  # F523
 "{:{}}".format(1, 2)  # No issues
 "{:{}}".format(1, 2, 3)  # F523
+
+# With *args
+"{0}{1}".format(*args)  # No issues
+"{0}{1}".format(1, *args)  # No issues
+"{0}{1}".format(1, 2, *args)  # No issues
+"{0}{1}".format(1, 2, 3, *args)  # F523

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -493,12 +493,15 @@ pub(crate) fn string_dot_format_extra_positional_arguments(
     args: &[Expr],
     location: Range,
 ) {
-    if has_star_args(args) {
-        return;
-    }
-
-    let missing: Vec<usize> = (0..args.len())
-        .filter(|i| !(summary.autos.contains(i) || summary.indices.contains(i)))
+    let missing: Vec<usize> = args
+        .iter()
+        .enumerate()
+        .filter(|(i, arg)| {
+            !(matches!(arg.node, ExprKind::Starred { .. })
+                || summary.autos.contains(i)
+                || summary.indices.contains(i))
+        })
+        .map(|(i, _)| i)
         .collect();
 
     if missing.is_empty() {

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F523_F523.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F523_F523.py.snap
@@ -170,4 +170,25 @@ expression: diagnostics
           row: 13
           column: 23
   parent: ~
+- kind:
+    name: StringDotFormatExtraPositionalArguments
+    body: "`.format` call has unused arguments at position(s): 2"
+    suggestion: "Remove extra positional arguments at position(s): 2"
+    fixable: true
+  location:
+    row: 19
+    column: 0
+  end_location:
+    row: 19
+    column: 31
+  fix:
+    edits:
+      - content: "\"{0}{1}\".format(1, 2, *args)"
+        location:
+          row: 19
+          column: 0
+        end_location:
+          row: 19
+          column: 31
+  parent: ~
 


### PR DESCRIPTION
The `*args` argument will be skipped while collecting indices for extra positional arguments. Here, it's not required for the argument name to be `args`.

fixes: #2567 