### PR TITLE
JSON Emitter: Use one indexed column numbers for edits

### DIFF
--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -14,11 +14,11 @@ expression: content
           "content": "",
           "location": {
             "row": 1,
-            "column": 0
+            "column": 1
           },
           "end_location": {
             "row": 2,
-            "column": 0
+            "column": 1
           }
         }
       ]
@@ -45,11 +45,11 @@ expression: content
           "content": "",
           "location": {
             "row": 6,
-            "column": 4
+            "column": 5
           },
           "end_location": {
             "row": 6,
-            "column": 9
+            "column": 10
           }
         }
       ]

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -100,11 +100,11 @@ fn test_stdin_json() -> Result<()> {
           "content": "",
           "location": {{
             "row": 1,
-            "column": 0
+            "column": 1
           }},
           "end_location": {{
             "row": 2,
-            "column": 0
+            "column": 1
           }}
         }}
       ]


### PR DESCRIPTION
 I noticed in the byte-offsets refactor that the `JsonEmitter` uses one indexed column numbers for the diagnostic start and end locations but not for `edits`.

This PR changes the `JsonEmitter` to emit one-indexed column numbers for edits, as we already do for `Message::location` and `Message::end_location`.

## Open questions

~We'll need to change the LSP to subtract 1 from the columns in `_parse_fix`~

https://github.com/charliermarsh/ruff-lsp/blob/6e44fadf8a5954adaf3c21af196fa195708ff912/ruff_lsp/server.py#L129-L150

~@charliermarsh is there a way to get the ruff version in that method? If not, then I recommend adding a `version` that we increment whenever we make incompatible changes to the serialized message. We can then use it in the LSP to correctly compute the column offset.~

I'll use the presence of the `Fix::applicability` field to detect if the Ruff version uses one or zero-based column indices.

See https://github.com/charliermarsh/ruff-lsp/pull/103