### PR TITLE
Treat non-future function annotations as required-at-runtime

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 def f():
     # Even in strict mode, this shouldn't rase an error, since `pkg` is used at runtime,
     # and implicitly imports `pkg.bar`.

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -598,14 +598,9 @@ where
                     self.visit_expr(expr);
                 }
 
-                // If we're in a class or module scope, then the annotation needs to be
-                // available at runtime.
-                // See: https://docs.python.org/3/reference/simple_stmts.html#annotated-assignment-statements
-                let runtime_annotation = !self.ctx.annotations_future_enabled
-                    && matches!(
-                        self.ctx.scope().kind,
-                        ScopeKind::Class(..) | ScopeKind::Module
-                    );
+                // Function annotations are always evaluated at runtime, unless future annotations
+                // are enabled.
+                let runtime_annotation = !self.ctx.annotations_future_enabled;
 
                 for arg in &args.posonlyargs {
                     if let Some(expr) = &arg.node.annotation {

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
@@ -1,34 +1,34 @@
 ---
 source: crates/ruff/src/rules/flake8_type_checking/mod.rs
 ---
-strict.py:24:21: TCH002 Move third-party import `pkg.A` into a type-checking block
+strict.py:27:21: TCH002 Move third-party import `pkg.A` into a type-checking block
    |
-24 |     # In un-strict mode, this shouldn't rase an error, since `pkg` is used at runtime.
-25 |     import pkg
-26 |     from pkg import A
+27 |     # In un-strict mode, this shouldn't rase an error, since `pkg` is used at runtime.
+28 |     import pkg
+29 |     from pkg import A
    |                     ^ TCH002
-27 | 
-28 |     def test(value: A):
+30 | 
+31 |     def test(value: A):
    |
 
-strict.py:32:21: TCH002 Move third-party import `pkg.A` into a type-checking block
+strict.py:35:21: TCH002 Move third-party import `pkg.A` into a type-checking block
    |
-32 | def f():
-33 |     # In un-strict mode, this shouldn't rase an error, since `pkg` is used at runtime.
-34 |     from pkg import A, B
+35 | def f():
+36 |     # In un-strict mode, this shouldn't rase an error, since `pkg` is used at runtime.
+37 |     from pkg import A, B
    |                     ^ TCH002
-35 | 
-36 |     def test(value: A):
+38 | 
+39 |     def test(value: A):
    |
 
-strict.py:51:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking block
+strict.py:54:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking block
    |
-51 |     # In un-strict mode, this _should_ rase an error, since `pkg` is used at runtime.
-52 |     import pkg
-53 |     from pkg.bar import A
+54 |     # In un-strict mode, this _should_ rase an error, since `pkg` is used at runtime.
+55 |     import pkg
+56 |     from pkg.bar import A
    |                         ^ TCH002
-54 | 
-55 |     def test(value: A):
+57 | 
+58 |     def test(value: A):
    |
 
 

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff/src/rules/flake8_type_checking/mod.rs
 ---
-strict.py:51:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking block
+strict.py:54:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking block
    |
-51 |     # In un-strict mode, this _should_ rase an error, since `pkg` is used at runtime.
-52 |     import pkg
-53 |     from pkg.bar import A
+54 |     # In un-strict mode, this _should_ rase an error, since `pkg` is used at runtime.
+55 |     import pkg
+56 |     from pkg.bar import A
    |                         ^ TCH002
-54 | 
-55 |     def test(value: A):
+57 | 
+58 |     def test(value: A):
    |
 
 


### PR DESCRIPTION
## Summary

It turns out that if `from __future__ import annotations` isn't enabled, then annotations on function arguments or return values _are_ required at runtime, as in this example:

```py
from collections.abc import Callable, Collection

def test():
    def nested(x: Callable) -> Callable[[Collection[str]], list[str]]:
        def double_nested(x: Collection[str]) -> list[str]:
            return list(x)

        return double_nested

    a = nested(None)
    return a(("a", "b"))

print(test())
```

To be consistent with our logic for this rule, we thus need to avoid raising `TCH` errors here.

We might want to change the semantics of the rule such that it tells you to move the types into a `TYPE_CHECKING` block _and_ quote them, but as of now, users that follow these suggestions will break their code. (As a corollary, these rules effectively require that you're using `from __future__ import annotations` to be useful.)

Closes #4020.
