### PR TITLE
Remove `ScopeStack` in favor of child-parent `ScopeId` pointers

### DIFF
--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -1,14 +1,14 @@
-use ruff_python_semantic::scope::ScopeStack;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Expr, Stmt};
 
 use ruff_python_ast::types::RefEquality;
 use ruff_python_semantic::analyze::visibility::{Visibility, VisibleScope};
+use ruff_python_semantic::scope::ScopeId;
 
 use crate::checkers::ast::AnnotationContext;
 use crate::docstrings::definition::Definition;
 
-type Context<'a> = (ScopeStack, Vec<RefEquality<'a, Stmt>>);
+type Context<'a> = (ScopeId, Vec<RefEquality<'a, Stmt>>);
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4861,12 +4861,7 @@ impl<'a> Checker<'a> {
                         Rule::UnusedLambdaArgument,
                     ]) {
                         let scope = &self.ctx.scopes[scope_id];
-                        let parent = &self
-                            .ctx
-                            .scopes
-                            .parent(scope_id)
-                            .map(|scope_id| &self.ctx.scopes[scope_id])
-                            .unwrap();
+                        let parent = &self.ctx.scopes[scope.parent.unwrap()];
                         self.diagnostics
                             .extend(flake8_unused_arguments::rules::unused_arguments(
                                 self,

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4861,7 +4861,12 @@ impl<'a> Checker<'a> {
                         Rule::UnusedLambdaArgument,
                     ]) {
                         let scope = &self.ctx.scopes[scope_id];
-                        let parent = &self.ctx.scopes[scope.parent.unwrap()];
+                        let parent = &self
+                            .ctx
+                            .scopes
+                            .parent(scope_id)
+                            .map(|scope_id| &self.ctx.scopes[scope_id])
+                            .unwrap();
                         self.diagnostics
                             .extend(flake8_unused_arguments::rules::unused_arguments(
                                 self,

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -17,14 +17,12 @@ impl Violation for ReturnOutsideFunction {
 }
 
 pub fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
-    if let Some(index) = checker.ctx.scope_stack.top() {
-        if matches!(
-            checker.ctx.scopes[index].kind,
-            ScopeKind::Class(_) | ScopeKind::Module
-        ) {
-            checker
-                .diagnostics
-                .push(Diagnostic::new(ReturnOutsideFunction, stmt.range()));
-        }
+    if matches!(
+        checker.ctx.scope().kind,
+        ScopeKind::Class(_) | ScopeKind::Module
+    ) {
+        checker
+            .diagnostics
+            .push(Diagnostic::new(ReturnOutsideFunction, stmt.range()));
     }
 }

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -27,12 +27,12 @@ pub fn undefined_local(checker: &mut Checker, name: &str) {
         return;
     }
 
-    let Some(parent_scope_id) = checker.ctx.scopes.parent(current.id) else {
+    let Some(parent) = current.parent else {
         return;
     };
 
     // For every function and module scope above us...
-    for scope_id in checker.ctx.scopes.ancestors(parent_scope_id) {
+    for scope_id in checker.ctx.scopes.ancestors(parent) {
         let scope = &checker.ctx.scopes[scope_id];
         if !(scope.kind.is_function() || scope.kind.is_module()) {
             continue;

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -2,8 +2,8 @@ use std::string::ToString;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::binding::Bindings;
-use ruff_python_semantic::scope::{Scope, ScopeKind};
+
+use crate::checkers::ast::Checker;
 
 #[violation]
 pub struct UndefinedLocal {
@@ -18,26 +18,41 @@ impl Violation for UndefinedLocal {
     }
 }
 
-/// F821
-pub fn undefined_local(name: &str, scopes: &[&Scope], bindings: &Bindings) -> Option<Diagnostic> {
-    let current = &scopes.last().expect("No current scope found");
-    if matches!(current.kind, ScopeKind::Function(_)) && !current.defines(name) {
-        for scope in scopes.iter().rev().skip(1) {
-            if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Module) {
-                if let Some(binding) = scope.get(name).map(|index| &bindings[*index]) {
-                    if let Some((scope_id, location)) = binding.runtime_usage {
-                        if scope_id == current.id {
-                            return Some(Diagnostic::new(
-                                UndefinedLocal {
-                                    name: name.to_string(),
-                                },
-                                location,
-                            ));
-                        }
-                    }
+/// F823
+pub fn undefined_local(checker: &mut Checker, name: &str) {
+    let current = &checker.ctx.scopes[checker.ctx.scope_id];
+
+    // If the name hasn't already been defined in the current scope...
+    if !current.kind.is_function() || current.defines(name) {
+        return;
+    }
+
+    let Some(parent) = current.parent else {
+        return;
+    };
+
+    // For every function and module scope above us...
+    for scope_id in checker.ctx.scopes.ancestors(parent) {
+        let scope = &checker.ctx.scopes[scope_id];
+        if !(scope.kind.is_function() || scope.kind.is_module()) {
+            continue;
+        }
+
+        // If the name was defined in that scope...
+        if let Some(binding) = scope.get(name).map(|index| &checker.ctx.bindings[*index]) {
+            // And has already been accessed in the current scope...
+            if let Some((scope_id, location)) = binding.runtime_usage {
+                if scope_id == current.id {
+                    // Then it's probably an error.
+                    checker.diagnostics.push(Diagnostic::new(
+                        UndefinedLocal {
+                            name: name.to_string(),
+                        },
+                        location,
+                    ));
+                    return;
                 }
             }
         }
     }
-    None
 }

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -27,12 +27,12 @@ pub fn undefined_local(checker: &mut Checker, name: &str) {
         return;
     }
 
-    let Some(parent) = current.parent else {
+    let Some(parent_scope_id) = checker.ctx.scopes.parent(current.id) else {
         return;
     };
 
     // For every function and module scope above us...
-    for scope_id in checker.ctx.scopes.ancestors(parent) {
+    for scope_id in checker.ctx.scopes.ancestors(parent_scope_id) {
         let scope = &checker.ctx.scopes[scope_id];
         if !(scope.kind.is_function() || scope.kind.is_module()) {
             continue;

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -16,7 +16,7 @@ pub fn in_dunder_init(checker: &Checker) -> bool {
     if name != "__init__" {
         return false;
     }
-    let Some(parent) = checker.ctx.parent_scope() else {
+    let Some(parent) = scope.parent.map(|scope_id| &checker.ctx.scopes[scope_id]) else {
         return false;
     };
 

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -332,7 +332,7 @@ impl<'a> Context<'a> {
 
     /// Push a [`Scope`] with the given [`ScopeKind`] onto the stack.
     pub fn push_scope(&mut self, kind: ScopeKind<'a>) {
-        let id = self.scopes.push_scope(self.scope_id, kind);
+        let id = self.scopes.push_scope(kind, self.scope_id);
         self.scope_id = id;
     }
 
@@ -389,26 +389,17 @@ impl<'a> Context<'a> {
         &self.scopes[self.scope_id]
     }
 
-    /// Returns the id of the top-most scope
-    pub fn scope_id(&self) -> ScopeId {
-        self.scope_id
-    }
-
     /// Returns a mutable reference to the current top most scope.
     pub fn scope_mut(&mut self) -> &mut Scope<'a> {
         &mut self.scopes[self.scope_id]
     }
 
-    pub fn parent_scope(&self) -> Option<&Scope> {
-        self.scopes[self.scope_id]
-            .parent
-            .map(|index| &self.scopes[index])
-    }
-
+    /// Returns an iterator over all scopes, starting from the current scope.
     pub fn scopes(&self) -> impl Iterator<Item = &Scope> {
         self.scopes.ancestor_scopes(self.scope_id)
     }
 
+    /// Returns `true` if the context is in an exception handler.
     pub const fn in_exception_handler(&self) -> bool {
         self.in_exception_handler
     }

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -339,8 +339,9 @@ impl<'a> Context<'a> {
     /// Pop the current [`Scope`] off the stack.
     pub fn pop_scope(&mut self) {
         self.dead_scopes.push(self.scope_id);
-        self.scope_id = self.scopes[self.scope_id]
-            .parent
+        self.scope_id = self
+            .scopes
+            .parent(self.scope_id)
             .expect("Attempted to pop without scope");
     }
 
@@ -400,9 +401,9 @@ impl<'a> Context<'a> {
     }
 
     pub fn parent_scope(&self) -> Option<&Scope> {
-        self.scopes[self.scope_id]
-            .parent
-            .map(|index| &self.scopes[index])
+        self.scopes
+            .parent(self.scope_id)
+            .map(|scope_id| &self.scopes[scope_id])
     }
 
     pub fn scopes(&self) -> impl Iterator<Item = &Scope> {

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -396,7 +396,7 @@ impl<'a> Context<'a> {
 
     /// Returns an iterator over all scopes, starting from the current scope.
     pub fn scopes(&self) -> impl Iterator<Item = &Scope> {
-        self.scopes.ancestor_scopes(self.scope_id)
+        self.scopes.ancestors(self.scope_id)
     }
 
     /// Returns `true` if the context is in an exception handler.

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -339,9 +339,8 @@ impl<'a> Context<'a> {
     /// Pop the current [`Scope`] off the stack.
     pub fn pop_scope(&mut self) {
         self.dead_scopes.push(self.scope_id);
-        self.scope_id = self
-            .scopes
-            .parent(self.scope_id)
+        self.scope_id = self.scopes[self.scope_id]
+            .parent
             .expect("Attempted to pop without scope");
     }
 
@@ -401,9 +400,9 @@ impl<'a> Context<'a> {
     }
 
     pub fn parent_scope(&self) -> Option<&Scope> {
-        self.scopes
-            .parent(self.scope_id)
-            .map(|scope_id| &self.scopes[scope_id])
+        self.scopes[self.scope_id]
+            .parent
+            .map(|index| &self.scopes[index])
     }
 
     pub fn scopes(&self) -> impl Iterator<Item = &Scope> {

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -8,7 +8,6 @@ use crate::binding::{BindingId, StarImportation};
 
 #[derive(Debug)]
 pub struct Scope<'a> {
-    pub id: ScopeId,
     pub kind: ScopeKind<'a>,
     pub parent: Option<ScopeId>,
     /// Whether this scope uses the `locals()` builtin.
@@ -25,7 +24,6 @@ pub struct Scope<'a> {
 impl<'a> Scope<'a> {
     pub fn global() -> Self {
         Scope {
-            id: ScopeId::global(),
             kind: ScopeKind::Module,
             parent: None,
             uses_locals: false,
@@ -35,9 +33,8 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn local(id: ScopeId, parent: ScopeId, kind: ScopeKind<'a>) -> Self {
+    pub fn local(kind: ScopeKind<'a>, parent: ScopeId) -> Self {
         Scope {
-            id,
             kind,
             parent: Some(parent),
             uses_locals: false,
@@ -202,19 +199,19 @@ impl<'a> Scopes<'a> {
     /// Pushes a new scope and returns its unique id
     pub fn push_scope(&mut self, kind: ScopeKind<'a>, parent: ScopeId) -> ScopeId {
         let next_id = ScopeId::try_from(self.0.len()).unwrap();
-        self.0.push(Scope::local(next_id, parent, kind));
+        self.0.push(Scope::local(kind, parent));
         next_id
     }
 
     /// Returns an iterator over all [`ScopeId`] ancestors, starting from the given [`ScopeId`].
-    pub fn ancestors(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-        std::iter::successors(Some(scope), |&scope| self[scope].parent)
+    pub fn ancestor_ids(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
+        std::iter::successors(Some(scope_id), |&scope_id| self[scope_id].parent)
     }
 
     /// Returns an iterator over all [`Scope`] ancestors, starting from the given [`ScopeId`].
-    pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = &Scope> + '_ {
-        std::iter::successors(Some(&self[scope]), |&scope| {
-            scope.parent.map(|parent| &self[parent])
+    pub fn ancestors(&self, scope_id: ScopeId) -> impl Iterator<Item = &Scope> + '_ {
+        std::iter::successors(Some(&self[scope_id]), |&scope| {
+            scope.parent.map(|scope_id| &self[scope_id])
         })
     }
 }

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -10,6 +10,7 @@ use crate::binding::{BindingId, StarImportation};
 pub struct Scope<'a> {
     pub id: ScopeId,
     pub kind: ScopeKind<'a>,
+    pub parent: Option<ScopeId>,
     /// Whether this scope uses the `locals()` builtin.
     pub uses_locals: bool,
     /// A list of star imports in this scope. These represent _module_ imports (e.g., `sys` in
@@ -26,6 +27,7 @@ impl<'a> Scope<'a> {
         Scope {
             id: ScopeId::global(),
             kind: ScopeKind::Module,
+            parent: None,
             uses_locals: false,
             star_imports: Vec::default(),
             bindings: FxHashMap::default(),
@@ -33,10 +35,11 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn local(id: ScopeId, kind: ScopeKind<'a>) -> Self {
+    pub fn local(id: ScopeId, parent: ScopeId, kind: ScopeKind<'a>) -> Self {
         Scope {
             id,
             kind,
+            parent: Some(parent),
             uses_locals: false,
             star_imports: Vec::default(),
             bindings: FxHashMap::default(),
@@ -183,7 +186,7 @@ pub struct Lambda<'a> {
 
 /// The scopes of a program indexed by [`ScopeId`]
 #[derive(Debug)]
-pub struct Scopes<'a>(Vec<Scope<'a>>, Vec<ScopeId>);
+pub struct Scopes<'a>(Vec<Scope<'a>>);
 
 impl<'a> Scopes<'a> {
     /// Returns a reference to the global scope
@@ -199,33 +202,26 @@ impl<'a> Scopes<'a> {
     /// Pushes a new scope and returns its unique id
     pub fn push_scope(&mut self, parent: ScopeId, kind: ScopeKind<'a>) -> ScopeId {
         let next_id = ScopeId::try_from(self.0.len()).unwrap();
-        self.0.push(Scope::local(next_id, kind));
-        self.1.push(parent);
+        self.0.push(Scope::local(next_id, parent, kind));
         next_id
     }
 
     /// Returns an iterator over all [`ScopeId`] ancestors, starting from the given [`ScopeId`].
     pub fn ancestors(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-        std::iter::successors(Some(scope), |&scope| self.parent(scope))
+        std::iter::successors(Some(scope), |&scope| self[scope].parent)
     }
 
     /// Returns an iterator over all [`Scope`] ancestors, starting from the given [`ScopeId`].
     pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = &Scope> + '_ {
-        self.ancestors(scope).map(move |scope| &self[scope])
-    }
-
-    pub fn parent(&self, scope: ScopeId) -> Option<ScopeId> {
-        if scope.is_global() {
-            None
-        } else {
-            Some(self.1[usize::from(scope) - 1])
-        }
+        std::iter::successors(Some(&self[scope]), |&scope| {
+            scope.parent.map(|parent| &self[parent])
+        })
     }
 }
 
 impl Default for Scopes<'_> {
     fn default() -> Self {
-        Self(vec![Scope::global()], Vec::new())
+        Self(vec![Scope::global()])
     }
 }
 

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -200,7 +200,7 @@ impl<'a> Scopes<'a> {
     }
 
     /// Pushes a new scope and returns its unique id
-    pub fn push_scope(&mut self, parent: ScopeId, kind: ScopeKind<'a>) -> ScopeId {
+    pub fn push_scope(&mut self, kind: ScopeKind<'a>, parent: ScopeId) -> ScopeId {
         let next_id = ScopeId::try_from(self.0.len()).unwrap();
         self.0.push(Scope::local(next_id, parent, kind));
         next_id


### PR DESCRIPTION
## Summary

Currently, we maintain a stack of `ScopeId` elements to track the current stack of scopes (module, function, etc.). This makes iteration and scope traversal very easy, but a common operation we perform is "Save the current scope, so we can restore it later" -- and with our current design, that operation becomes unnecessarily expensive, as we need to clone the entire vector of `ScopeId` elements in order to save our position in the stack.

This PR instead migrates to a model in which we store the parent `ScopeId` on every scope, which in turn allows us to merely store the current `ScopeId` when saving and restoring the current scope.

We could introduce a crate like [`indextree`](https://docs.rs/indextree) to help with this, and it may make sense to do so in the future, but for now, I've just implemented this tracking manually, since it's very straightforward.

## Test Plan

This improves benchmark performance by a couple of percentage points:

```
❯ cargo benchmark --baseline=main
    Finished bench [optimized] target(s) in 0.14s
     Running benches/linter.rs (target/release/deps/linter-200959ba3da63cb3)
linter/default-rules/numpy/globals.py
                        time:   [72.278 µs 72.403 µs 72.539 µs]
                        thrpt:  [40.677 MiB/s 40.753 MiB/s 40.824 MiB/s]
                 change:
                        time:   [-1.1862% -0.8772% -0.5622%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5654% +0.8850% +1.2005%]
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  10 (10.00%) high mild
  1 (1.00%) high severe
linter/default-rules/pydantic/types.py
                        time:   [1.4848 ms 1.4873 ms 1.4896 ms]
                        thrpt:  [17.120 MiB/s 17.147 MiB/s 17.176 MiB/s]
                 change:
                        time:   [-1.8008% -1.3902% -0.9916%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0015% +1.4098% +1.8338%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
linter/default-rules/numpy/ctypeslib.py
                        time:   [684.87 µs 685.87 µs 686.82 µs]
                        thrpt:  [24.244 MiB/s 24.277 MiB/s 24.313 MiB/s]
                 change:
                        time:   [-4.2976% -3.6049% -2.9363%] (p = 0.00 < 0.05)
                        thrpt:  [+3.0251% +3.7397% +4.4906%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
linter/default-rules/large/dataset.py
                        time:   [3.4197 ms 3.4205 ms 3.4213 ms]
                        thrpt:  [11.891 MiB/s 11.894 MiB/s 11.896 MiB/s]
                 change:
                        time:   [-1.8290% -1.5224% -1.2507%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2666% +1.5460% +1.8631%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) low severe
  4 (4.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

linter/all-rules/numpy/globals.py
                        time:   [144.15 µs 144.35 µs 144.56 µs]
                        thrpt:  [20.411 MiB/s 20.441 MiB/s 20.469 MiB/s]
                 change:
                        time:   [-0.2085% +0.1292% +0.5449%] (p = 0.52 > 0.05)
                        thrpt:  [-0.5420% -0.1291% +0.2090%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
linter/all-rules/pydantic/types.py
                        time:   [2.9117 ms 2.9158 ms 2.9199 ms]
                        thrpt:  [8.7343 MiB/s 8.7465 MiB/s 8.7589 MiB/s]
                 change:
                        time:   [-1.2509% -0.7777% -0.3998%] (p = 0.00 < 0.05)
                        thrpt:  [+0.4014% +0.7838% +1.2668%]
                        Change within noise threshold.
linter/all-rules/numpy/ctypeslib.py
                        time:   [1.6440 ms 1.6464 ms 1.6488 ms]
                        thrpt:  [10.099 MiB/s 10.114 MiB/s 10.128 MiB/s]
                 change:
                        time:   [-1.0992% -0.8788% -0.6667%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6712% +0.8866% +1.1114%]
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
linter/all-rules/large/dataset.py
                        time:   [6.9923 ms 6.9971 ms 7.0015 ms]
                        thrpt:  [5.8106 MiB/s 5.8143 MiB/s 5.8182 MiB/s]
                 change:
                        time:   [-1.6946% -1.4648% -1.2491%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2649% +1.4866% +1.7239%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) low mild
  2 (2.00%) high severe
```

I also experimented with a design in which we stored parallel vectors on `Scopes`: a vector of `Scope` structs, and a parallel vector of parent pointers (`ScopeId`). While I expected this to perform _better_ (SoA vs. AoS), it actually performed worse in practice 🤔 
