### PR TITLE
Use `memchr` to speedup newline search on x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "is-macro",
  "itertools",
  "log",
+ "memchr",
  "num-bigint",
  "num-traits",
  "once_cell",

--- a/crates/ruff/src/importer.rs
+++ b/crates/ruff/src/importer.rs
@@ -234,11 +234,12 @@ fn top_of_file_insertion(body: &[Stmt], locator: &Locator, stylist: &Stylist) ->
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
+    use ruff_python_ast::newlines::LineEnding;
     use ruff_text_size::TextSize;
     use rustpython_parser as parser;
     use rustpython_parser::lexer::LexResult;
 
-    use ruff_python_ast::source_code::{LineEnding, Locator, Stylist};
+    use ruff_python_ast::source_code::{Locator, Stylist};
 
     use crate::importer::{top_of_file_insertion, Insertion};
 

--- a/crates/ruff/src/noqa.rs
+++ b/crates/ruff/src/noqa.rs
@@ -11,7 +11,8 @@ use regex::Regex;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use ruff_diagnostics::Diagnostic;
-use ruff_python_ast::source_code::{LineEnding, Locator};
+use ruff_python_ast::newlines::LineEnding;
+use ruff_python_ast::source_code::Locator;
 
 use crate::codes::NoqaCode;
 use crate::registry::{AsRule, Rule, RuleSet};
@@ -511,7 +512,8 @@ mod tests {
     use ruff_text_size::{TextRange, TextSize};
 
     use ruff_diagnostics::Diagnostic;
-    use ruff_python_ast::source_code::{LineEnding, Locator};
+    use ruff_python_ast::newlines::LineEnding;
+    use ruff_python_ast::source_code::Locator;
 
     use crate::noqa::{add_noqa_inner, NoqaMapping, NOQA_LINE_REGEX};
     use crate::rules::pycodestyle::rules::AmbiguousVariableName;

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -13,10 +13,10 @@ ruff_text_size = { workspace = true, features = ["serde"] }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
-memchr = "2.5.0"
 is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+memchr = "2.5.0"
 num-bigint = { version = "0.4.3" }
 num-traits = { version = "0.2.15" }
 once_cell = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -13,6 +13,7 @@ ruff_text_size = { workspace = true, features = ["serde"] }
 
 anyhow = { workspace = true }
 bitflags = { workspace = true }
+memchr = "2.5.0"
 is-macro = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }

