### PR TITLE
Fix SIM222 and SIM223 false positives and auto-fix

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
@@ -97,7 +97,7 @@ a or frozenset({1}) or True or frozenset({2})  # SIM222
 a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
 
 
-# Inside test `a` is simplified
+# Inside test `a` is simplified.
 
 bool(a or [1] or True or [2])  # SIM222
 
@@ -143,7 +143,7 @@ while a or [1] or True or [2]:  # SIM222
     if b or [1] or True or [2]  # SIM222
 )
 
-# Outside test `a` is not simplified
+# Outside test `a` is not simplified.
 
 a or [1] or True or [2]  # SIM222
 

--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
@@ -42,3 +42,139 @@ if False and f() and a and g() and b:  # OK
 
 if a and False and f() and b and g():  # OK
     pass
+
+
+if a or "" or True:  # SIM222
+    pass
+
+if a or "foo" or True or "bar":  # SIM222
+    pass
+
+if a or 0 or True:  # SIM222
+    pass
+
+if a or 1 or True or 2:  # SIM222
+    pass
+
+if a or 0.0 or True:  # SIM222
+    pass
+
+if a or 0.1 or True or 0.2:  # SIM222
+    pass
+
+if a or [] or True:  # SIM222
+    pass
+
+if a or list([]) or True:  # SIM222
+    pass
+
+if a or [1] or True or [2]:  # SIM222
+    pass
+
+if a or list([1]) or True or list([2]):  # SIM222
+    pass
+
+if a or {} or True:  # SIM222
+    pass
+
+if a or dict() or True:  # SIM222
+    pass
+
+if a or {1: 1} or True or {2: 2}:  # SIM222
+    pass
+
+if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+    pass
+
+if a or set() or True:  # SIM222
+    pass
+
+if a or set(set()) or True:  # SIM222
+    pass
+
+if a or {1} or True or {2}:  # SIM222
+    pass
+
+if a or set({1}) or True or set({2}):  # SIM222
+    pass
+
+if a or () or True:  # SIM222
+    pass
+
+if a or tuple(()) or True:  # SIM222
+    pass
+
+if a or (1,) or True or (2,):  # SIM222
+    pass
+
+if a or tuple((1,)) or True or tuple((2,)):  # SIM222
+    pass
+
+if a or frozenset() or True:  # SIM222
+    pass
+
+if a or frozenset(frozenset()) or True:  # SIM222
+    pass
+
+if a or frozenset({1}) or True or frozenset({2}):  # SIM222
+    pass
+
+if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
+    pass
+
+
+# Inside test `a` is simplified
+
+bool(a or [1] or True or [2])  # SIM222
+
+assert a or [1] or True or [2]  # SIM222
+
+if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    pass
+
+0 if a or [1] or True or [2] else 1  # SIM222
+
+while a or [1] or True or [2]:  # SIM222
+    pass
+
+[
+    0
+    for a in range(10)
+    for b in range(10)
+    if a or [1] or True or [2]  # SIM222
+    if b or [1] or True or [2]  # SIM222
+]
+
+{
+    0
+    for a in range(10)
+    for b in range(10)
+    if a or [1] or True or [2]  # SIM222
+    if b or [1] or True or [2]  # SIM222
+}
+
+{
+    0: 0
+    for a in range(10)
+    for b in range(10)
+    if a or [1] or True or [2]  # SIM222
+    if b or [1] or True or [2]  # SIM222
+}
+
+(
+    0
+    for a in range(10)
+    for b in range(10)
+    if a or [1] or True or [2]  # SIM222
+    if b or [1] or True or [2]  # SIM222
+)
+
+# Outside test `a` is not simplified
+
+a or [1] or True or [2]  # SIM222
+
+if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+    pass
+
+if f(a or [1] or True or [2]):  # SIM222
+    pass

--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM222.py
@@ -44,83 +44,57 @@ if a and False and f() and b and g():  # OK
     pass
 
 
-if a or "" or True:  # SIM222
-    pass
+a or "" or True  # SIM222
 
-if a or "foo" or True or "bar":  # SIM222
-    pass
+a or "foo" or True or "bar"  # SIM222
 
-if a or 0 or True:  # SIM222
-    pass
+a or 0 or True  # SIM222
 
-if a or 1 or True or 2:  # SIM222
-    pass
+a or 1 or True or 2  # SIM222
 
-if a or 0.0 or True:  # SIM222
-    pass
+a or 0.0 or True  # SIM222
 
-if a or 0.1 or True or 0.2:  # SIM222
-    pass
+a or 0.1 or True or 0.2  # SIM222
 
-if a or [] or True:  # SIM222
-    pass
+a or [] or True  # SIM222
 
-if a or list([]) or True:  # SIM222
-    pass
+a or list([]) or True  # SIM222
 
-if a or [1] or True or [2]:  # SIM222
-    pass
+a or [1] or True or [2]  # SIM222
 
-if a or list([1]) or True or list([2]):  # SIM222
-    pass
+a or list([1]) or True or list([2])  # SIM222
 
-if a or {} or True:  # SIM222
-    pass
+a or {} or True  # SIM222
 
-if a or dict() or True:  # SIM222
-    pass
+a or dict() or True  # SIM222
 
-if a or {1: 1} or True or {2: 2}:  # SIM222
-    pass
+a or {1: 1} or True or {2: 2}  # SIM222
 
-if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
-    pass
+a or dict({1: 1}) or True or dict({2: 2})  # SIM222
 
-if a or set() or True:  # SIM222
-    pass
+a or set() or True  # SIM222
 
-if a or set(set()) or True:  # SIM222
-    pass
+a or set(set()) or True  # SIM222
 
-if a or {1} or True or {2}:  # SIM222
-    pass
+a or {1} or True or {2}  # SIM222
 
-if a or set({1}) or True or set({2}):  # SIM222
-    pass
+a or set({1}) or True or set({2})  # SIM222
 
-if a or () or True:  # SIM222
-    pass
+a or () or True  # SIM222
 
-if a or tuple(()) or True:  # SIM222
-    pass
+a or tuple(()) or True  # SIM222
 
-if a or (1,) or True or (2,):  # SIM222
-    pass
+a or (1,) or True or (2,)  # SIM222
 
-if a or tuple((1,)) or True or tuple((2,)):  # SIM222
-    pass
+a or tuple((1,)) or True or tuple((2,))  # SIM222
 
-if a or frozenset() or True:  # SIM222
-    pass
+a or frozenset() or True  # SIM222
 
-if a or frozenset(frozenset()) or True:  # SIM222
-    pass
+a or frozenset(frozenset()) or True  # SIM222
 
-if a or frozenset({1}) or True or frozenset({2}):  # SIM222
-    pass
+a or frozenset({1}) or True or frozenset({2})  # SIM222
 
-if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
-    pass
+a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
 
 
 # Inside test `a` is simplified

--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
@@ -92,7 +92,7 @@ a and frozenset({1}) and False and frozenset({2})  # SIM222
 a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
 
 
-# Inside test `a` is simplified
+# Inside test `a` is simplified.
 
 bool(a and [] and False and [])  # SIM223
 
@@ -138,7 +138,7 @@ while a and [] and False and []:  # SIM223
     if b and [] and False and []  # SIM223
 )
 
-# Outside test `a` is not simplified
+# Outside test `a` is not simplified.
 
 a and [] and False and []  # SIM223
 

--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
@@ -39,83 +39,57 @@ if a or True or f() or b or g():  # OK
     pass
 
 
-if a and "" and False:  # SIM223
-    pass
+a and "" and False  # SIM223
 
-if a and "foo" and False and "bar":  # SIM223
-    pass
+a and "foo" and False and "bar"  # SIM223
 
-if a and 0 and False:  # SIM223
-    pass
+a and 0 and False  # SIM223
 
-if a and 1 and False and 2:  # SIM223
-    pass
+a and 1 and False and 2  # SIM223
 
-if a and 0.0 and False:  # SIM223
-    pass
+a and 0.0 and False  # SIM223
 
-if a and 0.1 and False and 0.2:  # SIM223
-    pass
+a and 0.1 and False and 0.2  # SIM223
 
-if a and [] and False:  # SIM223
-    pass
+a and [] and False  # SIM223
 
-if a and list([]) and False:  # SIM223
-    pass
+a and list([]) and False  # SIM223
 
-if a and [1] and False and [2]:  # SIM223
-    pass
+a and [1] and False and [2]  # SIM223
 
-if a and list([1]) and False and list([2]):  # SIM223
-    pass
+a and list([1]) and False and list([2])  # SIM223
 
-if a and {} and False:  # SIM223
-    pass
+a and {} and False  # SIM223
 
-if a and dict() and False:  # SIM223
-    pass
+a and dict() and False  # SIM223
 
-if a and {1: 1} and False and {2: 2}:  # SIM223
-    pass
+a and {1: 1} and False and {2: 2}  # SIM223
 
-if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
-    pass
+a and dict({1: 1}) and False and dict({2: 2})  # SIM223
 
-if a and set() and False:  # SIM223
-    pass
+a and set() and False  # SIM223
 
-if a and set(set()) and False:  # SIM223
-    pass
+a and set(set()) and False  # SIM223
 
-if a and {1} and False and {2}:  # SIM223
-    pass
+a and {1} and False and {2}  # SIM223
 
-if a and set({1}) and False and set({2}):  # SIM223
-    pass
+a and set({1}) and False and set({2})  # SIM223
 
-if a and () and False:  # SIM222
-    pass
+a and () and False  # SIM222
 
-if a and tuple(()) and False:  # SIM222
-    pass
+a and tuple(()) and False  # SIM222
 
-if a and (1,) and False and (2,):  # SIM222
-    pass
+a and (1,) and False and (2,)  # SIM222
 
-if a and tuple((1,)) and False and tuple((2,)):  # SIM222
-    pass
+a and tuple((1,)) and False and tuple((2,))  # SIM222
 
-if a and frozenset() and False:  # SIM222
-    pass
+a and frozenset() and False  # SIM222
 
-if a and frozenset(frozenset()) and False:  # SIM222
-    pass
+a and frozenset(frozenset()) and False  # SIM222
 
-if a and frozenset({1}) and False and frozenset({2}):  # SIM222
-    pass
+a and frozenset({1}) and False and frozenset({2})  # SIM222
 
-if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
-    pass
+a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
 
 
 # Inside test `a` is simplified

--- a/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
+++ b/crates/ruff/resources/test/fixtures/flake8_simplify/SIM223.py
@@ -37,3 +37,139 @@ if True or f() or a or g() or b:  # OK
 
 if a or True or f() or b or g():  # OK
     pass
+
+
+if a and "" and False:  # SIM223
+    pass
+
+if a and "foo" and False and "bar":  # SIM223
+    pass
+
+if a and 0 and False:  # SIM223
+    pass
+
+if a and 1 and False and 2:  # SIM223
+    pass
+
+if a and 0.0 and False:  # SIM223
+    pass
+
+if a and 0.1 and False and 0.2:  # SIM223
+    pass
+
+if a and [] and False:  # SIM223
+    pass
+
+if a and list([]) and False:  # SIM223
+    pass
+
+if a and [1] and False and [2]:  # SIM223
+    pass
+
+if a and list([1]) and False and list([2]):  # SIM223
+    pass
+
+if a and {} and False:  # SIM223
+    pass
+
+if a and dict() and False:  # SIM223
+    pass
+
+if a and {1: 1} and False and {2: 2}:  # SIM223
+    pass
+
+if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
+    pass
+
+if a and set() and False:  # SIM223
+    pass
+
+if a and set(set()) and False:  # SIM223
+    pass
+
+if a and {1} and False and {2}:  # SIM223
+    pass
+
+if a and set({1}) and False and set({2}):  # SIM223
+    pass
+
+if a and () and False:  # SIM222
+    pass
+
+if a and tuple(()) and False:  # SIM222
+    pass
+
+if a and (1,) and False and (2,):  # SIM222
+    pass
+
+if a and tuple((1,)) and False and tuple((2,)):  # SIM222
+    pass
+
+if a and frozenset() and False:  # SIM222
+    pass
+
+if a and frozenset(frozenset()) and False:  # SIM222
+    pass
+
+if a and frozenset({1}) and False and frozenset({2}):  # SIM222
+    pass
+
+if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
+    pass
+
+
+# Inside test `a` is simplified
+
+bool(a and [] and False and [])  # SIM223
+
+assert a and [] and False and []  # SIM223
+
+if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    pass
+
+0 if a and [] and False and [] else 1  # SIM222
+
+while a and [] and False and []:  # SIM223
+    pass
+
+[
+    0
+    for a in range(10)
+    for b in range(10)
+    if a and [] and False and []  # SIM223
+    if b and [] and False and []  # SIM223
+]
+
+{
+    0
+    for a in range(10)
+    for b in range(10)
+    if a and [] and False and []  # SIM223
+    if b and [] and False and []  # SIM223
+}
+
+{
+    0: 0
+    for a in range(10)
+    for b in range(10)
+    if a and [] and False and []  # SIM223
+    if b and [] and False and []  # SIM223
+}
+
+(
+    0
+    for a in range(10)
+    for b in range(10)
+    if a and [] and False and []  # SIM223
+    if b and [] and False and []  # SIM223
+)
+
+# Outside test `a` is not simplified
+
+a and [] and False and []  # SIM223
+
+if (a and [] and False and []) == (a and []):  # SIM223
+    pass
+
+if f(a and [] and False and []):  # SIM223
+    pass

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -3643,7 +3643,7 @@ where
                     .any(|target| call_path.as_slice() == ["mypy_extensions", target])
                     {
                         Some(Callable::MypyExtension)
-                    } else if call_path.as_slice() == ["", "bool"] && self.ctx.is_builtin("bool") {
+                    } else if call_path.as_slice() == ["", "bool"] {
                         Some(Callable::Bool)
                     } else {
                         None

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -3643,7 +3643,7 @@ where
                     .any(|target| call_path.as_slice() == ["mypy_extensions", target])
                     {
                         Some(Callable::MypyExtension)
-                    } else if call_path.as_slice() == ["", "bool"] {
+                    } else if call_path.as_slice() == ["", "bool"] && self.ctx.is_builtin("bool") {
                         Some(Callable::Bool)
                     } else {
                         None

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -136,18 +136,17 @@ pub enum ContentAround {
 }
 
 /// ## What it does
-/// Checks if `or` expressions with truthy value can be simplified.
-///
-/// If the expression is used as a condition, it can be replaced with
-/// `False`. It can be simplified further than in other cases.
-///
-/// In other cases, the expression can be replaced with the first truthy
-/// value.
+/// Checks for `or` expressions that contain truthy values.
 ///
 /// ## Why is this bad?
-/// The code is less readable and more difficult to understand.
-/// The code is also less efficient, as multiple expressions are evaluated
-/// instead of just one.
+/// If the expression is used as a condition, it can be replaced in-full with
+/// `True`.
+///
+/// In other cases, the expression can be short-circuited to the first truthy
+/// value.
+///
+/// By using `True` (or the first truthy value), the code is more concise
+/// and easier to understand, since it no longer contains redundant conditions.
 ///
 /// ## Example
 /// ```python
@@ -189,18 +188,17 @@ impl AlwaysAutofixableViolation for ExprOrTrue {
 }
 
 /// ## What it does
-/// Checks if `and` expressions with falsey value can be simplified.
-///
-/// If the expression is used as a condition, it can be replaced with
-/// `False`. It can be simplified further than in other cases.
-///
-/// In other cases, the expression can be replaced with the first falsey
-/// value.
+/// Checks for `and` expressions that contain falsey values.
 ///
 /// ## Why is this bad?
-/// The code is less readable and more difficult to understand.
-/// The code is also less efficient, as multiple expressions are evaluated
-/// instead of just one.
+/// If the expression is used as a condition, it can be replaced in-full with
+/// `False`.
+///
+/// In other cases, the expression can be short-circuited to the first falsey
+/// value.
+///
+/// By using `False` (or the first falsey value), the code is more concise
+/// and easier to understand, since it no longer contains redundant conditions.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -128,6 +128,25 @@ impl AlwaysAutofixableViolation for ExprOrNotExpr {
     }
 }
 
+/// ## What it does
+/// Checks if `or` expressions with truthy value can be simplified.
+///
+/// ## Why is this bad?
+/// The code is less readable and more difficult to understand.
+/// The code is also less efficient, as multiple expressions are evaluated
+/// instead of just one.
+///
+/// ## Example
+/// ```python
+/// if x or True:
+///     pass
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if True:
+///     pass
+/// ```
 #[violation]
 pub struct ExprOrTrue {
     pub expr: String,
@@ -137,15 +156,42 @@ impl AlwaysAutofixableViolation for ExprOrTrue {
     #[derive_message_formats]
     fn message(&self) -> String {
         let ExprOrTrue { expr } = self;
-        format!("Use `{expr}` instead of `... or {expr}`")
+        if expr.as_str() == "True" {
+            format!("Use `True` instead of `... or True`")
+        } else {
+            format!("Use truthy `{expr}` instead of `... or {expr}`")
+        }
     }
 
     fn autofix_title(&self) -> String {
         let ExprOrTrue { expr } = self;
-        format!("Replace with `{expr}`")
+        if expr.as_str() == "True" {
+            format!("Replace with `True`")
+        } else {
+            format!("Replace with truthy `{expr}`")
+        }
     }
 }
 
+/// ## What it does
+/// Checks if `and` expressions with falsey value can be simplified.
+/// 
+/// ## Why is this bad?
+/// The code is less readable and more difficult to understand.
+/// The code is also less efficient, as multiple expressions are evaluated
+/// instead of just one.
+/// 
+/// ## Example
+/// ```python
+/// if x and False:
+///     pass
+/// ```
+/// 
+/// Use instead:
+/// ```python
+/// if False:
+///     pass
+/// ```
 #[violation]
 pub struct ExprAndFalse {
     pub expr: String,
@@ -155,12 +201,20 @@ impl AlwaysAutofixableViolation for ExprAndFalse {
     #[derive_message_formats]
     fn message(&self) -> String {
         let ExprAndFalse { expr } = self;
-        format!("Use `{expr}` instead of `... and {expr}`")
+        if expr.as_str() == "False" {
+            format!("Use `False` instead of `... and False`")
+        } else {
+            format!("Use falsey `{expr}` instead of `... and {expr}`")
+        }
     }
 
     fn autofix_title(&self) -> String {
         let ExprAndFalse { expr } = self;
-        format!("Replace with `{expr}`")
+        if expr.as_str() == "False" {
+            format!("Replace with `False`")
+        } else {
+            format!("Replace with falsey `{expr}`")
+        }
     }
 }
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -134,7 +134,7 @@ SIM222.py:47:4: SIM222 [*] Use `True` instead of `... or True`
 49 49 | 
 50 50 | if a or "foo" or True or "bar":  # SIM222
 
-SIM222.py:50:4: SIM222 [*] Use `"foo"` instead of `... or "foo"`
+SIM222.py:50:4: SIM222 [*] Use truthy `"foo"` instead of `... or "foo"`
    |
 50 |     pass
 51 | 
@@ -142,7 +142,7 @@ SIM222.py:50:4: SIM222 [*] Use `"foo"` instead of `... or "foo"`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 53 |     pass
    |
-   = help: Replace with `"foo"`
+   = help: Replace with truthy `"foo"`
 
 ℹ Suggested fix
 47 47 | if a or "" or True:  # SIM222
@@ -174,7 +174,7 @@ SIM222.py:53:4: SIM222 [*] Use `True` instead of `... or True`
 55 55 | 
 56 56 | if a or 1 or True or 2:  # SIM222
 
-SIM222.py:56:4: SIM222 [*] Use `1` instead of `... or 1`
+SIM222.py:56:4: SIM222 [*] Use truthy `1` instead of `... or 1`
    |
 56 |     pass
 57 | 
@@ -182,7 +182,7 @@ SIM222.py:56:4: SIM222 [*] Use `1` instead of `... or 1`
    |    ^^^^^^^^^^^^^^^^^^^ SIM222
 59 |     pass
    |
-   = help: Replace with `1`
+   = help: Replace with truthy `1`
 
 ℹ Suggested fix
 53 53 | if a or 0 or True:  # SIM222
@@ -214,7 +214,7 @@ SIM222.py:59:4: SIM222 [*] Use `True` instead of `... or True`
 61 61 | 
 62 62 | if a or 0.1 or True or 0.2:  # SIM222
 
-SIM222.py:62:4: SIM222 [*] Use `0.1` instead of `... or 0.1`
+SIM222.py:62:4: SIM222 [*] Use truthy `0.1` instead of `... or 0.1`
    |
 62 |     pass
 63 | 
@@ -222,7 +222,7 @@ SIM222.py:62:4: SIM222 [*] Use `0.1` instead of `... or 0.1`
    |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 65 |     pass
    |
-   = help: Replace with `0.1`
+   = help: Replace with truthy `0.1`
 
 ℹ Suggested fix
 59 59 | if a or 0.0 or True:  # SIM222
@@ -274,7 +274,7 @@ SIM222.py:68:4: SIM222 [*] Use `True` instead of `... or True`
 70 70 | 
 71 71 | if a or [1] or True or [2]:  # SIM222
 
-SIM222.py:71:4: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:71:4: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
    |
 71 |     pass
 72 | 
@@ -282,7 +282,7 @@ SIM222.py:71:4: SIM222 [*] Use `[1]` instead of `... or [1]`
    |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 74 |     pass
    |
-   = help: Replace with `[1]`
+   = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 68 68 | if a or list([]) or True:  # SIM222
@@ -294,7 +294,7 @@ SIM222.py:71:4: SIM222 [*] Use `[1]` instead of `... or [1]`
 73 73 | 
 74 74 | if a or list([1]) or True or list([2]):  # SIM222
 
-SIM222.py:74:4: SIM222 [*] Use `list([1])` instead of `... or list([1])`
+SIM222.py:74:4: SIM222 [*] Use truthy `list([1])` instead of `... or list([1])`
    |
 74 |     pass
 75 | 
@@ -302,7 +302,7 @@ SIM222.py:74:4: SIM222 [*] Use `list([1])` instead of `... or list([1])`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 77 |     pass
    |
-   = help: Replace with `list([1])`
+   = help: Replace with truthy `list([1])`
 
 ℹ Suggested fix
 71 71 | if a or [1] or True or [2]:  # SIM222
@@ -354,7 +354,7 @@ SIM222.py:80:4: SIM222 [*] Use `True` instead of `... or True`
 82 82 | 
 83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
 
-SIM222.py:83:4: SIM222 [*] Use `{1: 1}` instead of `... or {1: 1}`
+SIM222.py:83:4: SIM222 [*] Use truthy `{1: 1}` instead of `... or {1: 1}`
    |
 83 |     pass
 84 | 
@@ -362,7 +362,7 @@ SIM222.py:83:4: SIM222 [*] Use `{1: 1}` instead of `... or {1: 1}`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 86 |     pass
    |
-   = help: Replace with `{1: 1}`
+   = help: Replace with truthy `{1: 1}`
 
 ℹ Suggested fix
 80 80 | if a or dict() or True:  # SIM222
@@ -374,7 +374,7 @@ SIM222.py:83:4: SIM222 [*] Use `{1: 1}` instead of `... or {1: 1}`
 85 85 | 
 86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
 
-SIM222.py:86:4: SIM222 [*] Use `dict({1: 1})` instead of `... or dict({1: 1})`
+SIM222.py:86:4: SIM222 [*] Use truthy `dict({1: 1})` instead of `... or dict({1: 1})`
    |
 86 |     pass
 87 | 
@@ -382,7 +382,7 @@ SIM222.py:86:4: SIM222 [*] Use `dict({1: 1})` instead of `... or dict({1: 1})`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 89 |     pass
    |
-   = help: Replace with `dict({1: 1})`
+   = help: Replace with truthy `dict({1: 1})`
 
 ℹ Suggested fix
 83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
@@ -434,7 +434,7 @@ SIM222.py:92:4: SIM222 [*] Use `True` instead of `... or True`
 94 94 | 
 95 95 | if a or {1} or True or {2}:  # SIM222
 
-SIM222.py:95:4: SIM222 [*] Use `{1}` instead of `... or {1}`
+SIM222.py:95:4: SIM222 [*] Use truthy `{1}` instead of `... or {1}`
    |
 95 |     pass
 96 | 
@@ -442,7 +442,7 @@ SIM222.py:95:4: SIM222 [*] Use `{1}` instead of `... or {1}`
    |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 98 |     pass
    |
-   = help: Replace with `{1}`
+   = help: Replace with truthy `{1}`
 
 ℹ Suggested fix
 92 92 | if a or set(set()) or True:  # SIM222
@@ -454,7 +454,7 @@ SIM222.py:95:4: SIM222 [*] Use `{1}` instead of `... or {1}`
 97 97 | 
 98 98 | if a or set({1}) or True or set({2}):  # SIM222
 
-SIM222.py:98:4: SIM222 [*] Use `set({1})` instead of `... or set({1})`
+SIM222.py:98:4: SIM222 [*] Use truthy `set({1})` instead of `... or set({1})`
     |
  98 |     pass
  99 | 
@@ -462,7 +462,7 @@ SIM222.py:98:4: SIM222 [*] Use `set({1})` instead of `... or set({1})`
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 101 |     pass
     |
-    = help: Replace with `set({1})`
+    = help: Replace with truthy `set({1})`
 
 ℹ Suggested fix
 95 95 | if a or {1} or True or {2}:  # SIM222
@@ -514,7 +514,7 @@ SIM222.py:104:4: SIM222 [*] Use `True` instead of `... or True`
 106 106 | 
 107 107 | if a or (1,) or True or (2,):  # SIM222
 
-SIM222.py:107:4: SIM222 [*] Use `1,` instead of `... or 1,`
+SIM222.py:107:4: SIM222 [*] Use truthy `1,` instead of `... or 1,`
     |
 107 |     pass
 108 | 
@@ -522,7 +522,7 @@ SIM222.py:107:4: SIM222 [*] Use `1,` instead of `... or 1,`
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 110 |     pass
     |
-    = help: Replace with `1,`
+    = help: Replace with truthy `1,`
 
 ℹ Suggested fix
 104 104 | if a or tuple(()) or True:  # SIM222
@@ -534,7 +534,7 @@ SIM222.py:107:4: SIM222 [*] Use `1,` instead of `... or 1,`
 109 109 | 
 110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
 
-SIM222.py:110:4: SIM222 [*] Use `tuple((1,))` instead of `... or tuple((1,))`
+SIM222.py:110:4: SIM222 [*] Use truthy `tuple((1,))` instead of `... or tuple((1,))`
     |
 110 |     pass
 111 | 
@@ -542,7 +542,7 @@ SIM222.py:110:4: SIM222 [*] Use `tuple((1,))` instead of `... or tuple((1,))`
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 113 |     pass
     |
-    = help: Replace with `tuple((1,))`
+    = help: Replace with truthy `tuple((1,))`
 
 ℹ Suggested fix
 107 107 | if a or (1,) or True or (2,):  # SIM222
@@ -594,7 +594,7 @@ SIM222.py:116:4: SIM222 [*] Use `True` instead of `... or True`
 118 118 | 
 119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
 
-SIM222.py:119:4: SIM222 [*] Use `frozenset({1})` instead of `... or frozenset({1})`
+SIM222.py:119:4: SIM222 [*] Use truthy `frozenset({1})` instead of `... or frozenset({1})`
     |
 119 |     pass
 120 | 
@@ -602,7 +602,7 @@ SIM222.py:119:4: SIM222 [*] Use `frozenset({1})` instead of `... or frozenset({1
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 122 |     pass
     |
-    = help: Replace with `frozenset({1})`
+    = help: Replace with truthy `frozenset({1})`
 
 ℹ Suggested fix
 116 116 | if a or frozenset(frozenset()) or True:  # SIM222
@@ -614,7 +614,7 @@ SIM222.py:119:4: SIM222 [*] Use `frozenset({1})` instead of `... or frozenset({1
 121 121 | 
 122 122 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
 
-SIM222.py:122:4: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1}))`
+SIM222.py:122:4: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1}))`
     |
 122 |     pass
 123 | 
@@ -622,7 +622,7 @@ SIM222.py:122:4: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `... or f
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 125 |     pass
     |
-    = help: Replace with `frozenset(frozenset({1}))`
+    = help: Replace with truthy `frozenset(frozenset({1}))`
 
 ℹ Suggested fix
 119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
@@ -634,7 +634,7 @@ SIM222.py:122:4: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `... or f
 124 124 | 
 125 125 | 
 
-SIM222.py:128:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:128:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 128 | # Inside test `a` is simplified
 129 | 
@@ -643,7 +643,7 @@ SIM222.py:128:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 131 | 
 132 | assert a or [1] or True or [2]  # SIM222
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 125 125 | 
@@ -655,7 +655,7 @@ SIM222.py:128:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 130 130 | assert a or [1] or True or [2]  # SIM222
 131 131 | 
 
-SIM222.py:130:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:130:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 130 | bool(a or [1] or True or [2])  # SIM222
 131 | 
@@ -664,7 +664,7 @@ SIM222.py:130:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 133 | 
 134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 127 127 | 
@@ -676,7 +676,7 @@ SIM222.py:130:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
 133 133 |     pass
 
-SIM222.py:132:5: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:132:5: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 132 | assert a or [1] or True or [2]  # SIM222
 133 | 
@@ -684,7 +684,7 @@ SIM222.py:132:5: SIM222 [*] Use `[1]` instead of `... or [1]`
     |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 135 |     pass
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 129 129 | 
@@ -696,7 +696,7 @@ SIM222.py:132:5: SIM222 [*] Use `[1]` instead of `... or [1]`
 134 134 | 
 135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:132:35: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:132:35: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 132 | assert a or [1] or True or [2]  # SIM222
 133 | 
@@ -704,7 +704,7 @@ SIM222.py:132:35: SIM222 [*] Use `[1]` instead of `... or [1]`
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 135 |     pass
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 129 129 | 
@@ -716,7 +716,7 @@ SIM222.py:132:35: SIM222 [*] Use `[1]` instead of `... or [1]`
 134 134 | 
 135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:135:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:135:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 135 |     pass
 136 | 
@@ -725,7 +725,7 @@ SIM222.py:135:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 138 | 
 139 | while a or [1] or True or [2]:  # SIM222
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
@@ -737,7 +737,7 @@ SIM222.py:135:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 137 137 | while a or [1] or True or [2]:  # SIM222
 138 138 |     pass
 
-SIM222.py:137:7: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:137:7: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 137 | 0 if a or [1] or True or [2] else 1  # SIM222
 138 | 
@@ -745,7 +745,7 @@ SIM222.py:137:7: SIM222 [*] Use `[1]` instead of `... or [1]`
     |       ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 140 |     pass
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 134 134 | 
@@ -757,7 +757,7 @@ SIM222.py:137:7: SIM222 [*] Use `[1]` instead of `... or [1]`
 139 139 | 
 140 140 | [
 
-SIM222.py:144:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:144:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 144 |     for a in range(10)
 145 |     for b in range(10)
@@ -766,7 +766,7 @@ SIM222.py:144:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 147 |     if b or [1] or True or [2]  # SIM222
 148 | ]
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 141 141 |     0
@@ -778,7 +778,7 @@ SIM222.py:144:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 146 146 | ]
 147 147 | 
 
-SIM222.py:145:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:145:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 145 |     for b in range(10)
 146 |     if a or [1] or True or [2]  # SIM222
@@ -786,7 +786,7 @@ SIM222.py:145:8: SIM222 [*] Use `[1]` instead of `... or [1]`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 148 | ]
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 142 142 |     for a in range(10)
@@ -798,7 +798,7 @@ SIM222.py:145:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 147 147 | 
 148 148 | {
 
-SIM222.py:152:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:152:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 152 |     for a in range(10)
 153 |     for b in range(10)
@@ -807,7 +807,7 @@ SIM222.py:152:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 155 |     if b or [1] or True or [2]  # SIM222
 156 | }
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 149 149 |     0
@@ -819,7 +819,7 @@ SIM222.py:152:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 154 154 | }
 155 155 | 
 
-SIM222.py:153:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:153:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 153 |     for b in range(10)
 154 |     if a or [1] or True or [2]  # SIM222
