### PR TITLE
Change `--fix-only` exit semantics to mirror `--fix`

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,16 @@
 # Breaking Changes
 
+## 0.0.265
+
+### `--fix-only` now exits with a zero exit code, unless `--exit-non-zero-on-fix` is specified ([#4146](https://github.com/charliermarsh/ruff/pull/4146))
+
+Previously, `--fix-only` would exit with a non-zero exit code if any fixes were applied. This
+behavior was inconsistent with `--fix`, and further, meant that `--exit-non-zero-on-fix` was
+effectively ignored when `--fix-only` was specified.
+
+Now, `--fix-only` will exit with a zero exit code, unless `--exit-non-zero-on-fix` is specified,
+in which case it will exit with a non-zero exit code if any fixes were applied.
+
 ## 0.0.260
 
 ### Fixes are now represented as a list of edits ([#3709](https://github.com/charliermarsh/ruff/pull/3709))


### PR DESCRIPTION
## Summary

After this change, running `ruff --fix-only` will exit with status code 0 unless the program hits an internal error, while `ruff --fix-only --exit-non-zero-on-fix` will exit with status code 1 if at least one diagnostic is fixed. This effectively mirrors `ruff --fix`, taking into account that non-fixable diagnostics are ignored. Previously, the `--exit-non-zero-on-fix` flag had no effect when combined with `--fix-only`.

Closes #4092.