--- a/crates/ruff_python_ast/src/newlines.rs
+++ b/crates/ruff_python_ast/src/newlines.rs
@@ -56,7 +56,7 @@ impl<'a> UniversalNewlineIterator<'a> {
 pub fn find_newline(text: &str) -> Option<(usize, LineEnding)> {
     let bytes = text.as_bytes();
     if let Some(position) = memchr2(b'\n', b'\r', bytes) {
-        // SAFEtY: memchr guarantees to return valid positions
+        // SAFETY: memchr guarantees to return valid positions
         #[allow(unsafe_code)]
         let newline_character = unsafe { *bytes.get_unchecked(position) };
 

--- a/crates/ruff_python_ast/src/newlines.rs
+++ b/crates/ruff_python_ast/src/newlines.rs
@@ -1,3 +1,4 @@
+use memchr::{memchr2, memrchr2};
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::iter::FusedIterator;
 use std::ops::Deref;
@@ -50,6 +51,30 @@ impl<'a> UniversalNewlineIterator<'a> {
     }
 }
 
+/// Finds the next newline character. Returns its position and the [`LineEnding`].
+#[inline]
+pub fn find_newline(text: &str) -> Option<(usize, LineEnding)> {
+    let bytes = text.as_bytes();
+    if let Some(position) = memchr2(b'\n', b'\r', bytes) {
+        // SAFEtY: memchr guarantees to return valid positions
+        #[allow(unsafe_code)]
+        let newline_character = unsafe { *bytes.get_unchecked(position) };
+
+        let line_ending = match newline_character {
+            // Explicit branch for `\n` as this is the most likely path
+            b'\n' => LineEnding::Lf,
+            // '\r\n'
+            b'\r' if bytes.get(position.saturating_add(1)) == Some(&b'\n') => LineEnding::CrLf,
+            // '\r'
+            _ => LineEnding::Cr,
+        };
+
+        Some((position, line_ending))
+    } else {
+        None
+    }
+}
+
 impl<'a> Iterator for UniversalNewlineIterator<'a> {
     type Item = Line<'a>;
 
@@ -59,35 +84,25 @@ impl<'a> Iterator for UniversalNewlineIterator<'a> {
             return None;
         }
 
-        let line = match self.text.find(['\n', '\r']) {
-            // Non-last line
-            Some(line_end) => {
-                let offset: usize = match self.text.as_bytes()[line_end] {
-                    // Explicit branch for `\n` as this is the most likely path
-                    b'\n' => 1,
-                    // '\r\n'
-                    b'\r' if self.text.as_bytes().get(line_end + 1) == Some(&b'\n') => 2,
-                    // '\r'
-                    _ => 1,
-                };
+        let line = if let Some((newline_position, line_ending)) = find_newline(self.text) {
+            let (text, remainder) = self.text.split_at(newline_position + line_ending.len());
 
-                let (text, remainder) = self.text.split_at(line_end + offset);
+            let line = Line {
+                offset: self.offset,
+                text,
+            };
 
-                let line = Line {
-                    offset: self.offset,
-                    text,
-                };
+            self.text = remainder;
+            self.offset += text.text_len();
 
-                self.text = remainder;
-                self.offset += text.text_len();
-
-                line
-            }
-            // Last line
-            None => Line {
+            line
+        }
+        // Last line
+        else {
+            Line {
                 offset: self.offset,
                 text: std::mem::take(&mut self.text),
-            },
+            }
         };
 
         Some(line)
@@ -116,7 +131,7 @@ impl DoubleEndedIterator for UniversalNewlineIterator<'_> {
 
         // Find the end of the previous line. The previous line is the text up to, but not including
         // the newline character.
-        let line = if let Some(line_end) = haystack.rfind(['\n', '\r']) {
+        let line = if let Some(line_end) = memrchr2(b'\n', b'\r', haystack.as_bytes()) {
             // '\n' or '\r' or '\r\n'
             let (remainder, line) = self.text.split_at(line_end + 1);
             self.text = remainder;
@@ -265,6 +280,58 @@ impl PartialEq<&str> for Line<'_> {
 impl PartialEq<Line<'_>> for &str {
     fn eq(&self, other: &Line<'_>) -> bool {
         *self == other.as_str()
+    }
+}
+
+/// The line ending style used in Python source code.
+/// See <https://docs.python.org/3/reference/lexical_analysis.html#physical-lines>
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum LineEnding {
+    Lf,
+    Cr,
+    CrLf,
+}
+
+impl Default for LineEnding {
+    fn default() -> Self {
+        if cfg!(windows) {
+            LineEnding::CrLf
+        } else {
+            LineEnding::Lf
+        }
+    }
+}
+
+impl LineEnding {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            LineEnding::Lf => "\n",
+            LineEnding::CrLf => "\r\n",
+            LineEnding::Cr => "\r",
+        }
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub const fn len(&self) -> usize {
+        match self {
+            LineEnding::Lf | LineEnding::Cr => 1,
+            LineEnding::CrLf => 2,
+        }
+    }
+
+    pub const fn text_len(&self) -> TextSize {
+        match self {
+            LineEnding::Lf | LineEnding::Cr => TextSize::new(1),
+            LineEnding::CrLf => TextSize::new(2),
+        }
+    }
+}
+
+impl Deref for LineEnding {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
     }
 }
 

--- a/crates/ruff_python_ast/src/source_code/generator.rs
+++ b/crates/ruff_python_ast/src/source_code/generator.rs
@@ -9,9 +9,10 @@ use rustpython_parser::ast::{
 };
 use rustpython_parser::ConversionFlag;
 
+use crate::newlines::LineEnding;
 use ruff_rustpython::vendor::{bytes, str};
 
-use crate::source_code::stylist::{Indentation, LineEnding, Quote, Stylist};
+use crate::source_code::stylist::{Indentation, Quote, Stylist};
 
 mod precedence {
     pub const ASSIGN: u8 = 3;
@@ -1256,9 +1257,10 @@ impl<'a> Generator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::newlines::LineEnding;
     use rustpython_parser as parser;
 
-    use crate::source_code::stylist::{Indentation, LineEnding, Quote};
+    use crate::source_code::stylist::{Indentation, Quote};
     use crate::source_code::Generator;
 
     fn round_trip(contents: &str) -> String {

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -15,8 +15,7 @@ use rustpython_parser::{lexer, Mode, ParseError};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-
-pub use stylist::{LineEnding, Stylist};
+pub use stylist::Stylist;
 
 /// Run round-trip source code generation on a given Python code.
 pub fn round_trip(code: &str, source_path: &str) -> Result<String, ParseError> {


### PR DESCRIPTION
Use `memchr` to find the newline characters in strings. I expect this to improve performance on X86 processors because `memchr` uses `SIMD` internally. 

<pre>group                                      bytes                                  bytes-logical                          memchr                                 memchr-logical
-----                                      -----                                  -------------                          ------                                 --------------
linter/all-rules/large/dataset.py          1.02      8.6±0.08ms     4.7 MB/sec    1.06      8.9±0.17ms     4.6 MB/sec<span style="color:#26A269"><b>    1.00      8.4±0.08ms     4.9 MB/sec</b></span>    1.04      8.7±0.13ms     4.7 MB/sec
linter/all-rules/numpy/ctypeslib.py        1.02      2.0±0.07ms     8.3 MB/sec    1.08      2.1±0.03ms     7.9 MB/sec<span style="color:#26A269"><b>    1.00  1957.1±37.12µs     8.5 MB/sec</b></span>    1.04      2.0±0.04ms     8.2 MB/sec
linter/all-rules/numpy/globals.py          1.05    220.7±4.63µs    13.4 MB/sec    1.11    232.3±4.36µs    12.7 MB/sec<span style="color:#26A269"><b>    1.00    209.3±2.68µs    14.1 MB/sec</b></span>    1.07    223.2±1.44µs    13.2 MB/sec
linter/all-rules/pydantic/types.py<span style="color:#26A269"><b>         1.00      3.5±0.04ms     7.3 MB/sec</b></span>    1.08      3.8±0.03ms     6.7 MB/sec    1.00      3.5±0.01ms     7.3 MB/sec    1.04      3.7±0.10ms     7.0 MB/sec
linter/default-rules/large/dataset.py      1.03      4.3±0.07ms     9.5 MB/sec    1.11      4.6±0.08ms     8.8 MB/sec<span style="color:#26A269"><b>    1.00      4.2±0.07ms     9.7 MB/sec</b></span>    1.09      4.5±0.03ms     9.0 MB/sec
linter/default-rules/numpy/ctypeslib.py    1.00    870.1±5.69µs    19.1 MB/sec    1.10   956.6±10.45µs    17.4 MB/sec<span style="color:#26A269"><b>    1.00   866.6±19.79µs    19.2 MB/sec</b></span>    1.12    972.7±2.62µs    17.1 MB/sec
linter/default-rules/numpy/globals.py      1.03     95.9±0.72µs    30.8 MB/sec    1.13    105.4±1.49µs    28.0 MB/sec<span style="color:#26A269"><b>    1.00     93.3±0.54µs    31.6 MB/sec</b></span>    1.09    101.7±1.74µs    29.0 MB/sec
linter/default-rules/pydantic/types.py     1.01  1883.0±10.58µs    13.5 MB/sec    1.13      2.1±0.03ms    12.2 MB/sec<span style="color:#26A269"><b>    1.00  1855.8±20.37µs    13.7 MB/sec</b></span>    1.12      2.1±0.00ms    12.3 MB/sec
</pre>