@@ -827,7 +827,7 @@ SIM222.py:153:8: SIM222 [*] Use `[1]` instead of `... or [1]`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 156 | }
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 150 150 |     for a in range(10)
@@ -839,7 +839,7 @@ SIM222.py:153:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 155 155 | 
 156 156 | {
 
-SIM222.py:160:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:160:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 160 |     for a in range(10)
 161 |     for b in range(10)
@@ -848,7 +848,7 @@ SIM222.py:160:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 163 |     if b or [1] or True or [2]  # SIM222
 164 | }
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 157 157 |     0: 0
@@ -860,7 +860,7 @@ SIM222.py:160:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 162 162 | }
 163 163 | 
 
-SIM222.py:161:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:161:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 161 |     for b in range(10)
 162 |     if a or [1] or True or [2]  # SIM222
@@ -868,7 +868,7 @@ SIM222.py:161:8: SIM222 [*] Use `[1]` instead of `... or [1]`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 164 | }
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 158 158 |     for a in range(10)
@@ -880,7 +880,7 @@ SIM222.py:161:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 163 163 | 
 164 164 | (
 
-SIM222.py:168:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:168:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 168 |     for a in range(10)
 169 |     for b in range(10)
@@ -889,7 +889,7 @@ SIM222.py:168:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 171 |     if b or [1] or True or [2]  # SIM222
 172 | )
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 165 165 |     0
@@ -901,7 +901,7 @@ SIM222.py:168:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 170 170 | )
 171 171 | 
 
-SIM222.py:169:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:169:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 169 |     for b in range(10)
 170 |     if a or [1] or True or [2]  # SIM222
@@ -909,7 +909,7 @@ SIM222.py:169:8: SIM222 [*] Use `[1]` instead of `... or [1]`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 172 | )
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 166 166 |     for a in range(10)
@@ -921,7 +921,7 @@ SIM222.py:169:8: SIM222 [*] Use `[1]` instead of `... or [1]`
 171 171 | 
 172 172 | # Outside test `a` is not simplified
 
-SIM222.py:174:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:174:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 174 | # Outside test `a` is not simplified
 175 | 
@@ -930,7 +930,7 @@ SIM222.py:174:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 177 | 
 178 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 171 171 | 
@@ -942,7 +942,7 @@ SIM222.py:174:6: SIM222 [*] Use `[1]` instead of `... or [1]`
 176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
 177 177 |     pass
 
-SIM222.py:176:10: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:176:10: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 176 | a or [1] or True or [2]  # SIM222
 177 | 
@@ -950,7 +950,7 @@ SIM222.py:176:10: SIM222 [*] Use `[1]` instead of `... or [1]`
     |          ^^^^^^^^^^^^^^^^^^ SIM222
 179 |     pass
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 173 173 | 
@@ -962,7 +962,7 @@ SIM222.py:176:10: SIM222 [*] Use `[1]` instead of `... or [1]`
 178 178 | 
 179 179 | if f(a or [1] or True or [2]):  # SIM222
 
-SIM222.py:179:11: SIM222 [*] Use `[1]` instead of `... or [1]`
+SIM222.py:179:11: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
     |
 179 |     pass
 180 | 
@@ -970,7 +970,7 @@ SIM222.py:179:11: SIM222 [*] Use `[1]` instead of `... or [1]`
     |           ^^^^^^^^^^^^^^^^^^ SIM222
 182 |     pass
     |
-    = help: Replace with `[1]`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
 176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -116,11 +116,12 @@ SIM222.py:30:4: SIM222 [*] Use `True` instead of `... or True or ...`
 32 32 | 
 33 33 | 
 
-SIM222.py:47:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:47:6: SIM222 [*] Use `True` instead of `... or True`
    |
-47 | if a or "" or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^ SIM222
-48 |     pass
+47 | a or "" or True  # SIM222
+   |      ^^^^^^^^^^ SIM222
+48 | 
+49 | a or "foo" or True or "bar"  # SIM222
    |
    = help: Replace with `True`
 
@@ -128,856 +129,879 @@ SIM222.py:47:4: SIM222 [*] Use `True` instead of `... or True`
 44 44 |     pass
 45 45 | 
 46 46 | 
-47    |-if a or "" or True:  # SIM222
-   47 |+if True:  # SIM222
-48 48 |     pass
-49 49 | 
-50 50 | if a or "foo" or True or "bar":  # SIM222
+47    |-a or "" or True  # SIM222
+   47 |+a or True  # SIM222
+48 48 | 
+49 49 | a or "foo" or True or "bar"  # SIM222
+50 50 | 
 
-SIM222.py:50:4: SIM222 [*] Use truthy `"foo"` instead of `... or "foo" or ...`
+SIM222.py:49:6: SIM222 [*] Use truthy `"foo"` instead of `"foo" or ...`
    |
-50 |     pass
-51 | 
-52 | if a or "foo" or True or "bar":  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-53 |     pass
+49 | a or "" or True  # SIM222
+50 | 
+51 | a or "foo" or True or "bar"  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^ SIM222
+52 | 
+53 | a or 0 or True  # SIM222
    |
    = help: Replace with truthy `"foo"`
 
 ℹ Suggested fix
-47 47 | if a or "" or True:  # SIM222
-48 48 |     pass
-49 49 | 
-50    |-if a or "foo" or True or "bar":  # SIM222
-   50 |+if "foo":  # SIM222
-51 51 |     pass
+46 46 | 
+47 47 | a or "" or True  # SIM222
+48 48 | 
+49    |-a or "foo" or True or "bar"  # SIM222
+   49 |+a or "foo"  # SIM222
+50 50 | 
+51 51 | a or 0 or True  # SIM222
 52 52 | 
-53 53 | if a or 0 or True:  # SIM222
 
-SIM222.py:53:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:51:6: SIM222 [*] Use `True` instead of `... or True`
    |
-53 |     pass
+51 | a or "foo" or True or "bar"  # SIM222
+52 | 
+53 | a or 0 or True  # SIM222
+   |      ^^^^^^^^^ SIM222
 54 | 
-55 | if a or 0 or True:  # SIM222
-   |    ^^^^^^^^^^^^^^ SIM222
-56 |     pass
+55 | a or 1 or True or 2  # SIM222
    |
    = help: Replace with `True`
 
 ℹ Suggested fix
-50 50 | if a or "foo" or True or "bar":  # SIM222
-51 51 |     pass
+48 48 | 
+49 49 | a or "foo" or True or "bar"  # SIM222
+50 50 | 
+51    |-a or 0 or True  # SIM222
+   51 |+a or True  # SIM222
 52 52 | 
-53    |-if a or 0 or True:  # SIM222
-   53 |+if True:  # SIM222
-54 54 |     pass
-55 55 | 
-56 56 | if a or 1 or True or 2:  # SIM222
+53 53 | a or 1 or True or 2  # SIM222
+54 54 | 
 
-SIM222.py:56:4: SIM222 [*] Use truthy `1` instead of `... or 1 or ...`
+SIM222.py:53:6: SIM222 [*] Use truthy `1` instead of `1 or ...`
    |
-56 |     pass
-57 | 
-58 | if a or 1 or True or 2:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^ SIM222
-59 |     pass
+53 | a or 0 or True  # SIM222
+54 | 
+55 | a or 1 or True or 2  # SIM222
+   |      ^^^^^^^^^^^^^^ SIM222
+56 | 
+57 | a or 0.0 or True  # SIM222
    |
    = help: Replace with truthy `1`
 
 ℹ Suggested fix
-53 53 | if a or 0 or True:  # SIM222
-54 54 |     pass
-55 55 | 
-56    |-if a or 1 or True or 2:  # SIM222
-   56 |+if 1:  # SIM222
-57 57 |     pass
-58 58 | 
-59 59 | if a or 0.0 or True:  # SIM222
+50 50 | 
+51 51 | a or 0 or True  # SIM222
+52 52 | 
+53    |-a or 1 or True or 2  # SIM222
+   53 |+a or 1  # SIM222
+54 54 | 
+55 55 | a or 0.0 or True  # SIM222
+56 56 | 
 
-SIM222.py:59:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:55:6: SIM222 [*] Use `True` instead of `... or True`
    |
-59 |     pass
-60 | 
-61 | if a or 0.0 or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^^ SIM222
-62 |     pass
+55 | a or 1 or True or 2  # SIM222
+56 | 
+57 | a or 0.0 or True  # SIM222
+   |      ^^^^^^^^^^^ SIM222
+58 | 
+59 | a or 0.1 or True or 0.2  # SIM222
    |
    = help: Replace with `True`
 
 ℹ Suggested fix
-56 56 | if a or 1 or True or 2:  # SIM222
-57 57 |     pass
+52 52 | 
+53 53 | a or 1 or True or 2  # SIM222
+54 54 | 
+55    |-a or 0.0 or True  # SIM222
+   55 |+a or True  # SIM222
+56 56 | 
+57 57 | a or 0.1 or True or 0.2  # SIM222
 58 58 | 
-59    |-if a or 0.0 or True:  # SIM222
-   59 |+if True:  # SIM222
-60 60 |     pass
-61 61 | 
-62 62 | if a or 0.1 or True or 0.2:  # SIM222
 
-SIM222.py:62:4: SIM222 [*] Use truthy `0.1` instead of `... or 0.1 or ...`
+SIM222.py:57:6: SIM222 [*] Use truthy `0.1` instead of `0.1 or ...`
    |
-62 |     pass
-63 | 
-64 | if a or 0.1 or True or 0.2:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-65 |     pass
+57 | a or 0.0 or True  # SIM222
+58 | 
+59 | a or 0.1 or True or 0.2  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^ SIM222
+60 | 
+61 | a or [] or True  # SIM222
    |
    = help: Replace with truthy `0.1`
 
 ℹ Suggested fix
-59 59 | if a or 0.0 or True:  # SIM222
-60 60 |     pass
-61 61 | 
-62    |-if a or 0.1 or True or 0.2:  # SIM222
-   62 |+if 0.1:  # SIM222
-63 63 |     pass
-64 64 | 
-65 65 | if a or [] or True:  # SIM222
+54 54 | 
+55 55 | a or 0.0 or True  # SIM222
+56 56 | 
+57    |-a or 0.1 or True or 0.2  # SIM222
+   57 |+a or 0.1  # SIM222
+58 58 | 
+59 59 | a or [] or True  # SIM222
+60 60 | 
 
-SIM222.py:65:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:59:6: SIM222 [*] Use `True` instead of `... or True`
    |
-65 |     pass
+59 | a or 0.1 or True or 0.2  # SIM222
+60 | 
+61 | a or [] or True  # SIM222
+   |      ^^^^^^^^^^ SIM222
+62 | 
+63 | a or list([]) or True  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+56 56 | 
+57 57 | a or 0.1 or True or 0.2  # SIM222
+58 58 | 
+59    |-a or [] or True  # SIM222
+   59 |+a or True  # SIM222
+60 60 | 
+61 61 | a or list([]) or True  # SIM222
+62 62 | 
+
+SIM222.py:61:6: SIM222 [*] Use `True` instead of `... or True`
+   |
+61 | a or [] or True  # SIM222
+62 | 
+63 | a or list([]) or True  # SIM222
+   |      ^^^^^^^^^^^^^^^^ SIM222
+64 | 
+65 | a or [1] or True or [2]  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+58 58 | 
+59 59 | a or [] or True  # SIM222
+60 60 | 
+61    |-a or list([]) or True  # SIM222
+   61 |+a or True  # SIM222
+62 62 | 
+63 63 | a or [1] or True or [2]  # SIM222
+64 64 | 
+
+SIM222.py:63:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+   |
+63 | a or list([]) or True  # SIM222
+64 | 
+65 | a or [1] or True or [2]  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^ SIM222
 66 | 
-67 | if a or [] or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^ SIM222
-68 |     pass
-   |
-   = help: Replace with `True`
-
-ℹ Suggested fix
-62 62 | if a or 0.1 or True or 0.2:  # SIM222
-63 63 |     pass
-64 64 | 
-65    |-if a or [] or True:  # SIM222
-   65 |+if True:  # SIM222
-66 66 |     pass
-67 67 | 
-68 68 | if a or list([]) or True:  # SIM222
-
-SIM222.py:68:4: SIM222 [*] Use `True` instead of `... or True`
-   |
-68 |     pass
-69 | 
-70 | if a or list([]) or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^ SIM222
-71 |     pass
-   |
-   = help: Replace with `True`
-
-ℹ Suggested fix
-65 65 | if a or [] or True:  # SIM222
-66 66 |     pass
-67 67 | 
-68    |-if a or list([]) or True:  # SIM222
-   68 |+if True:  # SIM222
-69 69 |     pass
-70 70 | 
-71 71 | if a or [1] or True or [2]:  # SIM222
-
-SIM222.py:71:4: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
-   |
-71 |     pass
-72 | 
-73 | if a or [1] or True or [2]:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-74 |     pass
+67 | a or list([1]) or True or list([2])  # SIM222
    |
    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-68 68 | if a or list([]) or True:  # SIM222
-69 69 |     pass
-70 70 | 
-71    |-if a or [1] or True or [2]:  # SIM222
-   71 |+if [1]:  # SIM222
-72 72 |     pass
-73 73 | 
-74 74 | if a or list([1]) or True or list([2]):  # SIM222
+60 60 | 
+61 61 | a or list([]) or True  # SIM222
+62 62 | 
+63    |-a or [1] or True or [2]  # SIM222
+   63 |+a or [1]  # SIM222
+64 64 | 
+65 65 | a or list([1]) or True or list([2])  # SIM222
+66 66 | 
 
-SIM222.py:74:4: SIM222 [*] Use truthy `list([1])` instead of `... or list([1]) or ...`
+SIM222.py:65:6: SIM222 [*] Use truthy `list([1])` instead of `list([1]) or ...`
    |
-74 |     pass
-75 | 
-76 | if a or list([1]) or True or list([2]):  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-77 |     pass
+65 | a or [1] or True or [2]  # SIM222
+66 | 
+67 | a or list([1]) or True or list([2])  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+68 | 
+69 | a or {} or True  # SIM222
    |
    = help: Replace with truthy `list([1])`
 
 ℹ Suggested fix
-71 71 | if a or [1] or True or [2]:  # SIM222
-72 72 |     pass
-73 73 | 
-74    |-if a or list([1]) or True or list([2]):  # SIM222
-   74 |+if list([1]):  # SIM222
-75 75 |     pass
-76 76 | 
-77 77 | if a or {} or True:  # SIM222
+62 62 | 
+63 63 | a or [1] or True or [2]  # SIM222
+64 64 | 
+65    |-a or list([1]) or True or list([2])  # SIM222
+   65 |+a or list([1])  # SIM222
+66 66 | 
+67 67 | a or {} or True  # SIM222
+68 68 | 
 
-SIM222.py:77:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:67:6: SIM222 [*] Use `True` instead of `... or True`
    |
-77 |     pass
-78 | 
-79 | if a or {} or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^ SIM222
-80 |     pass
-   |
-   = help: Replace with `True`
-
-ℹ Suggested fix
-74 74 | if a or list([1]) or True or list([2]):  # SIM222
-75 75 |     pass
-76 76 | 
-77    |-if a or {} or True:  # SIM222
-   77 |+if True:  # SIM222
-78 78 |     pass
-79 79 | 
-80 80 | if a or dict() or True:  # SIM222
-
-SIM222.py:80:4: SIM222 [*] Use `True` instead of `... or True`
-   |
-80 |     pass
-81 | 
-82 | if a or dict() or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^ SIM222
-83 |     pass
+67 | a or list([1]) or True or list([2])  # SIM222
+68 | 
+69 | a or {} or True  # SIM222
+   |      ^^^^^^^^^^ SIM222
+70 | 
+71 | a or dict() or True  # SIM222
    |
    = help: Replace with `True`
 
 ℹ Suggested fix
-77 77 | if a or {} or True:  # SIM222
-78 78 |     pass
-79 79 | 
-80    |-if a or dict() or True:  # SIM222
-   80 |+if True:  # SIM222
-81 81 |     pass
-82 82 | 
-83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
+64 64 | 
+65 65 | a or list([1]) or True or list([2])  # SIM222
+66 66 | 
+67    |-a or {} or True  # SIM222
+   67 |+a or True  # SIM222
+68 68 | 
+69 69 | a or dict() or True  # SIM222
+70 70 | 
 
-SIM222.py:83:4: SIM222 [*] Use truthy `{1: 1}` instead of `... or {1: 1} or ...`
+SIM222.py:69:6: SIM222 [*] Use `True` instead of `... or True`
    |
-83 |     pass
-84 | 
-85 | if a or {1: 1} or True or {2: 2}:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-86 |     pass
+69 | a or {} or True  # SIM222
+70 | 
+71 | a or dict() or True  # SIM222
+   |      ^^^^^^^^^^^^^^ SIM222
+72 | 
+73 | a or {1: 1} or True or {2: 2}  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+66 66 | 
+67 67 | a or {} or True  # SIM222
+68 68 | 
+69    |-a or dict() or True  # SIM222
+   69 |+a or True  # SIM222
+70 70 | 
+71 71 | a or {1: 1} or True or {2: 2}  # SIM222
+72 72 | 
+
+SIM222.py:71:6: SIM222 [*] Use truthy `{1: 1}` instead of `{1: 1} or ...`
+   |
+71 | a or dict() or True  # SIM222
+72 | 
+73 | a or {1: 1} or True or {2: 2}  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+74 | 
+75 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
    |
    = help: Replace with truthy `{1: 1}`
 
 ℹ Suggested fix
-80 80 | if a or dict() or True:  # SIM222
-81 81 |     pass
-82 82 | 
-83    |-if a or {1: 1} or True or {2: 2}:  # SIM222
-   83 |+if {1: 1}:  # SIM222
-84 84 |     pass
-85 85 | 
-86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+68 68 | 
+69 69 | a or dict() or True  # SIM222
+70 70 | 
+71    |-a or {1: 1} or True or {2: 2}  # SIM222
+   71 |+a or {1: 1}  # SIM222
+72 72 | 
+73 73 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
+74 74 | 
 
-SIM222.py:86:4: SIM222 [*] Use truthy `dict({1: 1})` instead of `... or dict({1: 1}) or ...`
+SIM222.py:73:6: SIM222 [*] Use truthy `dict({1: 1})` instead of `dict({1: 1}) or ...`
    |
-86 |     pass
-87 | 
-88 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-89 |     pass
+73 | a or {1: 1} or True or {2: 2}  # SIM222
+74 | 
+75 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+76 | 
+77 | a or set() or True  # SIM222
    |
    = help: Replace with truthy `dict({1: 1})`
 
 ℹ Suggested fix
-83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
-84 84 |     pass
-85 85 | 
-86    |-if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
-   86 |+if dict({1: 1}):  # SIM222
-87 87 |     pass
-88 88 | 
-89 89 | if a or set() or True:  # SIM222
+70 70 | 
+71 71 | a or {1: 1} or True or {2: 2}  # SIM222
+72 72 | 
+73    |-a or dict({1: 1}) or True or dict({2: 2})  # SIM222
+   73 |+a or dict({1: 1})  # SIM222
+74 74 | 
+75 75 | a or set() or True  # SIM222
+76 76 | 
 
-SIM222.py:89:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:75:6: SIM222 [*] Use `True` instead of `... or True`
    |
-89 |     pass
-90 | 
-91 | if a or set() or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^ SIM222
-92 |     pass
-   |
-   = help: Replace with `True`
-
-ℹ Suggested fix
-86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
-87 87 |     pass
-88 88 | 
-89    |-if a or set() or True:  # SIM222
-   89 |+if True:  # SIM222
-90 90 |     pass
-91 91 | 
-92 92 | if a or set(set()) or True:  # SIM222
-
-SIM222.py:92:4: SIM222 [*] Use `True` instead of `... or True`
-   |
-92 |     pass
-93 | 
-94 | if a or set(set()) or True:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-95 |     pass
+75 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
+76 | 
+77 | a or set() or True  # SIM222
+   |      ^^^^^^^^^^^^^ SIM222
+78 | 
+79 | a or set(set()) or True  # SIM222
    |
    = help: Replace with `True`
 
 ℹ Suggested fix
-89 89 | if a or set() or True:  # SIM222
-90 90 |     pass
-91 91 | 
-92    |-if a or set(set()) or True:  # SIM222
-   92 |+if True:  # SIM222
-93 93 |     pass
-94 94 | 
-95 95 | if a or {1} or True or {2}:  # SIM222
+72 72 | 
+73 73 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
+74 74 | 
+75    |-a or set() or True  # SIM222
+   75 |+a or True  # SIM222
+76 76 | 
+77 77 | a or set(set()) or True  # SIM222
+78 78 | 
 
-SIM222.py:95:4: SIM222 [*] Use truthy `{1}` instead of `... or {1} or ...`
+SIM222.py:77:6: SIM222 [*] Use `True` instead of `... or True`
    |
-95 |     pass
-96 | 
-97 | if a or {1} or True or {2}:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-98 |     pass
+77 | a or set() or True  # SIM222
+78 | 
+79 | a or set(set()) or True  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^ SIM222
+80 | 
+81 | a or {1} or True or {2}  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+74 74 | 
+75 75 | a or set() or True  # SIM222
+76 76 | 
+77    |-a or set(set()) or True  # SIM222
+   77 |+a or True  # SIM222
+78 78 | 
+79 79 | a or {1} or True or {2}  # SIM222
+80 80 | 
+
+SIM222.py:79:6: SIM222 [*] Use truthy `{1}` instead of `{1} or ...`
+   |
+79 | a or set(set()) or True  # SIM222
+80 | 
+81 | a or {1} or True or {2}  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^ SIM222
+82 | 
+83 | a or set({1}) or True or set({2})  # SIM222
    |
    = help: Replace with truthy `{1}`
 
 ℹ Suggested fix
-92 92 | if a or set(set()) or True:  # SIM222
-93 93 |     pass
+76 76 | 
+77 77 | a or set(set()) or True  # SIM222
+78 78 | 
+79    |-a or {1} or True or {2}  # SIM222
+   79 |+a or {1}  # SIM222
+80 80 | 
+81 81 | a or set({1}) or True or set({2})  # SIM222
+82 82 | 
+
+SIM222.py:81:6: SIM222 [*] Use truthy `set({1})` instead of `set({1}) or ...`
+   |
+81 | a or {1} or True or {2}  # SIM222
+82 | 
+83 | a or set({1}) or True or set({2})  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+84 | 
+85 | a or () or True  # SIM222
+   |
+   = help: Replace with truthy `set({1})`
+
+ℹ Suggested fix
+78 78 | 
+79 79 | a or {1} or True or {2}  # SIM222
+80 80 | 
+81    |-a or set({1}) or True or set({2})  # SIM222
+   81 |+a or set({1})  # SIM222
+82 82 | 
+83 83 | a or () or True  # SIM222
+84 84 | 
+
+SIM222.py:83:6: SIM222 [*] Use `True` instead of `... or True`
+   |
+83 | a or set({1}) or True or set({2})  # SIM222
+84 | 
+85 | a or () or True  # SIM222
+   |      ^^^^^^^^^^ SIM222
+86 | 
+87 | a or tuple(()) or True  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+80 80 | 
+81 81 | a or set({1}) or True or set({2})  # SIM222
+82 82 | 
+83    |-a or () or True  # SIM222
+   83 |+a or True  # SIM222
+84 84 | 
+85 85 | a or tuple(()) or True  # SIM222
+86 86 | 
+
+SIM222.py:85:6: SIM222 [*] Use `True` instead of `... or True`
+   |
+85 | a or () or True  # SIM222
+86 | 
+87 | a or tuple(()) or True  # SIM222
+   |      ^^^^^^^^^^^^^^^^^ SIM222
+88 | 
+89 | a or (1,) or True or (2,)  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+82 82 | 
+83 83 | a or () or True  # SIM222
+84 84 | 
+85    |-a or tuple(()) or True  # SIM222
+   85 |+a or True  # SIM222
+86 86 | 
+87 87 | a or (1,) or True or (2,)  # SIM222
+88 88 | 
+
+SIM222.py:87:6: SIM222 [*] Use truthy `1,` instead of `1, or ...`
+   |
+87 | a or tuple(()) or True  # SIM222
+88 | 
+89 | a or (1,) or True or (2,)  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^ SIM222
+90 | 
+91 | a or tuple((1,)) or True or tuple((2,))  # SIM222
+   |
+   = help: Replace with truthy `1,`
+
+ℹ Suggested fix
+84 84 | 
+85 85 | a or tuple(()) or True  # SIM222
+86 86 | 
+87    |-a or (1,) or True or (2,)  # SIM222
+   87 |+a or 1,  # SIM222
+88 88 | 
+89 89 | a or tuple((1,)) or True or tuple((2,))  # SIM222
+90 90 | 
+
+SIM222.py:89:6: SIM222 [*] Use truthy `tuple((1,))` instead of `tuple((1,)) or ...`
+   |
+89 | a or (1,) or True or (2,)  # SIM222
+90 | 
+91 | a or tuple((1,)) or True or tuple((2,))  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+92 | 
+93 | a or frozenset() or True  # SIM222
+   |
+   = help: Replace with truthy `tuple((1,))`
+
+ℹ Suggested fix
+86 86 | 
+87 87 | a or (1,) or True or (2,)  # SIM222
+88 88 | 
+89    |-a or tuple((1,)) or True or tuple((2,))  # SIM222
+   89 |+a or tuple((1,))  # SIM222
+90 90 | 
+91 91 | a or frozenset() or True  # SIM222
+92 92 | 
+
+SIM222.py:91:6: SIM222 [*] Use `True` instead of `... or True`
+   |
+91 | a or tuple((1,)) or True or tuple((2,))  # SIM222
+92 | 
+93 | a or frozenset() or True  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^ SIM222
+94 | 
+95 | a or frozenset(frozenset()) or True  # SIM222
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+88 88 | 
+89 89 | a or tuple((1,)) or True or tuple((2,))  # SIM222
+90 90 | 
+91    |-a or frozenset() or True  # SIM222
+   91 |+a or True  # SIM222
+92 92 | 
+93 93 | a or frozenset(frozenset()) or True  # SIM222
 94 94 | 
-95    |-if a or {1} or True or {2}:  # SIM222
-   95 |+if {1}:  # SIM222
-96 96 |     pass
-97 97 | 
-98 98 | if a or set({1}) or True or set({2}):  # SIM222
 
-SIM222.py:98:4: SIM222 [*] Use truthy `set({1})` instead of `... or set({1}) or ...`
-    |
- 98 |     pass
- 99 | 
-100 | if a or set({1}) or True or set({2}):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-101 |     pass
-    |
-    = help: Replace with truthy `set({1})`
+SIM222.py:93:6: SIM222 [*] Use `True` instead of `... or True`
+   |
+93 | a or frozenset() or True  # SIM222
+94 | 
+95 | a or frozenset(frozenset()) or True  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+96 | 
+97 | a or frozenset({1}) or True or frozenset({2})  # SIM222
+   |
+   = help: Replace with `True`
 
 ℹ Suggested fix
-95 95 | if a or {1} or True or {2}:  # SIM222
-96 96 |     pass
-97 97 | 
-98    |-if a or set({1}) or True or set({2}):  # SIM222
-   98 |+if set({1}):  # SIM222
-99 99 |     pass
-100 100 | 
-101 101 | if a or () or True:  # SIM222
+90 90 | 
+91 91 | a or frozenset() or True  # SIM222
+92 92 | 
+93    |-a or frozenset(frozenset()) or True  # SIM222
+   93 |+a or True  # SIM222
+94 94 | 
+95 95 | a or frozenset({1}) or True or frozenset({2})  # SIM222
+96 96 | 
 
-SIM222.py:101:4: SIM222 [*] Use `True` instead of `... or True`
-    |
-101 |     pass
-102 | 
-103 | if a or () or True:  # SIM222
-    |    ^^^^^^^^^^^^^^^ SIM222
-104 |     pass
-    |
-    = help: Replace with `True`
+SIM222.py:95:6: SIM222 [*] Use truthy `frozenset({1})` instead of `frozenset({1}) or ...`
+   |
+95 | a or frozenset(frozenset()) or True  # SIM222
+96 | 
+97 | a or frozenset({1}) or True or frozenset({2})  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+98 | 
+99 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
+   |
+   = help: Replace with truthy `frozenset({1})`
 
 ℹ Suggested fix
-98  98  | if a or set({1}) or True or set({2}):  # SIM222
-99  99  |     pass
-100 100 | 
-101     |-if a or () or True:  # SIM222
-    101 |+if True:  # SIM222
-102 102 |     pass
-103 103 | 
-104 104 | if a or tuple(()) or True:  # SIM222
+92 92 | 
+93 93 | a or frozenset(frozenset()) or True  # SIM222
+94 94 | 
+95    |-a or frozenset({1}) or True or frozenset({2})  # SIM222
+   95 |+a or frozenset({1})  # SIM222
+96 96 | 
+97 97 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
+98 98 | 
 
-SIM222.py:104:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:97:6: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `frozenset(frozenset({1})) or ...`
+   |
+97 | a or frozenset({1}) or True or frozenset({2})  # SIM222
+98 | 
+99 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+   |
+   = help: Replace with truthy `frozenset(frozenset({1}))`
+
+ℹ Suggested fix
+94 94 | 
+95 95 | a or frozenset({1}) or True or frozenset({2})  # SIM222
+96 96 | 
+97    |-a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
+   97 |+a or frozenset(frozenset({1}))  # SIM222
+98 98 | 
+99 99 | 
+100 100 | # Inside test `a` is simplified
+
+SIM222.py:102:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-104 |     pass
+102 | # Inside test `a` is simplified
+103 | 
+104 | bool(a or [1] or True or [2])  # SIM222
+    |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 105 | 
-106 | if a or tuple(()) or True:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^ SIM222
-107 |     pass
+106 | assert a or [1] or True or [2]  # SIM222
     |
-    = help: Replace with `True`
+    = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-101 101 | if a or () or True:  # SIM222
-102 102 |     pass
+99  99  | 
+100 100 | # Inside test `a` is simplified
+101 101 | 
+102     |-bool(a or [1] or True or [2])  # SIM222
+    102 |+bool([1])  # SIM222
 103 103 | 
-104     |-if a or tuple(()) or True:  # SIM222
-    104 |+if True:  # SIM222
-105 105 |     pass
-106 106 | 
-107 107 | if a or (1,) or True or (2,):  # SIM222
+104 104 | assert a or [1] or True or [2]  # SIM222
+105 105 | 
 
