### PR TITLE
Avoid `PYI015` for valid default value without annotation

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.py
@@ -84,3 +84,10 @@ class Class1:
 
 # We shouldn't emit Y015 for __all__
 __all__ = ["Class1"]
+
+# Ignore the following for PYI015
+field26 = typing.Sequence[int]
+field27 = list[str]
+field28 = builtins.str
+field29 = str
+field30 = str | bytes | None

--- a/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.pyi
+++ b/crates/ruff/resources/test/fixtures/flake8_pyi/PYI015.pyi
@@ -91,3 +91,10 @@ class Class1:
 
 # We shouldn't emit Y015 for __all__
 __all__ = ["Class1"]
+
+# Ignore the following for PYI015
+field26 = typing.Sequence[int]
+field27 = list[str]
+field28 = builtins.str
+field29 = str
+field30 = str | bytes | None


### PR DESCRIPTION
## Summary

As per the original implementation in `flake8-pyi` [^1] [^2], we need to first check if the assignment value is valid.

**Valid values are:**
* Type aliases
* Type variable function calls
* Union types (`int | str`)

## Limitations:

This doesn't perform any type inference, so any variable or call would also be valid.

fixes: #4036 

[^1]: https://github.com/PyCQA/flake8-pyi/blob/4d575338389bbf7b27fc2dac05e833c818388431/pyi.py#L1021
[^2]: https://github.com/PyCQA/flake8-pyi/blob/4d575338389bbf7b27fc2dac05e833c818388431/pyi.py#L832-L840