### PR TITLE
Increment priority should be (branch-local, global)

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B031.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B031.py
@@ -149,6 +149,16 @@ for group in groupby(items, key=lambda p: p[1]):
     collect_shop_items("Joe", group[1])
 
 
+# https://github.com/charliermarsh/ruff/issues/4050
+for _section, section_items in itertools.groupby(items, key=lambda p: p[1]):
+    if _section == "greens":
+        for item in section_items:
+            collect_shop_items(shopper, item)
+    elif _section == "frozen items":
+        _ = [item for item in section_items]
+    else:
+        collect_shop_items(shopper, section_items)
+
 #  Make sure we ignore - but don't fail on more complicated invocations
 for _key, (_value1, _value2) in groupby(
     [("a", (1, 2)), ("b", (3, 4)), ("a", (5, 6))], key=lambda p: p[1]


### PR DESCRIPTION
## Problem:
Updating the global usage count even if the visitor is inside a mutually exclusive branch. This leads to reporting an error in the subsequent branches due to the global count being incremented.

## Solution:
Always increment the branch-local count first if we're in one, only then update the global count.

fixes: #4050 