### PR TITLE
Preserve whitespace around `ListComp` brackets in `C419`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -17,3 +17,23 @@ all((x.id for x in bar))
 
 async def f() -> bool:
     return all([await use_greeting(greeting) for greeting in await greetings()])
+
+
+# Special comment handling
+any(
+    [  # lbracket comment
+        # second line comment
+        i.bit_count()
+        # random middle comment
+        for i in range(5)  # rbracket comment
+    ]  # rpar comment
+    # trailing comment
+)
+
+# Weird case where the function call, opening bracket, and comment are all
+# on the same line.
+any([  # lbracket comment
+        # second line comment
+        i.bit_count() for i in range(5)  # rbracket comment
+    ]  # rpar comment
+)

--- a/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -6,6 +6,13 @@ any(  # first comment
 all(  # first comment
     [x.id for x in bar],  # second comment
 )  # third comment
+any(  # first comment
+    (  # left paren comment
+        [  # left bracket comment
+            x.id for x in bar  # right bracket comment
+        ]  # right paren comment
+    )  # last comment
+)  # post call comment
 any({x.id for x in bar})
 
 # OK

--- a/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
+++ b/crates/ruff/resources/test/fixtures/flake8_comprehensions/C419.py
@@ -6,13 +6,6 @@ any(  # first comment
 all(  # first comment
     [x.id for x in bar],  # second comment
 )  # third comment
-any(  # first comment
-    (  # left paren comment
-        [  # left bracket comment
-            x.id for x in bar  # right bracket comment
-        ]  # right paren comment
-    )  # last comment
-)  # post call comment
 any({x.id for x in bar})
 
 # OK

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -1156,11 +1156,24 @@ pub fn fix_unnecessary_comprehension_any_all(
         );
     };
 
+    let mut lpar = list_comp.lpar.clone();
+    lpar.push(LeftParen {
+        whitespace_after: list_comp.lbracket.whitespace_after.clone(),
+    });
+
+    let mut rpar = list_comp.rpar.clone();
+    rpar.insert(
+        0,
+        RightParen {
+            whitespace_before: list_comp.rbracket.whitespace_before.clone(),
+        },
+    );
+
     call.args[0].value = Expression::GeneratorExp(Box::new(GeneratorExp {
         elt: list_comp.elt.clone(),
         for_in: list_comp.for_in.clone(),
-        lpar: list_comp.lpar.clone(),
-        rpar: list_comp.rpar.clone(),
+        lpar,
+        rpar,
     }));
 
     if let Some(comma) = &call.args[0].comma {

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -1156,24 +1156,11 @@ pub fn fix_unnecessary_comprehension_any_all(
         );
     };
 
-    let mut lpar = list_comp.lpar.clone();
-    lpar.push(LeftParen {
-        whitespace_after: list_comp.lbracket.whitespace_after.clone(),
-    });
-
-    let mut rpar = list_comp.rpar.clone();
-    rpar.insert(
-        0,
-        RightParen {
-            whitespace_before: list_comp.rbracket.whitespace_before.clone(),
-        },
-    );
-
     call.args[0].value = Expression::GeneratorExp(Box::new(GeneratorExp {
         elt: list_comp.elt.clone(),
         for_in: list_comp.for_in.clone(),
-        lpar,
-        rpar,
+        lpar: list_comp.lpar.clone(),
+        rpar: list_comp.rpar.clone(),
     }));
 
     if let Some(comma) = &call.args[0].comma {

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -88,4 +88,67 @@ C419.py:9:5: C419 [*] Unnecessary list comprehension.
    |
    = help: Remove unnecessary list comprehension
 
+C419.py:24:5: C419 [*] Unnecessary list comprehension.
+   |
+24 |   # Special comment handling
+25 |   any(
+26 |       [  # lbracket comment
+   |  _____^
+27 | |         # second line comment
+28 | |         i.bit_count()
+29 | |         # random middle comment
+30 | |         for i in range(5)  # rbracket comment
+31 | |     ]  # rpar comment
+   | |_____^ C419
+32 |       # trailing comment
+33 |   )
+   |
+   = help: Remove unnecessary list comprehension
+
+ℹ Suggested fix
+21 21 | 
+22 22 | # Special comment handling
+23 23 | any(
+24    |-    [  # lbracket comment
+25    |-        # second line comment
+26    |-        i.bit_count()
+   24 |+    # lbracket comment
+   25 |+    # second line comment
+   26 |+    i.bit_count()
+27 27 |         # random middle comment
+28    |-        for i in range(5)  # rbracket comment
+29    |-    ]  # rpar comment
+   28 |+        for i in range(5)  # rbracket comment  # rpar comment
+30 29 |     # trailing comment
+31 30 | )
+32 31 | 
+
+C419.py:35:5: C419 [*] Unnecessary list comprehension.
+   |
+35 |   # Weird case where the function call, opening bracket, and comment are all
+36 |   # on the same line.
+37 |   any([  # lbracket comment
+   |  _____^
+38 | |         # second line comment
+39 | |         i.bit_count() for i in range(5)  # rbracket comment
+40 | |     ]  # rpar comment
+   | |_____^ C419
+41 |   )
+   |
+   = help: Remove unnecessary list comprehension
+
+ℹ Suggested fix
+32 32 | 
+33 33 | # Weird case where the function call, opening bracket, and comment are all
+34 34 | # on the same line.
+35    |-any([  # lbracket comment
+36    |-        # second line comment
+37    |-        i.bit_count() for i in range(5)  # rbracket comment
+38    |-    ]  # rpar comment
+   35 |+any(
+   36 |+# lbracket comment
+   37 |+# second line comment
+   38 |+i.bit_count() for i in range(5)  # rbracket comment  # rpar comment
+39 39 | )
+
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -12,7 +12,7 @@ C419.py:1:5: C419 [*] Unnecessary list comprehension.
 
 ℹ Suggested fix
 1   |-any([x.id for x in bar])
-  1 |+any(x.id for x in bar)
+  1 |+any((x.id for x in bar))
 2 2 | all([x.id for x in bar])
 3 3 | any(  # first comment
 4 4 |     [x.id for x in bar],  # second comment
@@ -30,7 +30,7 @@ C419.py:2:5: C419 [*] Unnecessary list comprehension.
 ℹ Suggested fix
 1 1 | any([x.id for x in bar])
 2   |-all([x.id for x in bar])
-  2 |+all(x.id for x in bar)
+  2 |+all((x.id for x in bar))
 3 3 | any(  # first comment
 4 4 |     [x.id for x in bar],  # second comment
 5 5 | )  # third comment
@@ -51,7 +51,7 @@ C419.py:4:5: C419 [*] Unnecessary list comprehension.
 2 2 | all([x.id for x in bar])
 3 3 | any(  # first comment
 4   |-    [x.id for x in bar],  # second comment
-  4 |+    x.id for x in bar  # second comment
+  4 |+    (x.id for x in bar)  # second comment
 5 5 | )  # third comment
 6 6 | all(  # first comment
 7 7 |     [x.id for x in bar],  # second comment
@@ -63,7 +63,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
  9 |     [x.id for x in bar],  # second comment
    |     ^^^^^^^^^^^^^^^^^^^ C419
 10 | )  # third comment
-11 | any({x.id for x in bar})
+11 | any(  # first comment
    |
    = help: Remove unnecessary list comprehension
 
@@ -72,19 +72,46 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
 5 5 | )  # third comment
 6 6 | all(  # first comment
 7   |-    [x.id for x in bar],  # second comment
-  7 |+    x.id for x in bar  # second comment
+  7 |+    (x.id for x in bar)  # second comment
 8 8 | )  # third comment
-9 9 | any({x.id for x in bar})
-10 10 | 
+9 9 | any(  # first comment
+10 10 |     (  # left paren comment
 
-C419.py:9:5: C419 [*] Unnecessary list comprehension.
+C419.py:11:9: C419 [*] Unnecessary list comprehension.
    |
- 9 |     [x.id for x in bar],  # second comment
-10 | )  # third comment
-11 | any({x.id for x in bar})
+11 |   any(  # first comment
+12 |       (  # left paren comment
+13 |           [  # left bracket comment
+   |  _________^
+14 | |             x.id for x in bar  # right bracket comment
+15 | |         ]  # right paren comment
+   | |_________^ C419
+16 |       )  # last comment
+17 |   )  # post call comment
+   |
+   = help: Remove unnecessary list comprehension
+
+ℹ Suggested fix
+8  8  | )  # third comment
+9  9  | any(  # first comment
+10 10 |     (  # left paren comment
+11    |-        [  # left bracket comment
+   11 |+        (  # left bracket comment
+12 12 |             x.id for x in bar  # right bracket comment
+13    |-        ]  # right paren comment
+   13 |+        )  # right paren comment
+14 14 |     )  # last comment
+15 15 | )  # post call comment
+16 16 | any({x.id for x in bar})
+
+C419.py:16:5: C419 [*] Unnecessary list comprehension.
+   |
+16 |     )  # last comment
+17 | )  # post call comment
+18 | any({x.id for x in bar})
    |     ^^^^^^^^^^^^^^^^^^^ C419
-12 | 
-13 | # OK
+19 | 
+20 | # OK
    |
    = help: Remove unnecessary list comprehension
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -12,7 +12,7 @@ C419.py:1:5: C419 [*] Unnecessary list comprehension.
 
 ℹ Suggested fix
 1   |-any([x.id for x in bar])
-  1 |+any((x.id for x in bar))
+  1 |+any(x.id for x in bar)
 2 2 | all([x.id for x in bar])
 3 3 | any(  # first comment
 4 4 |     [x.id for x in bar],  # second comment
@@ -30,7 +30,7 @@ C419.py:2:5: C419 [*] Unnecessary list comprehension.
 ℹ Suggested fix
 1 1 | any([x.id for x in bar])
 2   |-all([x.id for x in bar])
-  2 |+all((x.id for x in bar))
+  2 |+all(x.id for x in bar)
 3 3 | any(  # first comment
 4 4 |     [x.id for x in bar],  # second comment
 5 5 | )  # third comment
@@ -51,7 +51,7 @@ C419.py:4:5: C419 [*] Unnecessary list comprehension.
 2 2 | all([x.id for x in bar])
 3 3 | any(  # first comment
 4   |-    [x.id for x in bar],  # second comment
-  4 |+    (x.id for x in bar)  # second comment
+  4 |+    x.id for x in bar  # second comment
 5 5 | )  # third comment
 6 6 | all(  # first comment
 7 7 |     [x.id for x in bar],  # second comment
@@ -63,7 +63,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
  9 |     [x.id for x in bar],  # second comment
    |     ^^^^^^^^^^^^^^^^^^^ C419
 10 | )  # third comment
-11 | any(  # first comment
+11 | any({x.id for x in bar})
    |
    = help: Remove unnecessary list comprehension
 
@@ -72,46 +72,19 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
 5 5 | )  # third comment
 6 6 | all(  # first comment
 7   |-    [x.id for x in bar],  # second comment
-  7 |+    (x.id for x in bar)  # second comment
+  7 |+    x.id for x in bar  # second comment
 8 8 | )  # third comment
-9 9 | any(  # first comment
-10 10 |     (  # left paren comment
+9 9 | any({x.id for x in bar})
+10 10 | 
 
-C419.py:11:9: C419 [*] Unnecessary list comprehension.
+C419.py:9:5: C419 [*] Unnecessary list comprehension.
    |
-11 |   any(  # first comment
-12 |       (  # left paren comment
-13 |           [  # left bracket comment
-   |  _________^
-14 | |             x.id for x in bar  # right bracket comment
-15 | |         ]  # right paren comment
-   | |_________^ C419
-16 |       )  # last comment
-17 |   )  # post call comment
-   |
-   = help: Remove unnecessary list comprehension
-
-ℹ Suggested fix
-8  8  | )  # third comment
-9  9  | any(  # first comment
-10 10 |     (  # left paren comment
-11    |-        [  # left bracket comment
-   11 |+        (  # left bracket comment
-12 12 |             x.id for x in bar  # right bracket comment
-13    |-        ]  # right paren comment
-   13 |+        )  # right paren comment
-14 14 |     )  # last comment
-15 15 | )  # post call comment
-16 16 | any({x.id for x in bar})
-
-C419.py:16:5: C419 [*] Unnecessary list comprehension.
-   |
-16 |     )  # last comment
-17 | )  # post call comment
-18 | any({x.id for x in bar})
+ 9 |     [x.id for x in bar],  # second comment
+10 | )  # third comment
+11 | any({x.id for x in bar})
    |     ^^^^^^^^^^^^^^^^^^^ C419
-19 | 
-20 | # OK
+12 | 
+13 | # OK
    |
    = help: Remove unnecessary list comprehension
 


### PR DESCRIPTION
## Summary

While converting from a list comprehension to a generator expression, the square brackets are not preserved as that are only present on a list comprehension.

We'll convert the brackets into a paren node and add it at the _end_ and _start_ of the left and right parens respectively.

fixes: #4094