### PR TITLE
Fix docs failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ python scripts/check_ecosystem.py path/to/your/ruff path/to/older/ruff
 
 You can also run the Ecosystem CI check in a Docker container across a larger set of projects by
 downloading the [`known-github-tomls.json`](https://github.com/akx/ruff-usage-aggregate/blob/master/data/known-github-tomls.jsonl)
-as `github_search.jsonl` and following the instructions in [scripts/Dockerfile.ecosystem](scripts/Dockerfile.ecosystem).
+as `github_search.jsonl` and following the instructions in [scripts/Dockerfile.ecosystem](https://github.com/charliermarsh/ruff/blob/main/scripts/Dockerfile.ecosystem).
 Note that this check will take a while to run.
 
 ## Benchmarks


### PR DESCRIPTION
The mkdocs workflow for v0.0.263 failed with the error:

```
WARNING  -  Documentation file 'contributing.md' contains a link to 'scripts/Dockerfile.ecosystem' which is not found in the documentation files.

Aborted with 1 warnings in strict mode!
```

This PR updates the link to use a URL to the referenced file. 

Hopefully fixes #4088 and fixes #4089. I am unable to test locally as I currently don't have `rustup` installed at this time.