### PR TITLE
Ignore certain flake8-pyi errors within function bodies

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.py
@@ -11,3 +11,7 @@ _T = TypeVar("_T")  # OK
 _TTuple = TypeVarTuple("_TTuple")  # OK
 
 _P = ParamSpec("_P")  # OK
+
+
+def f():
+    T = TypeVar("T")  # OK

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi
@@ -11,3 +11,6 @@ _T = TypeVar("_T")  # OK
 _TTuple = TypeVarTuple("_TTuple")  # OK
 
 _P = ParamSpec("_P")  # OK
+
+def f():
+    T = TypeVar("T")  # OK

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.py
@@ -46,3 +46,7 @@ field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values a
 field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+
+# We shouldn't emit Y015 within functions
+def f():
+  field26: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.pyi
@@ -53,3 +53,7 @@ field229: dict[int, int] = {1: 2, **{3: 4}}  # Y015 Only simple default values a
 field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+
+# We shouldn't emit Y015 within functions
+def f():
+  field26: list[int] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
+++ b/crates/ruff/src/rules/flake8_pyi/snapshots/ruff__rules__flake8_pyi__tests__PYI015_PYI015.pyi.snap
@@ -187,6 +187,7 @@ PYI015.pyi:53:11: PYI015 [*] Only simple default values allowed for assignments
    53 |+field23 = ...  # Y015 Only simple default values are allowed for assignments
 54 54 | field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 55 55 | field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+56 56 | 
 
 PYI015.pyi:54:11: PYI015 [*] Only simple default values allowed for assignments
    |
@@ -205,6 +206,8 @@ PYI015.pyi:54:11: PYI015 [*] Only simple default values allowed for assignments
 54    |-field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
    54 |+field24 = ...  # Y015 Only simple default values are allowed for assignments
 55 55 | field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+56 56 | 
+57 57 | # We shouldn't emit Y015 within functions
 
 PYI015.pyi:55:11: PYI015 [*] Only simple default values allowed for assignments
    |
@@ -212,6 +215,8 @@ PYI015.pyi:55:11: PYI015 [*] Only simple default values allowed for assignments
 56 | field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 57 | field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
    |           ^^^^^ PYI015
+58 | 
+59 | # We shouldn't emit Y015 within functions
    |
    = help: Replace default value with `...`
 
@@ -221,5 +226,8 @@ PYI015.pyi:55:11: PYI015 [*] Only simple default values allowed for assignments
 54 54 | field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 55    |-field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
    55 |+field25 = ...  # Y015 Only simple default values are allowed for assignments
+56 56 | 
+57 57 | # We shouldn't emit Y015 within functions
+58 58 | def f():
 
 

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -131,7 +131,7 @@ impl From<ScopeId> for usize {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, is_macro::Is)]
 pub enum ScopeKind<'a> {
     Class(ClassDef<'a>),
     Function(FunctionDef<'a>),


### PR DESCRIPTION
## Summary

`flake8-pyi` ignores some errors when a statement occurs within a function scope (as any parent scope), since `flake8-pyi` will flag function bodies that contain anything beyond `...`.
