### PR TITLE
[`flake8-bugbear`] Add `pytest.raises(Exception)` support to B017

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B017.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B017.py
@@ -1,9 +1,10 @@
 """
 Should emit:
-B017 - on lines 20
+B017 - on lines 23 and 41
 """
 import asyncio
 import unittest
+import pytest
 
 CONSTANT = True
 
@@ -34,3 +35,10 @@ class Foobar(unittest.TestCase):
     def raises_with_absolute_reference(self):
         with self.assertRaises(asyncio.CancelledError):
             Foo()
+
+def test_pytest_raises():
+    with pytest.raises(Exception):
+        raise ValueError("Hello")
+
+    with pytest.raises(Exception, match="hello"):
+        raise ValueError("Hello")

--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B017.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B017.py
@@ -36,9 +36,13 @@ class Foobar(unittest.TestCase):
         with self.assertRaises(asyncio.CancelledError):
             Foo()
 
+
 def test_pytest_raises():
     with pytest.raises(Exception):
         raise ValueError("Hello")
 
+    with pytest.raises(Exception, "hello"):
+        raise ValueError("This is fine")
+
     with pytest.raises(Exception, match="hello"):
-        raise ValueError("Hello")
+        raise ValueError("This is also fine")

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -83,18 +83,15 @@ pub fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items: &[With
             .map_or(false, |call_path| {
                 call_path.as_slice() == ["pytest", "raises"]
             })
-        {
-            if keywords.iter().any(|keyword| {
+            && !keywords.iter().any(|keyword| {
                 keyword
                     .node
                     .arg
                     .as_ref()
                     .map_or(false, |arg| arg == "match")
-            }) {
-                return;
-            } else {
-                AssertionKind::PytestRaises
-            }
+            })
+        {
+            AssertionKind::PytestRaises
         } else {
             return;
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -13,8 +13,8 @@ use crate::checkers::ast::Checker;
 /// These forms catch every Exception, which can lead to passing tests even
 /// the code being tested is never executed due to a typo.
 ///
-/// Either assert for a more specific exception (builtin or custom), use
-/// `assertRaisesRegex` or the context manager form of `assertRaises`.
+/// Either assert for a more specific exception (builtin or custom),
+/// `assertRaisesRegex`, or `pytest.raises(..., match=<REGEX>)`.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B017_B017.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B017_B017.py.snap
@@ -1,16 +1,37 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B017.py:22:9: B017 `assertRaises(Exception)` should be considered evil
+B017.py:23:9: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
    |
-22 |   class Foobar(unittest.TestCase):
-23 |       def evil_raises(self) -> None:
-24 |           with self.assertRaises(Exception):
+23 |   class Foobar(unittest.TestCase):
+24 |       def evil_raises(self) -> None:
+25 |           with self.assertRaises(Exception):
    |  _________^
-25 | |             raise Exception("Evil I say!")
+26 | |             raise Exception("Evil I say!")
    | |__________________________________________^ B017
-26 |   
-27 |       def context_manager_raises(self) -> None:
+27 |   
+28 |       def context_manager_raises(self) -> None:
+   |
+
+B017.py:40:5: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
+   |
+40 |   def test_pytest_raises():
+41 |       with pytest.raises(Exception):
+   |  _____^
+42 | |         raise ValueError("Hello")
+   | |_________________________________^ B017
+43 |   
+44 |       with pytest.raises(Exception, match="hello"):
+   |
+
+B017.py:43:5: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
+   |
+43 |           raise ValueError("Hello")
+44 |   
+45 |       with pytest.raises(Exception, match="hello"):
+   |  _____^
+46 | |         raise ValueError("Hello")
+   | |_________________________________^ B017
    |
 
 

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B017_B017.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B017_B017.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B017.py:23:9: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
+B017.py:23:9: B017 `assertRaises(Exception)` should be considered evil
    |
 23 |   class Foobar(unittest.TestCase):
 24 |       def evil_raises(self) -> None:
@@ -13,25 +13,15 @@ B017.py:23:9: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` shou
 28 |       def context_manager_raises(self) -> None:
    |
 
-B017.py:40:5: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
+B017.py:41:5: B017 `pytest.raises(Exception)` should be considered evil
    |
-40 |   def test_pytest_raises():
-41 |       with pytest.raises(Exception):
+41 |   def test_pytest_raises():
+42 |       with pytest.raises(Exception):
    |  _____^
-42 | |         raise ValueError("Hello")
+43 | |         raise ValueError("Hello")
    | |_________________________________^ B017
-43 |   
-44 |       with pytest.raises(Exception, match="hello"):
-   |
-
-B017.py:43:5: B017 `assertRaises(Exception)` and `pytest.raises(Exception)` should be considered evil
-   |
-43 |           raise ValueError("Hello")
 44 |   
-45 |       with pytest.raises(Exception, match="hello"):
-   |  _____^
-46 | |         raise ValueError("Hello")
-   | |_________________________________^ B017
+45 |       with pytest.raises(Exception, "hello"):
    |
 
 


### PR DESCRIPTION
`pytest.raises(Exception)` has the same problem as `self.assertRaises(Exception)`, and so we should also raise a lint error when people use it. This matches the upstream flake8-bugbear behavior (see https://github.com/PyCQA/flake8-bugbear/issues/169).

This makes `with pytest.raises(Exception)` a lint failure, although it leaves `pytest.raises(Exception, match="<REGEX>")` alone (since that corresponds to the `assertRaisesRegex`. 