### PR TITLE
perf(logical-lines): Various small perf improvements

### DIFF
--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -60,8 +60,8 @@ pub fn check_logical_lines(
     for line in &LogicalLines::from_tokens(tokens, locator) {
         if line.flags().contains(TokenFlags::OPERATOR) {
             space_around_operator(&line, &mut context);
-            whitespace_around_named_parameter_equals(&line.tokens(), &mut context);
-            missing_whitespace_around_operator(&line.tokens(), &mut context);
+            whitespace_around_named_parameter_equals(&line, &mut context);
+            missing_whitespace_around_operator(&line, &mut context);
             missing_whitespace(&line, should_fix_missing_whitespace, &mut context);
         }
 
@@ -73,16 +73,16 @@ pub fn check_logical_lines(
         }
         if line.flags().contains(TokenFlags::KEYWORD) {
             whitespace_around_keywords(&line, &mut context);
-            missing_whitespace_after_keyword(&line.tokens(), &mut context);
+            missing_whitespace_after_keyword(&line, &mut context);
         }
 
         if line.flags().contains(TokenFlags::COMMENT) {
-            whitespace_before_comment(&line.tokens(), locator, prev_line.is_none(), &mut context);
+            whitespace_before_comment(&line, locator, prev_line.is_none(), &mut context);
         }
 
         if line.flags().contains(TokenFlags::BRACKET) {
             whitespace_before_parameters(
-                &line.tokens(),
+                &line,
                 should_fix_whitespace_before_parameters,
                 &mut context,
             );

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/extraneous_whitespace.rs
@@ -109,7 +109,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
         let kind = token.kind();
         match kind {
             TokenKind::Lbrace | TokenKind::Lpar | TokenKind::Lsqb => {
-                if !matches!(line.trailing_whitespace(&token), Whitespace::None) {
+                if !matches!(line.trailing_whitespace(token), Whitespace::None) {
                     context.push(WhitespaceAfterOpenBracket, TextRange::empty(token.end()));
                 }
             }
@@ -120,7 +120,7 @@ pub(crate) fn extraneous_whitespace(line: &LogicalLine, context: &mut LogicalLin
             | TokenKind::Semi
             | TokenKind::Colon => {
                 if let (Whitespace::Single | Whitespace::Many | Whitespace::Tab, offset) =
-                    line.leading_whitespace(&token)
+                    line.leading_whitespace(token)
                 {
                     if !matches!(last_token, TokenKind::Comma | TokenKind::EndOfFile) {
                         let diagnostic_kind = if matches!(

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -61,7 +61,7 @@ pub(crate) fn missing_whitespace(
             }
 
             TokenKind::Comma | TokenKind::Semi | TokenKind::Colon => {
-                let after = line.text_after(&token);
+                let after = line.text_after(token);
 
                 if !after.chars().next().map_or(false, char::is_whitespace) {
                     if let Some(next_token) = iter.peek() {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -1,9 +1,10 @@
 use super::LogicalLine;
+use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::Edit;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::TextRange;
+use ruff_text_size::{TextRange, TextSize};
 
 #[violation]
 pub struct MissingWhitespace {
@@ -35,12 +36,14 @@ impl AlwaysAutofixableViolation for MissingWhitespace {
 }
 
 /// E231
-pub(crate) fn missing_whitespace(line: &LogicalLine, autofix: bool) -> Vec<Diagnostic> {
-    let mut diagnostics = vec![];
-
+pub(crate) fn missing_whitespace(
+    line: &LogicalLine,
+    autofix: bool,
+    context: &mut LogicalLinesContext,
+) {
     let mut open_parentheses = 0u32;
-    let mut prev_lsqb = None;
-    let mut prev_lbrace = None;
+    let mut prev_lsqb = TextSize::default();
+    let mut prev_lbrace = TextSize::default();
     let mut iter = line.tokens().iter().peekable();
 
     while let Some(token) = iter.next() {
@@ -48,13 +51,13 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, autofix: bool) -> Vec<Diagn
         match kind {
             TokenKind::Lsqb => {
                 open_parentheses += 1;
-                prev_lsqb = Some(token.start());
+                prev_lsqb = token.start();
             }
             TokenKind::Rsqb => {
                 open_parentheses += 1;
             }
             TokenKind::Lbrace => {
-                prev_lbrace = Some(token.start());
+                prev_lbrace = token.start();
             }
 
             TokenKind::Comma | TokenKind::Semi | TokenKind::Colon => {
@@ -85,11 +88,10 @@ pub(crate) fn missing_whitespace(line: &LogicalLine, autofix: bool) -> Vec<Diagn
                     if autofix {
                         diagnostic.set_fix(Edit::insertion(" ".to_string(), token.end()));
                     }
-                    diagnostics.push(diagnostic);
+                    context.push_diagnostic(diagnostic);
                 }
             }
             _ => {}
         }
     }
-    diagnostics
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -2,11 +2,10 @@ use itertools::Itertools;
 use ruff_text_size::TextRange;
 
 use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-
-use super::LogicalLineTokens;
 
 #[violation]
 pub struct MissingWhitespaceAfterKeyword;
@@ -20,10 +19,10 @@ impl Violation for MissingWhitespaceAfterKeyword {
 
 /// E275
 pub(crate) fn missing_whitespace_after_keyword(
-    tokens: &LogicalLineTokens,
+    line: &LogicalLine,
     context: &mut LogicalLinesContext,
 ) {
-    for (tok0, tok1) in tokens.iter().tuple_windows() {
+    for (tok0, tok1) in line.tokens().iter().tuple_windows() {
         let tok0_kind = tok0.kind();
         let tok1_kind = tok1.kind();
 

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
-use ruff_text_size::TextSize;
+use ruff_text_size::TextRange;
 
-use ruff_diagnostics::DiagnosticKind;
+use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
@@ -21,9 +21,8 @@ impl Violation for MissingWhitespaceAfterKeyword {
 /// E275
 pub(crate) fn missing_whitespace_after_keyword(
     tokens: &LogicalLineTokens,
-) -> Vec<(TextSize, DiagnosticKind)> {
-    let mut diagnostics = vec![];
-
+    context: &mut LogicalLinesContext,
+) {
     for (tok0, tok1) in tokens.iter().tuple_windows() {
         let tok0_kind = tok0.kind();
         let tok1_kind = tok1.kind();
@@ -36,8 +35,7 @@ pub(crate) fn missing_whitespace_after_keyword(
                 || matches!(tok1_kind, TokenKind::Colon | TokenKind::Newline))
             && tok0.end() == tok1.start()
         {
-            diagnostics.push((tok0.end(), MissingWhitespaceAfterKeyword.into()));
+            context.push(MissingWhitespaceAfterKeyword, TextRange::empty(tok0.end()));
         }
     }
-    diagnostics
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -4,7 +4,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
 use ruff_text_size::{TextRange, TextSize};
 
-use crate::rules::pycodestyle::rules::logical_lines::LogicalLineTokens;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 // E225
 #[violation]
@@ -53,7 +53,7 @@ impl Violation for MissingWhitespaceAroundModuloOperator {
 /// E225, E226, E227, E228
 #[allow(clippy::if_same_then_else)]
 pub(crate) fn missing_whitespace_around_operator(
-    tokens: &LogicalLineTokens,
+    line: &LogicalLine,
     context: &mut LogicalLinesContext,
 ) {
     #[derive(Copy, Clone, Eq, PartialEq)]
@@ -70,7 +70,7 @@ pub(crate) fn missing_whitespace_around_operator(
     let mut prev_type: TokenKind = TokenKind::EndOfFile;
     let mut prev_end = TextSize::default();
 
-    for token in tokens {
+    for token in line.tokens() {
         let kind = token.kind();
 
         if kind.is_skip_comment() {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -77,7 +77,7 @@ bitflags! {
 
 #[derive(Clone)]
 pub(crate) struct LogicalLines<'a> {
-    tokens: Tokens,
+    tokens: Vec<LogicalLineToken>,
     lines: Vec<Line>,
     locator: &'a Locator<'a>,
 }
@@ -160,65 +160,69 @@ impl<'a> LogicalLine<'a> {
 
     /// Returns logical line's text including comments, indents, dedent and trailing new lines.
     pub fn text(&self) -> &'a str {
-        self.tokens().text()
+        let tokens = self.tokens();
+        match (tokens.first(), tokens.last()) {
+            (Some(first), Some(last)) => self
+                .lines
+                .locator
+                .slice(TextRange::new(first.start(), last.end())),
+            _ => "",
+        }
     }
 
     /// Returns the text without any leading or trailing newline, comment, indent, or dedent of this line
     #[cfg(test)]
     pub fn text_trimmed(&self) -> &'a str {
-        self.tokens_trimmed().text()
+        let tokens = self.tokens_trimmed();
+
+        match (tokens.first(), tokens.last()) {
+            (Some(first), Some(last)) => self
+                .lines
+                .locator
+                .slice(TextRange::new(first.start(), last.end())),
+            _ => "",
+        }
     }
 
-    pub fn tokens_trimmed(&self) -> LogicalLineTokens<'a> {
-        let mut front = self.line.tokens_start as usize;
-        let mut back = self.line.tokens_end as usize;
+    pub fn tokens_trimmed(&self) -> &'a [LogicalLineToken] {
+        let tokens = self.tokens();
 
-        let mut kinds = self.lines.tokens.kinds[front..back].iter();
+        let start = tokens
+            .iter()
+            .position(|t| {
+                !matches!(
+                    t.kind(),
+                    TokenKind::Newline
+                        | TokenKind::NonLogicalNewline
+                        | TokenKind::Indent
+                        | TokenKind::Dedent
+                        | TokenKind::Comment,
+                )
+            })
+            .unwrap_or(tokens.len());
 
-        for kind in kinds.by_ref() {
-            if !matches!(
-                kind,
-                TokenKind::Newline
-                    | TokenKind::NonLogicalNewline
-                    | TokenKind::Indent
-                    | TokenKind::Dedent
-                    | TokenKind::Comment
-            ) {
-                break;
-            }
-            front += 1;
-        }
+        let tokens = &tokens[start..];
 
-        for kind in kinds.rev() {
-            if !matches!(
-                kind,
-                TokenKind::Newline
-                    | TokenKind::NonLogicalNewline
-                    | TokenKind::Indent
-                    | TokenKind::Dedent
-                    | TokenKind::Comment
-            ) {
-                break;
-            }
-            back -= 1;
-        }
+        let end = tokens
+            .iter()
+            .rposition(|t| {
+                !matches!(
+                    t.kind(),
+                    TokenKind::Newline
+                        | TokenKind::NonLogicalNewline
+                        | TokenKind::Indent
+                        | TokenKind::Dedent
+                        | TokenKind::Comment,
+                )
+            })
+            .map_or(0, |pos| pos + 1);
 
-        LogicalLineTokens {
-            lines: self.lines,
-            front,
-            back,
-        }
+        &tokens[..end]
     }
 
     /// Returns the text after `token`
     #[inline]
-    pub fn text_after(&self, token: &LogicalLineToken<'a>) -> &str {
-        debug_assert!(
-            (self.line.tokens_start as usize..self.line.tokens_end as usize)
-                .contains(&token.position),
-            "Token does not belong to this line"
-        );
-
+    pub fn text_after(&self, token: &'a LogicalLineToken) -> &str {
         // SAFETY: The line must have at least one token or `token` would not belong to this line.
         let last_token = self.tokens().last().unwrap();
         self.lines
@@ -228,13 +232,7 @@ impl<'a> LogicalLine<'a> {
 
     /// Returns the text before `token`
     #[inline]
-    pub fn text_before(&self, token: &LogicalLineToken<'a>) -> &str {
-        debug_assert!(
-            (self.line.tokens_start as usize..self.line.tokens_end as usize)
-                .contains(&token.position),
-            "Token does not belong to this line"
-        );
-
+    pub fn text_before(&self, token: &'a LogicalLineToken) -> &str {
         // SAFETY: The line must have at least one token or `token` would not belong to this line.
         let first_token = self.tokens().first().unwrap();
         self.lines
@@ -243,25 +241,21 @@ impl<'a> LogicalLine<'a> {
     }
 
     /// Returns the whitespace *after* the `token`
-    pub fn trailing_whitespace(&self, token: &LogicalLineToken<'a>) -> Whitespace {
+    pub fn trailing_whitespace(&self, token: &'a LogicalLineToken) -> Whitespace {
         Whitespace::leading(self.text_after(token))
     }
 
     /// Returns the whitespace and whitespace byte-length *before* the `token`
-    pub fn leading_whitespace(&self, token: &LogicalLineToken<'a>) -> (Whitespace, TextSize) {
+    pub fn leading_whitespace(&self, token: &'a LogicalLineToken) -> (Whitespace, TextSize) {
         Whitespace::trailing(self.text_before(token))
     }
 
     /// Returns all tokens of the line, including comments and trailing new lines.
-    pub fn tokens(&self) -> LogicalLineTokens<'a> {
-        LogicalLineTokens {
-            lines: self.lines,
-            front: self.line.tokens_start as usize,
-            back: self.line.tokens_end as usize,
-        }
+    pub fn tokens(&self) -> &'a [LogicalLineToken] {
+        &self.lines.tokens[self.line.tokens_start as usize..self.line.tokens_end as usize]
     }
 
-    pub fn first_token(&self) -> Option<LogicalLineToken> {
+    pub fn first_token(&self) -> Option<&'a LogicalLineToken> {
         self.tokens().first()
     }
 
@@ -322,160 +316,36 @@ impl ExactSizeIterator for LogicalLinesIter<'_> {}
 
 impl FusedIterator for LogicalLinesIter<'_> {}
 
-/// The tokens of a logical line
-pub(crate) struct LogicalLineTokens<'a> {
-    lines: &'a LogicalLines<'a>,
-    front: usize,
-    back: usize,
-}
-
-impl<'a> LogicalLineTokens<'a> {
-    pub fn iter(&self) -> LogicalLineTokensIter<'a> {
-        LogicalLineTokensIter {
-            tokens: &self.lines.tokens,
-            front: self.front,
-            back: self.back,
-        }
-    }
-
-    pub fn text(&self) -> &'a str {
-        match (self.first(), self.last()) {
-            (Some(first), Some(last)) => {
-                let locator = self.lines.locator;
-                locator.slice(TextRange::new(first.start(), last.end()))
-            }
-            _ => "",
-        }
-    }
-
-    /// Returns the first token
-    pub fn first(&self) -> Option<LogicalLineToken<'a>> {
-        self.iter().next()
-    }
-
-    /// Returns the last token
-    pub fn last(&self) -> Option<LogicalLineToken<'a>> {
-        self.iter().next_back()
-    }
-}
-
-impl<'a> IntoIterator for LogicalLineTokens<'a> {
-    type Item = LogicalLineToken<'a>;
-    type IntoIter = LogicalLineTokensIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a> IntoIterator for &LogicalLineTokens<'a> {
-    type Item = LogicalLineToken<'a>;
-    type IntoIter = LogicalLineTokensIter<'a>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl Debug for LogicalLineTokens<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self.iter()).finish()
-    }
-}
-
-/// Iterator over the tokens of a [`LogicalLine`]
-pub(crate) struct LogicalLineTokensIter<'a> {
-    tokens: &'a Tokens,
-    front: usize,
-    back: usize,
-}
-
-impl<'a> Iterator for LogicalLineTokensIter<'a> {
-    type Item = LogicalLineToken<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.front < self.back {
-            let result = Some(LogicalLineToken {
-                tokens: self.tokens,
-                position: self.front,
-            });
-
-            self.front += 1;
-            result
-        } else {
-            None
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = self.back - self.front;
-        (len, Some(len))
-    }
-}
-
-impl ExactSizeIterator for LogicalLineTokensIter<'_> {}
-
-impl FusedIterator for LogicalLineTokensIter<'_> {}
-
-impl DoubleEndedIterator for LogicalLineTokensIter<'_> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.front < self.back {
-            self.back -= 1;
-            Some(LogicalLineToken {
-                position: self.back,
-                tokens: self.tokens,
-            })
-        } else {
-            None
-        }
-    }
-}
-
 /// A token of a [`LogicalLine`]
-#[derive(Clone)]
-pub(crate) struct LogicalLineToken<'a> {
-    tokens: &'a Tokens,
-    position: usize,
+#[derive(Clone, Debug)]
+pub(crate) struct LogicalLineToken {
+    kind: TokenKind,
+    range: TextRange,
 }
 
-impl<'a> LogicalLineToken<'a> {
+impl LogicalLineToken {
     /// Returns the token's kind
     #[inline]
-    pub fn kind(&self) -> TokenKind {
-        #[allow(unsafe_code)]
-        unsafe {
-            *self.tokens.kinds.get_unchecked(self.position)
-        }
+    pub const fn kind(&self) -> TokenKind {
+        self.kind
     }
 
     /// Returns the token's start location
     #[inline]
-    pub fn start(&self) -> TextSize {
-        self.range().start()
+    pub const fn start(&self) -> TextSize {
+        self.range.start()
     }
 
     /// Returns the token's end location
     #[inline]
-    pub fn end(&self) -> TextSize {
-        self.range().end()
+    pub const fn end(&self) -> TextSize {
+        self.range.end()
     }
 
     /// Returns a tuple with the token's `(start, end)` locations
     #[inline]
-    pub fn range(&self) -> TextRange {
-        #[allow(unsafe_code)]
-        unsafe {
-            *self.tokens.ranges.get_unchecked(self.position)
-        }
-    }
-}
-
-impl Debug for LogicalLineToken<'_> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("LogicalLineToken")
-            .field("kind", &self.kind())
-            .field("range", &self.range())
-            .finish()
+    pub const fn range(&self) -> TextRange {
+        self.range
     }
 }
 
@@ -552,7 +422,7 @@ struct CurrentLine {
 /// Builder for [`LogicalLines`]
 #[derive(Debug, Default)]
 struct LogicalLinesBuilder {
-    tokens: Tokens,
+    tokens: Vec<LogicalLineToken>,
     lines: Vec<Line>,
     current_line: CurrentLine,
 }
@@ -560,7 +430,7 @@ struct LogicalLinesBuilder {
 impl LogicalLinesBuilder {
     fn with_capacity(tokens: usize) -> Self {
         Self {
-            tokens: Tokens::with_capacity(tokens),
+            tokens: Vec::with_capacity(tokens),
             ..Self::default()
         }
     }
@@ -607,7 +477,7 @@ impl LogicalLinesBuilder {
             ),
         );
 
-        self.tokens.push(kind, range);
+        self.tokens.push(LogicalLineToken { kind, range });
     }
 
     // SAFETY: `LogicalLines::from_tokens` asserts that the file has less than `u32::MAX` tokens and each tokens is at least one character long
@@ -622,7 +492,7 @@ impl LogicalLinesBuilder {
             });
 
             self.current_line = CurrentLine {
-                flags: Default::default(),
+                flags: TokenFlags::default(),
                 tokens_start: end,
             }
         }
@@ -644,34 +514,4 @@ struct Line {
     flags: TokenFlags,
     tokens_start: u32,
     tokens_end: u32,
-}
-
-#[derive(Debug, Clone, Default)]
-struct Tokens {
-    /// The token kinds
-    kinds: Vec<TokenKind>,
-
-    /// The ranges
-    ranges: Vec<TextRange>,
-}
-
-impl Tokens {
-    /// Creates new tokens with a reserved size of `capacity`
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            kinds: Vec::with_capacity(capacity),
-            ranges: Vec::with_capacity(capacity),
-        }
-    }
-
-    /// Returns the number of stored tokens.
-    fn len(&self) -> usize {
-        self.kinds.len()
-    }
-
-    /// Adds a new token with the given `kind` and `range`
-    fn push(&mut self, kind: TokenKind, range: TextRange) {
-        self.kinds.push(kind);
-        self.ranges.push(range);
-    }
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -131,7 +131,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
 
         if is_operator {
             if !after_operator {
-                match line.leading_whitespace(&token) {
+                match line.leading_whitespace(token) {
                     (Whitespace::Tab, offset) => {
                         let start = token.start();
                         context.push(TabBeforeOperator, TextRange::empty(start - offset));
@@ -147,7 +147,7 @@ pub(crate) fn space_around_operator(line: &LogicalLine, context: &mut LogicalLin
                 }
             }
 
-            match line.trailing_whitespace(&token) {
+            match line.trailing_whitespace(token) {
                 Whitespace::Tab => {
                     let end = token.end();
                     context.push(TabAfterOperator, TextRange::empty(end));

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -115,7 +115,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
         let is_keyword = token.kind().is_keyword();
         if is_keyword {
             if !after_keyword {
-                match line.leading_whitespace(&token) {
+                match line.leading_whitespace(token) {
                     (Whitespace::Tab, offset) => {
                         let start = token.start();
                         context.push(TabBeforeKeyword, TextRange::empty(start - offset));
@@ -131,7 +131,7 @@ pub(crate) fn whitespace_around_keywords(line: &LogicalLine, context: &mut Logic
                 }
             }
 
-            match line.trailing_whitespace(&token) {
+            match line.trailing_whitespace(token) {
                 Whitespace::Tab => {
                     let end = token.end();
                     context.push(TabAfterKeyword, TextRange::empty(end));

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -1,10 +1,9 @@
 use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::{LogicalLine, LogicalLineToken};
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
 use ruff_text_size::{TextRange, TextSize};
-
-use super::LogicalLineTokens;
 
 #[violation]
 pub struct UnexpectedSpacesAroundKeywordParameterEquals;
@@ -26,7 +25,7 @@ impl Violation for MissingWhitespaceAroundParameterEquals {
     }
 }
 
-fn is_in_def(tokens: &LogicalLineTokens) -> bool {
+fn is_in_def(tokens: &[LogicalLineToken]) -> bool {
     for token in tokens {
         match token.kind() {
             TokenKind::Async | TokenKind::Indent | TokenKind::Dedent => continue,
@@ -40,15 +39,15 @@ fn is_in_def(tokens: &LogicalLineTokens) -> bool {
 
 /// E251, E252
 pub(crate) fn whitespace_around_named_parameter_equals(
-    tokens: &LogicalLineTokens,
+    line: &LogicalLine,
     context: &mut LogicalLinesContext,
 ) {
     let mut parens = 0u32;
     let mut annotated_func_arg = false;
     let mut prev_end = TextSize::default();
 
-    let in_def = is_in_def(tokens);
-    let mut iter = tokens.iter().peekable();
+    let in_def = is_in_def(line.tokens());
+    let mut iter = line.tokens().iter().peekable();
 
     while let Some(token) = iter.next() {
         let kind = token.kind();

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -1,5 +1,5 @@
-use super::LogicalLineTokens;
 use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
@@ -137,13 +137,13 @@ impl Violation for MultipleLeadingHashesForBlockComment {
 
 /// E261, E262, E265, E266
 pub(crate) fn whitespace_before_comment(
-    tokens: &LogicalLineTokens,
+    line: &LogicalLine,
     locator: &Locator,
     is_first_row: bool,
     context: &mut LogicalLinesContext,
 ) {
     let mut prev_end = TextSize::default();
-    for token in tokens {
+    for token in line.tokens() {
         let kind = token.kind();
 
         if let TokenKind::Comment = kind {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -1,5 +1,5 @@
 use super::LogicalLineTokens;
-use ruff_diagnostics::DiagnosticKind;
+use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
@@ -140,8 +140,8 @@ pub(crate) fn whitespace_before_comment(
     tokens: &LogicalLineTokens,
     locator: &Locator,
     is_first_row: bool,
-) -> Vec<(TextRange, DiagnosticKind)> {
-    let mut diagnostics = vec![];
+    context: &mut LogicalLinesContext,
+) {
     let mut prev_end = TextSize::default();
     for token in tokens {
         let kind = token.kind();
@@ -158,10 +158,10 @@ pub(crate) fn whitespace_before_comment(
             let is_inline_comment = !line.trim().is_empty();
             if is_inline_comment {
                 if range.start() - prev_end < "  ".text_len() {
-                    diagnostics.push((
+                    context.push(
+                        TooFewSpacesBeforeInlineComment,
                         TextRange::new(prev_end, range.start()),
-                        TooFewSpacesBeforeInlineComment.into(),
-                    ));
+                    );
                 }
             }
 
@@ -179,14 +179,14 @@ pub(crate) fn whitespace_before_comment(
             if is_inline_comment {
                 if bad_prefix.is_some() || comment.chars().next().map_or(false, char::is_whitespace)
                 {
-                    diagnostics.push((range, NoSpaceAfterInlineComment.into()));
+                    context.push(NoSpaceAfterInlineComment, range);
                 }
             } else if let Some(bad_prefix) = bad_prefix {
                 if bad_prefix != '!' || !is_first_row {
                     if bad_prefix != '#' {
-                        diagnostics.push((range, NoSpaceAfterBlockComment.into()));
+                        context.push(NoSpaceAfterBlockComment, range);
                     } else if !comment.is_empty() {
-                        diagnostics.push((range, MultipleLeadingHashesForBlockComment.into()));
+                        context.push(MultipleLeadingHashesForBlockComment, range);
                     }
                 }
             }
@@ -194,5 +194,4 @@ pub(crate) fn whitespace_before_comment(
             prev_end = token.end();
         }
     }
-    diagnostics
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -1,10 +1,9 @@
 use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
 use ruff_text_size::{TextRange, TextSize};
-
-use super::LogicalLineTokens;
 
 #[violation]
 pub struct WhitespaceBeforeParameters {
@@ -36,17 +35,17 @@ impl AlwaysAutofixableViolation for WhitespaceBeforeParameters {
 
 /// E211
 pub(crate) fn whitespace_before_parameters(
-    tokens: &LogicalLineTokens,
+    line: &LogicalLine,
     autofix: bool,
     context: &mut LogicalLinesContext,
 ) {
-    let previous = tokens.first().unwrap();
+    let previous = line.tokens().first().unwrap();
 
     let mut pre_pre_kind: Option<TokenKind> = None;
     let mut prev_token = previous.kind();
     let mut prev_end = previous.end();
 
-    for token in tokens {
+    for token in line.tokens() {
         let kind = token.kind();
 
         if matches!(kind, TokenKind::Lpar | TokenKind::Lsqb)

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -1,3 +1,4 @@
+use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
@@ -37,8 +38,8 @@ impl AlwaysAutofixableViolation for WhitespaceBeforeParameters {
 pub(crate) fn whitespace_before_parameters(
     tokens: &LogicalLineTokens,
     autofix: bool,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = vec![];
+    context: &mut LogicalLinesContext,
+) {
     let previous = tokens.first().unwrap();
 
     let mut pre_pre_kind: Option<TokenKind> = None;
@@ -65,11 +66,10 @@ pub(crate) fn whitespace_before_parameters(
             if autofix {
                 diagnostic.set_fix(Edit::deletion(start, end));
             }
-            diagnostics.push(diagnostic);
+            context.push_diagnostic(diagnostic);
         }
         pre_pre_kind = Some(prev_token);
         prev_token = kind;
         prev_end = token.end();
     }
-    diagnostics
 }

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Fix;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DiagnosticKind {
     /// The identifier of the diagnostic, used to align the diagnostic with a rule.
@@ -20,7 +20,7 @@ pub struct DiagnosticKind {
     pub fixable: bool,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Diagnostic {
     pub kind: DiagnosticKind,
     pub range: TextRange,

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::edit::Edit;
 
 /// A collection of [`Edit`] elements to be applied to a source file.
-#[derive(Default, Debug, PartialEq, Eq)]
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Fix {
     edits: Vec<Edit>,

--- a/crates/ruff_python_ast/src/token_kind.rs
+++ b/crates/ruff_python_ast/src/token_kind.rs
@@ -167,6 +167,7 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
+    #[inline]
     pub const fn is_whitespace_needed(&self) -> bool {
         matches!(
             self,
@@ -197,6 +198,7 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_whitespace_optional(&self) -> bool {
         self.is_arithmetic()
             || matches!(
@@ -210,6 +212,7 @@ impl TokenKind {
             )
     }
 
+    #[inline]
     pub const fn is_unary(&self) -> bool {
         matches!(
             self,
@@ -221,6 +224,7 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_keyword(&self) -> bool {
         matches!(
             self,
@@ -261,6 +265,7 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_operator(&self) -> bool {
         matches!(
             self,
@@ -313,10 +318,12 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_singleton(&self) -> bool {
         matches!(self, TokenKind::False | TokenKind::True | TokenKind::None)
     }
 
+    #[inline]
     pub const fn is_skip_comment(&self) -> bool {
         matches!(
             self,
@@ -328,6 +335,7 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_arithmetic(&self) -> bool {
         matches!(
             self,
@@ -340,6 +348,7 @@ impl TokenKind {
         )
     }
 
+    #[inline]
     pub const fn is_soft_keyword(&self) -> bool {
         matches!(self, TokenKind::Match | TokenKind::Case)
     }


### PR DESCRIPTION
This PR introduces a few perf improvements to the pycodestyle rules:

* Introduce a new `LogicalLinesContext` to which rules add their diagnostics directly. This reduces the need to copy `Diagnostic`s between different `Vec`s. 
* Avoid using `Option<T>` where we can instead use `TextSize::default` or `Tok::EndOfFile`. This reduces the required branching.
* `extraneous_whitespace`: Move the `DiagnosticKind::from` closer to where we create the `Diagnostic` to avoid unnecessary allocations and message formatting in case the code is valid
* `LogicalLines`: Use a `Slice` instead of a struct of vecs. Both implementations have roughly the same performance but using a `Slice` requires significantly less code. 
* `LineIndex`: Replace `TextSize::try_from` with a single assertion on the length of the string. We call this function so often that it shows up in traces. Using `TextSize::new(x as u32)` removes that slight overhead.