### PR TITLE
Do not consider nested comment as part of code

### DIFF
--- a/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
+++ b/crates/ruff/resources/test/fixtures/eradicate/ERA001.py
@@ -9,6 +9,7 @@ def foo(x, y, z):
     print(x, y, z)
 
     # This is a real comment.
+    # # This is a (nested) comment.
     #return True
     return False
 

--- a/crates/ruff/src/rules/eradicate/detection.rs
+++ b/crates/ruff/src/rules/eradicate/detection.rs
@@ -33,7 +33,7 @@ static PRINT_RETURN_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(print|retur
 /// Returns `true` if a comment contains Python code.
 pub fn comment_contains_code(line: &str, task_tags: &[String]) -> bool {
     let line = if let Some(line) = line.trim().strip_prefix('#') {
-        line.trim()
+        line.trim_start_matches([' ', '#'])
     } else {
         return false;
     };
@@ -105,6 +105,7 @@ mod tests {
     #[test]
     fn comment_contains_code_basic() {
         assert!(comment_contains_code("# x = 1", &[]));
+        assert!(comment_contains_code("# # x = 1", &[]));
         assert!(comment_contains_code("#from foo import eradicate", &[]));
         assert!(comment_contains_code("#import eradicate", &[]));
         assert!(comment_contains_code(r#"#"key": value,"#, &[]));
@@ -117,6 +118,7 @@ mod tests {
 
         assert!(!comment_contains_code("#", &[]));
         assert!(!comment_contains_code("# This is a (real) comment.", &[]));
+        assert!(!comment_contains_code("# # A (nested) comment.", &[]));
         assert!(!comment_contains_code("# 123", &[]));
         assert!(!comment_contains_code("# 123.1", &[]));
         assert!(!comment_contains_code("# 1, 2, 3", &[]));

--- a/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
+++ b/crates/ruff/src/rules/eradicate/snapshots/ruff__rules__eradicate__tests__ERA001_ERA001.py.snap
@@ -72,22 +72,23 @@ ERA001.py:5:1: ERA001 [*] Found commented-out code
 7 6 | def foo(x, y, z):
 8 7 |     content = 1 # print('hello')
 
-ERA001.py:12:5: ERA001 [*] Found commented-out code
+ERA001.py:13:5: ERA001 [*] Found commented-out code
    |
-12 |     # This is a real comment.
-13 |     #return True
+13 |     # This is a real comment.
+14 |     # # This is a (nested) comment.
+15 |     #return True
    |     ^^^^^^^^^^^^ ERA001
-14 |     return False
+16 |     return False
    |
    = help: Remove commented-out code
 
 ℹ Suggested fix
-9  9  |     print(x, y, z)
 10 10 | 
 11 11 |     # This is a real comment.
-12    |-    #return True
-13 12 |     return False
-14 13 | 
-15 14 | #import os  # noqa: ERA001
+12 12 |     # # This is a (nested) comment.
+13    |-    #return True
+14 13 |     return False
+15 14 | 
+16 15 | #import os  # noqa: ERA001
 
 


### PR DESCRIPTION
## Summary

When there are nested comments, the old logic was to remove the comment prefix and check if now the content is code or not. This would mean that the remaining content would itself be a comment and when `parse` is called on that, it'll succeed.

```python
# # This is a nested comment
```

After removing the '#' prefix
```python
# This is a nested comment
```

Now, this is a valid Python code even though it's just a comment. This means that the function `comment_contains_code` returned true, triggering the warning in the linked issue.

fixes: #3980 