### PR TITLE
[B030] Add support for Union usage in except expression

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B030.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B030.py
@@ -76,3 +76,9 @@ try:
     pass
 except what_to_catch():  # ok
     pass
+
+
+try:
+    pass
+except ValueError | TypeError | KeyError:
+    pass


### PR DESCRIPTION
Conforming to https://peps.python.org/pep-0604/
Except expressions can be written with Unions

```python
try:
    pass
except ValueError | TypeError:
    pass
```