-SIM222.py:107:4: SIM222 [*] Use truthy `1,` instead of `... or 1, or ...`
+SIM222.py:104:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-107 |     pass
-108 | 
-109 | if a or (1,) or True or (2,):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-110 |     pass
-    |
-    = help: Replace with truthy `1,`
-
-ℹ Suggested fix
-104 104 | if a or tuple(()) or True:  # SIM222
-105 105 |     pass
-106 106 | 
-107     |-if a or (1,) or True or (2,):  # SIM222
-    107 |+if 1,:  # SIM222
-108 108 |     pass
-109 109 | 
-110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
-
-SIM222.py:110:4: SIM222 [*] Use truthy `tuple((1,))` instead of `... or tuple((1,)) or ...`
-    |
-110 |     pass
-111 | 
-112 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-113 |     pass
-    |
-    = help: Replace with truthy `tuple((1,))`
-
-ℹ Suggested fix
-107 107 | if a or (1,) or True or (2,):  # SIM222
-108 108 |     pass
-109 109 | 
-110     |-if a or tuple((1,)) or True or tuple((2,)):  # SIM222
-    110 |+if tuple((1,)):  # SIM222
-111 111 |     pass
-112 112 | 
-113 113 | if a or frozenset() or True:  # SIM222
-
-SIM222.py:113:4: SIM222 [*] Use `True` instead of `... or True`
-    |
-113 |     pass
-114 | 
-115 | if a or frozenset() or True:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-116 |     pass
-    |
-    = help: Replace with `True`
-
-ℹ Suggested fix
-110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
-111 111 |     pass
-112 112 | 
-113     |-if a or frozenset() or True:  # SIM222
-    113 |+if True:  # SIM222
-114 114 |     pass
-115 115 | 
-116 116 | if a or frozenset(frozenset()) or True:  # SIM222
-
-SIM222.py:116:4: SIM222 [*] Use `True` instead of `... or True`
-    |
-116 |     pass
-117 | 
-118 | if a or frozenset(frozenset()) or True:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-119 |     pass
-    |
-    = help: Replace with `True`
-
-ℹ Suggested fix
-113 113 | if a or frozenset() or True:  # SIM222
-114 114 |     pass
-115 115 | 
-116     |-if a or frozenset(frozenset()) or True:  # SIM222
-    116 |+if True:  # SIM222
-117 117 |     pass
-118 118 | 
-119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
-
-SIM222.py:119:4: SIM222 [*] Use truthy `frozenset({1})` instead of `... or frozenset({1}) or ...`
-    |
-119 |     pass
-120 | 
-121 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-122 |     pass
-    |
-    = help: Replace with truthy `frozenset({1})`
-
-ℹ Suggested fix
-116 116 | if a or frozenset(frozenset()) or True:  # SIM222
-117 117 |     pass
-118 118 | 
-119     |-if a or frozenset({1}) or True or frozenset({2}):  # SIM222
-    119 |+if frozenset({1}):  # SIM222
-120 120 |     pass
-121 121 | 
-122 122 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
-
-SIM222.py:122:4: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1})) or ...`
-    |
-122 |     pass
-123 | 
-124 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-125 |     pass
-    |
-    = help: Replace with truthy `frozenset(frozenset({1}))`
-
-ℹ Suggested fix
-119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
-120 120 |     pass
-121 121 | 
-122     |-if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
-    122 |+if frozenset(frozenset({1})):  # SIM222
-123 123 |     pass
-124 124 | 
-125 125 | 
-
-SIM222.py:128:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
-    |
-128 | # Inside test `a` is simplified
-129 | 
-130 | bool(a or [1] or True or [2])  # SIM222
-    |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-131 | 
-132 | assert a or [1] or True or [2]  # SIM222
-    |
-    = help: Replace with truthy `[1]`
-
-ℹ Suggested fix
-125 125 | 
-126 126 | # Inside test `a` is simplified
-127 127 | 
-128     |-bool(a or [1] or True or [2])  # SIM222
-    128 |+bool([1])  # SIM222
-129 129 | 
-130 130 | assert a or [1] or True or [2]  # SIM222
-131 131 | 
-
-SIM222.py:130:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
-    |
-130 | bool(a or [1] or True or [2])  # SIM222
-131 | 
-132 | assert a or [1] or True or [2]  # SIM222
+104 | bool(a or [1] or True or [2])  # SIM222
+105 | 
+106 | assert a or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-133 | 
-134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+107 | 
+108 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-127 127 | 
-128 128 | bool(a or [1] or True or [2])  # SIM222
-129 129 | 
-130     |-assert a or [1] or True or [2]  # SIM222
-    130 |+assert [1]  # SIM222
-131 131 | 
-132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-133 133 |     pass
+101 101 | 
+102 102 | bool(a or [1] or True or [2])  # SIM222
+103 103 | 
+104     |-assert a or [1] or True or [2]  # SIM222
+    104 |+assert [1]  # SIM222
+105 105 | 
+106 106 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+107 107 |     pass
 
-SIM222.py:132:5: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:106:5: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-132 | assert a or [1] or True or [2]  # SIM222
-133 | 
-134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+106 | assert a or [1] or True or [2]  # SIM222
+107 | 
+108 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
     |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-135 |     pass
+109 |     pass
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-129 129 | 
-130 130 | assert a or [1] or True or [2]  # SIM222
-131 131 | 
-132     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-    132 |+if ([1]) and (a or [1] or True or [2]):  # SIM222
-133 133 |     pass
-134 134 | 
-135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
+103 103 | 
+104 104 | assert a or [1] or True or [2]  # SIM222
+105 105 | 
+106     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    106 |+if ([1]) and (a or [1] or True or [2]):  # SIM222
+107 107 |     pass
+108 108 | 
+109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:132:35: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:106:35: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-132 | assert a or [1] or True or [2]  # SIM222
-133 | 
-134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+106 | assert a or [1] or True or [2]  # SIM222
+107 | 
+108 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-135 |     pass
+109 |     pass
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-129 129 | 
-130 130 | assert a or [1] or True or [2]  # SIM222
-131 131 | 
-132     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-    132 |+if (a or [1] or True or [2]) and ([1]):  # SIM222
-133 133 |     pass
-134 134 | 
-135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
+103 103 | 
+104 104 | assert a or [1] or True or [2]  # SIM222
+105 105 | 
+106     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    106 |+if (a or [1] or True or [2]) and ([1]):  # SIM222
+107 107 |     pass
+108 108 | 
+109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:135:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:109:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-135 |     pass
-136 | 
-137 | 0 if a or [1] or True or [2] else 1  # SIM222
+109 |     pass
+110 | 
+111 | 0 if a or [1] or True or [2] else 1  # SIM222
     |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-138 | 
-139 | while a or [1] or True or [2]:  # SIM222
+112 | 
+113 | while a or [1] or True or [2]:  # SIM222
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-133 133 |     pass
-134 134 | 
-135     |-0 if a or [1] or True or [2] else 1  # SIM222
-    135 |+0 if [1] else 1  # SIM222
-136 136 | 
-137 137 | while a or [1] or True or [2]:  # SIM222
-138 138 |     pass
+106 106 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+107 107 |     pass
+108 108 | 
+109     |-0 if a or [1] or True or [2] else 1  # SIM222
+    109 |+0 if [1] else 1  # SIM222
+110 110 | 
+111 111 | while a or [1] or True or [2]:  # SIM222
+112 112 |     pass
 
-SIM222.py:137:7: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:111:7: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-137 | 0 if a or [1] or True or [2] else 1  # SIM222
-138 | 
-139 | while a or [1] or True or [2]:  # SIM222
+111 | 0 if a or [1] or True or [2] else 1  # SIM222
+112 | 
+113 | while a or [1] or True or [2]:  # SIM222
     |       ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-140 |     pass
+114 |     pass
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-134 134 | 
-135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
-136 136 | 
-137     |-while a or [1] or True or [2]:  # SIM222
-    137 |+while [1]:  # SIM222
-138 138 |     pass
-139 139 | 
-140 140 | [
+108 108 | 
+109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
+110 110 | 
+111     |-while a or [1] or True or [2]:  # SIM222
+    111 |+while [1]:  # SIM222
+112 112 |     pass
+113 113 | 
+114 114 | [
 
-SIM222.py:144:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:118:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-144 |     for a in range(10)
-145 |     for b in range(10)
-146 |     if a or [1] or True or [2]  # SIM222
+118 |     for a in range(10)
+119 |     for b in range(10)
+120 |     if a or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-147 |     if b or [1] or True or [2]  # SIM222
-148 | ]
+121 |     if b or [1] or True or [2]  # SIM222
+122 | ]
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-141 141 |     0
-142 142 |     for a in range(10)
-143 143 |     for b in range(10)
-144     |-    if a or [1] or True or [2]  # SIM222
-    144 |+    if [1]  # SIM222
-145 145 |     if b or [1] or True or [2]  # SIM222
-146 146 | ]
-147 147 | 
+115 115 |     0
+116 116 |     for a in range(10)
+117 117 |     for b in range(10)
+118     |-    if a or [1] or True or [2]  # SIM222
+    118 |+    if [1]  # SIM222
+119 119 |     if b or [1] or True or [2]  # SIM222
+120 120 | ]
+121 121 | 
 
-SIM222.py:145:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:119:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-145 |     for b in range(10)
-146 |     if a or [1] or True or [2]  # SIM222
-147 |     if b or [1] or True or [2]  # SIM222
+119 |     for b in range(10)
+120 |     if a or [1] or True or [2]  # SIM222
+121 |     if b or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-148 | ]
+122 | ]
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-142 142 |     for a in range(10)
-143 143 |     for b in range(10)
-144 144 |     if a or [1] or True or [2]  # SIM222
-145     |-    if b or [1] or True or [2]  # SIM222
-    145 |+    if [1]  # SIM222
-146 146 | ]
-147 147 | 
-148 148 | {
+116 116 |     for a in range(10)
+117 117 |     for b in range(10)
+118 118 |     if a or [1] or True or [2]  # SIM222
+119     |-    if b or [1] or True or [2]  # SIM222
+    119 |+    if [1]  # SIM222
+120 120 | ]
+121 121 | 
+122 122 | {
 
-SIM222.py:152:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:126:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-152 |     for a in range(10)
-153 |     for b in range(10)
-154 |     if a or [1] or True or [2]  # SIM222
+126 |     for a in range(10)
+127 |     for b in range(10)
+128 |     if a or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-155 |     if b or [1] or True or [2]  # SIM222
-156 | }
+129 |     if b or [1] or True or [2]  # SIM222
+130 | }
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-149 149 |     0
-150 150 |     for a in range(10)
-151 151 |     for b in range(10)
-152     |-    if a or [1] or True or [2]  # SIM222
-    152 |+    if [1]  # SIM222
-153 153 |     if b or [1] or True or [2]  # SIM222
-154 154 | }
-155 155 | 
+123 123 |     0
+124 124 |     for a in range(10)
+125 125 |     for b in range(10)
+126     |-    if a or [1] or True or [2]  # SIM222
+    126 |+    if [1]  # SIM222
+127 127 |     if b or [1] or True or [2]  # SIM222
+128 128 | }
+129 129 | 
 
-SIM222.py:153:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:127:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-153 |     for b in range(10)
-154 |     if a or [1] or True or [2]  # SIM222
-155 |     if b or [1] or True or [2]  # SIM222
+127 |     for b in range(10)
+128 |     if a or [1] or True or [2]  # SIM222
+129 |     if b or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-156 | }
+130 | }
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-150 150 |     for a in range(10)
-151 151 |     for b in range(10)
-152 152 |     if a or [1] or True or [2]  # SIM222
-153     |-    if b or [1] or True or [2]  # SIM222
-    153 |+    if [1]  # SIM222
-154 154 | }
-155 155 | 
-156 156 | {
+124 124 |     for a in range(10)
+125 125 |     for b in range(10)
+126 126 |     if a or [1] or True or [2]  # SIM222
+127     |-    if b or [1] or True or [2]  # SIM222
+    127 |+    if [1]  # SIM222
+128 128 | }
+129 129 | 
+130 130 | {
 
-SIM222.py:160:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:134:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-160 |     for a in range(10)
-161 |     for b in range(10)
-162 |     if a or [1] or True or [2]  # SIM222
+134 |     for a in range(10)
+135 |     for b in range(10)
+136 |     if a or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-163 |     if b or [1] or True or [2]  # SIM222
-164 | }
+137 |     if b or [1] or True or [2]  # SIM222
+138 | }
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-157 157 |     0: 0
-158 158 |     for a in range(10)
-159 159 |     for b in range(10)
-160     |-    if a or [1] or True or [2]  # SIM222
-    160 |+    if [1]  # SIM222
-161 161 |     if b or [1] or True or [2]  # SIM222
-162 162 | }
-163 163 | 
+131 131 |     0: 0
+132 132 |     for a in range(10)
+133 133 |     for b in range(10)
+134     |-    if a or [1] or True or [2]  # SIM222
+    134 |+    if [1]  # SIM222
+135 135 |     if b or [1] or True or [2]  # SIM222
+136 136 | }
+137 137 | 
 
-SIM222.py:161:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:135:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-161 |     for b in range(10)
-162 |     if a or [1] or True or [2]  # SIM222
-163 |     if b or [1] or True or [2]  # SIM222
+135 |     for b in range(10)
+136 |     if a or [1] or True or [2]  # SIM222
+137 |     if b or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-164 | }
+138 | }
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-158 158 |     for a in range(10)
-159 159 |     for b in range(10)
-160 160 |     if a or [1] or True or [2]  # SIM222
-161     |-    if b or [1] or True or [2]  # SIM222
-    161 |+    if [1]  # SIM222
-162 162 | }
-163 163 | 
-164 164 | (
+132 132 |     for a in range(10)
+133 133 |     for b in range(10)
+134 134 |     if a or [1] or True or [2]  # SIM222
+135     |-    if b or [1] or True or [2]  # SIM222
+    135 |+    if [1]  # SIM222
+136 136 | }
+137 137 | 
+138 138 | (
 
-SIM222.py:168:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:142:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-168 |     for a in range(10)
-169 |     for b in range(10)
-170 |     if a or [1] or True or [2]  # SIM222
+142 |     for a in range(10)
+143 |     for b in range(10)
+144 |     if a or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-171 |     if b or [1] or True or [2]  # SIM222
-172 | )
+145 |     if b or [1] or True or [2]  # SIM222
+146 | )
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-165 165 |     0
-166 166 |     for a in range(10)
-167 167 |     for b in range(10)
-168     |-    if a or [1] or True or [2]  # SIM222
-    168 |+    if [1]  # SIM222
-169 169 |     if b or [1] or True or [2]  # SIM222
-170 170 | )
-171 171 | 
+139 139 |     0
+140 140 |     for a in range(10)
+141 141 |     for b in range(10)
+142     |-    if a or [1] or True or [2]  # SIM222
+    142 |+    if [1]  # SIM222
+143 143 |     if b or [1] or True or [2]  # SIM222
+144 144 | )
+145 145 | 
 
-SIM222.py:169:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:143:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
-169 |     for b in range(10)
-170 |     if a or [1] or True or [2]  # SIM222
-171 |     if b or [1] or True or [2]  # SIM222
+143 |     for b in range(10)
+144 |     if a or [1] or True or [2]  # SIM222
+145 |     if b or [1] or True or [2]  # SIM222
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
-172 | )
+146 | )
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-166 166 |     for a in range(10)
-167 167 |     for b in range(10)
-168 168 |     if a or [1] or True or [2]  # SIM222
-169     |-    if b or [1] or True or [2]  # SIM222
-    169 |+    if [1]  # SIM222
-170 170 | )
-171 171 | 
-172 172 | # Outside test `a` is not simplified
+140 140 |     for a in range(10)
+141 141 |     for b in range(10)
+142 142 |     if a or [1] or True or [2]  # SIM222
+143     |-    if b or [1] or True or [2]  # SIM222
+    143 |+    if [1]  # SIM222
+144 144 | )
+145 145 | 
+146 146 | # Outside test `a` is not simplified
 
-SIM222.py:174:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:148:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
-174 | # Outside test `a` is not simplified
-175 | 
-176 | a or [1] or True or [2]  # SIM222
+148 | # Outside test `a` is not simplified
+149 | 
+150 | a or [1] or True or [2]  # SIM222
     |      ^^^^^^^^^^^^^^^^^^ SIM222
-177 | 
-178 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+151 | 
+152 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-171 171 | 
-172 172 | # Outside test `a` is not simplified
-173 173 | 
-174     |-a or [1] or True or [2]  # SIM222
-    174 |+a or [1]  # SIM222
-175 175 | 
-176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
-177 177 |     pass
+145 145 | 
+146 146 | # Outside test `a` is not simplified
+147 147 | 
+148     |-a or [1] or True or [2]  # SIM222
+    148 |+a or [1]  # SIM222
+149 149 | 
+150 150 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+151 151 |     pass
 
-SIM222.py:176:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:150:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
-176 | a or [1] or True or [2]  # SIM222
-177 | 
-178 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+150 | a or [1] or True or [2]  # SIM222
+151 | 
+152 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
     |          ^^^^^^^^^^^^^^^^^^ SIM222
-179 |     pass
+153 |     pass
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-173 173 | 
-174 174 | a or [1] or True or [2]  # SIM222
-175 175 | 
-176     |-if (a or [1] or True or [2]) == (a or [1]):  # SIM222
-    176 |+if (a or [1]) == (a or [1]):  # SIM222
-177 177 |     pass
-178 178 | 
-179 179 | if f(a or [1] or True or [2]):  # SIM222
+147 147 | 
+148 148 | a or [1] or True or [2]  # SIM222
+149 149 | 
+150     |-if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+    150 |+if (a or [1]) == (a or [1]):  # SIM222
+151 151 |     pass
+152 152 | 
+153 153 | if f(a or [1] or True or [2]):  # SIM222
 
-SIM222.py:179:11: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:153:11: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
-179 |     pass
-180 | 
-181 | if f(a or [1] or True or [2]):  # SIM222
+153 |     pass
+154 | 
+155 | if f(a or [1] or True or [2]):  # SIM222
     |           ^^^^^^^^^^^^^^^^^^ SIM222
-182 |     pass
+156 |     pass
     |
     = help: Replace with truthy `[1]`
 
 ℹ Suggested fix
-176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
-177 177 |     pass
-178 178 | 
-179     |-if f(a or [1] or True or [2]):  # SIM222
-    179 |+if f(a or [1]):  # SIM222
-180 180 |     pass
+150 150 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+151 151 |     pass
+152 152 | 
+153     |-if f(a or [1] or True or [2]):  # SIM222
+    153 |+if f(a or [1]):  # SIM222
+154 154 |     pass
 
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -656,11 +656,11 @@ SIM222.py:97:6: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `frozenset
    97 |+a or frozenset(frozenset({1}))  # SIM222
 98 98 | 
 99 99 | 
-100 100 | # Inside test `a` is simplified
+100 100 | # Inside test `a` is simplified.
 
 SIM222.py:102:6: SIM222 [*] Use `True` instead of `... or True or ...`
     |
-102 | # Inside test `a` is simplified
+102 | # Inside test `a` is simplified.
 103 | 
 104 | bool(a or [1] or True or [2])  # SIM222
     |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
@@ -671,7 +671,7 @@ SIM222.py:102:6: SIM222 [*] Use `True` instead of `... or True or ...`
 
 ℹ Suggested fix
 99  99  | 
-100 100 | # Inside test `a` is simplified
+100 100 | # Inside test `a` is simplified.
 101 101 | 
 102     |-bool(a or [1] or True or [2])  # SIM222
     102 |+bool(True)  # SIM222
@@ -943,11 +943,11 @@ SIM222.py:143:8: SIM222 [*] Use `True` instead of `... or True or ...`
     143 |+    if True  # SIM222
 144 144 | )
 145 145 | 
-146 146 | # Outside test `a` is not simplified
+146 146 | # Outside test `a` is not simplified.
 
 SIM222.py:148:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
-148 | # Outside test `a` is not simplified
+148 | # Outside test `a` is not simplified.
 149 | 
 150 | a or [1] or True or [2]  # SIM222
     |      ^^^^^^^^^^^^^^^^^^ SIM222
@@ -958,7 +958,7 @@ SIM222.py:148:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
 
 ℹ Suggested fix
 145 145 | 
-146 146 | # Outside test `a` is not simplified
+146 146 | # Outside test `a` is not simplified.
 147 147 | 
 148     |-a or [1] or True or [2]  # SIM222
     148 |+a or [1]  # SIM222

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -56,7 +56,7 @@ SIM222.py:7:10: SIM222 [*] Use `True` instead of `... or True`
 9 9 | 
 10 10 | if a and True:  # OK
 
-SIM222.py:24:16: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:24:16: SIM222 [*] Use `True` instead of `True or ...`
    |
 24 |     pass
 25 | 
@@ -76,7 +76,7 @@ SIM222.py:24:16: SIM222 [*] Use `True` instead of `... or True`
 26 26 | 
 27 27 | if True or f() or a or g() or b:  # SIM222
 
-SIM222.py:27:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:27:4: SIM222 [*] Use `True` instead of `True or ...`
    |
 27 |     pass
 28 | 
@@ -96,7 +96,7 @@ SIM222.py:27:4: SIM222 [*] Use `True` instead of `... or True`
 29 29 | 
 30 30 | if a or True or f() or b or g():  # SIM222
 
-SIM222.py:30:4: SIM222 [*] Use `True` instead of `... or True`
+SIM222.py:30:4: SIM222 [*] Use `True` instead of `... or True or ...`
    |
 30 |     pass
 31 | 
@@ -134,7 +134,7 @@ SIM222.py:47:4: SIM222 [*] Use `True` instead of `... or True`
 49 49 | 
 50 50 | if a or "foo" or True or "bar":  # SIM222
 
-SIM222.py:50:4: SIM222 [*] Use truthy `"foo"` instead of `... or "foo"`
+SIM222.py:50:4: SIM222 [*] Use truthy `"foo"` instead of `... or "foo" or ...`
    |
 50 |     pass
 51 | 
@@ -174,7 +174,7 @@ SIM222.py:53:4: SIM222 [*] Use `True` instead of `... or True`
 55 55 | 
 56 56 | if a or 1 or True or 2:  # SIM222
 
-SIM222.py:56:4: SIM222 [*] Use truthy `1` instead of `... or 1`
+SIM222.py:56:4: SIM222 [*] Use truthy `1` instead of `... or 1 or ...`
    |
 56 |     pass
 57 | 
@@ -214,7 +214,7 @@ SIM222.py:59:4: SIM222 [*] Use `True` instead of `... or True`
 61 61 | 
 62 62 | if a or 0.1 or True or 0.2:  # SIM222
 
-SIM222.py:62:4: SIM222 [*] Use truthy `0.1` instead of `... or 0.1`
+SIM222.py:62:4: SIM222 [*] Use truthy `0.1` instead of `... or 0.1 or ...`
    |
 62 |     pass
 63 | 
@@ -274,7 +274,7 @@ SIM222.py:68:4: SIM222 [*] Use `True` instead of `... or True`
 70 70 | 
 71 71 | if a or [1] or True or [2]:  # SIM222
 
-SIM222.py:71:4: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:71:4: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
    |
 71 |     pass
 72 | 
@@ -294,7 +294,7 @@ SIM222.py:71:4: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 73 73 | 
 74 74 | if a or list([1]) or True or list([2]):  # SIM222
 
-SIM222.py:74:4: SIM222 [*] Use truthy `list([1])` instead of `... or list([1])`
+SIM222.py:74:4: SIM222 [*] Use truthy `list([1])` instead of `... or list([1]) or ...`
    |
 74 |     pass
 75 | 
@@ -354,7 +354,7 @@ SIM222.py:80:4: SIM222 [*] Use `True` instead of `... or True`
 82 82 | 
 83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
 
-SIM222.py:83:4: SIM222 [*] Use truthy `{1: 1}` instead of `... or {1: 1}`
+SIM222.py:83:4: SIM222 [*] Use truthy `{1: 1}` instead of `... or {1: 1} or ...`
    |
 83 |     pass
 84 | 
@@ -374,7 +374,7 @@ SIM222.py:83:4: SIM222 [*] Use truthy `{1: 1}` instead of `... or {1: 1}`
 85 85 | 
 86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
 
-SIM222.py:86:4: SIM222 [*] Use truthy `dict({1: 1})` instead of `... or dict({1: 1})`
+SIM222.py:86:4: SIM222 [*] Use truthy `dict({1: 1})` instead of `... or dict({1: 1}) or ...`
    |
 86 |     pass
 87 | 
@@ -434,7 +434,7 @@ SIM222.py:92:4: SIM222 [*] Use `True` instead of `... or True`
 94 94 | 
 95 95 | if a or {1} or True or {2}:  # SIM222
 
-SIM222.py:95:4: SIM222 [*] Use truthy `{1}` instead of `... or {1}`
+SIM222.py:95:4: SIM222 [*] Use truthy `{1}` instead of `... or {1} or ...`
    |
 95 |     pass
 96 | 
@@ -454,7 +454,7 @@ SIM222.py:95:4: SIM222 [*] Use truthy `{1}` instead of `... or {1}`
 97 97 | 
 98 98 | if a or set({1}) or True or set({2}):  # SIM222
 
-SIM222.py:98:4: SIM222 [*] Use truthy `set({1})` instead of `... or set({1})`
+SIM222.py:98:4: SIM222 [*] Use truthy `set({1})` instead of `... or set({1}) or ...`
     |
  98 |     pass
  99 | 
@@ -514,7 +514,7 @@ SIM222.py:104:4: SIM222 [*] Use `True` instead of `... or True`
 106 106 | 
 107 107 | if a or (1,) or True or (2,):  # SIM222
 
-SIM222.py:107:4: SIM222 [*] Use truthy `1,` instead of `... or 1,`
+SIM222.py:107:4: SIM222 [*] Use truthy `1,` instead of `... or 1, or ...`
     |
 107 |     pass
 108 | 
@@ -534,7 +534,7 @@ SIM222.py:107:4: SIM222 [*] Use truthy `1,` instead of `... or 1,`
 109 109 | 
 110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
 
-SIM222.py:110:4: SIM222 [*] Use truthy `tuple((1,))` instead of `... or tuple((1,))`
+SIM222.py:110:4: SIM222 [*] Use truthy `tuple((1,))` instead of `... or tuple((1,)) or ...`
     |
 110 |     pass
 111 | 
@@ -594,7 +594,7 @@ SIM222.py:116:4: SIM222 [*] Use `True` instead of `... or True`
 118 118 | 
 119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
 
-SIM222.py:119:4: SIM222 [*] Use truthy `frozenset({1})` instead of `... or frozenset({1})`
+SIM222.py:119:4: SIM222 [*] Use truthy `frozenset({1})` instead of `... or frozenset({1}) or ...`
     |
 119 |     pass
 120 | 
@@ -614,7 +614,7 @@ SIM222.py:119:4: SIM222 [*] Use truthy `frozenset({1})` instead of `... or froze
 121 121 | 
 122 122 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
 
-SIM222.py:122:4: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1}))`
+SIM222.py:122:4: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1})) or ...`
     |
 122 |     pass
 123 | 
@@ -634,7 +634,7 @@ SIM222.py:122:4: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `.
 124 124 | 
 125 125 | 
 
-SIM222.py:128:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:128:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 128 | # Inside test `a` is simplified
 129 | 
@@ -655,7 +655,7 @@ SIM222.py:128:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 130 130 | assert a or [1] or True or [2]  # SIM222
 131 131 | 
 
-SIM222.py:130:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:130:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 130 | bool(a or [1] or True or [2])  # SIM222
 131 | 
@@ -676,7 +676,7 @@ SIM222.py:130:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
 133 133 |     pass
 
-SIM222.py:132:5: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:132:5: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 132 | assert a or [1] or True or [2]  # SIM222
 133 | 
@@ -696,7 +696,7 @@ SIM222.py:132:5: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 134 134 | 
 135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:132:35: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:132:35: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 132 | assert a or [1] or True or [2]  # SIM222
 133 | 
@@ -716,7 +716,7 @@ SIM222.py:132:35: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 134 134 | 
 135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:135:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:135:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 135 |     pass
 136 | 
@@ -737,7 +737,7 @@ SIM222.py:135:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 137 137 | while a or [1] or True or [2]:  # SIM222
 138 138 |     pass
 
-SIM222.py:137:7: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:137:7: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 137 | 0 if a or [1] or True or [2] else 1  # SIM222
 138 | 
@@ -757,7 +757,7 @@ SIM222.py:137:7: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 139 139 | 
 140 140 | [
 
-SIM222.py:144:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:144:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 144 |     for a in range(10)
 145 |     for b in range(10)
@@ -778,7 +778,7 @@ SIM222.py:144:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 146 146 | ]
 147 147 | 
 
-SIM222.py:145:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:145:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 145 |     for b in range(10)
 146 |     if a or [1] or True or [2]  # SIM222
@@ -798,7 +798,7 @@ SIM222.py:145:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 147 147 | 
 148 148 | {
 
-SIM222.py:152:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:152:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 152 |     for a in range(10)
 153 |     for b in range(10)
@@ -819,7 +819,7 @@ SIM222.py:152:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 154 154 | }
 155 155 | 
 
-SIM222.py:153:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:153:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 153 |     for b in range(10)
 154 |     if a or [1] or True or [2]  # SIM222
@@ -839,7 +839,7 @@ SIM222.py:153:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 155 155 | 
 156 156 | {
 
-SIM222.py:160:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:160:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 160 |     for a in range(10)
 161 |     for b in range(10)
@@ -860,7 +860,7 @@ SIM222.py:160:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 162 162 | }
 163 163 | 
 
-SIM222.py:161:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:161:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 161 |     for b in range(10)
 162 |     if a or [1] or True or [2]  # SIM222
@@ -880,7 +880,7 @@ SIM222.py:161:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 163 163 | 
 164 164 | (
 
-SIM222.py:168:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:168:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 168 |     for a in range(10)
 169 |     for b in range(10)
@@ -901,7 +901,7 @@ SIM222.py:168:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 170 170 | )
 171 171 | 
 
-SIM222.py:169:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:169:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |
 169 |     for b in range(10)
 170 |     if a or [1] or True or [2]  # SIM222
@@ -921,7 +921,7 @@ SIM222.py:169:8: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 171 171 | 
 172 172 | # Outside test `a` is not simplified
 
-SIM222.py:174:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:174:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
 174 | # Outside test `a` is not simplified
 175 | 
@@ -942,7 +942,7 @@ SIM222.py:174:6: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
 177 177 |     pass
 
-SIM222.py:176:10: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:176:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
 176 | a or [1] or True or [2]  # SIM222
 177 | 
@@ -962,7 +962,7 @@ SIM222.py:176:10: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
 178 178 | 
 179 179 | if f(a or [1] or True or [2]):  # SIM222
 
-SIM222.py:179:11: SIM222 [*] Use truthy `[1]` instead of `... or [1]`
+SIM222.py:179:11: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |
 179 |     pass
 180 | 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -135,7 +135,7 @@ SIM222.py:47:6: SIM222 [*] Use `True` instead of `... or True`
 49 49 | a or "foo" or True or "bar"  # SIM222
 50 50 | 
 
-SIM222.py:49:6: SIM222 [*] Use truthy `"foo"` instead of `"foo" or ...`
+SIM222.py:49:6: SIM222 [*] Use `"foo"` instead of `"foo" or ...`
    |
 49 | a or "" or True  # SIM222
 50 | 
@@ -144,7 +144,7 @@ SIM222.py:49:6: SIM222 [*] Use truthy `"foo"` instead of `"foo" or ...`
 52 | 
 53 | a or 0 or True  # SIM222
    |
-   = help: Replace with truthy `"foo"`
+   = help: Replace with `"foo"`
 
 ℹ Suggested fix
 46 46 | 
@@ -177,7 +177,7 @@ SIM222.py:51:6: SIM222 [*] Use `True` instead of `... or True`
 53 53 | a or 1 or True or 2  # SIM222
 54 54 | 
 
-SIM222.py:53:6: SIM222 [*] Use truthy `1` instead of `1 or ...`
+SIM222.py:53:6: SIM222 [*] Use `1` instead of `1 or ...`
    |
 53 | a or 0 or True  # SIM222
 54 | 
@@ -186,7 +186,7 @@ SIM222.py:53:6: SIM222 [*] Use truthy `1` instead of `1 or ...`
 56 | 
 57 | a or 0.0 or True  # SIM222
    |
-   = help: Replace with truthy `1`
+   = help: Replace with `1`
 
 ℹ Suggested fix
 50 50 | 
@@ -219,7 +219,7 @@ SIM222.py:55:6: SIM222 [*] Use `True` instead of `... or True`
 57 57 | a or 0.1 or True or 0.2  # SIM222
 58 58 | 
 
-SIM222.py:57:6: SIM222 [*] Use truthy `0.1` instead of `0.1 or ...`
+SIM222.py:57:6: SIM222 [*] Use `0.1` instead of `0.1 or ...`
    |
 57 | a or 0.0 or True  # SIM222
 58 | 
@@ -228,7 +228,7 @@ SIM222.py:57:6: SIM222 [*] Use truthy `0.1` instead of `0.1 or ...`
 60 | 
 61 | a or [] or True  # SIM222
    |
-   = help: Replace with truthy `0.1`
+   = help: Replace with `0.1`
 
 ℹ Suggested fix
 54 54 | 
@@ -282,7 +282,7 @@ SIM222.py:61:6: SIM222 [*] Use `True` instead of `... or True`
 63 63 | a or [1] or True or [2]  # SIM222
 64 64 | 
 
-SIM222.py:63:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:63:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
    |
 63 | a or list([]) or True  # SIM222
 64 | 
@@ -291,7 +291,7 @@ SIM222.py:63:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
 66 | 
 67 | a or list([1]) or True or list([2])  # SIM222
    |
-   = help: Replace with truthy `[1]`
+   = help: Replace with `[1]`
 
 ℹ Suggested fix
 60 60 | 
