### PR TITLE
Ignore argument assignments when enforcing `RET504`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
@@ -3,7 +3,7 @@
 ###
 def x():
     a = 1
-    return a  # error
+    return a  # RET504
 
 
 # Can be refactored false positives
@@ -211,10 +211,10 @@ def nonlocal_assignment():
 def decorator() -> Flask:
     app = Flask(__name__)
 
-    @app.route('/hello')
+    @app.route("/hello")
     def hello() -> str:
         """Hello endpoint."""
-        return 'Hello, World!'
+        return "Hello, World!"
 
     return app
 
@@ -222,12 +222,13 @@ def decorator() -> Flask:
 def default():
     y = 1
 
-    def f(x = y) -> X:
+    def f(x=y) -> X:
         return x
 
     return y
 
 
+# Multiple assignment
 def get_queryset(option_1, option_2):
     queryset: Any = None
     queryset = queryset.filter(a=1)
@@ -246,4 +247,28 @@ def get_queryset():
 
 def get_queryset():
     queryset = Model.filter(a=1)
-    return queryset  # error
+    return queryset  # RET504
+
+
+# Function arguments
+def str_to_bool(val):
+    if isinstance(val, bool):
+        return val
+    val = val.strip().lower()
+    if val in ("1", "true", "yes"):
+        return True
+
+    return False
+
+
+def str_to_bool(val):
+    if isinstance(val, bool):
+        return val
+    val = 1
+    return val  # RET504
+
+
+def str_to_bool(val):
+    if isinstance(val, bool):
+        return some_obj
+    return val

--- a/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
+++ b/crates/ruff/src/rules/flake8_return/snapshots/ruff__rules__flake8_return__tests__RET504_RET504.py.snap
@@ -5,16 +5,24 @@ RET504.py:6:12: RET504 Unnecessary variable assignment before `return` statement
   |
 6 | def x():
 7 |     a = 1
-8 |     return a  # error
+8 |     return a  # RET504
   |            ^ RET504
   |
 
-RET504.py:249:12: RET504 Unnecessary variable assignment before `return` statement
+RET504.py:250:12: RET504 Unnecessary variable assignment before `return` statement
     |
-249 | def get_queryset():
-250 |     queryset = Model.filter(a=1)
-251 |     return queryset  # error
+250 | def get_queryset():
+251 |     queryset = Model.filter(a=1)
+252 |     return queryset  # RET504
     |            ^^^^^^^^ RET504
+    |
+
+RET504.py:268:12: RET504 Unnecessary variable assignment before `return` statement
+    |
+268 |         return val
+269 |     val = 1
+270 |     return val  # RET504
+    |            ^^^ RET504
     |
 
 


### PR DESCRIPTION
## Summary

Right now, we trigger a `RET504` (`unnecessary-assign`) error here:

```py
def str_to_bool(val):
    if isinstance(val, bool):
        return val
    val = val.strip().lower()
    if val in ("1", "true", "yes"):
        return True

    return False
```

The issue is that we can't find an assignment to `val` prior to the first `return val`, so the code as it exists today falls back to assuming that `val` is defined at the start of the function. Instead, we need to avoid flagging cases in which the return comes before an explicit in-function assignment (like arguments, or returning values defined outside of the function).

Closes #3992.
