### PR TITLE
Update maturin to maturin 0.15

### DIFF
--- a/crates/flake8_to_ruff/pyproject.toml
+++ b/crates/flake8_to_ruff/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.7"
 repository = "https://github.com/charliermarsh/ruff#subdirectory=crates/flake8_to_ruff"
 
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=0.15.1,<0.16"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -67,9 +67,6 @@ ureq = { version = "2.6.2", features = [] }
 [features]
 jupyter_notebook = ["ruff/jupyter_notebook"]
 
-[package.metadata.maturin]
-name = "ruff"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.34"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14.17,<0.15"]
+requires = ["maturin>=0.15.1,<0.16"]
 
 build-backend = "maturin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14.10,<0.15"]
-# We depend on >=0.14.10 because we specify name in
-# [package.metadata.maturin] in ruff_cli/Cargo.toml.
+requires = ["maturin>=0.14.17,<0.15"]
 
 build-backend = "maturin"
 


### PR DESCRIPTION
This allows removing the deprecated `[package.metadata.maturin]`

See https://github.com/charliermarsh/ruff/pull/3998#discussion_r1168985807