@@ -303,7 +303,7 @@ SIM222.py:63:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
 65 65 | a or list([1]) or True or list([2])  # SIM222
 66 66 | 
 
-SIM222.py:65:6: SIM222 [*] Use truthy `list([1])` instead of `list([1]) or ...`
+SIM222.py:65:6: SIM222 [*] Use `list([1])` instead of `list([1]) or ...`
    |
 65 | a or [1] or True or [2]  # SIM222
 66 | 
@@ -312,7 +312,7 @@ SIM222.py:65:6: SIM222 [*] Use truthy `list([1])` instead of `list([1]) or ...`
 68 | 
 69 | a or {} or True  # SIM222
    |
-   = help: Replace with truthy `list([1])`
+   = help: Replace with `list([1])`
 
 ℹ Suggested fix
 62 62 | 
@@ -366,7 +366,7 @@ SIM222.py:69:6: SIM222 [*] Use `True` instead of `... or True`
 71 71 | a or {1: 1} or True or {2: 2}  # SIM222
 72 72 | 
 
-SIM222.py:71:6: SIM222 [*] Use truthy `{1: 1}` instead of `{1: 1} or ...`
+SIM222.py:71:6: SIM222 [*] Use `{1: 1}` instead of `{1: 1} or ...`
    |
 71 | a or dict() or True  # SIM222
 72 | 
@@ -375,7 +375,7 @@ SIM222.py:71:6: SIM222 [*] Use truthy `{1: 1}` instead of `{1: 1} or ...`
 74 | 
 75 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
    |
-   = help: Replace with truthy `{1: 1}`
+   = help: Replace with `{1: 1}`
 
 ℹ Suggested fix
 68 68 | 
@@ -387,7 +387,7 @@ SIM222.py:71:6: SIM222 [*] Use truthy `{1: 1}` instead of `{1: 1} or ...`
 73 73 | a or dict({1: 1}) or True or dict({2: 2})  # SIM222
 74 74 | 
 
-SIM222.py:73:6: SIM222 [*] Use truthy `dict({1: 1})` instead of `dict({1: 1}) or ...`
+SIM222.py:73:6: SIM222 [*] Use `dict({1: 1})` instead of `dict({1: 1}) or ...`
    |
 73 | a or {1: 1} or True or {2: 2}  # SIM222
 74 | 
@@ -396,7 +396,7 @@ SIM222.py:73:6: SIM222 [*] Use truthy `dict({1: 1})` instead of `dict({1: 1}) or
 76 | 
 77 | a or set() or True  # SIM222
    |
-   = help: Replace with truthy `dict({1: 1})`
+   = help: Replace with `dict({1: 1})`
 
 ℹ Suggested fix
 70 70 | 
@@ -450,7 +450,7 @@ SIM222.py:77:6: SIM222 [*] Use `True` instead of `... or True`
 79 79 | a or {1} or True or {2}  # SIM222
 80 80 | 
 
-SIM222.py:79:6: SIM222 [*] Use truthy `{1}` instead of `{1} or ...`
+SIM222.py:79:6: SIM222 [*] Use `{1}` instead of `{1} or ...`
    |
 79 | a or set(set()) or True  # SIM222
 80 | 
@@ -459,7 +459,7 @@ SIM222.py:79:6: SIM222 [*] Use truthy `{1}` instead of `{1} or ...`
 82 | 
 83 | a or set({1}) or True or set({2})  # SIM222
    |
-   = help: Replace with truthy `{1}`
+   = help: Replace with `{1}`
 
 ℹ Suggested fix
 76 76 | 
@@ -471,7 +471,7 @@ SIM222.py:79:6: SIM222 [*] Use truthy `{1}` instead of `{1} or ...`
 81 81 | a or set({1}) or True or set({2})  # SIM222
 82 82 | 
 
-SIM222.py:81:6: SIM222 [*] Use truthy `set({1})` instead of `set({1}) or ...`
+SIM222.py:81:6: SIM222 [*] Use `set({1})` instead of `set({1}) or ...`
    |
 81 | a or {1} or True or {2}  # SIM222
 82 | 
@@ -480,7 +480,7 @@ SIM222.py:81:6: SIM222 [*] Use truthy `set({1})` instead of `set({1}) or ...`
 84 | 
 85 | a or () or True  # SIM222
    |
-   = help: Replace with truthy `set({1})`
+   = help: Replace with `set({1})`
 
 ℹ Suggested fix
 78 78 | 
@@ -534,7 +534,7 @@ SIM222.py:85:6: SIM222 [*] Use `True` instead of `... or True`
 87 87 | a or (1,) or True or (2,)  # SIM222
 88 88 | 
 
-SIM222.py:87:6: SIM222 [*] Use truthy `1,` instead of `1, or ...`
+SIM222.py:87:6: SIM222 [*] Use `1,` instead of `1, or ...`
    |
 87 | a or tuple(()) or True  # SIM222
 88 | 
@@ -543,7 +543,7 @@ SIM222.py:87:6: SIM222 [*] Use truthy `1,` instead of `1, or ...`
 90 | 
 91 | a or tuple((1,)) or True or tuple((2,))  # SIM222
    |
-   = help: Replace with truthy `1,`
+   = help: Replace with `1,`
 
 ℹ Suggested fix
 84 84 | 
@@ -555,7 +555,7 @@ SIM222.py:87:6: SIM222 [*] Use truthy `1,` instead of `1, or ...`
 89 89 | a or tuple((1,)) or True or tuple((2,))  # SIM222
 90 90 | 
 
-SIM222.py:89:6: SIM222 [*] Use truthy `tuple((1,))` instead of `tuple((1,)) or ...`
+SIM222.py:89:6: SIM222 [*] Use `tuple((1,))` instead of `tuple((1,)) or ...`
    |
 89 | a or (1,) or True or (2,)  # SIM222
 90 | 
@@ -564,7 +564,7 @@ SIM222.py:89:6: SIM222 [*] Use truthy `tuple((1,))` instead of `tuple((1,)) or .
 92 | 
 93 | a or frozenset() or True  # SIM222
    |
-   = help: Replace with truthy `tuple((1,))`
+   = help: Replace with `tuple((1,))`
 
 ℹ Suggested fix
 86 86 | 
@@ -618,7 +618,7 @@ SIM222.py:93:6: SIM222 [*] Use `True` instead of `... or True`
 95 95 | a or frozenset({1}) or True or frozenset({2})  # SIM222
 96 96 | 
 
-SIM222.py:95:6: SIM222 [*] Use truthy `frozenset({1})` instead of `frozenset({1}) or ...`
+SIM222.py:95:6: SIM222 [*] Use `frozenset({1})` instead of `frozenset({1}) or ...`
    |
 95 | a or frozenset(frozenset()) or True  # SIM222
 96 | 
@@ -627,7 +627,7 @@ SIM222.py:95:6: SIM222 [*] Use truthy `frozenset({1})` instead of `frozenset({1}
 98 | 
 99 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
    |
-   = help: Replace with truthy `frozenset({1})`
+   = help: Replace with `frozenset({1})`
 
 ℹ Suggested fix
 92 92 | 
@@ -639,14 +639,14 @@ SIM222.py:95:6: SIM222 [*] Use truthy `frozenset({1})` instead of `frozenset({1}
 97 97 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
 98 98 | 
 
-SIM222.py:97:6: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `frozenset(frozenset({1})) or ...`
+SIM222.py:97:6: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `frozenset(frozenset({1})) or ...`
    |
 97 | a or frozenset({1}) or True or frozenset({2})  # SIM222
 98 | 
 99 | a or frozenset(frozenset({1})) or True or frozenset(frozenset({2}))  # SIM222
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
    |
-   = help: Replace with truthy `frozenset(frozenset({1}))`
+   = help: Replace with `frozenset(frozenset({1}))`
 
 ℹ Suggested fix
 94 94 | 
@@ -945,7 +945,7 @@ SIM222.py:143:8: SIM222 [*] Use `True` instead of `... or True or ...`
 145 145 | 
 146 146 | # Outside test `a` is not simplified
 
-SIM222.py:148:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:148:6: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
 148 | # Outside test `a` is not simplified
 149 | 
@@ -954,7 +954,7 @@ SIM222.py:148:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
 151 | 
 152 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `[1]`
 
 ℹ Suggested fix
 145 145 | 
@@ -966,7 +966,7 @@ SIM222.py:148:6: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
 150 150 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
 151 151 |     pass
 
-SIM222.py:150:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:150:10: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
 150 | a or [1] or True or [2]  # SIM222
 151 | 
@@ -974,7 +974,7 @@ SIM222.py:150:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |          ^^^^^^^^^^^^^^^^^^ SIM222
 153 |     pass
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `[1]`
 
 ℹ Suggested fix
 147 147 | 
@@ -986,7 +986,7 @@ SIM222.py:150:10: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
 152 152 | 
 153 153 | if f(a or [1] or True or [2]):  # SIM222
 
-SIM222.py:153:11: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
+SIM222.py:153:11: SIM222 [*] Use `[1]` instead of `[1] or ...`
     |
 153 |     pass
 154 | 
@@ -994,7 +994,7 @@ SIM222.py:153:11: SIM222 [*] Use truthy `[1]` instead of `[1] or ...`
     |           ^^^^^^^^^^^^^^^^^^ SIM222
 156 |     pass
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `[1]`
 
 ℹ Suggested fix
 150 150 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -658,7 +658,7 @@ SIM222.py:97:6: SIM222 [*] Use truthy `frozenset(frozenset({1}))` instead of `fr
 99 99 | 
 100 100 | # Inside test `a` is simplified
 
-SIM222.py:102:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:102:6: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 102 | # Inside test `a` is simplified
 103 | 
@@ -667,19 +667,19 @@ SIM222.py:102:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 105 | 
 106 | assert a or [1] or True or [2]  # SIM222
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 99  99  | 
 100 100 | # Inside test `a` is simplified
 101 101 | 
 102     |-bool(a or [1] or True or [2])  # SIM222
-    102 |+bool([1])  # SIM222
+    102 |+bool(True)  # SIM222
 103 103 | 
 104 104 | assert a or [1] or True or [2]  # SIM222
 105 105 | 
 
-SIM222.py:104:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:104:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 104 | bool(a or [1] or True or [2])  # SIM222
 105 | 
@@ -688,19 +688,19 @@ SIM222.py:104:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 107 | 
 108 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 101 101 | 
 102 102 | bool(a or [1] or True or [2])  # SIM222
 103 103 | 
 104     |-assert a or [1] or True or [2]  # SIM222
-    104 |+assert [1]  # SIM222
+    104 |+assert True  # SIM222
 105 105 | 
 106 106 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
 107 107 |     pass
 
-SIM222.py:106:5: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:106:5: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 106 | assert a or [1] or True or [2]  # SIM222
 107 | 
@@ -708,19 +708,19 @@ SIM222.py:106:5: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 109 |     pass
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 103 103 | 
 104 104 | assert a or [1] or True or [2]  # SIM222
 105 105 | 
 106     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-    106 |+if ([1]) and (a or [1] or True or [2]):  # SIM222
+    106 |+if (True) and (a or [1] or True or [2]):  # SIM222
 107 107 |     pass
 108 108 | 
 109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:106:35: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:106:35: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 106 | assert a or [1] or True or [2]  # SIM222
 107 | 
@@ -728,19 +728,19 @@ SIM222.py:106:35: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |                                   ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 109 |     pass
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 103 103 | 
 104 104 | assert a or [1] or True or [2]  # SIM222
 105 105 | 
 106     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
-    106 |+if (a or [1] or True or [2]) and ([1]):  # SIM222
+    106 |+if (a or [1] or True or [2]) and (True):  # SIM222
 107 107 |     pass
 108 108 | 
 109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 
-SIM222.py:109:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:109:6: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 109 |     pass
 110 | 
@@ -749,19 +749,19 @@ SIM222.py:109:6: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 112 | 
 113 | while a or [1] or True or [2]:  # SIM222
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 106 106 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
 107 107 |     pass
 108 108 | 
 109     |-0 if a or [1] or True or [2] else 1  # SIM222
-    109 |+0 if [1] else 1  # SIM222
+    109 |+0 if True else 1  # SIM222
 110 110 | 
 111 111 | while a or [1] or True or [2]:  # SIM222
 112 112 |     pass
 
-SIM222.py:111:7: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:111:7: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 111 | 0 if a or [1] or True or [2] else 1  # SIM222
 112 | 
@@ -769,19 +769,19 @@ SIM222.py:111:7: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |       ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 114 |     pass
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 108 108 | 
 109 109 | 0 if a or [1] or True or [2] else 1  # SIM222
 110 110 | 
 111     |-while a or [1] or True or [2]:  # SIM222
-    111 |+while [1]:  # SIM222
+    111 |+while True:  # SIM222
 112 112 |     pass
 113 113 | 
 114 114 | [
 
-SIM222.py:118:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:118:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 118 |     for a in range(10)
 119 |     for b in range(10)
@@ -790,19 +790,19 @@ SIM222.py:118:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 121 |     if b or [1] or True or [2]  # SIM222
 122 | ]
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 115 115 |     0
 116 116 |     for a in range(10)
 117 117 |     for b in range(10)
 118     |-    if a or [1] or True or [2]  # SIM222
-    118 |+    if [1]  # SIM222
+    118 |+    if True  # SIM222
 119 119 |     if b or [1] or True or [2]  # SIM222
 120 120 | ]
 121 121 | 
 
-SIM222.py:119:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:119:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 119 |     for b in range(10)
 120 |     if a or [1] or True or [2]  # SIM222
@@ -810,19 +810,19 @@ SIM222.py:119:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 122 | ]
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 116 116 |     for a in range(10)
 117 117 |     for b in range(10)
 118 118 |     if a or [1] or True or [2]  # SIM222
 119     |-    if b or [1] or True or [2]  # SIM222
-    119 |+    if [1]  # SIM222
+    119 |+    if True  # SIM222
 120 120 | ]
 121 121 | 
 122 122 | {
 
-SIM222.py:126:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:126:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 126 |     for a in range(10)
 127 |     for b in range(10)
@@ -831,19 +831,19 @@ SIM222.py:126:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 129 |     if b or [1] or True or [2]  # SIM222
 130 | }
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 123 123 |     0
 124 124 |     for a in range(10)
 125 125 |     for b in range(10)
 126     |-    if a or [1] or True or [2]  # SIM222
-    126 |+    if [1]  # SIM222
+    126 |+    if True  # SIM222
 127 127 |     if b or [1] or True or [2]  # SIM222
 128 128 | }
 129 129 | 
 
-SIM222.py:127:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:127:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 127 |     for b in range(10)
 128 |     if a or [1] or True or [2]  # SIM222
@@ -851,19 +851,19 @@ SIM222.py:127:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 130 | }
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 124 124 |     for a in range(10)
 125 125 |     for b in range(10)
 126 126 |     if a or [1] or True or [2]  # SIM222
 127     |-    if b or [1] or True or [2]  # SIM222
-    127 |+    if [1]  # SIM222
+    127 |+    if True  # SIM222
 128 128 | }
 129 129 | 
 130 130 | {
 
-SIM222.py:134:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:134:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 134 |     for a in range(10)
 135 |     for b in range(10)
@@ -872,19 +872,19 @@ SIM222.py:134:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 137 |     if b or [1] or True or [2]  # SIM222
 138 | }
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 131 131 |     0: 0
 132 132 |     for a in range(10)
 133 133 |     for b in range(10)
 134     |-    if a or [1] or True or [2]  # SIM222
-    134 |+    if [1]  # SIM222
+    134 |+    if True  # SIM222
 135 135 |     if b or [1] or True or [2]  # SIM222
 136 136 | }
 137 137 | 
 
-SIM222.py:135:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:135:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 135 |     for b in range(10)
 136 |     if a or [1] or True or [2]  # SIM222
@@ -892,19 +892,19 @@ SIM222.py:135:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 138 | }
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 132 132 |     for a in range(10)
 133 133 |     for b in range(10)
 134 134 |     if a or [1] or True or [2]  # SIM222
 135     |-    if b or [1] or True or [2]  # SIM222
-    135 |+    if [1]  # SIM222
+    135 |+    if True  # SIM222
 136 136 | }
 137 137 | 
 138 138 | (
 
-SIM222.py:142:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:142:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 142 |     for a in range(10)
 143 |     for b in range(10)
@@ -913,19 +913,19 @@ SIM222.py:142:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
 145 |     if b or [1] or True or [2]  # SIM222
 146 | )
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 139 139 |     0
 140 140 |     for a in range(10)
 141 141 |     for b in range(10)
 142     |-    if a or [1] or True or [2]  # SIM222
-    142 |+    if [1]  # SIM222
+    142 |+    if True  # SIM222
 143 143 |     if b or [1] or True or [2]  # SIM222
 144 144 | )
 145 145 | 
 
-SIM222.py:143:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
+SIM222.py:143:8: SIM222 [*] Use `True` instead of `... or True or ...`
     |
 143 |     for b in range(10)
 144 |     if a or [1] or True or [2]  # SIM222
@@ -933,14 +933,14 @@ SIM222.py:143:8: SIM222 [*] Use truthy `[1]` instead of `... or [1] or ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
 146 | )
     |
-    = help: Replace with truthy `[1]`
+    = help: Replace with `True`
 
 ℹ Suggested fix
 140 140 |     for a in range(10)
 141 141 |     for b in range(10)
 142 142 |     if a or [1] or True or [2]  # SIM222
 143     |-    if b or [1] or True or [2]  # SIM222
-    143 |+    if [1]  # SIM222
+    143 |+    if True  # SIM222
 144 144 | )
 145 145 | 
 146 146 | # Outside test `a` is not simplified

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM222_SIM222.py.snap
@@ -116,4 +116,868 @@ SIM222.py:30:4: SIM222 [*] Use `True` instead of `... or True`
 32 32 | 
 33 33 | 
 
+SIM222.py:47:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+47 | if a or "" or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^ SIM222
+48 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+44 44 |     pass
+45 45 | 
+46 46 | 
+47    |-if a or "" or True:  # SIM222
+   47 |+if True:  # SIM222
+48 48 |     pass
+49 49 | 
+50 50 | if a or "foo" or True or "bar":  # SIM222
+
+SIM222.py:50:4: SIM222 [*] Use `"foo"` instead of `... or "foo"`
+   |
+50 |     pass
+51 | 
+52 | if a or "foo" or True or "bar":  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+53 |     pass
+   |
+   = help: Replace with `"foo"`
+
+ℹ Suggested fix
+47 47 | if a or "" or True:  # SIM222
+48 48 |     pass
+49 49 | 
+50    |-if a or "foo" or True or "bar":  # SIM222
+   50 |+if "foo":  # SIM222
+51 51 |     pass
+52 52 | 
+53 53 | if a or 0 or True:  # SIM222
+
+SIM222.py:53:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+53 |     pass
+54 | 
+55 | if a or 0 or True:  # SIM222
+   |    ^^^^^^^^^^^^^^ SIM222
+56 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+50 50 | if a or "foo" or True or "bar":  # SIM222
+51 51 |     pass
+52 52 | 
+53    |-if a or 0 or True:  # SIM222
+   53 |+if True:  # SIM222
+54 54 |     pass
+55 55 | 
+56 56 | if a or 1 or True or 2:  # SIM222
+
+SIM222.py:56:4: SIM222 [*] Use `1` instead of `... or 1`
+   |
+56 |     pass
+57 | 
+58 | if a or 1 or True or 2:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^ SIM222
+59 |     pass
+   |
+   = help: Replace with `1`
+
+ℹ Suggested fix
+53 53 | if a or 0 or True:  # SIM222
+54 54 |     pass
+55 55 | 
+56    |-if a or 1 or True or 2:  # SIM222
+   56 |+if 1:  # SIM222
+57 57 |     pass
+58 58 | 
+59 59 | if a or 0.0 or True:  # SIM222
+
+SIM222.py:59:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+59 |     pass
+60 | 
+61 | if a or 0.0 or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^^ SIM222
+62 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+56 56 | if a or 1 or True or 2:  # SIM222
+57 57 |     pass
+58 58 | 
+59    |-if a or 0.0 or True:  # SIM222
+   59 |+if True:  # SIM222
+60 60 |     pass
+61 61 | 
+62 62 | if a or 0.1 or True or 0.2:  # SIM222
+
+SIM222.py:62:4: SIM222 [*] Use `0.1` instead of `... or 0.1`
+   |
+62 |     pass
+63 | 
+64 | if a or 0.1 or True or 0.2:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+65 |     pass
+   |
+   = help: Replace with `0.1`
+
+ℹ Suggested fix
+59 59 | if a or 0.0 or True:  # SIM222
+60 60 |     pass
+61 61 | 
+62    |-if a or 0.1 or True or 0.2:  # SIM222
+   62 |+if 0.1:  # SIM222
+63 63 |     pass
+64 64 | 
+65 65 | if a or [] or True:  # SIM222
+
+SIM222.py:65:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+65 |     pass
+66 | 
+67 | if a or [] or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^ SIM222
+68 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+62 62 | if a or 0.1 or True or 0.2:  # SIM222
+63 63 |     pass
+64 64 | 
+65    |-if a or [] or True:  # SIM222
+   65 |+if True:  # SIM222
+66 66 |     pass
+67 67 | 
+68 68 | if a or list([]) or True:  # SIM222
+
+SIM222.py:68:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+68 |     pass
+69 | 
+70 | if a or list([]) or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^ SIM222
+71 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+65 65 | if a or [] or True:  # SIM222
+66 66 |     pass
+67 67 | 
+68    |-if a or list([]) or True:  # SIM222
+   68 |+if True:  # SIM222
+69 69 |     pass
+70 70 | 
+71 71 | if a or [1] or True or [2]:  # SIM222
+
+SIM222.py:71:4: SIM222 [*] Use `[1]` instead of `... or [1]`
+   |
+71 |     pass
+72 | 
+73 | if a or [1] or True or [2]:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+74 |     pass
+   |
+   = help: Replace with `[1]`
+
+ℹ Suggested fix
+68 68 | if a or list([]) or True:  # SIM222
+69 69 |     pass
+70 70 | 
+71    |-if a or [1] or True or [2]:  # SIM222
+   71 |+if [1]:  # SIM222
+72 72 |     pass
+73 73 | 
+74 74 | if a or list([1]) or True or list([2]):  # SIM222
+
+SIM222.py:74:4: SIM222 [*] Use `list([1])` instead of `... or list([1])`
+   |
+74 |     pass
+75 | 
+76 | if a or list([1]) or True or list([2]):  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+77 |     pass
+   |
+   = help: Replace with `list([1])`
+
+ℹ Suggested fix
+71 71 | if a or [1] or True or [2]:  # SIM222
+72 72 |     pass
+73 73 | 
+74    |-if a or list([1]) or True or list([2]):  # SIM222
+   74 |+if list([1]):  # SIM222
+75 75 |     pass
+76 76 | 
+77 77 | if a or {} or True:  # SIM222
+
+SIM222.py:77:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+77 |     pass
+78 | 
+79 | if a or {} or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^ SIM222
+80 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+74 74 | if a or list([1]) or True or list([2]):  # SIM222
+75 75 |     pass
+76 76 | 
+77    |-if a or {} or True:  # SIM222
+   77 |+if True:  # SIM222
+78 78 |     pass
+79 79 | 
+80 80 | if a or dict() or True:  # SIM222
+
+SIM222.py:80:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+80 |     pass
+81 | 
+82 | if a or dict() or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^ SIM222
+83 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+77 77 | if a or {} or True:  # SIM222
+78 78 |     pass
+79 79 | 
+80    |-if a or dict() or True:  # SIM222
+   80 |+if True:  # SIM222
+81 81 |     pass
+82 82 | 
+83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
+
+SIM222.py:83:4: SIM222 [*] Use `{1: 1}` instead of `... or {1: 1}`
+   |
+83 |     pass
+84 | 
+85 | if a or {1: 1} or True or {2: 2}:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+86 |     pass
+   |
+   = help: Replace with `{1: 1}`
+
+ℹ Suggested fix
+80 80 | if a or dict() or True:  # SIM222
+81 81 |     pass
+82 82 | 
+83    |-if a or {1: 1} or True or {2: 2}:  # SIM222
+   83 |+if {1: 1}:  # SIM222
+84 84 |     pass
+85 85 | 
+86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+
+SIM222.py:86:4: SIM222 [*] Use `dict({1: 1})` instead of `... or dict({1: 1})`
+   |
+86 |     pass
+87 | 
+88 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+89 |     pass
+   |
+   = help: Replace with `dict({1: 1})`
+
+ℹ Suggested fix
+83 83 | if a or {1: 1} or True or {2: 2}:  # SIM222
+84 84 |     pass
+85 85 | 
+86    |-if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+   86 |+if dict({1: 1}):  # SIM222
+87 87 |     pass
+88 88 | 
+89 89 | if a or set() or True:  # SIM222
+
+SIM222.py:89:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+89 |     pass
+90 | 
+91 | if a or set() or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^ SIM222
+92 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+86 86 | if a or dict({1: 1}) or True or dict({2: 2}):  # SIM222
+87 87 |     pass
+88 88 | 
+89    |-if a or set() or True:  # SIM222
+   89 |+if True:  # SIM222
+90 90 |     pass
+91 91 | 
+92 92 | if a or set(set()) or True:  # SIM222
+
+SIM222.py:92:4: SIM222 [*] Use `True` instead of `... or True`
+   |
+92 |     pass
+93 | 
+94 | if a or set(set()) or True:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+95 |     pass
+   |
+   = help: Replace with `True`
+
+ℹ Suggested fix
+89 89 | if a or set() or True:  # SIM222
+90 90 |     pass
+91 91 | 
+92    |-if a or set(set()) or True:  # SIM222
+   92 |+if True:  # SIM222
+93 93 |     pass
+94 94 | 
+95 95 | if a or {1} or True or {2}:  # SIM222
+
+SIM222.py:95:4: SIM222 [*] Use `{1}` instead of `... or {1}`
+   |
+95 |     pass
+96 | 
+97 | if a or {1} or True or {2}:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+98 |     pass
+   |
+   = help: Replace with `{1}`
+
+ℹ Suggested fix
+92 92 | if a or set(set()) or True:  # SIM222
+93 93 |     pass
+94 94 | 
+95    |-if a or {1} or True or {2}:  # SIM222
+   95 |+if {1}:  # SIM222
+96 96 |     pass
+97 97 | 
+98 98 | if a or set({1}) or True or set({2}):  # SIM222
+
+SIM222.py:98:4: SIM222 [*] Use `set({1})` instead of `... or set({1})`
+    |
+ 98 |     pass
+ 99 | 
+100 | if a or set({1}) or True or set({2}):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+101 |     pass
+    |
+    = help: Replace with `set({1})`
+
+ℹ Suggested fix
+95 95 | if a or {1} or True or {2}:  # SIM222
+96 96 |     pass
+97 97 | 
+98    |-if a or set({1}) or True or set({2}):  # SIM222
+   98 |+if set({1}):  # SIM222
+99 99 |     pass
+100 100 | 
+101 101 | if a or () or True:  # SIM222
+
+SIM222.py:101:4: SIM222 [*] Use `True` instead of `... or True`
+    |
+101 |     pass
+102 | 
+103 | if a or () or True:  # SIM222
+    |    ^^^^^^^^^^^^^^^ SIM222
+104 |     pass
+    |
+    = help: Replace with `True`
+
+ℹ Suggested fix
+98  98  | if a or set({1}) or True or set({2}):  # SIM222
+99  99  |     pass
+100 100 | 
+101     |-if a or () or True:  # SIM222
+    101 |+if True:  # SIM222
+102 102 |     pass
+103 103 | 
+104 104 | if a or tuple(()) or True:  # SIM222
+
+SIM222.py:104:4: SIM222 [*] Use `True` instead of `... or True`
+    |
+104 |     pass
+105 | 
+106 | if a or tuple(()) or True:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^ SIM222
+107 |     pass
+    |
+    = help: Replace with `True`
+
+ℹ Suggested fix
+101 101 | if a or () or True:  # SIM222
+102 102 |     pass
+103 103 | 
+104     |-if a or tuple(()) or True:  # SIM222
+    104 |+if True:  # SIM222
+105 105 |     pass
+106 106 | 
+107 107 | if a or (1,) or True or (2,):  # SIM222
+
+SIM222.py:107:4: SIM222 [*] Use `1,` instead of `... or 1,`
+    |
+107 |     pass
+108 | 
+109 | if a or (1,) or True or (2,):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+110 |     pass
+    |
+    = help: Replace with `1,`
+
+ℹ Suggested fix
+104 104 | if a or tuple(()) or True:  # SIM222
+105 105 |     pass
+106 106 | 
+107     |-if a or (1,) or True or (2,):  # SIM222
+    107 |+if 1,:  # SIM222
+108 108 |     pass
+109 109 | 
+110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
+
+SIM222.py:110:4: SIM222 [*] Use `tuple((1,))` instead of `... or tuple((1,))`
+    |
+110 |     pass
+111 | 
+112 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+113 |     pass
+    |
+    = help: Replace with `tuple((1,))`
+
+ℹ Suggested fix
+107 107 | if a or (1,) or True or (2,):  # SIM222
+108 108 |     pass
+109 109 | 
+110     |-if a or tuple((1,)) or True or tuple((2,)):  # SIM222
+    110 |+if tuple((1,)):  # SIM222
+111 111 |     pass
+112 112 | 
+113 113 | if a or frozenset() or True:  # SIM222
+
+SIM222.py:113:4: SIM222 [*] Use `True` instead of `... or True`
+    |
+113 |     pass
+114 | 
+115 | if a or frozenset() or True:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+116 |     pass
+    |
+    = help: Replace with `True`
+
+ℹ Suggested fix
+110 110 | if a or tuple((1,)) or True or tuple((2,)):  # SIM222
+111 111 |     pass
+112 112 | 
+113     |-if a or frozenset() or True:  # SIM222
+    113 |+if True:  # SIM222
+114 114 |     pass
+115 115 | 
+116 116 | if a or frozenset(frozenset()) or True:  # SIM222
+
+SIM222.py:116:4: SIM222 [*] Use `True` instead of `... or True`
+    |
+116 |     pass
+117 | 
+118 | if a or frozenset(frozenset()) or True:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+119 |     pass
+    |
+    = help: Replace with `True`
+
+ℹ Suggested fix
+113 113 | if a or frozenset() or True:  # SIM222
+114 114 |     pass
+115 115 | 
+116     |-if a or frozenset(frozenset()) or True:  # SIM222
+    116 |+if True:  # SIM222
+117 117 |     pass
+118 118 | 
+119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
+
+SIM222.py:119:4: SIM222 [*] Use `frozenset({1})` instead of `... or frozenset({1})`
+    |
+119 |     pass
+120 | 
+121 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+122 |     pass
+    |
+    = help: Replace with `frozenset({1})`
+
+ℹ Suggested fix
+116 116 | if a or frozenset(frozenset()) or True:  # SIM222
+117 117 |     pass
+118 118 | 
+119     |-if a or frozenset({1}) or True or frozenset({2}):  # SIM222
+    119 |+if frozenset({1}):  # SIM222
+120 120 |     pass
+121 121 | 
+122 122 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
+
+SIM222.py:122:4: SIM222 [*] Use `frozenset(frozenset({1}))` instead of `... or frozenset(frozenset({1}))`
+    |
+122 |     pass
+123 | 
+124 | if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+125 |     pass
+    |
+    = help: Replace with `frozenset(frozenset({1}))`
+
+ℹ Suggested fix
+119 119 | if a or frozenset({1}) or True or frozenset({2}):  # SIM222
+120 120 |     pass
+121 121 | 
+122     |-if a or frozenset(frozenset({1})) or True or frozenset(frozenset({2})):  # SIM222
+    122 |+if frozenset(frozenset({1})):  # SIM222
+123 123 |     pass
+124 124 | 
+125 125 | 
+
+SIM222.py:128:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+128 | # Inside test `a` is simplified
+129 | 
+130 | bool(a or [1] or True or [2])  # SIM222
+    |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+131 | 
+132 | assert a or [1] or True or [2]  # SIM222
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+125 125 | 
+126 126 | # Inside test `a` is simplified
+127 127 | 
+128     |-bool(a or [1] or True or [2])  # SIM222
+    128 |+bool([1])  # SIM222
+129 129 | 
+130 130 | assert a or [1] or True or [2]  # SIM222
+131 131 | 
+
+SIM222.py:130:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+130 | bool(a or [1] or True or [2])  # SIM222
+131 | 
+132 | assert a or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+133 | 
+134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+127 127 | 
+128 128 | bool(a or [1] or True or [2])  # SIM222
+129 129 | 
+130     |-assert a or [1] or True or [2]  # SIM222
+    130 |+assert [1]  # SIM222
+131 131 | 
+132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+133 133 |     pass
+
+SIM222.py:132:5: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+132 | assert a or [1] or True or [2]  # SIM222
+133 | 
+134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    |     ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+135 |     pass
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+129 129 | 
+130 130 | assert a or [1] or True or [2]  # SIM222
+131 131 | 
+132     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    132 |+if ([1]) and (a or [1] or True or [2]):  # SIM222
+133 133 |     pass
+134 134 | 
+135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
+
+SIM222.py:132:35: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+132 | assert a or [1] or True or [2]  # SIM222
+133 | 
+134 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    |                                   ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+135 |     pass
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+129 129 | 
+130 130 | assert a or [1] or True or [2]  # SIM222
+131 131 | 
+132     |-if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+    132 |+if (a or [1] or True or [2]) and ([1]):  # SIM222
+133 133 |     pass
+134 134 | 
+135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
+
+SIM222.py:135:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+135 |     pass
+136 | 
+137 | 0 if a or [1] or True or [2] else 1  # SIM222
+    |      ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+138 | 
+139 | while a or [1] or True or [2]:  # SIM222
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+132 132 | if (a or [1] or True or [2]) and (a or [1] or True or [2]):  # SIM222
+133 133 |     pass
+134 134 | 
+135     |-0 if a or [1] or True or [2] else 1  # SIM222
+    135 |+0 if [1] else 1  # SIM222
+136 136 | 
+137 137 | while a or [1] or True or [2]:  # SIM222
+138 138 |     pass
+
+SIM222.py:137:7: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+137 | 0 if a or [1] or True or [2] else 1  # SIM222
+138 | 
+139 | while a or [1] or True or [2]:  # SIM222
+    |       ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+140 |     pass
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+134 134 | 
+135 135 | 0 if a or [1] or True or [2] else 1  # SIM222
+136 136 | 
+137     |-while a or [1] or True or [2]:  # SIM222
+    137 |+while [1]:  # SIM222
+138 138 |     pass
+139 139 | 
+140 140 | [
+
+SIM222.py:144:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+144 |     for a in range(10)
+145 |     for b in range(10)
+146 |     if a or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+147 |     if b or [1] or True or [2]  # SIM222
+148 | ]
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+141 141 |     0
+142 142 |     for a in range(10)
+143 143 |     for b in range(10)
+144     |-    if a or [1] or True or [2]  # SIM222
+    144 |+    if [1]  # SIM222
+145 145 |     if b or [1] or True or [2]  # SIM222
+146 146 | ]
+147 147 | 
+
+SIM222.py:145:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+145 |     for b in range(10)
+146 |     if a or [1] or True or [2]  # SIM222
+147 |     if b or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+148 | ]
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+142 142 |     for a in range(10)
+143 143 |     for b in range(10)
+144 144 |     if a or [1] or True or [2]  # SIM222
+145     |-    if b or [1] or True or [2]  # SIM222
+    145 |+    if [1]  # SIM222
+146 146 | ]
+147 147 | 
+148 148 | {
+
+SIM222.py:152:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+152 |     for a in range(10)
+153 |     for b in range(10)
+154 |     if a or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+155 |     if b or [1] or True or [2]  # SIM222
+156 | }
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+149 149 |     0
+150 150 |     for a in range(10)
+151 151 |     for b in range(10)
+152     |-    if a or [1] or True or [2]  # SIM222
+    152 |+    if [1]  # SIM222
+153 153 |     if b or [1] or True or [2]  # SIM222
+154 154 | }
+155 155 | 
+
+SIM222.py:153:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+153 |     for b in range(10)
+154 |     if a or [1] or True or [2]  # SIM222
+155 |     if b or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+156 | }
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+150 150 |     for a in range(10)
+151 151 |     for b in range(10)
+152 152 |     if a or [1] or True or [2]  # SIM222
+153     |-    if b or [1] or True or [2]  # SIM222
+    153 |+    if [1]  # SIM222
+154 154 | }
+155 155 | 
+156 156 | {
+
+SIM222.py:160:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+160 |     for a in range(10)
+161 |     for b in range(10)
+162 |     if a or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+163 |     if b or [1] or True or [2]  # SIM222
+164 | }
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+157 157 |     0: 0
+158 158 |     for a in range(10)
+159 159 |     for b in range(10)
+160     |-    if a or [1] or True or [2]  # SIM222
+    160 |+    if [1]  # SIM222
+161 161 |     if b or [1] or True or [2]  # SIM222
+162 162 | }
+163 163 | 
+
+SIM222.py:161:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+161 |     for b in range(10)
+162 |     if a or [1] or True or [2]  # SIM222
+163 |     if b or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+164 | }
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+158 158 |     for a in range(10)
+159 159 |     for b in range(10)
+160 160 |     if a or [1] or True or [2]  # SIM222
+161     |-    if b or [1] or True or [2]  # SIM222
+    161 |+    if [1]  # SIM222
+162 162 | }
+163 163 | 
+164 164 | (
+
+SIM222.py:168:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+168 |     for a in range(10)
+169 |     for b in range(10)
+170 |     if a or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+171 |     if b or [1] or True or [2]  # SIM222
+172 | )
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+165 165 |     0
+166 166 |     for a in range(10)
+167 167 |     for b in range(10)
+168     |-    if a or [1] or True or [2]  # SIM222
+    168 |+    if [1]  # SIM222
+169 169 |     if b or [1] or True or [2]  # SIM222
+170 170 | )
+171 171 | 
+
+SIM222.py:169:8: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+169 |     for b in range(10)
+170 |     if a or [1] or True or [2]  # SIM222
+171 |     if b or [1] or True or [2]  # SIM222
+    |        ^^^^^^^^^^^^^^^^^^^^^^^ SIM222
+172 | )
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+166 166 |     for a in range(10)
+167 167 |     for b in range(10)
+168 168 |     if a or [1] or True or [2]  # SIM222
+169     |-    if b or [1] or True or [2]  # SIM222
+    169 |+    if [1]  # SIM222
+170 170 | )
+171 171 | 
+172 172 | # Outside test `a` is not simplified
+
+SIM222.py:174:6: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+174 | # Outside test `a` is not simplified
+175 | 
+176 | a or [1] or True or [2]  # SIM222
+    |      ^^^^^^^^^^^^^^^^^^ SIM222
+177 | 
+178 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+171 171 | 
+172 172 | # Outside test `a` is not simplified
+173 173 | 
+174     |-a or [1] or True or [2]  # SIM222
+    174 |+a or [1]  # SIM222
+175 175 | 
+176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+177 177 |     pass
+
+SIM222.py:176:10: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+176 | a or [1] or True or [2]  # SIM222
+177 | 
+178 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+    |          ^^^^^^^^^^^^^^^^^^ SIM222
+179 |     pass
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+173 173 | 
+174 174 | a or [1] or True or [2]  # SIM222
+175 175 | 
+176     |-if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+    176 |+if (a or [1]) == (a or [1]):  # SIM222
+177 177 |     pass
+178 178 | 
+179 179 | if f(a or [1] or True or [2]):  # SIM222
+
+SIM222.py:179:11: SIM222 [*] Use `[1]` instead of `... or [1]`
+    |
+179 |     pass
+180 | 
+181 | if f(a or [1] or True or [2]):  # SIM222
+    |           ^^^^^^^^^^^^^^^^^^ SIM222
+182 |     pass
+    |
+    = help: Replace with `[1]`
+
+ℹ Suggested fix
+176 176 | if (a or [1] or True or [2]) == (a or [1]):  # SIM222
+177 177 |     pass
+178 178 | 
+179     |-if f(a or [1] or True or [2]):  # SIM222
+    179 |+if f(a or [1]):  # SIM222
+180 180 |     pass
+
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -656,11 +656,11 @@ SIM223.py:92:7: SIM223 [*] Use `False` instead of `... and False and ...`
    92 |+a and False  # SIM222
 93 93 | 
 94 94 | 
