### PR TITLE
Add `PrefectHQ/prefect` to list of ruff users

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Pandas](https://github.com/pandas-dev/pandas)
 - [Polars](https://github.com/pola-rs/polars)
 - [PostHog](https://github.com/PostHog/posthog)
-- Prefect ([Python SDK and Server](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin))
+- Prefect ([Python SDK](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin))
 - [Pydantic](https://github.com/pydantic/pydantic)
 - [PyInstaller](https://github.com/pyinstaller/pyinstaller)
 - [Pylint](https://github.com/PyCQA/pylint)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Pandas](https://github.com/pandas-dev/pandas)
 - [Polars](https://github.com/pola-rs/polars)
 - [PostHog](https://github.com/PostHog/posthog)
-- [Prefect](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin)
+- Prefect ([Python SDK and Server](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin))
 - [Pydantic](https://github.com/pydantic/pydantic)
 - [PyInstaller](https://github.com/pyinstaller/pyinstaller)
 - [Pylint](https://github.com/PyCQA/pylint)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Pandas](https://github.com/pandas-dev/pandas)
 - [Polars](https://github.com/pola-rs/polars)
 - [PostHog](https://github.com/PostHog/posthog)
-- Prefect ([Marvin](https://github.com/PrefectHQ/marvin))
+- [Prefect](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin)
 - [Pydantic](https://github.com/pydantic/pydantic)
 - [PyInstaller](https://github.com/pyinstaller/pyinstaller)
 - [Pylint](https://github.com/PyCQA/pylint)


### PR DESCRIPTION
Prefect switched their main repository to use ruff in https://github.com/PrefectHQ/prefect/pull/9283

Retains the reference to the `PrefectHQ/marvin` project following the style of other organizations with multiple projects.

Preview at https://github.com/madkinsz/ruff/blob/using-prefect/README.md#whos-using-ruff
