### PR TITLE
Reference related settings in rules

### DIFF
--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -2,6 +2,7 @@
 
 use itertools::Itertools;
 use ruff::registry::{Linter, Rule, RuleNamespace, UpstreamCategory};
+use ruff::settings::options::Options;
 use ruff_diagnostics::AutofixKind;
 use strum::IntoEnumIterator;
 
@@ -76,6 +77,18 @@ pub fn generate() -> String {
             ));
             table_out.push('\n');
             table_out.push('\n');
+        }
+
+        for (name, _) in Options::metadata().into_iter().collect::<Vec<_>>() {
+            if name == &linter.name() {
+                table_out.push_str(&format!(
+                    "For related settings, see [{}](settings.md#{}).",
+                    linter.name(),
+                    linter.name(),
+                ));
+                table_out.push('\n');
+                table_out.push('\n');
+            }
         }
 
         if let Some(categories) = linter.upstream_categories() {

--- a/crates/ruff_dev/src/generate_rules_table.rs
+++ b/crates/ruff_dev/src/generate_rules_table.rs
@@ -1,10 +1,11 @@
 //! Generate a Markdown-compatible table of supported lint rules.
 
 use itertools::Itertools;
+use strum::IntoEnumIterator;
+
 use ruff::registry::{Linter, Rule, RuleNamespace, UpstreamCategory};
 use ruff::settings::options::Options;
 use ruff_diagnostics::AutofixKind;
-use strum::IntoEnumIterator;
 
 const FIX_SYMBOL: &str = "🛠";
 
@@ -79,16 +80,17 @@ pub fn generate() -> String {
             table_out.push('\n');
         }
 
-        for (name, _) in Options::metadata().into_iter().collect::<Vec<_>>() {
-            if name == &linter.name() {
-                table_out.push_str(&format!(
-                    "For related settings, see [{}](settings.md#{}).",
-                    linter.name(),
-                    linter.name(),
-                ));
-                table_out.push('\n');
-                table_out.push('\n');
-            }
+        if Options::metadata()
+            .iter()
+            .any(|(name, _)| name == &linter.name())
+        {
+            table_out.push_str(&format!(
+                "For related settings, see [{}](settings.md#{}).",
+                linter.name(),
+                linter.name(),
+            ));
+            table_out.push('\n');
+            table_out.push('\n');
         }
 
         if let Some(categories) = linter.upstream_categories() {


### PR DESCRIPTION
This PR adds a note to rules documentation to point at related settings where applicable. Closes #4109

Example: 
![image](https://user-images.githubusercontent.com/32770960/235347552-30f16f40-8d07-48d1-89ff-b15e8b7c88b6.png)


This is my first time trying to write Rust, so I'm sure there will be some tweaks required.