### PR TITLE
Set non-empty range for indentation diagnostics

### DIFF
--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -183,7 +183,7 @@ pub fn check_logical_lines(
             if settings.rules.enabled(kind.rule()) {
                 diagnostics.push(Diagnostic {
                     kind,
-                    location,
+                    location: Location::new(start_loc.row(), 0),
                     end_location: location,
                     fix: Fix::empty(),
                     parent: None,

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -230,7 +230,7 @@ impl Violation for OverIndented {
 }
 
 /// E111, E114, E112, E113, E115, E116, E117
-pub(crate) fn indentation(
+pub(crate) fn n indentation(
     logical_line: &LogicalLine,
     prev_logical_line: Option<&LogicalLine>,
     indent_char: char,

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/indentation.rs
@@ -230,7 +230,7 @@ impl Violation for OverIndented {
 }
 
 /// E111, E114, E112, E113, E115, E116, E117
-pub(crate) fn n indentation(
+pub(crate) fn indentation(
     logical_line: &LogicalLine,
     prev_logical_line: Option<&LogicalLine>,
     indent_char: char,

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E111_E11.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E111_E11.py.snap
@@ -1,22 +1,22 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E11.py:3:3: E111 Indentation is not a multiple of 4
+E11.py:3:1: E111 Indentation is not a multiple of 4
   |
 3 | #: E111
 4 | if x > 2:
 5 |   print(x)
-  |    E111
+  | ^^ E111
 6 | #: E111 E117
 7 | if True:
   |
 
-E11.py:6:6: E111 Indentation is not a multiple of 4
+E11.py:6:1: E111 Indentation is not a multiple of 4
    |
  6 | #: E111 E117
  7 | if True:
  8 |      print()
-   |       E111
+   | ^^^^^ E111
  9 | #: E112
 10 | if False:
    |

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E113_E11.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E113_E11.py.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E11.py:12:5: E113 Unexpected indentation
+E11.py:12:1: E113 Unexpected indentation
    |
 12 | #: E113
 13 | print()
 14 |     print()
-   |      E113
+   | ^^^^ E113
 15 | #: E114 E116
 16 | mimetype = 'application/x-directory'
    |

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E114_E11.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E114_E11.py.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E11.py:15:6: E114 Indentation is not a multiple of 4 (comment)
+E11.py:15:1: E114 Indentation is not a multiple of 4 (comment)
    |
 15 | #: E114 E116
 16 | mimetype = 'application/x-directory'
 17 |      # 'httpd/unix-directory'
-   |       E114
+   | ^^^^^ E114
 18 | create_date = False
 19 | #: E116 E116 E116
    |

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E116_E11.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E116_E11.py.snap
@@ -1,42 +1,42 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E11.py:15:6: E116 Unexpected indentation (comment)
+E11.py:15:1: E116 Unexpected indentation (comment)
    |
 15 | #: E114 E116
 16 | mimetype = 'application/x-directory'
 17 |      # 'httpd/unix-directory'
-   |       E116
+   | ^^^^^ E116
 18 | create_date = False
 19 | #: E116 E116 E116
    |
 
-E11.py:22:13: E116 Unexpected indentation (comment)
+E11.py:22:1: E116 Unexpected indentation (comment)
    |
 22 |         self.master.start()
 23 |         # try:
 24 |             # self.master.start()
-   |              E116
+   | ^^^^^^^^^^^^ E116
 25 |         # except MasterExit:
 26 |             # self.shutdown()
    |
 
-E11.py:24:13: E116 Unexpected indentation (comment)
+E11.py:24:1: E116 Unexpected indentation (comment)
    |
 24 |             # self.master.start()
 25 |         # except MasterExit:
 26 |             # self.shutdown()
-   |              E116
+   | ^^^^^^^^^^^^ E116
 27 |         # finally:
 28 |             # sys.exit()
    |
 
-E11.py:26:13: E116 Unexpected indentation (comment)
+E11.py:26:1: E116 Unexpected indentation (comment)
    |
 26 |             # self.shutdown()
 27 |         # finally:
 28 |             # sys.exit()
-   |              E116
+   | ^^^^^^^^^^^^ E116
 29 | #: E115 E115 E115 E115 E115 E115
 30 | def start(self):
    |

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E117_E11.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E117_E11.py.snap
@@ -1,27 +1,27 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E11.py:6:6: E117 Over-indented
+E11.py:6:1: E117 Over-indented
    |
  6 | #: E111 E117
  7 | if True:
  8 |      print()
-   |       E117
+   | ^^^^^ E117
  9 | #: E112
 10 | if False:
    |
 
-E11.py:39:9: E117 Over-indented
+E11.py:39:1: E117 Over-indented
    |
 39 | #: E117
 40 | def start():
 41 |         print()
-   |          E117
+   | ^^^^^^^^ E117
 42 | #: E117 W191
 43 | def start():
    |
 
-E11.py:42:3: E117 Over-indented
+E11.py:42:1: E117 Over-indented
    |
 42 | #: E117 W191
 43 | def start():


### PR DESCRIPTION
I noticed in the byte offsets refactor that we set an empty range for all logical-lines indentation diagnostics. 
The downside of an empty range is that the `TextEmitter` can't draw a carret pointing to the violating code, 
which looks odd. 

This PR sets `location` of the violation to the start of the violating line. 