-95 95 | # Inside test `a` is simplified
+95 95 | # Inside test `a` is simplified.
 
 SIM223.py:97:6: SIM223 [*] Use `False` instead of `... and False and ...`
     |
- 97 | # Inside test `a` is simplified
+ 97 | # Inside test `a` is simplified.
  98 | 
  99 | bool(a and [] and False and [])  # SIM223
     |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
@@ -671,7 +671,7 @@ SIM223.py:97:6: SIM223 [*] Use `False` instead of `... and False and ...`
 
 ℹ Suggested fix
 94 94 | 
-95 95 | # Inside test `a` is simplified
+95 95 | # Inside test `a` is simplified.
 96 96 | 
 97    |-bool(a and [] and False and [])  # SIM223
    97 |+bool(False)  # SIM223
@@ -943,11 +943,11 @@ SIM223.py:138:8: SIM223 [*] Use `False` instead of `... and False and ...`
     138 |+    if False  # SIM223
 139 139 | )
 140 140 | 
-141 141 | # Outside test `a` is not simplified
+141 141 | # Outside test `a` is not simplified.
 
 SIM223.py:143:7: SIM223 [*] Use `[]` instead of `[] and ...`
     |
-143 | # Outside test `a` is not simplified
+143 | # Outside test `a` is not simplified.
 144 | 
 145 | a and [] and False and []  # SIM223
     |       ^^^^^^^^^^^^^^^^^^^ SIM223
@@ -958,7 +958,7 @@ SIM223.py:143:7: SIM223 [*] Use `[]` instead of `[] and ...`
 
 ℹ Suggested fix
 140 140 | 
-141 141 | # Outside test `a` is not simplified
+141 141 | # Outside test `a` is not simplified.
 142 142 | 
 143     |-a and [] and False and []  # SIM223
     143 |+a and []  # SIM223

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -658,7 +658,7 @@ SIM223.py:92:7: SIM223 [*] Use `False` instead of `... and False and ...`
 94 94 | 
 95 95 | # Inside test `a` is simplified
 
-SIM223.py:97:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:97:6: SIM223 [*] Use `False` instead of `... and False and ...`
     |
  97 | # Inside test `a` is simplified
  98 | 
@@ -667,19 +667,19 @@ SIM223.py:97:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 100 | 
 101 | assert a and [] and False and []  # SIM223
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 94 94 | 
 95 95 | # Inside test `a` is simplified
 96 96 | 
 97    |-bool(a and [] and False and [])  # SIM223
-   97 |+bool([])  # SIM223
+   97 |+bool(False)  # SIM223
 98 98 | 
 99 99 | assert a and [] and False and []  # SIM223
 100 100 | 
 
-SIM223.py:99:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:99:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
  99 | bool(a and [] and False and [])  # SIM223
 100 | 
@@ -688,19 +688,19 @@ SIM223.py:99:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 102 | 
 103 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 96  96  | 
 97  97  | bool(a and [] and False and [])  # SIM223
 98  98  | 
 99      |-assert a and [] and False and []  # SIM223
-    99  |+assert []  # SIM223
+    99  |+assert False  # SIM223
 100 100 | 
 101 101 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
 102 102 |     pass
 
-SIM223.py:101:5: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:101:5: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 101 | assert a and [] and False and []  # SIM223
 102 | 
@@ -708,19 +708,19 @@ SIM223.py:101:5: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 104 |     pass
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 98  98  | 
 99  99  | assert a and [] and False and []  # SIM223
 100 100 | 
 101     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-    101 |+if ([]) or (a and [] and False and []):  # SIM223
+    101 |+if (False) or (a and [] and False and []):  # SIM223
 102 102 |     pass
 103 103 | 
 104 104 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:101:36: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:101:36: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 101 | assert a and [] and False and []  # SIM223
 102 | 
@@ -728,19 +728,19 @@ SIM223.py:101:36: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 104 |     pass
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 98  98  | 
 99  99  | assert a and [] and False and []  # SIM223
 100 100 | 
 101     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-    101 |+if (a and [] and False and []) or ([]):  # SIM223
+    101 |+if (a and [] and False and []) or (False):  # SIM223
 102 102 |     pass
 103 103 | 
 104 104 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:104:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:104:6: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 104 |     pass
 105 | 
@@ -749,19 +749,19 @@ SIM223.py:104:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 107 | 
 108 | while a and [] and False and []:  # SIM223
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 101 101 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
 102 102 |     pass
 103 103 | 
 104     |-0 if a and [] and False and [] else 1  # SIM222
-    104 |+0 if [] else 1  # SIM222
+    104 |+0 if False else 1  # SIM222
 105 105 | 
 106 106 | while a and [] and False and []:  # SIM223
 107 107 |     pass
 
-SIM223.py:106:7: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:106:7: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 106 | 0 if a and [] and False and [] else 1  # SIM222
 107 | 
@@ -769,19 +769,19 @@ SIM223.py:106:7: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 109 |     pass
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 103 103 | 
 104 104 | 0 if a and [] and False and [] else 1  # SIM222
 105 105 | 
 106     |-while a and [] and False and []:  # SIM223
-    106 |+while []:  # SIM223
+    106 |+while False:  # SIM223
 107 107 |     pass
 108 108 | 
 109 109 | [
 
-SIM223.py:113:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:113:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 113 |     for a in range(10)
 114 |     for b in range(10)
@@ -790,19 +790,19 @@ SIM223.py:113:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 116 |     if b and [] and False and []  # SIM223
 117 | ]
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 110 110 |     0
 111 111 |     for a in range(10)
 112 112 |     for b in range(10)
 113     |-    if a and [] and False and []  # SIM223
-    113 |+    if []  # SIM223
+    113 |+    if False  # SIM223
 114 114 |     if b and [] and False and []  # SIM223
 115 115 | ]
 116 116 | 
 
-SIM223.py:114:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:114:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 114 |     for b in range(10)
 115 |     if a and [] and False and []  # SIM223
@@ -810,19 +810,19 @@ SIM223.py:114:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 117 | ]
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 111 111 |     for a in range(10)
 112 112 |     for b in range(10)
 113 113 |     if a and [] and False and []  # SIM223
 114     |-    if b and [] and False and []  # SIM223
-    114 |+    if []  # SIM223
+    114 |+    if False  # SIM223
 115 115 | ]
 116 116 | 
 117 117 | {
 
-SIM223.py:121:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:121:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 121 |     for a in range(10)
 122 |     for b in range(10)
@@ -831,19 +831,19 @@ SIM223.py:121:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 124 |     if b and [] and False and []  # SIM223
 125 | }
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 118 118 |     0
 119 119 |     for a in range(10)
 120 120 |     for b in range(10)
 121     |-    if a and [] and False and []  # SIM223
-    121 |+    if []  # SIM223
+    121 |+    if False  # SIM223
 122 122 |     if b and [] and False and []  # SIM223
 123 123 | }
 124 124 | 
 
-SIM223.py:122:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:122:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 122 |     for b in range(10)
 123 |     if a and [] and False and []  # SIM223
@@ -851,19 +851,19 @@ SIM223.py:122:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 125 | }
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 119 119 |     for a in range(10)
 120 120 |     for b in range(10)
 121 121 |     if a and [] and False and []  # SIM223
 122     |-    if b and [] and False and []  # SIM223
-    122 |+    if []  # SIM223
+    122 |+    if False  # SIM223
 123 123 | }
 124 124 | 
 125 125 | {
 
-SIM223.py:129:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:129:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 129 |     for a in range(10)
 130 |     for b in range(10)
@@ -872,19 +872,19 @@ SIM223.py:129:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 132 |     if b and [] and False and []  # SIM223
 133 | }
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 126 126 |     0: 0
 127 127 |     for a in range(10)
 128 128 |     for b in range(10)
 129     |-    if a and [] and False and []  # SIM223
-    129 |+    if []  # SIM223
+    129 |+    if False  # SIM223
 130 130 |     if b and [] and False and []  # SIM223
 131 131 | }
 132 132 | 
 
-SIM223.py:130:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:130:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 130 |     for b in range(10)
 131 |     if a and [] and False and []  # SIM223
@@ -892,19 +892,19 @@ SIM223.py:130:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 133 | }
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 127 127 |     for a in range(10)
 128 128 |     for b in range(10)
 129 129 |     if a and [] and False and []  # SIM223
 130     |-    if b and [] and False and []  # SIM223
-    130 |+    if []  # SIM223
+    130 |+    if False  # SIM223
 131 131 | }
 132 132 | 
 133 133 | (
 
-SIM223.py:137:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:137:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 137 |     for a in range(10)
 138 |     for b in range(10)
@@ -913,19 +913,19 @@ SIM223.py:137:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
 140 |     if b and [] and False and []  # SIM223
 141 | )
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 134 134 |     0
 135 135 |     for a in range(10)
 136 136 |     for b in range(10)
 137     |-    if a and [] and False and []  # SIM223
-    137 |+    if []  # SIM223
+    137 |+    if False  # SIM223
 138 138 |     if b and [] and False and []  # SIM223
 139 139 | )
 140 140 | 
 
-SIM223.py:138:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:138:8: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 138 |     for b in range(10)
 139 |     if a and [] and False and []  # SIM223
@@ -933,14 +933,14 @@ SIM223.py:138:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 141 | )
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `False`
 
 ℹ Suggested fix
 135 135 |     for a in range(10)
 136 136 |     for b in range(10)
 137 137 |     if a and [] and False and []  # SIM223
 138     |-    if b and [] and False and []  # SIM223
-    138 |+    if []  # SIM223
+    138 |+    if False  # SIM223
 139 139 | )
 140 140 | 
 141 141 | # Outside test `a` is not simplified

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -56,7 +56,7 @@ SIM223.py:7:10: SIM223 [*] Use `False` instead of `... and False`
 9 9 | 
 10 10 | if a or False:
 
-SIM223.py:19:18: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:19:18: SIM223 [*] Use `False` instead of `False and ...`
    |
 19 |     pass
 20 | 
@@ -76,7 +76,7 @@ SIM223.py:19:18: SIM223 [*] Use `False` instead of `... and False`
 21 21 | 
 22 22 | if False and f() and a and g() and b:  # SIM223
 
-SIM223.py:22:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:22:4: SIM223 [*] Use `False` instead of `False and ...`
    |
 22 |     pass
 23 | 
@@ -96,7 +96,7 @@ SIM223.py:22:4: SIM223 [*] Use `False` instead of `... and False`
 24 24 | 
 25 25 | if a and False and f() and b and g():  # SIM223
 
-SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 25 |     pass
 26 | 
@@ -116,7 +116,7 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False`
 27 27 | 
 28 28 | 
 
-SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and ""`
+SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and "" and ...`
    |
 42 | if a and "" and False:  # SIM223
    |    ^^^^^^^^^^^^^^^^^^ SIM223
@@ -134,7 +134,7 @@ SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and ""`
 44 44 | 
 45 45 | if a and "foo" and False and "bar":  # SIM223
 
-SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 45 |     pass
 46 | 
@@ -154,7 +154,7 @@ SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False`
 47 47 | 
 48 48 | if a and 0 and False:  # SIM223
 
-SIM223.py:48:4: SIM223 [*] Use falsey `0` instead of `... and 0`
+SIM223.py:48:4: SIM223 [*] Use falsey `0` instead of `... and 0 and ...`
    |
 48 |     pass
 49 | 
@@ -174,7 +174,7 @@ SIM223.py:48:4: SIM223 [*] Use falsey `0` instead of `... and 0`
 50 50 | 
 51 51 | if a and 1 and False and 2:  # SIM223
 
-SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 51 |     pass
 52 | 
@@ -194,7 +194,7 @@ SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False`
 53 53 | 
 54 54 | if a and 0.0 and False:  # SIM223
 
-SIM223.py:54:4: SIM223 [*] Use falsey `0.0` instead of `... and 0.0`
+SIM223.py:54:4: SIM223 [*] Use falsey `0.0` instead of `... and 0.0 and ...`
    |
 54 |     pass
 55 | 
@@ -214,7 +214,7 @@ SIM223.py:54:4: SIM223 [*] Use falsey `0.0` instead of `... and 0.0`
 56 56 | 
 57 57 | if a and 0.1 and False and 0.2:  # SIM223
 
-SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 57 |     pass
 58 | 
@@ -234,7 +234,7 @@ SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False`
 59 59 | 
 60 60 | if a and [] and False:  # SIM223
 
-SIM223.py:60:4: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:60:4: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
    |
 60 |     pass
 61 | 
@@ -254,7 +254,7 @@ SIM223.py:60:4: SIM223 [*] Use falsey `[]` instead of `... and []`
 62 62 | 
 63 63 | if a and list([]) and False:  # SIM223
 
-SIM223.py:63:4: SIM223 [*] Use falsey `list([])` instead of `... and list([])`
+SIM223.py:63:4: SIM223 [*] Use falsey `list([])` instead of `... and list([]) and ...`
    |
 63 |     pass
 64 | 
@@ -274,7 +274,7 @@ SIM223.py:63:4: SIM223 [*] Use falsey `list([])` instead of `... and list([])`
 65 65 | 
 66 66 | if a and [1] and False and [2]:  # SIM223
 
-SIM223.py:66:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:66:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 66 |     pass
 67 | 
@@ -294,7 +294,7 @@ SIM223.py:66:4: SIM223 [*] Use `False` instead of `... and False`
 68 68 | 
 69 69 | if a and list([1]) and False and list([2]):  # SIM223
 
-SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 69 |     pass
 70 | 
@@ -314,7 +314,7 @@ SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False`
 71 71 | 
 72 72 | if a and {} and False:  # SIM223
 
-SIM223.py:72:4: SIM223 [*] Use falsey `{}` instead of `... and {}`
+SIM223.py:72:4: SIM223 [*] Use falsey `{}` instead of `... and {} and ...`
    |
 72 |     pass
 73 | 
@@ -334,7 +334,7 @@ SIM223.py:72:4: SIM223 [*] Use falsey `{}` instead of `... and {}`
 74 74 | 
 75 75 | if a and dict() and False:  # SIM223
 
-SIM223.py:75:4: SIM223 [*] Use falsey `dict()` instead of `... and dict()`
+SIM223.py:75:4: SIM223 [*] Use falsey `dict()` instead of `... and dict() and ...`
    |
 75 |     pass
 76 | 
@@ -354,7 +354,7 @@ SIM223.py:75:4: SIM223 [*] Use falsey `dict()` instead of `... and dict()`
 77 77 | 
 78 78 | if a and {1: 1} and False and {2: 2}:  # SIM223
 
-SIM223.py:78:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:78:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 78 |     pass
 79 | 
@@ -374,7 +374,7 @@ SIM223.py:78:4: SIM223 [*] Use `False` instead of `... and False`
 80 80 | 
 81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
 
-SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 81 |     pass
 82 | 
