### PR TITLE
Remove TODO in handle_node_store

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4490,7 +4490,6 @@ impl<'a> Checker<'a> {
             return;
         }
 
-        // TODO(charlie): Include comprehensions here.
         if matches!(
             parent.node,
             StmtKind::For { .. } | StmtKind::AsyncFor { .. }


### PR DESCRIPTION
I don't think this is relevant, since within a comprehension, assignments are part of the comprehension scope anyway.