### PR TITLE
Remove autofix behavior for uncapitalized-environment-variables (`SIM112`)

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
@@ -32,16 +32,6 @@ SIM112.py:6:16: SIM112 [*] Use capitalized environment variable `FOO` instead of
    |
    = help: Replace `foo` with `FOO`
 
-ℹ Suggested fix
-3 3 | # Bad
-4 4 | os.environ['foo']
-5 5 | 
-6   |-os.environ.get('foo')
-  6 |+os.environ.get('FOO')
-7 7 | 
-8 8 | os.environ.get('foo', 'bar')
-9 9 | 
-
 SIM112.py:8:16: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
    |
  8 | os.environ.get('foo')
@@ -52,16 +42,6 @@ SIM112.py:8:16: SIM112 [*] Use capitalized environment variable `FOO` instead of
 12 | os.getenv('foo')
    |
    = help: Replace `foo` with `FOO`
-
-ℹ Suggested fix
-5 5 | 
-6 6 | os.environ.get('foo')
-7 7 | 
-8   |-os.environ.get('foo', 'bar')
-  8 |+os.environ.get('FOO', 'bar')
-9 9 | 
-10 10 | os.getenv('foo')
-11 11 | 
 
 SIM112.py:10:11: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
    |
@@ -74,16 +54,6 @@ SIM112.py:10:11: SIM112 [*] Use capitalized environment variable `FOO` instead o
    |
    = help: Replace `foo` with `FOO`
 
-ℹ Suggested fix
-7  7  | 
-8  8  | os.environ.get('foo', 'bar')
-9  9  | 
-10    |-os.getenv('foo')
-   10 |+os.getenv('FOO')
-11 11 | 
-12 12 | env = os.environ.get('foo')
-13 13 | 
-
 SIM112.py:12:22: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
    |
 12 | os.getenv('foo')
@@ -94,16 +64,6 @@ SIM112.py:12:22: SIM112 [*] Use capitalized environment variable `FOO` instead o
 16 | env = os.environ['foo']
    |
    = help: Replace `foo` with `FOO`
-
-ℹ Suggested fix
-9  9  | 
-10 10 | os.getenv('foo')
-11 11 | 
-12    |-env = os.environ.get('foo')
-   12 |+env = os.environ.get('FOO')
-13 13 | 
-14 14 | env = os.environ['foo']
-15 15 | 
 
 SIM112.py:14:18: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
    |
@@ -135,16 +95,6 @@ SIM112.py:16:26: SIM112 [*] Use capitalized environment variable `FOO` instead o
 19 |     pass
    |
    = help: Replace `foo` with `FOO`
-
-ℹ Suggested fix
-13 13 | 
-14 14 | env = os.environ['foo']
-15 15 | 
-16    |-if env := os.environ.get('foo'):
-   16 |+if env := os.environ.get('FOO'):
-17 17 |     pass
-18 18 | 
-19 19 | if env := os.environ['foo']:
 
 SIM112.py:19:22: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
    |

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_simplify/mod.rs
 ---
-SIM910.py:2:1: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:2:1: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
   |
 2 | # SIM910
 3 | {}.get(key, None)
@@ -9,7 +9,6 @@ SIM910.py:2:1: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 4 | 
 5 | # SIM910
   |
-  = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 1 1 | # SIM910
@@ -19,7 +18,7 @@ SIM910.py:2:1: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 4 4 | # SIM910
 5 5 | {}.get("key", None)
 
-SIM910.py:5:1: SIM910 [*] Use `{}.get("key")` instead of `{}.get("key", None)`
+SIM910.py:5:1: SIM910 Use `{}.get("key")` instead of `{}.get("key", None)`
   |
 5 | # SIM910
 6 | {}.get("key", None)
@@ -27,7 +26,6 @@ SIM910.py:5:1: SIM910 [*] Use `{}.get("key")` instead of `{}.get("key", None)`
 7 | 
 8 | # OK
   |
-  = help: Replace `{}.get("key", None)` with `{}.get("key")`
 
 ℹ Suggested fix
 2 2 | {}.get(key, None)
@@ -39,14 +37,13 @@ SIM910.py:5:1: SIM910 [*] Use `{}.get("key")` instead of `{}.get("key", None)`
 7 7 | # OK
 8 8 | {}.get(key)
 
-SIM910.py:20:9: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:20:9: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
    |
 20 | # SIM910
 21 | if a := {}.get(key, None):
    |         ^^^^^^^^^^^^^^^^^ SIM910
 22 |     pass
    |
-   = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 17 17 | {}.get("key", False)
@@ -58,7 +55,7 @@ SIM910.py:20:9: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 22 22 | 
 23 23 | # SIM910
 
-SIM910.py:24:5: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:24:5: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
    |
 24 | # SIM910
 25 | a = {}.get(key, None)
@@ -66,7 +63,6 @@ SIM910.py:24:5: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 26 | 
 27 | # SIM910
    |
-   = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 21 21 |     pass
@@ -78,13 +74,12 @@ SIM910.py:24:5: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 26 26 | # SIM910
 27 27 | ({}).get(key, None)
 
-SIM910.py:27:1: SIM910 [*] Use `({}).get(key)` instead of `({}).get(key, None)`
+SIM910.py:27:1: SIM910 Use `({}).get(key)` instead of `({}).get(key, None)`
    |
 27 | # SIM910
 28 | ({}).get(key, None)
    | ^^^^^^^^^^^^^^^^^^^ SIM910
    |
-   = help: Replace `({}).get(key, None)` with `({}).get(key)`
 
 ℹ Suggested fix
 24 24 | a = {}.get(key, None)


### PR DESCRIPTION
This is a dangerous fix, since it's not purely contained within the code. That is: if you change the environment variable here, you're effectively guaranteed to break code if the user doesn't notice and propagate the change to their environment.

We can revisit when we support autofix severities or a review mode of some sort, but for now, it seems too dangerous.

Closes #3987.