@@ -394,7 +394,7 @@ SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False`
 83 83 | 
 84 84 | if a and set() and False:  # SIM223
 
-SIM223.py:84:4: SIM223 [*] Use falsey `set()` instead of `... and set()`
+SIM223.py:84:4: SIM223 [*] Use falsey `set()` instead of `... and set() and ...`
    |
 84 |     pass
 85 | 
@@ -414,7 +414,7 @@ SIM223.py:84:4: SIM223 [*] Use falsey `set()` instead of `... and set()`
 86 86 | 
 87 87 | if a and set(set()) and False:  # SIM223
 
-SIM223.py:87:4: SIM223 [*] Use falsey `set(set())` instead of `... and set(set())`
+SIM223.py:87:4: SIM223 [*] Use falsey `set(set())` instead of `... and set(set()) and ...`
    |
 87 |     pass
 88 | 
@@ -434,7 +434,7 @@ SIM223.py:87:4: SIM223 [*] Use falsey `set(set())` instead of `... and set(set()
 89 89 | 
 90 90 | if a and {1} and False and {2}:  # SIM223
 
-SIM223.py:90:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:90:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 90 |     pass
 91 | 
@@ -454,7 +454,7 @@ SIM223.py:90:4: SIM223 [*] Use `False` instead of `... and False`
 92 92 | 
 93 93 | if a and set({1}) and False and set({2}):  # SIM223
 
-SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False and ...`
    |
 93 |     pass
 94 | 
@@ -474,7 +474,7 @@ SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False`
 95 95 | 
 96 96 | if a and () and False:  # SIM222
 
-SIM223.py:96:4: SIM223 [*] Use falsey `()` instead of `... and ()`
+SIM223.py:96:4: SIM223 [*] Use falsey `()` instead of `... and () and ...`
    |
 96 |     pass
 97 | 
@@ -494,7 +494,7 @@ SIM223.py:96:4: SIM223 [*] Use falsey `()` instead of `... and ()`
 98 98 | 
 99 99 | if a and tuple(()) and False:  # SIM222
 
-SIM223.py:99:4: SIM223 [*] Use falsey `tuple(())` instead of `... and tuple(())`
+SIM223.py:99:4: SIM223 [*] Use falsey `tuple(())` instead of `... and tuple(()) and ...`
     |
  99 |     pass
 100 | 
@@ -514,7 +514,7 @@ SIM223.py:99:4: SIM223 [*] Use falsey `tuple(())` instead of `... and tuple(())`
 101 101 | 
 102 102 | if a and (1,) and False and (2,):  # SIM222
 
-SIM223.py:102:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:102:4: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 102 |     pass
 103 | 
@@ -534,7 +534,7 @@ SIM223.py:102:4: SIM223 [*] Use `False` instead of `... and False`
 104 104 | 
 105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
 
-SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 105 |     pass
 106 | 
@@ -554,7 +554,7 @@ SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False`
 107 107 | 
 108 108 | if a and frozenset() and False:  # SIM222
 
-SIM223.py:108:4: SIM223 [*] Use falsey `frozenset()` instead of `... and frozenset()`
+SIM223.py:108:4: SIM223 [*] Use falsey `frozenset()` instead of `... and frozenset() and ...`
     |
 108 |     pass
 109 | 
@@ -574,7 +574,7 @@ SIM223.py:108:4: SIM223 [*] Use falsey `frozenset()` instead of `... and frozens
 110 110 | 
 111 111 | if a and frozenset(frozenset()) and False:  # SIM222
 
-SIM223.py:111:4: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `... and frozenset(frozenset())`
+SIM223.py:111:4: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `... and frozenset(frozenset()) and ...`
     |
 111 |     pass
 112 | 
@@ -594,7 +594,7 @@ SIM223.py:111:4: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `... 
 113 113 | 
 114 114 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
 
-SIM223.py:114:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:114:4: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 114 |     pass
 115 | 
@@ -614,7 +614,7 @@ SIM223.py:114:4: SIM223 [*] Use `False` instead of `... and False`
 116 116 | 
 117 117 | if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
 
-SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False`
+SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False and ...`
     |
 117 |     pass
 118 | 
@@ -634,7 +634,7 @@ SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False`
 119 119 | 
 120 120 | 
 
-SIM223.py:123:6: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:123:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 123 | # Inside test `a` is simplified
 124 | 
@@ -655,7 +655,7 @@ SIM223.py:123:6: SIM223 [*] Use falsey `[]` instead of `... and []`
 125 125 | assert a and [] and False and []  # SIM223
 126 126 | 
 
-SIM223.py:125:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:125:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 125 | bool(a and [] and False and [])  # SIM223
 126 | 
@@ -676,7 +676,7 @@ SIM223.py:125:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
 128 128 |     pass
 
-SIM223.py:127:5: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:127:5: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 127 | assert a and [] and False and []  # SIM223
 128 | 
@@ -696,7 +696,7 @@ SIM223.py:127:5: SIM223 [*] Use falsey `[]` instead of `... and []`
 129 129 | 
 130 130 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:127:36: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:127:36: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 127 | assert a and [] and False and []  # SIM223
 128 | 
@@ -716,7 +716,7 @@ SIM223.py:127:36: SIM223 [*] Use falsey `[]` instead of `... and []`
 129 129 | 
 130 130 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:130:6: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:130:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 130 |     pass
 131 | 
@@ -737,7 +737,7 @@ SIM223.py:130:6: SIM223 [*] Use falsey `[]` instead of `... and []`
 132 132 | while a and [] and False and []:  # SIM223
 133 133 |     pass
 
-SIM223.py:132:7: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:132:7: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 132 | 0 if a and [] and False and [] else 1  # SIM222
 133 | 
@@ -757,7 +757,7 @@ SIM223.py:132:7: SIM223 [*] Use falsey `[]` instead of `... and []`
 134 134 | 
 135 135 | [
 
-SIM223.py:139:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:139:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 139 |     for a in range(10)
 140 |     for b in range(10)
@@ -778,7 +778,7 @@ SIM223.py:139:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 141 141 | ]
 142 142 | 
 
-SIM223.py:140:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:140:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 140 |     for b in range(10)
 141 |     if a and [] and False and []  # SIM223
@@ -798,7 +798,7 @@ SIM223.py:140:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 142 142 | 
 143 143 | {
 
-SIM223.py:147:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:147:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 147 |     for a in range(10)
 148 |     for b in range(10)
@@ -819,7 +819,7 @@ SIM223.py:147:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 149 149 | }
 150 150 | 
 
-SIM223.py:148:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:148:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 148 |     for b in range(10)
 149 |     if a and [] and False and []  # SIM223
@@ -839,7 +839,7 @@ SIM223.py:148:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 150 150 | 
 151 151 | {
 
-SIM223.py:155:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:155:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 155 |     for a in range(10)
 156 |     for b in range(10)
@@ -860,7 +860,7 @@ SIM223.py:155:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 157 157 | }
 158 158 | 
 
-SIM223.py:156:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:156:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 156 |     for b in range(10)
 157 |     if a and [] and False and []  # SIM223
@@ -880,7 +880,7 @@ SIM223.py:156:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 158 158 | 
 159 159 | (
 
-SIM223.py:163:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:163:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 163 |     for a in range(10)
 164 |     for b in range(10)
@@ -901,7 +901,7 @@ SIM223.py:163:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 165 165 | )
 166 166 | 
 
-SIM223.py:164:8: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:164:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
 164 |     for b in range(10)
 165 |     if a and [] and False and []  # SIM223
@@ -921,7 +921,7 @@ SIM223.py:164:8: SIM223 [*] Use falsey `[]` instead of `... and []`
 166 166 | 
 167 167 | # Outside test `a` is not simplified
 
-SIM223.py:169:7: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:169:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
 169 | # Outside test `a` is not simplified
 170 | 
@@ -942,7 +942,7 @@ SIM223.py:169:7: SIM223 [*] Use falsey `[]` instead of `... and []`
 171 171 | if (a and [] and False and []) == (a and []):  # SIM223
 172 172 |     pass
 
-SIM223.py:171:11: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:171:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
 171 | a and [] and False and []  # SIM223
 172 | 
@@ -962,7 +962,7 @@ SIM223.py:171:11: SIM223 [*] Use falsey `[]` instead of `... and []`
 173 173 | 
 174 174 | if f(a and [] and False and []):  # SIM223
 
-SIM223.py:174:12: SIM223 [*] Use falsey `[]` instead of `... and []`
+SIM223.py:174:12: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
 174 |     pass
 175 | 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -116,14 +116,14 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False and ...`
 27 27 | 
 28 28 | 
 
-SIM223.py:42:7: SIM223 [*] Use falsey `""` instead of `"" and ...`
+SIM223.py:42:7: SIM223 [*] Use `""` instead of `"" and ...`
    |
 42 | a and "" and False  # SIM223
    |       ^^^^^^^^^^^^ SIM223
 43 | 
 44 | a and "foo" and False and "bar"  # SIM223
    |
-   = help: Replace with falsey `""`
+   = help: Replace with `""`
 
 ℹ Suggested fix
 39 39 |     pass
@@ -156,7 +156,7 @@ SIM223.py:44:7: SIM223 [*] Use `False` instead of `... and False and ...`
 46 46 | a and 0 and False  # SIM223
 47 47 | 
 
-SIM223.py:46:7: SIM223 [*] Use falsey `0` instead of `0 and ...`
+SIM223.py:46:7: SIM223 [*] Use `0` instead of `0 and ...`
    |
 46 | a and "foo" and False and "bar"  # SIM223
 47 | 
@@ -165,7 +165,7 @@ SIM223.py:46:7: SIM223 [*] Use falsey `0` instead of `0 and ...`
 49 | 
 50 | a and 1 and False and 2  # SIM223
    |
-   = help: Replace with falsey `0`
+   = help: Replace with `0`
 
 ℹ Suggested fix
 43 43 | 
@@ -198,7 +198,7 @@ SIM223.py:48:7: SIM223 [*] Use `False` instead of `... and False and ...`
 50 50 | a and 0.0 and False  # SIM223
 51 51 | 
 
-SIM223.py:50:7: SIM223 [*] Use falsey `0.0` instead of `0.0 and ...`
+SIM223.py:50:7: SIM223 [*] Use `0.0` instead of `0.0 and ...`
    |
 50 | a and 1 and False and 2  # SIM223
 51 | 
@@ -207,7 +207,7 @@ SIM223.py:50:7: SIM223 [*] Use falsey `0.0` instead of `0.0 and ...`
 53 | 
 54 | a and 0.1 and False and 0.2  # SIM223
    |
-   = help: Replace with falsey `0.0`
+   = help: Replace with `0.0`
 
 ℹ Suggested fix
 47 47 | 
@@ -240,7 +240,7 @@ SIM223.py:52:7: SIM223 [*] Use `False` instead of `... and False and ...`
 54 54 | a and [] and False  # SIM223
 55 55 | 
 
-SIM223.py:54:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:54:7: SIM223 [*] Use `[]` instead of `[] and ...`
    |
 54 | a and 0.1 and False and 0.2  # SIM223
 55 | 
@@ -249,7 +249,7 @@ SIM223.py:54:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
 57 | 
 58 | a and list([]) and False  # SIM223
    |
-   = help: Replace with falsey `[]`
+   = help: Replace with `[]`
 
 ℹ Suggested fix
 51 51 | 
@@ -261,7 +261,7 @@ SIM223.py:54:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
 56 56 | a and list([]) and False  # SIM223
 57 57 | 
 
-SIM223.py:56:7: SIM223 [*] Use falsey `list([])` instead of `list([]) and ...`
+SIM223.py:56:7: SIM223 [*] Use `list([])` instead of `list([]) and ...`
    |
 56 | a and [] and False  # SIM223
 57 | 
@@ -270,7 +270,7 @@ SIM223.py:56:7: SIM223 [*] Use falsey `list([])` instead of `list([]) and ...`
 59 | 
 60 | a and [1] and False and [2]  # SIM223
    |
-   = help: Replace with falsey `list([])`
+   = help: Replace with `list([])`
 
 ℹ Suggested fix
 53 53 | 
@@ -324,7 +324,7 @@ SIM223.py:60:7: SIM223 [*] Use `False` instead of `... and False and ...`
 62 62 | a and {} and False  # SIM223
 63 63 | 
 
-SIM223.py:62:7: SIM223 [*] Use falsey `{}` instead of `{} and ...`
+SIM223.py:62:7: SIM223 [*] Use `{}` instead of `{} and ...`
    |
 62 | a and list([1]) and False and list([2])  # SIM223
 63 | 
@@ -333,7 +333,7 @@ SIM223.py:62:7: SIM223 [*] Use falsey `{}` instead of `{} and ...`
 65 | 
 66 | a and dict() and False  # SIM223
    |
-   = help: Replace with falsey `{}`
+   = help: Replace with `{}`
 
 ℹ Suggested fix
 59 59 | 
@@ -345,7 +345,7 @@ SIM223.py:62:7: SIM223 [*] Use falsey `{}` instead of `{} and ...`
 64 64 | a and dict() and False  # SIM223
 65 65 | 
 
-SIM223.py:64:7: SIM223 [*] Use falsey `dict()` instead of `dict() and ...`
+SIM223.py:64:7: SIM223 [*] Use `dict()` instead of `dict() and ...`
    |
 64 | a and {} and False  # SIM223
 65 | 
@@ -354,7 +354,7 @@ SIM223.py:64:7: SIM223 [*] Use falsey `dict()` instead of `dict() and ...`
 67 | 
 68 | a and {1: 1} and False and {2: 2}  # SIM223
    |
-   = help: Replace with falsey `dict()`
+   = help: Replace with `dict()`
 
 ℹ Suggested fix
 61 61 | 
@@ -408,7 +408,7 @@ SIM223.py:68:7: SIM223 [*] Use `False` instead of `... and False and ...`
 70 70 | a and set() and False  # SIM223
 71 71 | 
 
-SIM223.py:70:7: SIM223 [*] Use falsey `set()` instead of `set() and ...`
+SIM223.py:70:7: SIM223 [*] Use `set()` instead of `set() and ...`
    |
 70 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
 71 | 
@@ -417,7 +417,7 @@ SIM223.py:70:7: SIM223 [*] Use falsey `set()` instead of `set() and ...`
 73 | 
 74 | a and set(set()) and False  # SIM223
    |
-   = help: Replace with falsey `set()`
+   = help: Replace with `set()`
 
 ℹ Suggested fix
 67 67 | 
@@ -429,7 +429,7 @@ SIM223.py:70:7: SIM223 [*] Use falsey `set()` instead of `set() and ...`
 72 72 | a and set(set()) and False  # SIM223
 73 73 | 
 
-SIM223.py:72:7: SIM223 [*] Use falsey `set(set())` instead of `set(set()) and ...`
+SIM223.py:72:7: SIM223 [*] Use `set(set())` instead of `set(set()) and ...`
    |
 72 | a and set() and False  # SIM223
 73 | 
@@ -438,7 +438,7 @@ SIM223.py:72:7: SIM223 [*] Use falsey `set(set())` instead of `set(set()) and ..
 75 | 
 76 | a and {1} and False and {2}  # SIM223
    |
-   = help: Replace with falsey `set(set())`
+   = help: Replace with `set(set())`
 
 ℹ Suggested fix
 69 69 | 
@@ -492,7 +492,7 @@ SIM223.py:76:7: SIM223 [*] Use `False` instead of `... and False and ...`
 78 78 | a and () and False  # SIM222
 79 79 | 
 
-SIM223.py:78:7: SIM223 [*] Use falsey `()` instead of `() and ...`
+SIM223.py:78:7: SIM223 [*] Use `()` instead of `() and ...`
    |
 78 | a and set({1}) and False and set({2})  # SIM223
 79 | 
@@ -501,7 +501,7 @@ SIM223.py:78:7: SIM223 [*] Use falsey `()` instead of `() and ...`
 81 | 
 82 | a and tuple(()) and False  # SIM222
    |
-   = help: Replace with falsey `()`
+   = help: Replace with `()`
 
 ℹ Suggested fix
 75 75 | 
@@ -513,7 +513,7 @@ SIM223.py:78:7: SIM223 [*] Use falsey `()` instead of `() and ...`
 80 80 | a and tuple(()) and False  # SIM222
 81 81 | 
 
-SIM223.py:80:7: SIM223 [*] Use falsey `tuple(())` instead of `tuple(()) and ...`
+SIM223.py:80:7: SIM223 [*] Use `tuple(())` instead of `tuple(()) and ...`
    |
 80 | a and () and False  # SIM222
 81 | 
@@ -522,7 +522,7 @@ SIM223.py:80:7: SIM223 [*] Use falsey `tuple(())` instead of `tuple(()) and ...`
 83 | 
 84 | a and (1,) and False and (2,)  # SIM222
    |
-   = help: Replace with falsey `tuple(())`
+   = help: Replace with `tuple(())`
 
 ℹ Suggested fix
 77 77 | 
@@ -576,7 +576,7 @@ SIM223.py:84:7: SIM223 [*] Use `False` instead of `... and False and ...`
 86 86 | a and frozenset() and False  # SIM222
 87 87 | 
 
-SIM223.py:86:7: SIM223 [*] Use falsey `frozenset()` instead of `frozenset() and ...`
+SIM223.py:86:7: SIM223 [*] Use `frozenset()` instead of `frozenset() and ...`
    |
 86 | a and tuple((1,)) and False and tuple((2,))  # SIM222
 87 | 
@@ -585,7 +585,7 @@ SIM223.py:86:7: SIM223 [*] Use falsey `frozenset()` instead of `frozenset() and 
 89 | 
 90 | a and frozenset(frozenset()) and False  # SIM222
    |
-   = help: Replace with falsey `frozenset()`
+   = help: Replace with `frozenset()`
 
 ℹ Suggested fix
 83 83 | 
@@ -597,7 +597,7 @@ SIM223.py:86:7: SIM223 [*] Use falsey `frozenset()` instead of `frozenset() and 
 88 88 | a and frozenset(frozenset()) and False  # SIM222
 89 89 | 
 
-SIM223.py:88:7: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `frozenset(frozenset()) and ...`
+SIM223.py:88:7: SIM223 [*] Use `frozenset(frozenset())` instead of `frozenset(frozenset()) and ...`
    |
 88 | a and frozenset() and False  # SIM222
 89 | 
@@ -606,7 +606,7 @@ SIM223.py:88:7: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `froze
 91 | 
 92 | a and frozenset({1}) and False and frozenset({2})  # SIM222
    |
-   = help: Replace with falsey `frozenset(frozenset())`
+   = help: Replace with `frozenset(frozenset())`
 
 ℹ Suggested fix
 85 85 | 
@@ -945,7 +945,7 @@ SIM223.py:138:8: SIM223 [*] Use `False` instead of `... and False and ...`
 140 140 | 
 141 141 | # Outside test `a` is not simplified
 
-SIM223.py:143:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:143:7: SIM223 [*] Use `[]` instead of `[] and ...`
     |
 143 | # Outside test `a` is not simplified
 144 | 
@@ -954,7 +954,7 @@ SIM223.py:143:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
 146 | 
 147 | if (a and [] and False and []) == (a and []):  # SIM223
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `[]`
 
 ℹ Suggested fix
 140 140 | 
@@ -966,7 +966,7 @@ SIM223.py:143:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
 145 145 | if (a and [] and False and []) == (a and []):  # SIM223
 146 146 |     pass
 
-SIM223.py:145:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:145:11: SIM223 [*] Use `[]` instead of `[] and ...`
     |
 145 | a and [] and False and []  # SIM223
 146 | 
@@ -974,7 +974,7 @@ SIM223.py:145:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |           ^^^^^^^^^^^^^^^^^^^ SIM223
 148 |     pass
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `[]`
 
 ℹ Suggested fix
 142 142 | 
@@ -986,7 +986,7 @@ SIM223.py:145:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
 147 147 | 
 148 148 | if f(a and [] and False and []):  # SIM223
 
-SIM223.py:148:12: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:148:12: SIM223 [*] Use `[]` instead of `[] and ...`
     |
 148 |     pass
 149 | 
@@ -994,7 +994,7 @@ SIM223.py:148:12: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |            ^^^^^^^^^^^^^^^^^^^ SIM223
 151 |     pass
     |
-    = help: Replace with falsey `[]`
+    = help: Replace with `[]`
 
 ℹ Suggested fix
 145 145 | if (a and [] and False and []) == (a and []):  # SIM223

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -116,13 +116,13 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False`
 27 27 | 
 28 28 | 
 
-SIM223.py:42:4: SIM223 [*] Use `""` instead of `... and ""`
+SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and ""`
    |
 42 | if a and "" and False:  # SIM223
    |    ^^^^^^^^^^^^^^^^^^ SIM223
 43 |     pass
    |
-   = help: Replace with `""`
+   = help: Replace with falsey `""`
 
 ℹ Suggested fix
 39 39 |     pass
@@ -154,7 +154,7 @@ SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False`
 47 47 | 
 48 48 | if a and 0 and False:  # SIM223
 
-SIM223.py:48:4: SIM223 [*] Use `0` instead of `... and 0`
+SIM223.py:48:4: SIM223 [*] Use falsey `0` instead of `... and 0`
    |
 48 |     pass
 49 | 
@@ -162,7 +162,7 @@ SIM223.py:48:4: SIM223 [*] Use `0` instead of `... and 0`
    |    ^^^^^^^^^^^^^^^^^ SIM223
 51 |     pass
    |
-   = help: Replace with `0`
+   = help: Replace with falsey `0`
 
 ℹ Suggested fix
 45 45 | if a and "foo" and False and "bar":  # SIM223
@@ -194,7 +194,7 @@ SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False`
 53 53 | 
 54 54 | if a and 0.0 and False:  # SIM223
 
-SIM223.py:54:4: SIM223 [*] Use `0.0` instead of `... and 0.0`
+SIM223.py:54:4: SIM223 [*] Use falsey `0.0` instead of `... and 0.0`
    |
 54 |     pass
 55 | 
@@ -202,7 +202,7 @@ SIM223.py:54:4: SIM223 [*] Use `0.0` instead of `... and 0.0`
    |    ^^^^^^^^^^^^^^^^^^^ SIM223
 57 |     pass
    |
-   = help: Replace with `0.0`
+   = help: Replace with falsey `0.0`
 
 ℹ Suggested fix
 51 51 | if a and 1 and False and 2:  # SIM223
@@ -234,7 +234,7 @@ SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False`
 59 59 | 
 60 60 | if a and [] and False:  # SIM223
 
-SIM223.py:60:4: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:60:4: SIM223 [*] Use falsey `[]` instead of `... and []`
    |
 60 |     pass
 61 | 
@@ -242,7 +242,7 @@ SIM223.py:60:4: SIM223 [*] Use `[]` instead of `... and []`
    |    ^^^^^^^^^^^^^^^^^^ SIM223
 63 |     pass
    |
-   = help: Replace with `[]`
+   = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 57 57 | if a and 0.1 and False and 0.2:  # SIM223
@@ -254,7 +254,7 @@ SIM223.py:60:4: SIM223 [*] Use `[]` instead of `... and []`
 62 62 | 
 63 63 | if a and list([]) and False:  # SIM223
 
-SIM223.py:63:4: SIM223 [*] Use `list([])` instead of `... and list([])`
+SIM223.py:63:4: SIM223 [*] Use falsey `list([])` instead of `... and list([])`
    |
 63 |     pass
 64 | 
@@ -262,7 +262,7 @@ SIM223.py:63:4: SIM223 [*] Use `list([])` instead of `... and list([])`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 66 |     pass
    |
-   = help: Replace with `list([])`
+   = help: Replace with falsey `list([])`
 
 ℹ Suggested fix
 60 60 | if a and [] and False:  # SIM223
@@ -314,7 +314,7 @@ SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False`
 71 71 | 
 72 72 | if a and {} and False:  # SIM223
 
-SIM223.py:72:4: SIM223 [*] Use `{}` instead of `... and {}`
+SIM223.py:72:4: SIM223 [*] Use falsey `{}` instead of `... and {}`
    |
 72 |     pass
 73 | 
@@ -322,7 +322,7 @@ SIM223.py:72:4: SIM223 [*] Use `{}` instead of `... and {}`
    |    ^^^^^^^^^^^^^^^^^^ SIM223
 75 |     pass
    |
-   = help: Replace with `{}`
+   = help: Replace with falsey `{}`
 
 ℹ Suggested fix
 69 69 | if a and list([1]) and False and list([2]):  # SIM223
@@ -334,7 +334,7 @@ SIM223.py:72:4: SIM223 [*] Use `{}` instead of `... and {}`
 74 74 | 
 75 75 | if a and dict() and False:  # SIM223
 
-SIM223.py:75:4: SIM223 [*] Use `dict()` instead of `... and dict()`
+SIM223.py:75:4: SIM223 [*] Use falsey `dict()` instead of `... and dict()`
    |
 75 |     pass
 76 | 
@@ -342,7 +342,7 @@ SIM223.py:75:4: SIM223 [*] Use `dict()` instead of `... and dict()`
    |    ^^^^^^^^^^^^^^^^^^^^^^ SIM223
 78 |     pass
    |
-   = help: Replace with `dict()`
+   = help: Replace with falsey `dict()`
 
 ℹ Suggested fix
 72 72 | if a and {} and False:  # SIM223
@@ -394,7 +394,7 @@ SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False`
 83 83 | 
 84 84 | if a and set() and False:  # SIM223
 
-SIM223.py:84:4: SIM223 [*] Use `set()` instead of `... and set()`
+SIM223.py:84:4: SIM223 [*] Use falsey `set()` instead of `... and set()`
    |
 84 |     pass
 85 | 
@@ -402,7 +402,7 @@ SIM223.py:84:4: SIM223 [*] Use `set()` instead of `... and set()`
    |    ^^^^^^^^^^^^^^^^^^^^^ SIM223
 87 |     pass
    |
-   = help: Replace with `set()`
+   = help: Replace with falsey `set()`
 
 ℹ Suggested fix
 81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
@@ -414,7 +414,7 @@ SIM223.py:84:4: SIM223 [*] Use `set()` instead of `... and set()`
 86 86 | 
 87 87 | if a and set(set()) and False:  # SIM223
 
-SIM223.py:87:4: SIM223 [*] Use `set(set())` instead of `... and set(set())`
+SIM223.py:87:4: SIM223 [*] Use falsey `set(set())` instead of `... and set(set())`
    |
 87 |     pass
 88 | 
@@ -422,7 +422,7 @@ SIM223.py:87:4: SIM223 [*] Use `set(set())` instead of `... and set(set())`
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 90 |     pass
    |
-   = help: Replace with `set(set())`
+   = help: Replace with falsey `set(set())`
 
 ℹ Suggested fix
 84 84 | if a and set() and False:  # SIM223
@@ -474,7 +474,7 @@ SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False`
 95 95 | 
 96 96 | if a and () and False:  # SIM222
 
-SIM223.py:96:4: SIM223 [*] Use `()` instead of `... and ()`
+SIM223.py:96:4: SIM223 [*] Use falsey `()` instead of `... and ()`
    |
 96 |     pass
 97 | 
@@ -482,7 +482,7 @@ SIM223.py:96:4: SIM223 [*] Use `()` instead of `... and ()`
    |    ^^^^^^^^^^^^^^^^^^ SIM223
 99 |     pass
    |
-   = help: Replace with `()`
+   = help: Replace with falsey `()`
 
 ℹ Suggested fix
 93 93 | if a and set({1}) and False and set({2}):  # SIM223
@@ -494,7 +494,7 @@ SIM223.py:96:4: SIM223 [*] Use `()` instead of `... and ()`
 98 98 | 
 99 99 | if a and tuple(()) and False:  # SIM222
 
-SIM223.py:99:4: SIM223 [*] Use `tuple(())` instead of `... and tuple(())`
+SIM223.py:99:4: SIM223 [*] Use falsey `tuple(())` instead of `... and tuple(())`
     |
  99 |     pass
 100 | 
@@ -502,7 +502,7 @@ SIM223.py:99:4: SIM223 [*] Use `tuple(())` instead of `... and tuple(())`
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 102 |     pass
     |
-    = help: Replace with `tuple(())`
+    = help: Replace with falsey `tuple(())`
 
 ℹ Suggested fix
 96  96  | if a and () and False:  # SIM222
@@ -554,7 +554,7 @@ SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False`
 107 107 | 
 108 108 | if a and frozenset() and False:  # SIM222
 
-SIM223.py:108:4: SIM223 [*] Use `frozenset()` instead of `... and frozenset()`
+SIM223.py:108:4: SIM223 [*] Use falsey `frozenset()` instead of `... and frozenset()`
     |
 108 |     pass
 109 | 
@@ -562,7 +562,7 @@ SIM223.py:108:4: SIM223 [*] Use `frozenset()` instead of `... and frozenset()`
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 111 |     pass
     |
-    = help: Replace with `frozenset()`
+    = help: Replace with falsey `frozenset()`
 
 ℹ Suggested fix
 105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
@@ -574,7 +574,7 @@ SIM223.py:108:4: SIM223 [*] Use `frozenset()` instead of `... and frozenset()`
 110 110 | 
 111 111 | if a and frozenset(frozenset()) and False:  # SIM222
 
-SIM223.py:111:4: SIM223 [*] Use `frozenset(frozenset())` instead of `... and frozenset(frozenset())`
+SIM223.py:111:4: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `... and frozenset(frozenset())`
     |
 111 |     pass
 112 | 
@@ -582,7 +582,7 @@ SIM223.py:111:4: SIM223 [*] Use `frozenset(frozenset())` instead of `... and fro
     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 114 |     pass
     |
-    = help: Replace with `frozenset(frozenset())`
+    = help: Replace with falsey `frozenset(frozenset())`
 
 ℹ Suggested fix
 108 108 | if a and frozenset() and False:  # SIM222
@@ -634,7 +634,7 @@ SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False`
 119 119 | 
 120 120 | 
 
-SIM223.py:123:6: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:123:6: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 123 | # Inside test `a` is simplified
 124 | 
@@ -643,7 +643,7 @@ SIM223.py:123:6: SIM223 [*] Use `[]` instead of `... and []`
 126 | 
 127 | assert a and [] and False and []  # SIM223
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 120 120 | 
@@ -655,7 +655,7 @@ SIM223.py:123:6: SIM223 [*] Use `[]` instead of `... and []`
 125 125 | assert a and [] and False and []  # SIM223
 126 126 | 
 
-SIM223.py:125:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:125:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 125 | bool(a and [] and False and [])  # SIM223
 126 | 
@@ -664,7 +664,7 @@ SIM223.py:125:8: SIM223 [*] Use `[]` instead of `... and []`
 128 | 
 129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 122 122 | 
@@ -676,7 +676,7 @@ SIM223.py:125:8: SIM223 [*] Use `[]` instead of `... and []`
 127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
 128 128 |     pass
 
-SIM223.py:127:5: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:127:5: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 127 | assert a and [] and False and []  # SIM223
 128 | 
@@ -684,7 +684,7 @@ SIM223.py:127:5: SIM223 [*] Use `[]` instead of `... and []`
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 130 |     pass
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 124 124 | 
@@ -696,7 +696,7 @@ SIM223.py:127:5: SIM223 [*] Use `[]` instead of `... and []`
 129 129 | 
 130 130 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:127:36: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:127:36: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 127 | assert a and [] and False and []  # SIM223
 128 | 
@@ -704,7 +704,7 @@ SIM223.py:127:36: SIM223 [*] Use `[]` instead of `... and []`
     |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 130 |     pass
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 124 124 | 
@@ -716,7 +716,7 @@ SIM223.py:127:36: SIM223 [*] Use `[]` instead of `... and []`
 129 129 | 
 130 130 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:130:6: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:130:6: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 130 |     pass
 131 | 
@@ -725,7 +725,7 @@ SIM223.py:130:6: SIM223 [*] Use `[]` instead of `... and []`
 133 | 
 134 | while a and [] and False and []:  # SIM223
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
@@ -737,7 +737,7 @@ SIM223.py:130:6: SIM223 [*] Use `[]` instead of `... and []`
 132 132 | while a and [] and False and []:  # SIM223
 133 133 |     pass
 
-SIM223.py:132:7: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:132:7: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 132 | 0 if a and [] and False and [] else 1  # SIM222
 133 | 
@@ -745,7 +745,7 @@ SIM223.py:132:7: SIM223 [*] Use `[]` instead of `... and []`
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 135 |     pass
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 129 129 | 
@@ -757,7 +757,7 @@ SIM223.py:132:7: SIM223 [*] Use `[]` instead of `... and []`
 134 134 | 
 135 135 | [
 
-SIM223.py:139:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:139:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 139 |     for a in range(10)
 140 |     for b in range(10)
@@ -766,7 +766,7 @@ SIM223.py:139:8: SIM223 [*] Use `[]` instead of `... and []`
 142 |     if b and [] and False and []  # SIM223
 143 | ]
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 136 136 |     0
@@ -778,7 +778,7 @@ SIM223.py:139:8: SIM223 [*] Use `[]` instead of `... and []`
 141 141 | ]
 142 142 | 
 
-SIM223.py:140:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:140:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 140 |     for b in range(10)
 141 |     if a and [] and False and []  # SIM223
@@ -786,7 +786,7 @@ SIM223.py:140:8: SIM223 [*] Use `[]` instead of `... and []`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 143 | ]
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 137 137 |     for a in range(10)
@@ -798,7 +798,7 @@ SIM223.py:140:8: SIM223 [*] Use `[]` instead of `... and []`
 142 142 | 
 143 143 | {
 
-SIM223.py:147:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:147:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 147 |     for a in range(10)
 148 |     for b in range(10)
@@ -807,7 +807,7 @@ SIM223.py:147:8: SIM223 [*] Use `[]` instead of `... and []`
 150 |     if b and [] and False and []  # SIM223
 151 | }
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 144 144 |     0
@@ -819,7 +819,7 @@ SIM223.py:147:8: SIM223 [*] Use `[]` instead of `... and []`
 149 149 | }
 150 150 | 
 
-SIM223.py:148:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:148:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 148 |     for b in range(10)
 149 |     if a and [] and False and []  # SIM223
@@ -827,7 +827,7 @@ SIM223.py:148:8: SIM223 [*] Use `[]` instead of `... and []`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 151 | }
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 145 145 |     for a in range(10)
@@ -839,7 +839,7 @@ SIM223.py:148:8: SIM223 [*] Use `[]` instead of `... and []`
 150 150 | 
 151 151 | {
 
-SIM223.py:155:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:155:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 155 |     for a in range(10)
 156 |     for b in range(10)
@@ -848,7 +848,7 @@ SIM223.py:155:8: SIM223 [*] Use `[]` instead of `... and []`
 158 |     if b and [] and False and []  # SIM223
 159 | }
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 152 152 |     0: 0
@@ -860,7 +860,7 @@ SIM223.py:155:8: SIM223 [*] Use `[]` instead of `... and []`
 157 157 | }
 158 158 | 
 
-SIM223.py:156:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:156:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 156 |     for b in range(10)
 157 |     if a and [] and False and []  # SIM223
@@ -868,7 +868,7 @@ SIM223.py:156:8: SIM223 [*] Use `[]` instead of `... and []`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 159 | }
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 153 153 |     for a in range(10)
@@ -880,7 +880,7 @@ SIM223.py:156:8: SIM223 [*] Use `[]` instead of `... and []`
 158 158 | 
 159 159 | (
 
-SIM223.py:163:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:163:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 163 |     for a in range(10)
 164 |     for b in range(10)
@@ -889,7 +889,7 @@ SIM223.py:163:8: SIM223 [*] Use `[]` instead of `... and []`
 166 |     if b and [] and False and []  # SIM223
 167 | )
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 160 160 |     0
@@ -901,7 +901,7 @@ SIM223.py:163:8: SIM223 [*] Use `[]` instead of `... and []`
 165 165 | )
 166 166 | 
 
-SIM223.py:164:8: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:164:8: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 164 |     for b in range(10)
 165 |     if a and [] and False and []  # SIM223
@@ -909,7 +909,7 @@ SIM223.py:164:8: SIM223 [*] Use `[]` instead of `... and []`
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 167 | )
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 161 161 |     for a in range(10)
@@ -921,7 +921,7 @@ SIM223.py:164:8: SIM223 [*] Use `[]` instead of `... and []`
 166 166 | 
 167 167 | # Outside test `a` is not simplified
 
-SIM223.py:169:7: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:169:7: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 169 | # Outside test `a` is not simplified
 170 | 
@@ -930,7 +930,7 @@ SIM223.py:169:7: SIM223 [*] Use `[]` instead of `... and []`
 172 | 
 173 | if (a and [] and False and []) == (a and []):  # SIM223
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 166 166 | 
@@ -942,7 +942,7 @@ SIM223.py:169:7: SIM223 [*] Use `[]` instead of `... and []`
 171 171 | if (a and [] and False and []) == (a and []):  # SIM223
 172 172 |     pass
 
-SIM223.py:171:11: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:171:11: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 171 | a and [] and False and []  # SIM223
 172 | 
@@ -950,7 +950,7 @@ SIM223.py:171:11: SIM223 [*] Use `[]` instead of `... and []`
     |           ^^^^^^^^^^^^^^^^^^^ SIM223
 174 |     pass
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 168 168 | 
@@ -962,7 +962,7 @@ SIM223.py:171:11: SIM223 [*] Use `[]` instead of `... and []`
 173 173 | 
 174 174 | if f(a and [] and False and []):  # SIM223
 
-SIM223.py:174:12: SIM223 [*] Use `[]` instead of `... and []`
+SIM223.py:174:12: SIM223 [*] Use falsey `[]` instead of `... and []`
     |
 174 |     pass
 175 | 
@@ -970,7 +970,7 @@ SIM223.py:174:12: SIM223 [*] Use `[]` instead of `... and []`
     |            ^^^^^^^^^^^^^^^^^^^ SIM223
 177 |     pass
     |
-    = help: Replace with `[]`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
 171 171 | if (a and [] and False and []) == (a and []):  # SIM223

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -116,11 +116,12 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False and ...`
 27 27 | 
 28 28 | 
 
-SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and "" and ...`
+SIM223.py:42:7: SIM223 [*] Use falsey `""` instead of `"" and ...`
    |
-42 | if a and "" and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^ SIM223
-43 |     pass
+42 | a and "" and False  # SIM223
+   |       ^^^^^^^^^^^^ SIM223
+43 | 
+44 | a and "foo" and False and "bar"  # SIM223
    |
    = help: Replace with falsey `""`
 
@@ -128,856 +129,879 @@ SIM223.py:42:4: SIM223 [*] Use falsey `""` instead of `... and "" and ...`
 39 39 |     pass
 40 40 | 
 41 41 | 
-42    |-if a and "" and False:  # SIM223
-   42 |+if "":  # SIM223
-43 43 |     pass
-44 44 | 
-45 45 | if a and "foo" and False and "bar":  # SIM223
+42    |-a and "" and False  # SIM223
+   42 |+a and ""  # SIM223
+43 43 | 
+44 44 | a and "foo" and False and "bar"  # SIM223
+45 45 | 
 
-SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:44:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-45 |     pass
-46 | 
-47 | if a and "foo" and False and "bar":  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-48 |     pass
+44 | a and "" and False  # SIM223
+45 | 
+46 | a and "foo" and False and "bar"  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+47 | 
+48 | a and 0 and False  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-42 42 | if a and "" and False:  # SIM223
-43 43 |     pass
-44 44 | 
-45    |-if a and "foo" and False and "bar":  # SIM223
-   45 |+if False:  # SIM223
-46 46 |     pass
+41 41 | 
+42 42 | a and "" and False  # SIM223
+43 43 | 
+44    |-a and "foo" and False and "bar"  # SIM223
+   44 |+a and False  # SIM223
+45 45 | 
+46 46 | a and 0 and False  # SIM223
 47 47 | 
-48 48 | if a and 0 and False:  # SIM223
 
-SIM223.py:48:4: SIM223 [*] Use falsey `0` instead of `... and 0 and ...`
+SIM223.py:46:7: SIM223 [*] Use falsey `0` instead of `0 and ...`
    |
-48 |     pass
+46 | a and "foo" and False and "bar"  # SIM223
+47 | 
+48 | a and 0 and False  # SIM223
+   |       ^^^^^^^^^^^ SIM223
 49 | 
-50 | if a and 0 and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^ SIM223
-51 |     pass
+50 | a and 1 and False and 2  # SIM223
    |
    = help: Replace with falsey `0`
 
 ℹ Suggested fix
-45 45 | if a and "foo" and False and "bar":  # SIM223
-46 46 |     pass
+43 43 | 
+44 44 | a and "foo" and False and "bar"  # SIM223
+45 45 | 
+46    |-a and 0 and False  # SIM223
+   46 |+a and 0  # SIM223
 47 47 | 
-48    |-if a and 0 and False:  # SIM223
-   48 |+if 0:  # SIM223
-49 49 |     pass
-50 50 | 
-51 51 | if a and 1 and False and 2:  # SIM223
+48 48 | a and 1 and False and 2  # SIM223
+49 49 | 
 
-SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:48:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-51 |     pass
-52 | 
-53 | if a and 1 and False and 2:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-54 |     pass
+48 | a and 0 and False  # SIM223
+49 | 
+50 | a and 1 and False and 2  # SIM223
+   |       ^^^^^^^^^^^^^^^^^ SIM223
+51 | 
+52 | a and 0.0 and False  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-48 48 | if a and 0 and False:  # SIM223
-49 49 |     pass
-50 50 | 
-51    |-if a and 1 and False and 2:  # SIM223
-   51 |+if False:  # SIM223
-52 52 |     pass
-53 53 | 
-54 54 | if a and 0.0 and False:  # SIM223
+45 45 | 
+46 46 | a and 0 and False  # SIM223
+47 47 | 
+48    |-a and 1 and False and 2  # SIM223
+   48 |+a and False  # SIM223
+49 49 | 
+50 50 | a and 0.0 and False  # SIM223
+51 51 | 
 
