### PR TITLE
Make D410/D411 autofixes mutually exclusive

### DIFF
--- a/crates/ruff/src/docstrings/sections.rs
+++ b/crates/ruff/src/docstrings/sections.rs
@@ -266,6 +266,7 @@ struct SectionContextData {
     summary_full_end: TextSize,
 }
 
+#[derive(Clone)]
 pub struct SectionContext<'a> {
     data: &'a SectionContextData,
     docstring_body: DocstringBody<'a>,

--- a/crates/ruff/src/docstrings/sections.rs
+++ b/crates/ruff/src/docstrings/sections.rs
@@ -266,7 +266,6 @@ struct SectionContextData {
     summary_full_end: TextSize,
 }
 
-#[derive(Clone)]
 pub struct SectionContext<'a> {
     data: &'a SectionContextData,
     docstring_body: DocstringBody<'a>,


### PR DESCRIPTION
This should close #3827.

I tested by having a `test.py` file (repro'd from the issue):
```
def pow(self, exponent: int | float):
    """
    Raise expression to the power of the given exponent.

    Parameters
    ----------
    exponent
        ...
    Examples
    --------
    >>> df = pl.DataFrame({"foo": [1, 2, 3, 4]})

    """
    ...

```

I then ran `cargo run -p ruff_cli -- check test.py --fix --select D410 --select D411` and ensured that only one new line was created between `...` and `Examples`. As a sanity check, I also reset the file and performed the same test with no whitespace after `>>> df...`.