### PR TITLE
Add more documentation for flake8-type-checking

### DIFF
--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -9,6 +9,30 @@ use crate::autofix::actions::delete_stmt;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
+/// ## What it does
+/// Checks for an empty type-checking block.
+///
+/// ## Why is this bad?
+/// The type-checking block does not do anything and should be removed to avoid
+/// confusion.
+///
+/// ## Example
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///    pass
+///
+/// print("Hello, world!")
+/// ```
+///
+/// Use instead:
+/// ```python
+/// print("Hello, world!")
+/// ```
+///
+/// ## References
+/// - [PEP 535](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct EmptyTypeCheckingBlock;
 

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -4,6 +4,34 @@ use ruff_python_semantic::binding::{
     Binding, BindingKind, ExecutionContext, FromImportation, Importation, SubmoduleImportation,
 };
 
+/// ## What it does
+/// Checks for runtime imports defined in a type-checking block.
+///
+/// ## Why is this bad?
+/// The type-checking block is not executed at runtime, so the import will not
+/// be available at runtime.
+///
+/// ## Example
+/// ```python
+/// from typing import TYPE_CHECKING
+///
+/// if TYPE_CHECKING:
+///    import foo
+///
+/// def bar() -> None:
+///     foo.bar()  # raises NameError: name 'foo' is not defined
+/// ```
+///
+/// Use instead:
+/// ```python
+/// import foo
+///
+/// def bar() -> None:
+///    foo.bar()
+/// ```
+///
+/// ## References
+/// - [PEP 535](https://peps.python.org/pep-0563/#runtime-annotation-resolution-and-type-checking)
 #[violation]
 pub struct RuntimeImportInTypeCheckingBlock {
     pub full_name: String,


### PR DESCRIPTION
Add documentation to the flake8-type-checking rules that check for runtime imports inside type-checking blocks and empty runtime blocks.

Builds on #3886 to complete the flake8-type-checking ruleset.

Related to #2646.