-SIM223.py:54:4: SIM223 [*] Use falsey `0.0` instead of `... and 0.0 and ...`
+SIM223.py:50:7: SIM223 [*] Use falsey `0.0` instead of `0.0 and ...`
    |
-54 |     pass
-55 | 
-56 | if a and 0.0 and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^ SIM223
-57 |     pass
+50 | a and 1 and False and 2  # SIM223
+51 | 
+52 | a and 0.0 and False  # SIM223
+   |       ^^^^^^^^^^^^^ SIM223
+53 | 
+54 | a and 0.1 and False and 0.2  # SIM223
    |
    = help: Replace with falsey `0.0`
 
 ℹ Suggested fix
-51 51 | if a and 1 and False and 2:  # SIM223
-52 52 |     pass
+47 47 | 
+48 48 | a and 1 and False and 2  # SIM223
+49 49 | 
+50    |-a and 0.0 and False  # SIM223
+   50 |+a and 0.0  # SIM223
+51 51 | 
+52 52 | a and 0.1 and False and 0.2  # SIM223
 53 53 | 
-54    |-if a and 0.0 and False:  # SIM223
-   54 |+if 0.0:  # SIM223
-55 55 |     pass
-56 56 | 
-57 57 | if a and 0.1 and False and 0.2:  # SIM223
 
-SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:52:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-57 |     pass
-58 | 
-59 | if a and 0.1 and False and 0.2:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-60 |     pass
+52 | a and 0.0 and False  # SIM223
+53 | 
+54 | a and 0.1 and False and 0.2  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^ SIM223
+55 | 
+56 | a and [] and False  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-54 54 | if a and 0.0 and False:  # SIM223
-55 55 |     pass
-56 56 | 
-57    |-if a and 0.1 and False and 0.2:  # SIM223
-   57 |+if False:  # SIM223
-58 58 |     pass
-59 59 | 
-60 60 | if a and [] and False:  # SIM223
+49 49 | 
+50 50 | a and 0.0 and False  # SIM223
+51 51 | 
+52    |-a and 0.1 and False and 0.2  # SIM223
+   52 |+a and False  # SIM223
+53 53 | 
+54 54 | a and [] and False  # SIM223
+55 55 | 
 
-SIM223.py:60:4: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:54:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
    |
-60 |     pass
-61 | 
-62 | if a and [] and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^ SIM223
-63 |     pass
+54 | a and 0.1 and False and 0.2  # SIM223
+55 | 
+56 | a and [] and False  # SIM223
+   |       ^^^^^^^^^^^^ SIM223
+57 | 
+58 | a and list([]) and False  # SIM223
    |
    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-57 57 | if a and 0.1 and False and 0.2:  # SIM223
-58 58 |     pass
-59 59 | 
-60    |-if a and [] and False:  # SIM223
-   60 |+if []:  # SIM223
-61 61 |     pass
-62 62 | 
-63 63 | if a and list([]) and False:  # SIM223
+51 51 | 
+52 52 | a and 0.1 and False and 0.2  # SIM223
+53 53 | 
+54    |-a and [] and False  # SIM223
+   54 |+a and []  # SIM223
+55 55 | 
+56 56 | a and list([]) and False  # SIM223
+57 57 | 
 
-SIM223.py:63:4: SIM223 [*] Use falsey `list([])` instead of `... and list([]) and ...`
+SIM223.py:56:7: SIM223 [*] Use falsey `list([])` instead of `list([]) and ...`
    |
-63 |     pass
-64 | 
-65 | if a and list([]) and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-66 |     pass
+56 | a and [] and False  # SIM223
+57 | 
+58 | a and list([]) and False  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^ SIM223
+59 | 
+60 | a and [1] and False and [2]  # SIM223
    |
    = help: Replace with falsey `list([])`
 
 ℹ Suggested fix
-60 60 | if a and [] and False:  # SIM223
-61 61 |     pass
-62 62 | 
-63    |-if a and list([]) and False:  # SIM223
-   63 |+if list([]):  # SIM223
-64 64 |     pass
-65 65 | 
-66 66 | if a and [1] and False and [2]:  # SIM223
+53 53 | 
+54 54 | a and [] and False  # SIM223
+55 55 | 
+56    |-a and list([]) and False  # SIM223
+   56 |+a and list([])  # SIM223
+57 57 | 
+58 58 | a and [1] and False and [2]  # SIM223
+59 59 | 
 
-SIM223.py:66:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:58:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-66 |     pass
-67 | 
-68 | if a and [1] and False and [2]:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-69 |     pass
-   |
-   = help: Replace with `False`
-
-ℹ Suggested fix
-63 63 | if a and list([]) and False:  # SIM223
-64 64 |     pass
-65 65 | 
-66    |-if a and [1] and False and [2]:  # SIM223
-   66 |+if False:  # SIM223
-67 67 |     pass
-68 68 | 
-69 69 | if a and list([1]) and False and list([2]):  # SIM223
-
-SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False and ...`
-   |
-69 |     pass
-70 | 
-71 | if a and list([1]) and False and list([2]):  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-72 |     pass
+58 | a and list([]) and False  # SIM223
+59 | 
+60 | a and [1] and False and [2]  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^ SIM223
+61 | 
+62 | a and list([1]) and False and list([2])  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-66 66 | if a and [1] and False and [2]:  # SIM223
-67 67 |     pass
-68 68 | 
-69    |-if a and list([1]) and False and list([2]):  # SIM223
-   69 |+if False:  # SIM223
-70 70 |     pass
-71 71 | 
-72 72 | if a and {} and False:  # SIM223
+55 55 | 
+56 56 | a and list([]) and False  # SIM223
+57 57 | 
+58    |-a and [1] and False and [2]  # SIM223
+   58 |+a and False  # SIM223
+59 59 | 
+60 60 | a and list([1]) and False and list([2])  # SIM223
+61 61 | 
 
-SIM223.py:72:4: SIM223 [*] Use falsey `{}` instead of `... and {} and ...`
+SIM223.py:60:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-72 |     pass
-73 | 
-74 | if a and {} and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^ SIM223
-75 |     pass
+60 | a and [1] and False and [2]  # SIM223
+61 | 
+62 | a and list([1]) and False and list([2])  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+63 | 
+64 | a and {} and False  # SIM223
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+57 57 | 
+58 58 | a and [1] and False and [2]  # SIM223
+59 59 | 
+60    |-a and list([1]) and False and list([2])  # SIM223
+   60 |+a and False  # SIM223
+61 61 | 
+62 62 | a and {} and False  # SIM223
+63 63 | 
+
+SIM223.py:62:7: SIM223 [*] Use falsey `{}` instead of `{} and ...`
+   |
+62 | a and list([1]) and False and list([2])  # SIM223
+63 | 
+64 | a and {} and False  # SIM223
+   |       ^^^^^^^^^^^^ SIM223
+65 | 
+66 | a and dict() and False  # SIM223
    |
    = help: Replace with falsey `{}`
 
 ℹ Suggested fix
-69 69 | if a and list([1]) and False and list([2]):  # SIM223
-70 70 |     pass
-71 71 | 
-72    |-if a and {} and False:  # SIM223
-   72 |+if {}:  # SIM223
-73 73 |     pass
-74 74 | 
-75 75 | if a and dict() and False:  # SIM223
+59 59 | 
+60 60 | a and list([1]) and False and list([2])  # SIM223
+61 61 | 
+62    |-a and {} and False  # SIM223
+   62 |+a and {}  # SIM223
+63 63 | 
+64 64 | a and dict() and False  # SIM223
+65 65 | 
 
-SIM223.py:75:4: SIM223 [*] Use falsey `dict()` instead of `... and dict() and ...`
+SIM223.py:64:7: SIM223 [*] Use falsey `dict()` instead of `dict() and ...`
    |
-75 |     pass
-76 | 
-77 | if a and dict() and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^ SIM223
-78 |     pass
+64 | a and {} and False  # SIM223
+65 | 
+66 | a and dict() and False  # SIM223
+   |       ^^^^^^^^^^^^^^^^ SIM223
+67 | 
+68 | a and {1: 1} and False and {2: 2}  # SIM223
    |
    = help: Replace with falsey `dict()`
 
 ℹ Suggested fix
-72 72 | if a and {} and False:  # SIM223
-73 73 |     pass
-74 74 | 
-75    |-if a and dict() and False:  # SIM223
-   75 |+if dict():  # SIM223
-76 76 |     pass
-77 77 | 
-78 78 | if a and {1: 1} and False and {2: 2}:  # SIM223
+61 61 | 
+62 62 | a and {} and False  # SIM223
+63 63 | 
+64    |-a and dict() and False  # SIM223
+   64 |+a and dict()  # SIM223
+65 65 | 
+66 66 | a and {1: 1} and False and {2: 2}  # SIM223
+67 67 | 
 
-SIM223.py:78:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:66:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-78 |     pass
-79 | 
-80 | if a and {1: 1} and False and {2: 2}:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-81 |     pass
-   |
-   = help: Replace with `False`
-
-ℹ Suggested fix
-75 75 | if a and dict() and False:  # SIM223
-76 76 |     pass
-77 77 | 
-78    |-if a and {1: 1} and False and {2: 2}:  # SIM223
-   78 |+if False:  # SIM223
-79 79 |     pass
-80 80 | 
-81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
-
-SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False and ...`
-   |
-81 |     pass
-82 | 
-83 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-84 |     pass
+66 | a and dict() and False  # SIM223
+67 | 
+68 | a and {1: 1} and False and {2: 2}  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+69 | 
+70 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-78 78 | if a and {1: 1} and False and {2: 2}:  # SIM223
-79 79 |     pass
-80 80 | 
-81    |-if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
-   81 |+if False:  # SIM223
-82 82 |     pass
-83 83 | 
-84 84 | if a and set() and False:  # SIM223
+63 63 | 
+64 64 | a and dict() and False  # SIM223
+65 65 | 
+66    |-a and {1: 1} and False and {2: 2}  # SIM223
+   66 |+a and False  # SIM223
+67 67 | 
+68 68 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
+69 69 | 
 
-SIM223.py:84:4: SIM223 [*] Use falsey `set()` instead of `... and set() and ...`
+SIM223.py:68:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-84 |     pass
-85 | 
-86 | if a and set() and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^ SIM223
-87 |     pass
+68 | a and {1: 1} and False and {2: 2}  # SIM223
+69 | 
+70 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+71 | 
+72 | a and set() and False  # SIM223
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+65 65 | 
+66 66 | a and {1: 1} and False and {2: 2}  # SIM223
+67 67 | 
+68    |-a and dict({1: 1}) and False and dict({2: 2})  # SIM223
+   68 |+a and False  # SIM223
+69 69 | 
+70 70 | a and set() and False  # SIM223
+71 71 | 
+
+SIM223.py:70:7: SIM223 [*] Use falsey `set()` instead of `set() and ...`
+   |
+70 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
+71 | 
+72 | a and set() and False  # SIM223
+   |       ^^^^^^^^^^^^^^^ SIM223
+73 | 
+74 | a and set(set()) and False  # SIM223
    |
    = help: Replace with falsey `set()`
 
 ℹ Suggested fix
-81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
-82 82 |     pass
-83 83 | 
-84    |-if a and set() and False:  # SIM223
-   84 |+if set():  # SIM223
-85 85 |     pass
-86 86 | 
-87 87 | if a and set(set()) and False:  # SIM223
+67 67 | 
+68 68 | a and dict({1: 1}) and False and dict({2: 2})  # SIM223
+69 69 | 
+70    |-a and set() and False  # SIM223
+   70 |+a and set()  # SIM223
+71 71 | 
+72 72 | a and set(set()) and False  # SIM223
+73 73 | 
 
-SIM223.py:87:4: SIM223 [*] Use falsey `set(set())` instead of `... and set(set()) and ...`
+SIM223.py:72:7: SIM223 [*] Use falsey `set(set())` instead of `set(set()) and ...`
    |
-87 |     pass
-88 | 
-89 | if a and set(set()) and False:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-90 |     pass
+72 | a and set() and False  # SIM223
+73 | 
+74 | a and set(set()) and False  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^ SIM223
+75 | 
+76 | a and {1} and False and {2}  # SIM223
    |
    = help: Replace with falsey `set(set())`
 
 ℹ Suggested fix
-84 84 | if a and set() and False:  # SIM223
-85 85 |     pass
-86 86 | 
-87    |-if a and set(set()) and False:  # SIM223
-   87 |+if set(set()):  # SIM223
-88 88 |     pass
-89 89 | 
-90 90 | if a and {1} and False and {2}:  # SIM223
+69 69 | 
+70 70 | a and set() and False  # SIM223
+71 71 | 
+72    |-a and set(set()) and False  # SIM223
+   72 |+a and set(set())  # SIM223
+73 73 | 
+74 74 | a and {1} and False and {2}  # SIM223
+75 75 | 
 
