### PR TITLE
Warn on PEP 604 syntax not in an annotation, but don't autofix

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2281,8 +2281,7 @@ where
         match &expr.node {
             ExprKind::Subscript { value, slice, .. } => {
                 // Ex) Optional[...], Union[...]
-                if self.ctx.in_type_definition
-                    && !self.settings.pyupgrade.keep_runtime_typing
+                if !self.settings.pyupgrade.keep_runtime_typing
                     && self.settings.rules.enabled(Rule::NonPEP604Annotation)
                     && (self.settings.target_version >= PythonVersion::Py310
                         || (self.settings.target_version >= PythonVersion::Py37

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -100,12 +100,13 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
         return;
     };
 
-    // Avoid fixing forward references.
-    let fixable = checker
-        .ctx
-        .in_deferred_string_type_definition
-        .as_ref()
-        .map_or(true, AnnotationKind::is_simple);
+    // Avoid fixing forward references, or types not in an annotation.
+    let fixable = checker.ctx.in_type_definition
+        && checker
+            .ctx
+            .in_deferred_string_type_definition
+            .as_ref()
+            .map_or(true, AnnotationKind::is_simple);
 
     match typing_member {
         TypingMember::Optional => {

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP007.py.snap
@@ -200,6 +200,26 @@ UP007.py:47:8: UP007 [*] Use `X | Y` for type annotations
 49 49 | 
 50 50 |     x = Union[str, int]
 
+UP007.py:48:9: UP007 Use `X | Y` for type annotations
+   |
+48 | def f() -> None:
+49 |     x: Optional[str]
+50 |     x = Optional[str]
+   |         ^^^^^^^^^^^^^ UP007
+51 | 
+52 |     x = Union[str, int]
+   |
+
+UP007.py:50:9: UP007 Use `X | Y` for type annotations
+   |
+50 |     x = Optional[str]
+51 | 
+52 |     x = Union[str, int]
+   |         ^^^^^^^^^^^^^^^ UP007
+53 |     x = Union["str", "int"]
+54 |     x: Union[str, int]
+   |
+
 UP007.py:52:8: UP007 [*] Use `X | Y` for type annotations
    |
 52 |     x = Union[str, int]


### PR DESCRIPTION
Closes #3937. (also related, #4108)

This was removed after #3215 and #2981, although in both those cases, the issue isn't specific to the syntax not being in an annotation. AFAICT it's pretty much an equally safe change in both places, although in this PR i've made it so it will only warn and not autofix anyway.