-SIM223.py:90:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:74:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-90 |     pass
-91 | 
-92 | if a and {1} and False and {2}:  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-93 |     pass
-   |
-   = help: Replace with `False`
-
-ℹ Suggested fix
-87 87 | if a and set(set()) and False:  # SIM223
-88 88 |     pass
-89 89 | 
-90    |-if a and {1} and False and {2}:  # SIM223
-   90 |+if False:  # SIM223
-91 91 |     pass
-92 92 | 
-93 93 | if a and set({1}) and False and set({2}):  # SIM223
-
-SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False and ...`
-   |
-93 |     pass
-94 | 
-95 | if a and set({1}) and False and set({2}):  # SIM223
-   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-96 |     pass
+74 | a and set(set()) and False  # SIM223
+75 | 
+76 | a and {1} and False and {2}  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^ SIM223
+77 | 
+78 | a and set({1}) and False and set({2})  # SIM223
    |
    = help: Replace with `False`
 
 ℹ Suggested fix
-90 90 | if a and {1} and False and {2}:  # SIM223
-91 91 |     pass
-92 92 | 
-93    |-if a and set({1}) and False and set({2}):  # SIM223
-   93 |+if False:  # SIM223
-94 94 |     pass
-95 95 | 
-96 96 | if a and () and False:  # SIM222
+71 71 | 
+72 72 | a and set(set()) and False  # SIM223
+73 73 | 
+74    |-a and {1} and False and {2}  # SIM223
+   74 |+a and False  # SIM223
+75 75 | 
+76 76 | a and set({1}) and False and set({2})  # SIM223
+77 77 | 
 
-SIM223.py:96:4: SIM223 [*] Use falsey `()` instead of `... and () and ...`
+SIM223.py:76:7: SIM223 [*] Use `False` instead of `... and False and ...`
    |
-96 |     pass
-97 | 
-98 | if a and () and False:  # SIM222
-   |    ^^^^^^^^^^^^^^^^^^ SIM223
-99 |     pass
+76 | a and {1} and False and {2}  # SIM223
+77 | 
+78 | a and set({1}) and False and set({2})  # SIM223
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+79 | 
+80 | a and () and False  # SIM222
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+73 73 | 
+74 74 | a and {1} and False and {2}  # SIM223
+75 75 | 
+76    |-a and set({1}) and False and set({2})  # SIM223
+   76 |+a and False  # SIM223
+77 77 | 
+78 78 | a and () and False  # SIM222
+79 79 | 
+
+SIM223.py:78:7: SIM223 [*] Use falsey `()` instead of `() and ...`
+   |
+78 | a and set({1}) and False and set({2})  # SIM223
+79 | 
+80 | a and () and False  # SIM222
+   |       ^^^^^^^^^^^^ SIM223
+81 | 
+82 | a and tuple(()) and False  # SIM222
    |
    = help: Replace with falsey `()`
 
 ℹ Suggested fix
-93 93 | if a and set({1}) and False and set({2}):  # SIM223
-94 94 |     pass
-95 95 | 
-96    |-if a and () and False:  # SIM222
-   96 |+if ():  # SIM222
-97 97 |     pass
-98 98 | 
-99 99 | if a and tuple(()) and False:  # SIM222
+75 75 | 
+76 76 | a and set({1}) and False and set({2})  # SIM223
+77 77 | 
+78    |-a and () and False  # SIM222
+   78 |+a and ()  # SIM222
+79 79 | 
+80 80 | a and tuple(()) and False  # SIM222
+81 81 | 
 
-SIM223.py:99:4: SIM223 [*] Use falsey `tuple(())` instead of `... and tuple(()) and ...`
+SIM223.py:80:7: SIM223 [*] Use falsey `tuple(())` instead of `tuple(()) and ...`
+   |
+80 | a and () and False  # SIM222
+81 | 
+82 | a and tuple(()) and False  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^ SIM223
+83 | 
+84 | a and (1,) and False and (2,)  # SIM222
+   |
+   = help: Replace with falsey `tuple(())`
+
+ℹ Suggested fix
+77 77 | 
+78 78 | a and () and False  # SIM222
+79 79 | 
+80    |-a and tuple(()) and False  # SIM222
+   80 |+a and tuple(())  # SIM222
+81 81 | 
+82 82 | a and (1,) and False and (2,)  # SIM222
+83 83 | 
+
+SIM223.py:82:7: SIM223 [*] Use `False` instead of `... and False and ...`
+   |
+82 | a and tuple(()) and False  # SIM222
+83 | 
+84 | a and (1,) and False and (2,)  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+85 | 
+86 | a and tuple((1,)) and False and tuple((2,))  # SIM222
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+79 79 | 
+80 80 | a and tuple(()) and False  # SIM222
+81 81 | 
+82    |-a and (1,) and False and (2,)  # SIM222
+   82 |+a and False  # SIM222
+83 83 | 
+84 84 | a and tuple((1,)) and False and tuple((2,))  # SIM222
+85 85 | 
+
+SIM223.py:84:7: SIM223 [*] Use `False` instead of `... and False and ...`
+   |
+84 | a and (1,) and False and (2,)  # SIM222
+85 | 
+86 | a and tuple((1,)) and False and tuple((2,))  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+87 | 
+88 | a and frozenset() and False  # SIM222
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+81 81 | 
+82 82 | a and (1,) and False and (2,)  # SIM222
+83 83 | 
+84    |-a and tuple((1,)) and False and tuple((2,))  # SIM222
+   84 |+a and False  # SIM222
+85 85 | 
+86 86 | a and frozenset() and False  # SIM222
+87 87 | 
+
+SIM223.py:86:7: SIM223 [*] Use falsey `frozenset()` instead of `frozenset() and ...`
+   |
+86 | a and tuple((1,)) and False and tuple((2,))  # SIM222
+87 | 
+88 | a and frozenset() and False  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^ SIM223
+89 | 
+90 | a and frozenset(frozenset()) and False  # SIM222
+   |
+   = help: Replace with falsey `frozenset()`
+
+ℹ Suggested fix
+83 83 | 
+84 84 | a and tuple((1,)) and False and tuple((2,))  # SIM222
+85 85 | 
+86    |-a and frozenset() and False  # SIM222
+   86 |+a and frozenset()  # SIM222
+87 87 | 
+88 88 | a and frozenset(frozenset()) and False  # SIM222
+89 89 | 
+
+SIM223.py:88:7: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `frozenset(frozenset()) and ...`
+   |
+88 | a and frozenset() and False  # SIM222
+89 | 
+90 | a and frozenset(frozenset()) and False  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+91 | 
+92 | a and frozenset({1}) and False and frozenset({2})  # SIM222
+   |
+   = help: Replace with falsey `frozenset(frozenset())`
+
+ℹ Suggested fix
+85 85 | 
+86 86 | a and frozenset() and False  # SIM222
+87 87 | 
+88    |-a and frozenset(frozenset()) and False  # SIM222
+   88 |+a and frozenset(frozenset())  # SIM222
+89 89 | 
+90 90 | a and frozenset({1}) and False and frozenset({2})  # SIM222
+91 91 | 
+
+SIM223.py:90:7: SIM223 [*] Use `False` instead of `... and False and ...`
+   |
+90 | a and frozenset(frozenset()) and False  # SIM222
+91 | 
+92 | a and frozenset({1}) and False and frozenset({2})  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+93 | 
+94 | a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+87 87 | 
+88 88 | a and frozenset(frozenset()) and False  # SIM222
+89 89 | 
+90    |-a and frozenset({1}) and False and frozenset({2})  # SIM222
+   90 |+a and False  # SIM222
+91 91 | 
+92 92 | a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
+93 93 | 
+
+SIM223.py:92:7: SIM223 [*] Use `False` instead of `... and False and ...`
+   |
+92 | a and frozenset({1}) and False and frozenset({2})  # SIM222
+93 | 
+94 | a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+89 89 | 
+90 90 | a and frozenset({1}) and False and frozenset({2})  # SIM222
+91 91 | 
+92    |-a and frozenset(frozenset({1})) and False and frozenset(frozenset({2}))  # SIM222
+   92 |+a and False  # SIM222
+93 93 | 
+94 94 | 
+95 95 | # Inside test `a` is simplified
+
+SIM223.py:97:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
- 99 |     pass
+ 97 | # Inside test `a` is simplified
+ 98 | 
+ 99 | bool(a and [] and False and [])  # SIM223
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
 100 | 
-101 | if a and tuple(()) and False:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-102 |     pass
+101 | assert a and [] and False and []  # SIM223
     |
-    = help: Replace with falsey `tuple(())`
+    = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-96  96  | if a and () and False:  # SIM222
-97  97  |     pass
+94 94 | 
+95 95 | # Inside test `a` is simplified
+96 96 | 
+97    |-bool(a and [] and False and [])  # SIM223
+   97 |+bool([])  # SIM223
+98 98 | 
+99 99 | assert a and [] and False and []  # SIM223
+100 100 | 
+
+SIM223.py:99:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+    |
+ 99 | bool(a and [] and False and [])  # SIM223
+100 | 
+101 | assert a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+102 | 
+103 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    |
+    = help: Replace with falsey `[]`
+
+ℹ Suggested fix
+96  96  | 
+97  97  | bool(a and [] and False and [])  # SIM223
 98  98  | 
-99      |-if a and tuple(()) and False:  # SIM222
-    99  |+if tuple(()):  # SIM222
-100 100 |     pass
-101 101 | 
-102 102 | if a and (1,) and False and (2,):  # SIM222
+99      |-assert a and [] and False and []  # SIM223
+    99  |+assert []  # SIM223
+100 100 | 
+101 101 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+102 102 |     pass
 
-SIM223.py:102:4: SIM223 [*] Use `False` instead of `... and False and ...`
+SIM223.py:101:5: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-102 |     pass
-103 | 
-104 | if a and (1,) and False and (2,):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-105 |     pass
-    |
-    = help: Replace with `False`
-
-ℹ Suggested fix
-99  99  | if a and tuple(()) and False:  # SIM222
-100 100 |     pass
-101 101 | 
-102     |-if a and (1,) and False and (2,):  # SIM222
-    102 |+if False:  # SIM222
-103 103 |     pass
-104 104 | 
-105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
-
-SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False and ...`
-    |
-105 |     pass
-106 | 
-107 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-108 |     pass
-    |
-    = help: Replace with `False`
-
-ℹ Suggested fix
-102 102 | if a and (1,) and False and (2,):  # SIM222
-103 103 |     pass
-104 104 | 
-105     |-if a and tuple((1,)) and False and tuple((2,)):  # SIM222
-    105 |+if False:  # SIM222
-106 106 |     pass
-107 107 | 
-108 108 | if a and frozenset() and False:  # SIM222
-
-SIM223.py:108:4: SIM223 [*] Use falsey `frozenset()` instead of `... and frozenset() and ...`
-    |
-108 |     pass
-109 | 
-110 | if a and frozenset() and False:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-111 |     pass
-    |
-    = help: Replace with falsey `frozenset()`
-
-ℹ Suggested fix
-105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
-106 106 |     pass
-107 107 | 
-108     |-if a and frozenset() and False:  # SIM222
-    108 |+if frozenset():  # SIM222
-109 109 |     pass
-110 110 | 
-111 111 | if a and frozenset(frozenset()) and False:  # SIM222
-
-SIM223.py:111:4: SIM223 [*] Use falsey `frozenset(frozenset())` instead of `... and frozenset(frozenset()) and ...`
-    |
-111 |     pass
-112 | 
-113 | if a and frozenset(frozenset()) and False:  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-114 |     pass
-    |
-    = help: Replace with falsey `frozenset(frozenset())`
-
-ℹ Suggested fix
-108 108 | if a and frozenset() and False:  # SIM222
-109 109 |     pass
-110 110 | 
-111     |-if a and frozenset(frozenset()) and False:  # SIM222
-    111 |+if frozenset(frozenset()):  # SIM222
-112 112 |     pass
-113 113 | 
-114 114 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
-
-SIM223.py:114:4: SIM223 [*] Use `False` instead of `... and False and ...`
-    |
-114 |     pass
-115 | 
-116 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-117 |     pass
-    |
-    = help: Replace with `False`
-
-ℹ Suggested fix
-111 111 | if a and frozenset(frozenset()) and False:  # SIM222
-112 112 |     pass
-113 113 | 
-114     |-if a and frozenset({1}) and False and frozenset({2}):  # SIM222
-    114 |+if False:  # SIM222
-115 115 |     pass
-116 116 | 
-117 117 | if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
-
-SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False and ...`
-    |
-117 |     pass
-118 | 
-119 | if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
-    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-120 |     pass
-    |
-    = help: Replace with `False`
-
-ℹ Suggested fix
-114 114 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
-115 115 |     pass
-116 116 | 
-117     |-if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
-    117 |+if False:  # SIM222
-118 118 |     pass
-119 119 | 
-120 120 | 
-
-SIM223.py:123:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
-    |
-123 | # Inside test `a` is simplified
-124 | 
-125 | bool(a and [] and False and [])  # SIM223
-    |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-126 | 
-127 | assert a and [] and False and []  # SIM223
-    |
-    = help: Replace with falsey `[]`
-
-ℹ Suggested fix
-120 120 | 
-121 121 | # Inside test `a` is simplified
-122 122 | 
-123     |-bool(a and [] and False and [])  # SIM223
-    123 |+bool([])  # SIM223
-124 124 | 
-125 125 | assert a and [] and False and []  # SIM223
-126 126 | 
-
-SIM223.py:125:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
-    |
-125 | bool(a and [] and False and [])  # SIM223
-126 | 
-127 | assert a and [] and False and []  # SIM223
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-128 | 
-129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-    |
-    = help: Replace with falsey `[]`
-
-ℹ Suggested fix
-122 122 | 
-123 123 | bool(a and [] and False and [])  # SIM223
-124 124 | 
-125     |-assert a and [] and False and []  # SIM223
-    125 |+assert []  # SIM223
-126 126 | 
-127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-128 128 |     pass
-
-SIM223.py:127:5: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
-    |
-127 | assert a and [] and False and []  # SIM223
-128 | 
-129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+101 | assert a and [] and False and []  # SIM223
+102 | 
+103 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-130 |     pass
+104 |     pass
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-124 124 | 
-125 125 | assert a and [] and False and []  # SIM223
-126 126 | 
-127     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-    127 |+if ([]) or (a and [] and False and []):  # SIM223
-128 128 |     pass
-129 129 | 
-130 130 | 0 if a and [] and False and [] else 1  # SIM222
+98  98  | 
+99  99  | assert a and [] and False and []  # SIM223
+100 100 | 
+101     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    101 |+if ([]) or (a and [] and False and []):  # SIM223
+102 102 |     pass
+103 103 | 
+104 104 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:127:36: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:101:36: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-127 | assert a and [] and False and []  # SIM223
-128 | 
-129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+101 | assert a and [] and False and []  # SIM223
+102 | 
+103 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
     |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-130 |     pass
+104 |     pass
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-124 124 | 
-125 125 | assert a and [] and False and []  # SIM223
-126 126 | 
-127     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-    127 |+if (a and [] and False and []) or ([]):  # SIM223
-128 128 |     pass
-129 129 | 
-130 130 | 0 if a and [] and False and [] else 1  # SIM222
+98  98  | 
+99  99  | assert a and [] and False and []  # SIM223
+100 100 | 
+101     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    101 |+if (a and [] and False and []) or ([]):  # SIM223
+102 102 |     pass
+103 103 | 
+104 104 | 0 if a and [] and False and [] else 1  # SIM222
 
-SIM223.py:130:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:104:6: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-130 |     pass
-131 | 
-132 | 0 if a and [] and False and [] else 1  # SIM222
+104 |     pass
+105 | 
+106 | 0 if a and [] and False and [] else 1  # SIM222
     |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-133 | 
-134 | while a and [] and False and []:  # SIM223
+107 | 
+108 | while a and [] and False and []:  # SIM223
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
-128 128 |     pass
-129 129 | 
-130     |-0 if a and [] and False and [] else 1  # SIM222
-    130 |+0 if [] else 1  # SIM222
-131 131 | 
-132 132 | while a and [] and False and []:  # SIM223
-133 133 |     pass
+101 101 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+102 102 |     pass
+103 103 | 
+104     |-0 if a and [] and False and [] else 1  # SIM222
+    104 |+0 if [] else 1  # SIM222
+105 105 | 
+106 106 | while a and [] and False and []:  # SIM223
+107 107 |     pass
 
-SIM223.py:132:7: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:106:7: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-132 | 0 if a and [] and False and [] else 1  # SIM222
-133 | 
-134 | while a and [] and False and []:  # SIM223
+106 | 0 if a and [] and False and [] else 1  # SIM222
+107 | 
+108 | while a and [] and False and []:  # SIM223
     |       ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-135 |     pass
+109 |     pass
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-129 129 | 
-130 130 | 0 if a and [] and False and [] else 1  # SIM222
-131 131 | 
-132     |-while a and [] and False and []:  # SIM223
-    132 |+while []:  # SIM223
-133 133 |     pass
-134 134 | 
-135 135 | [
+103 103 | 
+104 104 | 0 if a and [] and False and [] else 1  # SIM222
+105 105 | 
+106     |-while a and [] and False and []:  # SIM223
+    106 |+while []:  # SIM223
+107 107 |     pass
+108 108 | 
+109 109 | [
 
-SIM223.py:139:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:113:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-139 |     for a in range(10)
-140 |     for b in range(10)
-141 |     if a and [] and False and []  # SIM223
+113 |     for a in range(10)
+114 |     for b in range(10)
+115 |     if a and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-142 |     if b and [] and False and []  # SIM223
-143 | ]
+116 |     if b and [] and False and []  # SIM223
+117 | ]
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-136 136 |     0
-137 137 |     for a in range(10)
-138 138 |     for b in range(10)
-139     |-    if a and [] and False and []  # SIM223
-    139 |+    if []  # SIM223
-140 140 |     if b and [] and False and []  # SIM223
-141 141 | ]
-142 142 | 
+110 110 |     0
+111 111 |     for a in range(10)
+112 112 |     for b in range(10)
+113     |-    if a and [] and False and []  # SIM223
+    113 |+    if []  # SIM223
+114 114 |     if b and [] and False and []  # SIM223
+115 115 | ]
+116 116 | 
 
-SIM223.py:140:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:114:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-140 |     for b in range(10)
-141 |     if a and [] and False and []  # SIM223
-142 |     if b and [] and False and []  # SIM223
+114 |     for b in range(10)
+115 |     if a and [] and False and []  # SIM223
+116 |     if b and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-143 | ]
+117 | ]
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-137 137 |     for a in range(10)
-138 138 |     for b in range(10)
-139 139 |     if a and [] and False and []  # SIM223
-140     |-    if b and [] and False and []  # SIM223
-    140 |+    if []  # SIM223
-141 141 | ]
-142 142 | 
-143 143 | {
+111 111 |     for a in range(10)
+112 112 |     for b in range(10)
+113 113 |     if a and [] and False and []  # SIM223
+114     |-    if b and [] and False and []  # SIM223
+    114 |+    if []  # SIM223
+115 115 | ]
+116 116 | 
+117 117 | {
 
-SIM223.py:147:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:121:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-147 |     for a in range(10)
-148 |     for b in range(10)
-149 |     if a and [] and False and []  # SIM223
+121 |     for a in range(10)
+122 |     for b in range(10)
+123 |     if a and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-150 |     if b and [] and False and []  # SIM223
-151 | }
+124 |     if b and [] and False and []  # SIM223
+125 | }
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-144 144 |     0
-145 145 |     for a in range(10)
-146 146 |     for b in range(10)
-147     |-    if a and [] and False and []  # SIM223
-    147 |+    if []  # SIM223
-148 148 |     if b and [] and False and []  # SIM223
-149 149 | }
-150 150 | 
+118 118 |     0
+119 119 |     for a in range(10)
+120 120 |     for b in range(10)
+121     |-    if a and [] and False and []  # SIM223
+    121 |+    if []  # SIM223
+122 122 |     if b and [] and False and []  # SIM223
+123 123 | }
+124 124 | 
 
-SIM223.py:148:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:122:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-148 |     for b in range(10)
-149 |     if a and [] and False and []  # SIM223
-150 |     if b and [] and False and []  # SIM223
+122 |     for b in range(10)
+123 |     if a and [] and False and []  # SIM223
+124 |     if b and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-151 | }
+125 | }
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-145 145 |     for a in range(10)
-146 146 |     for b in range(10)
-147 147 |     if a and [] and False and []  # SIM223
-148     |-    if b and [] and False and []  # SIM223
-    148 |+    if []  # SIM223
-149 149 | }
-150 150 | 
-151 151 | {
+119 119 |     for a in range(10)
+120 120 |     for b in range(10)
+121 121 |     if a and [] and False and []  # SIM223
+122     |-    if b and [] and False and []  # SIM223
+    122 |+    if []  # SIM223
+123 123 | }
+124 124 | 
+125 125 | {
 
-SIM223.py:155:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:129:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-155 |     for a in range(10)
-156 |     for b in range(10)
-157 |     if a and [] and False and []  # SIM223
+129 |     for a in range(10)
+130 |     for b in range(10)
+131 |     if a and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-158 |     if b and [] and False and []  # SIM223
-159 | }
+132 |     if b and [] and False and []  # SIM223
+133 | }
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-152 152 |     0: 0
-153 153 |     for a in range(10)
-154 154 |     for b in range(10)
-155     |-    if a and [] and False and []  # SIM223
-    155 |+    if []  # SIM223
-156 156 |     if b and [] and False and []  # SIM223
-157 157 | }
-158 158 | 
+126 126 |     0: 0
+127 127 |     for a in range(10)
+128 128 |     for b in range(10)
+129     |-    if a and [] and False and []  # SIM223
+    129 |+    if []  # SIM223
+130 130 |     if b and [] and False and []  # SIM223
+131 131 | }
+132 132 | 
 
-SIM223.py:156:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:130:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-156 |     for b in range(10)
-157 |     if a and [] and False and []  # SIM223
-158 |     if b and [] and False and []  # SIM223
+130 |     for b in range(10)
+131 |     if a and [] and False and []  # SIM223
+132 |     if b and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-159 | }
+133 | }
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-153 153 |     for a in range(10)
-154 154 |     for b in range(10)
-155 155 |     if a and [] and False and []  # SIM223
-156     |-    if b and [] and False and []  # SIM223
-    156 |+    if []  # SIM223
-157 157 | }
-158 158 | 
-159 159 | (
+127 127 |     for a in range(10)
+128 128 |     for b in range(10)
+129 129 |     if a and [] and False and []  # SIM223
+130     |-    if b and [] and False and []  # SIM223
+    130 |+    if []  # SIM223
+131 131 | }
+132 132 | 
+133 133 | (
 
-SIM223.py:163:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:137:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-163 |     for a in range(10)
-164 |     for b in range(10)
-165 |     if a and [] and False and []  # SIM223
+137 |     for a in range(10)
+138 |     for b in range(10)
+139 |     if a and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-166 |     if b and [] and False and []  # SIM223
-167 | )
+140 |     if b and [] and False and []  # SIM223
+141 | )
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-160 160 |     0
-161 161 |     for a in range(10)
-162 162 |     for b in range(10)
-163     |-    if a and [] and False and []  # SIM223
-    163 |+    if []  # SIM223
-164 164 |     if b and [] and False and []  # SIM223
-165 165 | )
-166 166 | 
+134 134 |     0
+135 135 |     for a in range(10)
+136 136 |     for b in range(10)
+137     |-    if a and [] and False and []  # SIM223
+    137 |+    if []  # SIM223
+138 138 |     if b and [] and False and []  # SIM223
+139 139 | )
+140 140 | 
 
-SIM223.py:164:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
+SIM223.py:138:8: SIM223 [*] Use falsey `[]` instead of `... and [] and ...`
     |
-164 |     for b in range(10)
-165 |     if a and [] and False and []  # SIM223
-166 |     if b and [] and False and []  # SIM223
+138 |     for b in range(10)
+139 |     if a and [] and False and []  # SIM223
+140 |     if b and [] and False and []  # SIM223
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
-167 | )
+141 | )
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-161 161 |     for a in range(10)
-162 162 |     for b in range(10)
-163 163 |     if a and [] and False and []  # SIM223
-164     |-    if b and [] and False and []  # SIM223
-    164 |+    if []  # SIM223
-165 165 | )
-166 166 | 
-167 167 | # Outside test `a` is not simplified
+135 135 |     for a in range(10)
+136 136 |     for b in range(10)
+137 137 |     if a and [] and False and []  # SIM223
+138     |-    if b and [] and False and []  # SIM223
+    138 |+    if []  # SIM223
+139 139 | )
+140 140 | 
+141 141 | # Outside test `a` is not simplified
 
-SIM223.py:169:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:143:7: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
-169 | # Outside test `a` is not simplified
-170 | 
-171 | a and [] and False and []  # SIM223
+143 | # Outside test `a` is not simplified
+144 | 
+145 | a and [] and False and []  # SIM223
     |       ^^^^^^^^^^^^^^^^^^^ SIM223
-172 | 
-173 | if (a and [] and False and []) == (a and []):  # SIM223
+146 | 
+147 | if (a and [] and False and []) == (a and []):  # SIM223
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-166 166 | 
-167 167 | # Outside test `a` is not simplified
-168 168 | 
-169     |-a and [] and False and []  # SIM223
-    169 |+a and []  # SIM223
-170 170 | 
-171 171 | if (a and [] and False and []) == (a and []):  # SIM223
-172 172 |     pass
+140 140 | 
+141 141 | # Outside test `a` is not simplified
+142 142 | 
+143     |-a and [] and False and []  # SIM223
+    143 |+a and []  # SIM223
+144 144 | 
+145 145 | if (a and [] and False and []) == (a and []):  # SIM223
+146 146 |     pass
 
-SIM223.py:171:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:145:11: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
-171 | a and [] and False and []  # SIM223
-172 | 
-173 | if (a and [] and False and []) == (a and []):  # SIM223
+145 | a and [] and False and []  # SIM223
+146 | 
+147 | if (a and [] and False and []) == (a and []):  # SIM223
     |           ^^^^^^^^^^^^^^^^^^^ SIM223
-174 |     pass
+148 |     pass
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-168 168 | 
-169 169 | a and [] and False and []  # SIM223
-170 170 | 
-171     |-if (a and [] and False and []) == (a and []):  # SIM223
-    171 |+if (a and []) == (a and []):  # SIM223
-172 172 |     pass
-173 173 | 
-174 174 | if f(a and [] and False and []):  # SIM223
+142 142 | 
+143 143 | a and [] and False and []  # SIM223
+144 144 | 
+145     |-if (a and [] and False and []) == (a and []):  # SIM223
+    145 |+if (a and []) == (a and []):  # SIM223
+146 146 |     pass
+147 147 | 
+148 148 | if f(a and [] and False and []):  # SIM223
 
-SIM223.py:174:12: SIM223 [*] Use falsey `[]` instead of `[] and ...`
+SIM223.py:148:12: SIM223 [*] Use falsey `[]` instead of `[] and ...`
     |
-174 |     pass
-175 | 
-176 | if f(a and [] and False and []):  # SIM223
+148 |     pass
+149 | 
+150 | if f(a and [] and False and []):  # SIM223
     |            ^^^^^^^^^^^^^^^^^^^ SIM223
-177 |     pass
+151 |     pass
     |
     = help: Replace with falsey `[]`
 
 ℹ Suggested fix
-171 171 | if (a and [] and False and []) == (a and []):  # SIM223
-172 172 |     pass
-173 173 | 
-174     |-if f(a and [] and False and []):  # SIM223
-    174 |+if f(a and []):  # SIM223
-175 175 |     pass
+145 145 | if (a and [] and False and []) == (a and []):  # SIM223
+146 146 |     pass
+147 147 | 
+148     |-if f(a and [] and False and []):  # SIM223
+    148 |+if f(a and []):  # SIM223
+149 149 |     pass
 
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM223_SIM223.py.snap
@@ -116,4 +116,868 @@ SIM223.py:25:4: SIM223 [*] Use `False` instead of `... and False`
 27 27 | 
 28 28 | 
 
+SIM223.py:42:4: SIM223 [*] Use `""` instead of `... and ""`
+   |
+42 | if a and "" and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^ SIM223
+43 |     pass
+   |
+   = help: Replace with `""`
+
+ℹ Suggested fix
+39 39 |     pass
+40 40 | 
+41 41 | 
+42    |-if a and "" and False:  # SIM223
+   42 |+if "":  # SIM223
+43 43 |     pass
+44 44 | 
+45 45 | if a and "foo" and False and "bar":  # SIM223
+
+SIM223.py:45:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+45 |     pass
+46 | 
+47 | if a and "foo" and False and "bar":  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+48 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+42 42 | if a and "" and False:  # SIM223
+43 43 |     pass
+44 44 | 
+45    |-if a and "foo" and False and "bar":  # SIM223
+   45 |+if False:  # SIM223
+46 46 |     pass
+47 47 | 
+48 48 | if a and 0 and False:  # SIM223
+
+SIM223.py:48:4: SIM223 [*] Use `0` instead of `... and 0`
+   |
+48 |     pass
+49 | 
+50 | if a and 0 and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^ SIM223
+51 |     pass
+   |
+   = help: Replace with `0`
+
+ℹ Suggested fix
+45 45 | if a and "foo" and False and "bar":  # SIM223
+46 46 |     pass
+47 47 | 
+48    |-if a and 0 and False:  # SIM223
+   48 |+if 0:  # SIM223
+49 49 |     pass
+50 50 | 
+51 51 | if a and 1 and False and 2:  # SIM223
+
+SIM223.py:51:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+51 |     pass
+52 | 
+53 | if a and 1 and False and 2:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+54 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+48 48 | if a and 0 and False:  # SIM223
+49 49 |     pass
+50 50 | 
+51    |-if a and 1 and False and 2:  # SIM223
+   51 |+if False:  # SIM223
+52 52 |     pass
+53 53 | 
+54 54 | if a and 0.0 and False:  # SIM223
+
+SIM223.py:54:4: SIM223 [*] Use `0.0` instead of `... and 0.0`
+   |
+54 |     pass
+55 | 
+56 | if a and 0.0 and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^ SIM223
+57 |     pass
+   |
+   = help: Replace with `0.0`
+
+ℹ Suggested fix
+51 51 | if a and 1 and False and 2:  # SIM223
+52 52 |     pass
+53 53 | 
+54    |-if a and 0.0 and False:  # SIM223
+   54 |+if 0.0:  # SIM223
+55 55 |     pass
+56 56 | 
+57 57 | if a and 0.1 and False and 0.2:  # SIM223
+
+SIM223.py:57:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+57 |     pass
+58 | 
+59 | if a and 0.1 and False and 0.2:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+60 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+54 54 | if a and 0.0 and False:  # SIM223
+55 55 |     pass
+56 56 | 
+57    |-if a and 0.1 and False and 0.2:  # SIM223
+   57 |+if False:  # SIM223
+58 58 |     pass
+59 59 | 
+60 60 | if a and [] and False:  # SIM223
+
+SIM223.py:60:4: SIM223 [*] Use `[]` instead of `... and []`
+   |
+60 |     pass
+61 | 
+62 | if a and [] and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^ SIM223
+63 |     pass
+   |
+   = help: Replace with `[]`
+
+ℹ Suggested fix
+57 57 | if a and 0.1 and False and 0.2:  # SIM223
+58 58 |     pass
+59 59 | 
+60    |-if a and [] and False:  # SIM223
+   60 |+if []:  # SIM223
+61 61 |     pass
+62 62 | 
+63 63 | if a and list([]) and False:  # SIM223
+
+SIM223.py:63:4: SIM223 [*] Use `list([])` instead of `... and list([])`
+   |
+63 |     pass
+64 | 
+65 | if a and list([]) and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+66 |     pass
+   |
+   = help: Replace with `list([])`
+
+ℹ Suggested fix
+60 60 | if a and [] and False:  # SIM223
+61 61 |     pass
+62 62 | 
+63    |-if a and list([]) and False:  # SIM223
+   63 |+if list([]):  # SIM223
+64 64 |     pass
+65 65 | 
+66 66 | if a and [1] and False and [2]:  # SIM223
+
+SIM223.py:66:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+66 |     pass
+67 | 
+68 | if a and [1] and False and [2]:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+69 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+63 63 | if a and list([]) and False:  # SIM223
+64 64 |     pass
+65 65 | 
+66    |-if a and [1] and False and [2]:  # SIM223
+   66 |+if False:  # SIM223
+67 67 |     pass
+68 68 | 
+69 69 | if a and list([1]) and False and list([2]):  # SIM223
+
+SIM223.py:69:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+69 |     pass
+70 | 
+71 | if a and list([1]) and False and list([2]):  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+72 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+66 66 | if a and [1] and False and [2]:  # SIM223
+67 67 |     pass
+68 68 | 
+69    |-if a and list([1]) and False and list([2]):  # SIM223
+   69 |+if False:  # SIM223
+70 70 |     pass
+71 71 | 
+72 72 | if a and {} and False:  # SIM223
+
+SIM223.py:72:4: SIM223 [*] Use `{}` instead of `... and {}`
+   |
+72 |     pass
+73 | 
+74 | if a and {} and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^ SIM223
+75 |     pass
+   |
+   = help: Replace with `{}`
+
+ℹ Suggested fix
+69 69 | if a and list([1]) and False and list([2]):  # SIM223
+70 70 |     pass
+71 71 | 
+72    |-if a and {} and False:  # SIM223
+   72 |+if {}:  # SIM223
+73 73 |     pass
+74 74 | 
+75 75 | if a and dict() and False:  # SIM223
+
+SIM223.py:75:4: SIM223 [*] Use `dict()` instead of `... and dict()`
+   |
+75 |     pass
+76 | 
+77 | if a and dict() and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^ SIM223
+78 |     pass
+   |
+   = help: Replace with `dict()`
+
+ℹ Suggested fix
+72 72 | if a and {} and False:  # SIM223
+73 73 |     pass
+74 74 | 
+75    |-if a and dict() and False:  # SIM223
+   75 |+if dict():  # SIM223
+76 76 |     pass
+77 77 | 
+78 78 | if a and {1: 1} and False and {2: 2}:  # SIM223
+
+SIM223.py:78:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+78 |     pass
+79 | 
+80 | if a and {1: 1} and False and {2: 2}:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+81 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+75 75 | if a and dict() and False:  # SIM223
+76 76 |     pass
+77 77 | 
+78    |-if a and {1: 1} and False and {2: 2}:  # SIM223
+   78 |+if False:  # SIM223
+79 79 |     pass
+80 80 | 
+81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
+
+SIM223.py:81:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+81 |     pass
+82 | 
+83 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+84 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+78 78 | if a and {1: 1} and False and {2: 2}:  # SIM223
+79 79 |     pass
+80 80 | 
+81    |-if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
+   81 |+if False:  # SIM223
+82 82 |     pass
+83 83 | 
+84 84 | if a and set() and False:  # SIM223
+
+SIM223.py:84:4: SIM223 [*] Use `set()` instead of `... and set()`
+   |
+84 |     pass
+85 | 
+86 | if a and set() and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^ SIM223
+87 |     pass
+   |
+   = help: Replace with `set()`
+
+ℹ Suggested fix
+81 81 | if a and dict({1: 1}) and False and dict({2: 2}):  # SIM223
+82 82 |     pass
+83 83 | 
+84    |-if a and set() and False:  # SIM223
+   84 |+if set():  # SIM223
+85 85 |     pass
+86 86 | 
+87 87 | if a and set(set()) and False:  # SIM223
+
+SIM223.py:87:4: SIM223 [*] Use `set(set())` instead of `... and set(set())`
+   |
+87 |     pass
+88 | 
+89 | if a and set(set()) and False:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+90 |     pass
+   |
+   = help: Replace with `set(set())`
+
+ℹ Suggested fix
+84 84 | if a and set() and False:  # SIM223
+85 85 |     pass
+86 86 | 
+87    |-if a and set(set()) and False:  # SIM223
+   87 |+if set(set()):  # SIM223
+88 88 |     pass
+89 89 | 
+90 90 | if a and {1} and False and {2}:  # SIM223
+
+SIM223.py:90:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+90 |     pass
+91 | 
+92 | if a and {1} and False and {2}:  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+93 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+87 87 | if a and set(set()) and False:  # SIM223
+88 88 |     pass
+89 89 | 
+90    |-if a and {1} and False and {2}:  # SIM223
+   90 |+if False:  # SIM223
+91 91 |     pass
+92 92 | 
+93 93 | if a and set({1}) and False and set({2}):  # SIM223
+
+SIM223.py:93:4: SIM223 [*] Use `False` instead of `... and False`
+   |
+93 |     pass
+94 | 
+95 | if a and set({1}) and False and set({2}):  # SIM223
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+96 |     pass
+   |
+   = help: Replace with `False`
+
+ℹ Suggested fix
+90 90 | if a and {1} and False and {2}:  # SIM223
+91 91 |     pass
+92 92 | 
+93    |-if a and set({1}) and False and set({2}):  # SIM223
+   93 |+if False:  # SIM223
+94 94 |     pass
+95 95 | 
+96 96 | if a and () and False:  # SIM222
+
+SIM223.py:96:4: SIM223 [*] Use `()` instead of `... and ()`
+   |
+96 |     pass
+97 | 
+98 | if a and () and False:  # SIM222
+   |    ^^^^^^^^^^^^^^^^^^ SIM223
+99 |     pass
+   |
+   = help: Replace with `()`
+
+ℹ Suggested fix
+93 93 | if a and set({1}) and False and set({2}):  # SIM223
+94 94 |     pass
+95 95 | 
+96    |-if a and () and False:  # SIM222
+   96 |+if ():  # SIM222
+97 97 |     pass
+98 98 | 
+99 99 | if a and tuple(()) and False:  # SIM222
+
+SIM223.py:99:4: SIM223 [*] Use `tuple(())` instead of `... and tuple(())`
+    |
+ 99 |     pass
+100 | 
+101 | if a and tuple(()) and False:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+102 |     pass
+    |
+    = help: Replace with `tuple(())`
+
+ℹ Suggested fix
+96  96  | if a and () and False:  # SIM222
+97  97  |     pass
+98  98  | 
+99      |-if a and tuple(()) and False:  # SIM222
+    99  |+if tuple(()):  # SIM222
+100 100 |     pass
+101 101 | 
+102 102 | if a and (1,) and False and (2,):  # SIM222
+
+SIM223.py:102:4: SIM223 [*] Use `False` instead of `... and False`
+    |
+102 |     pass
+103 | 
+104 | if a and (1,) and False and (2,):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+105 |     pass
+    |
+    = help: Replace with `False`
+
+ℹ Suggested fix
+99  99  | if a and tuple(()) and False:  # SIM222
+100 100 |     pass
+101 101 | 
+102     |-if a and (1,) and False and (2,):  # SIM222
+    102 |+if False:  # SIM222
+103 103 |     pass
+104 104 | 
+105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
+
+SIM223.py:105:4: SIM223 [*] Use `False` instead of `... and False`
+    |
+105 |     pass
+106 | 
+107 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+108 |     pass
+    |
+    = help: Replace with `False`
+
+ℹ Suggested fix
+102 102 | if a and (1,) and False and (2,):  # SIM222
+103 103 |     pass
+104 104 | 
+105     |-if a and tuple((1,)) and False and tuple((2,)):  # SIM222
+    105 |+if False:  # SIM222
+106 106 |     pass
+107 107 | 
+108 108 | if a and frozenset() and False:  # SIM222
+
+SIM223.py:108:4: SIM223 [*] Use `frozenset()` instead of `... and frozenset()`
+    |
+108 |     pass
+109 | 
+110 | if a and frozenset() and False:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+111 |     pass
+    |
+    = help: Replace with `frozenset()`
+
+ℹ Suggested fix
+105 105 | if a and tuple((1,)) and False and tuple((2,)):  # SIM222
+106 106 |     pass
+107 107 | 
+108     |-if a and frozenset() and False:  # SIM222
+    108 |+if frozenset():  # SIM222
+109 109 |     pass
+110 110 | 
+111 111 | if a and frozenset(frozenset()) and False:  # SIM222
+
+SIM223.py:111:4: SIM223 [*] Use `frozenset(frozenset())` instead of `... and frozenset(frozenset())`
+    |
+111 |     pass
+112 | 
+113 | if a and frozenset(frozenset()) and False:  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+114 |     pass
+    |
+    = help: Replace with `frozenset(frozenset())`
+
+ℹ Suggested fix
+108 108 | if a and frozenset() and False:  # SIM222
+109 109 |     pass
+110 110 | 
+111     |-if a and frozenset(frozenset()) and False:  # SIM222
+    111 |+if frozenset(frozenset()):  # SIM222
+112 112 |     pass
+113 113 | 
+114 114 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
+
+SIM223.py:114:4: SIM223 [*] Use `False` instead of `... and False`
+    |
+114 |     pass
+115 | 
+116 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+117 |     pass
+    |
+    = help: Replace with `False`
+
+ℹ Suggested fix
+111 111 | if a and frozenset(frozenset()) and False:  # SIM222
+112 112 |     pass
+113 113 | 
+114     |-if a and frozenset({1}) and False and frozenset({2}):  # SIM222
+    114 |+if False:  # SIM222
+115 115 |     pass
+116 116 | 
+117 117 | if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
+
+SIM223.py:117:4: SIM223 [*] Use `False` instead of `... and False`
+    |
+117 |     pass
+118 | 
+119 | if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
+    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+120 |     pass
+    |
+    = help: Replace with `False`
+
+ℹ Suggested fix
+114 114 | if a and frozenset({1}) and False and frozenset({2}):  # SIM222
+115 115 |     pass
+116 116 | 
+117     |-if a and frozenset(frozenset({1})) and False and frozenset(frozenset({2})):  # SIM222
+    117 |+if False:  # SIM222
+118 118 |     pass
+119 119 | 
+120 120 | 
+
+SIM223.py:123:6: SIM223 [*] Use `[]` instead of `... and []`
+    |
+123 | # Inside test `a` is simplified
+124 | 
+125 | bool(a and [] and False and [])  # SIM223
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+126 | 
+127 | assert a and [] and False and []  # SIM223
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+120 120 | 
+121 121 | # Inside test `a` is simplified
+122 122 | 
+123     |-bool(a and [] and False and [])  # SIM223
+    123 |+bool([])  # SIM223
+124 124 | 
+125 125 | assert a and [] and False and []  # SIM223
+126 126 | 
+
+SIM223.py:125:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+125 | bool(a and [] and False and [])  # SIM223
+126 | 
+127 | assert a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+128 | 
+129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+122 122 | 
+123 123 | bool(a and [] and False and [])  # SIM223
+124 124 | 
+125     |-assert a and [] and False and []  # SIM223
+    125 |+assert []  # SIM223
+126 126 | 
+127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+128 128 |     pass
+
+SIM223.py:127:5: SIM223 [*] Use `[]` instead of `... and []`
+    |
+127 | assert a and [] and False and []  # SIM223
+128 | 
+129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+130 |     pass
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+124 124 | 
+125 125 | assert a and [] and False and []  # SIM223
+126 126 | 
+127     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    127 |+if ([]) or (a and [] and False and []):  # SIM223
+128 128 |     pass
+129 129 | 
+130 130 | 0 if a and [] and False and [] else 1  # SIM222
+
+SIM223.py:127:36: SIM223 [*] Use `[]` instead of `... and []`
+    |
+127 | assert a and [] and False and []  # SIM223
+128 | 
+129 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+130 |     pass
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+124 124 | 
+125 125 | assert a and [] and False and []  # SIM223
+126 126 | 
+127     |-if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+    127 |+if (a and [] and False and []) or ([]):  # SIM223
+128 128 |     pass
+129 129 | 
+130 130 | 0 if a and [] and False and [] else 1  # SIM222
+
+SIM223.py:130:6: SIM223 [*] Use `[]` instead of `... and []`
+    |
+130 |     pass
+131 | 
+132 | 0 if a and [] and False and [] else 1  # SIM222
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+133 | 
+134 | while a and [] and False and []:  # SIM223
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+127 127 | if (a and [] and False and []) or (a and [] and False and []):  # SIM223
+128 128 |     pass
+129 129 | 
+130     |-0 if a and [] and False and [] else 1  # SIM222
+    130 |+0 if [] else 1  # SIM222
+131 131 | 
+132 132 | while a and [] and False and []:  # SIM223
+133 133 |     pass
+
+SIM223.py:132:7: SIM223 [*] Use `[]` instead of `... and []`
+    |
+132 | 0 if a and [] and False and [] else 1  # SIM222
+133 | 
+134 | while a and [] and False and []:  # SIM223
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+135 |     pass
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+129 129 | 
+130 130 | 0 if a and [] and False and [] else 1  # SIM222
+131 131 | 
+132     |-while a and [] and False and []:  # SIM223
+    132 |+while []:  # SIM223
+133 133 |     pass
+134 134 | 
+135 135 | [
+
+SIM223.py:139:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+139 |     for a in range(10)
+140 |     for b in range(10)
+141 |     if a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+142 |     if b and [] and False and []  # SIM223
+143 | ]
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+136 136 |     0
+137 137 |     for a in range(10)
+138 138 |     for b in range(10)
+139     |-    if a and [] and False and []  # SIM223
+    139 |+    if []  # SIM223
+140 140 |     if b and [] and False and []  # SIM223
+141 141 | ]
+142 142 | 
+
+SIM223.py:140:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+140 |     for b in range(10)
+141 |     if a and [] and False and []  # SIM223
+142 |     if b and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+143 | ]
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+137 137 |     for a in range(10)
+138 138 |     for b in range(10)
+139 139 |     if a and [] and False and []  # SIM223
+140     |-    if b and [] and False and []  # SIM223
+    140 |+    if []  # SIM223
+141 141 | ]
+142 142 | 
+143 143 | {
+
+SIM223.py:147:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+147 |     for a in range(10)
+148 |     for b in range(10)
+149 |     if a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+150 |     if b and [] and False and []  # SIM223
+151 | }
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+144 144 |     0
+145 145 |     for a in range(10)
+146 146 |     for b in range(10)
+147     |-    if a and [] and False and []  # SIM223
+    147 |+    if []  # SIM223
+148 148 |     if b and [] and False and []  # SIM223
+149 149 | }
+150 150 | 
+
+SIM223.py:148:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+148 |     for b in range(10)
+149 |     if a and [] and False and []  # SIM223
+150 |     if b and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+151 | }
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+145 145 |     for a in range(10)
+146 146 |     for b in range(10)
+147 147 |     if a and [] and False and []  # SIM223
+148     |-    if b and [] and False and []  # SIM223
+    148 |+    if []  # SIM223
+149 149 | }
+150 150 | 
+151 151 | {
+
+SIM223.py:155:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+155 |     for a in range(10)
+156 |     for b in range(10)
+157 |     if a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+158 |     if b and [] and False and []  # SIM223
+159 | }
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+152 152 |     0: 0
+153 153 |     for a in range(10)
+154 154 |     for b in range(10)
+155     |-    if a and [] and False and []  # SIM223
+    155 |+    if []  # SIM223
+156 156 |     if b and [] and False and []  # SIM223
+157 157 | }
+158 158 | 
+
+SIM223.py:156:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+156 |     for b in range(10)
+157 |     if a and [] and False and []  # SIM223
+158 |     if b and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+159 | }
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+153 153 |     for a in range(10)
+154 154 |     for b in range(10)
+155 155 |     if a and [] and False and []  # SIM223
+156     |-    if b and [] and False and []  # SIM223
+    156 |+    if []  # SIM223
+157 157 | }
+158 158 | 
+159 159 | (
+
+SIM223.py:163:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+163 |     for a in range(10)
+164 |     for b in range(10)
+165 |     if a and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+166 |     if b and [] and False and []  # SIM223
+167 | )
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+160 160 |     0
+161 161 |     for a in range(10)
+162 162 |     for b in range(10)
+163     |-    if a and [] and False and []  # SIM223
+    163 |+    if []  # SIM223
+164 164 |     if b and [] and False and []  # SIM223
+165 165 | )
+166 166 | 
+
+SIM223.py:164:8: SIM223 [*] Use `[]` instead of `... and []`
+    |
+164 |     for b in range(10)
+165 |     if a and [] and False and []  # SIM223
+166 |     if b and [] and False and []  # SIM223
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ SIM223
+167 | )
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+161 161 |     for a in range(10)
+162 162 |     for b in range(10)
+163 163 |     if a and [] and False and []  # SIM223
+164     |-    if b and [] and False and []  # SIM223
+    164 |+    if []  # SIM223
+165 165 | )
+166 166 | 
+167 167 | # Outside test `a` is not simplified
+
+SIM223.py:169:7: SIM223 [*] Use `[]` instead of `... and []`
+    |
+169 | # Outside test `a` is not simplified
+170 | 
+171 | a and [] and False and []  # SIM223
+    |       ^^^^^^^^^^^^^^^^^^^ SIM223
+172 | 
+173 | if (a and [] and False and []) == (a and []):  # SIM223
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+166 166 | 
+167 167 | # Outside test `a` is not simplified
+168 168 | 
+169     |-a and [] and False and []  # SIM223
+    169 |+a and []  # SIM223
+170 170 | 
+171 171 | if (a and [] and False and []) == (a and []):  # SIM223
+172 172 |     pass
+
+SIM223.py:171:11: SIM223 [*] Use `[]` instead of `... and []`
+    |
+171 | a and [] and False and []  # SIM223
+172 | 
+173 | if (a and [] and False and []) == (a and []):  # SIM223
+    |           ^^^^^^^^^^^^^^^^^^^ SIM223
+174 |     pass
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+168 168 | 
+169 169 | a and [] and False and []  # SIM223
+170 170 | 
+171     |-if (a and [] and False and []) == (a and []):  # SIM223
+    171 |+if (a and []) == (a and []):  # SIM223
+172 172 |     pass
+173 173 | 
+174 174 | if f(a and [] and False and []):  # SIM223
+
+SIM223.py:174:12: SIM223 [*] Use `[]` instead of `... and []`
+    |
+174 |     pass
+175 | 
+176 | if f(a and [] and False and []):  # SIM223
+    |            ^^^^^^^^^^^^^^^^^^^ SIM223
+177 |     pass
+    |
+    = help: Replace with `[]`
+
+ℹ Suggested fix
+171 171 | if (a and [] and False and []) == (a and []):  # SIM223
+172 172 |     pass
+173 173 | 
+174     |-if f(a and [] and False and []):  # SIM223
+    174 |+if f(a and []):  # SIM223
+175 175 |     pass
+
 


### PR DESCRIPTION
- Close #4058

Special case truthy expressions like side-effect expressions.
If a truthy expression is followed by the short-circuiting boolean, remove the short-circuiting boolean too as it is unnecessary.
The violation message should be changed in this case to something like "remove everything after the truth expression".
```python
assert ("foo" and False) == "foo"
assert ("foo" or True) == "foo"
```

I use `Truthiness` from `flake8-bandit`, but `flake8-pytest` also has `is_falsy_constant()`.
Should we make extract `Truthiness` from `flake8-bandit`, add the missing cases from `flake8-pytest`, and use it for `flake8-bandit`, `flake8-pytest`, and `flake8-simplify`?
I would be open making another PR for this.