### PR TITLE
Refactor `Fix` and `Edit` API

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -38,11 +38,10 @@ fn apply_fixes<'a>(
 
     for (rule, fix) in diagnostics
         .filter_map(|diagnostic| {
-            if diagnostic.fix.is_none() {
-                None
-            } else {
-                Some((diagnostic.kind.rule(), diagnostic.fix.as_ref().unwrap()))
-            }
+            diagnostic
+                .fix
+                .as_ref()
+                .map(|fix| (diagnostic.kind.rule(), fix))
         })
         .sorted_by(|(rule1, fix1), (rule2, fix2)| cmp_fix(*rule1, *rule2, fix1, fix2))
     {

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -16,7 +16,7 @@ pub mod actions;
 pub fn fix_file(diagnostics: &[Diagnostic], locator: &Locator) -> Option<(String, FixTable)> {
     let mut with_fixes = diagnostics
         .iter()
-        .filter(|diag| !diag.fix.is_empty())
+        .filter(|diag| diag.fix.is_some())
         .peekable();
 
     if with_fixes.peek().is_none() {
@@ -38,10 +38,10 @@ fn apply_fixes<'a>(
 
     for (rule, fix) in diagnostics
         .filter_map(|diagnostic| {
-            if diagnostic.fix.is_empty() {
+            if diagnostic.fix.is_none() {
                 None
             } else {
-                Some((diagnostic.kind.rule(), &diagnostic.fix))
+                Some((diagnostic.kind.rule(), diagnostic.fix.as_ref().unwrap()))
             }
         })
         .sorted_by(|(rule1, fix1), (rule2, fix2)| cmp_fix(*rule1, *rule2, fix1, fix2))
@@ -114,7 +114,7 @@ mod tests {
                 // The choice of rule here is arbitrary.
                 kind: MissingNewlineAtEndOfFile.into(),
                 range: edit.range(),
-                fix: edit.into(),
+                fix: Some(edit.into()),
                 parent: None,
             })
             .collect()

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -103,6 +103,7 @@ mod tests {
 
     use ruff_diagnostics::Diagnostic;
     use ruff_diagnostics::Edit;
+    use ruff_diagnostics::Fix;
     use ruff_python_ast::source_code::Locator;
 
     use crate::autofix::apply_fixes;
@@ -114,7 +115,7 @@ mod tests {
                 // The choice of rule here is arbitrary.
                 kind: MissingNewlineAtEndOfFile.into(),
                 range: edit.range(),
-                fix: Some(edit.into()),
+                fix: Some(Fix::unspecified(edit)),
                 parent: None,
             })
             .collect()

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::lexer::LexResult;
 
-use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::token_kind::TokenKind;
 
@@ -144,7 +144,7 @@ impl<'a> LogicalLinesContext<'a> {
             self.diagnostics.push(Diagnostic {
                 kind,
                 range,
-                fix: Fix::empty(),
+                fix: None,
                 parent: None,
             });
         }

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -3,7 +3,7 @@
 use itertools::Itertools;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_python_ast::source_code::Locator;
 
 use crate::noqa;
@@ -178,10 +178,10 @@ pub fn check_noqa(
                                     locator,
                                 ));
                             } else {
-                                diagnostic.set_fix(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     *range,
-                                ));
+                                )));
                             }
                         }
                         diagnostics.push(diagnostic);

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -27,7 +27,7 @@ impl<'a> Diff<'a> {
         } else {
             Some(Diff {
                 source_code: &message.file,
-                fix: &message.fix.as_ref().unwrap(),
+                fix: message.fix.as_ref().unwrap(),
             })
         }
     }

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -22,14 +22,10 @@ pub(super) struct Diff<'a> {
 
 impl<'a> Diff<'a> {
     pub fn from_message(message: &'a Message) -> Option<Diff> {
-        if message.fix.is_none() {
-            None
-        } else {
-            Some(Diff {
-                source_code: &message.file,
-                fix: message.fix.as_ref().unwrap(),
-            })
-        }
+        message.fix.as_ref().map(|fix| Diff {
+            source_code: &message.file,
+            fix,
+        })
     }
 }
 

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -22,12 +22,12 @@ pub(super) struct Diff<'a> {
 
 impl<'a> Diff<'a> {
     pub fn from_message(message: &'a Message) -> Option<Diff> {
-        if message.fix.is_empty() {
+        if message.fix.is_none() {
             None
         } else {
             Some(Diff {
                 source_code: &message.file,
-                fix: &message.fix,
+                fix: &message.fix.as_ref().unwrap(),
             })
         }
     }

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -37,14 +37,12 @@ impl Serialize for ExpandedMessages<'_> {
         for message in self.messages {
             let source_code = message.file.to_source_code();
 
-            let fix = if message.fix.is_none() {
-                None
-            } else {
-                Some(json!({
-                    "message": message.kind.suggestion.as_deref(),
-                    "edits": &ExpandedEdits { edits: message.fix.as_ref().unwrap().edits(), source_code: &source_code },
-                }))
-            };
+            let fix = message.fix.as_ref().map(|fix| {
+                json!({
+                        "message": message.kind.suggestion.as_deref(),
+                        "edits": &ExpandedEdits { edits: fix.edits(), source_code: &source_code },
+                })
+            });
 
             let start_location = source_code.source_location(message.start());
             let end_location = source_code.source_location(message.end());

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -37,12 +37,12 @@ impl Serialize for ExpandedMessages<'_> {
         for message in self.messages {
             let source_code = message.file.to_source_code();
 
-            let fix = if message.fix.is_empty() {
+            let fix = if message.fix.is_none() {
                 None
             } else {
                 Some(json!({
                     "message": message.kind.suggestion.as_deref(),
-                    "edits": &ExpandedEdits { edits: message.fix.edits(), source_code: &source_code },
+                    "edits": &ExpandedEdits { edits: message.fix.as_ref().unwrap().edits(), source_code: &source_code },
                 }))
             };
 

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -191,10 +191,10 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(94), TextSize::from(95)),
         )
-        .with_fix(Fix::unspecified(vec![Edit::deletion(
+        .with_fix(Fix::unspecified(Edit::deletion(
             TextSize::from(94),
             TextSize::from(99),
-        )]));
+        )));
 
         let file_2 = r#"if a == 1: pass"#;
 

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -33,7 +33,7 @@ use ruff_python_ast::source_code::{SourceFile, SourceLocation};
 pub struct Message {
     pub kind: DiagnosticKind,
     pub range: TextRange,
-    pub fix: Fix,
+    pub fix: Option<Fix>,
     pub file: SourceFile,
     pub noqa_offset: TextSize,
 }

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -191,7 +191,7 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(94), TextSize::from(95)),
         )
-        .with_fix(Fix::new(vec![Edit::deletion(
+        .with_fix(Fix::unspecified(vec![Edit::deletion(
             TextSize::from(94),
             TextSize::from(99),
         )]));

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::TextRange;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -58,7 +58,9 @@ pub fn commented_out_code(
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, range);
         if autofix.into() && settings.rules.should_fix(Rule::CommentedOutCode) {
-            diagnostic.set_fix(Edit::range_deletion(locator.full_lines_range(range)));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
+                locator.full_lines_range(range),
+            )));
         }
         Some(diagnostic)
     } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -94,7 +94,7 @@ fn fix_abstractmethod_missing(
         ),
         stmt.range().start(),
     );
-    Ok(Fix::from_iter([import_edit, reference_edit]))
+    Ok(Fix::unspecified_edits(import_edit, [reference_edit]))
 }
 
 /// B024

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 
@@ -63,10 +63,10 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
 
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_stmt(&assertion_error(msg), checker.stylist),
             stmt.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path;
 use ruff_python_ast::call_path::CallPath;
@@ -96,14 +96,14 @@ fn duplicate_handler_exceptions<'a>(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if unique_elts.len() == 1 {
                         unparse_expr(unique_elts[0], checker.stylist)
                     } else {
                         unparse_expr(&type_pattern(unique_elts), checker.stylist)
                     },
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
@@ -64,10 +64,10 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&attribute(obj, value), checker.stylist),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 
@@ -47,10 +47,10 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             type_.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(elt, checker.stylist),
                 type_.range(),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
 use ruff_python_ast::source_code::Stylist;
@@ -79,10 +79,10 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
 
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     assignment(obj, name, value, checker.stylist),
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -22,7 +22,7 @@ use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 use serde::{Deserialize, Serialize};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::RefEquality;
 use ruff_python_ast::visitor::Visitor;
@@ -176,7 +176,10 @@ pub fn unused_loop_control_variable(
                 if let Some(binding) = binding {
                     if binding.kind.is_loop_var() {
                         if !binding.used() {
-                            diagnostic.set_fix(Edit::range_replacement(rename, expr.range()));
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                                rename,
+                                expr.range(),
+                            )));
                         }
                     }
                 }

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -4,7 +4,7 @@ use rustpython_parser::lexer::{LexResult, Spanned};
 use rustpython_parser::Tok;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -333,7 +333,7 @@ pub fn trailing_commas(
             let comma = prev.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
             if autofix.into() && settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
-                diagnostic.set_fix(Edit::range_deletion(diagnostic.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(diagnostic.range())));
             }
             diagnostics.push(diagnostic);
         }
@@ -373,10 +373,10 @@ pub fn trailing_commas(
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
                 let contents = locator.slice(missing_comma.1);
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     format!("{contents},"),
                     missing_comma.1,
-                ));
+                )));
             }
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -203,7 +203,7 @@ fn generate_fix(stylist: &Stylist, stmt: &Stmt, exc_arg: &Expr, indentation: &st
         }),
         stylist,
     );
-    Fix::from_iter([
+    Fix::unspecified_edits(
         Edit::insertion(
             format!(
                 "{}{}{}",
@@ -213,8 +213,11 @@ fn generate_fix(stylist: &Stylist, stmt: &Stmt, exc_arg: &Expr, indentation: &st
             ),
             stmt.start(),
         ),
-        Edit::range_replacement(String::from("msg"), exc_arg.range()),
-    ])
+        [Edit::range_replacement(
+            String::from("msg"),
+            exc_arg.range(),
+        )],
+    )
 }
 
 /// EM101, EM102, EM103

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::{TextRange, TextSize};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::rules::flake8_executable::helpers::ShebangDirective;
@@ -32,10 +32,10 @@ pub fn shebang_whitespace(
                 TextRange::at(range.start(), *n_spaces),
             );
             if autofix {
-                diagnostic.set_fix(Edit::range_deletion(TextRange::at(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     range.start(),
                     *n_spaces,
-                )));
+                ))));
             }
             Some(diagnostic)
         } else {

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -2,7 +2,7 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword, Operator};
 use std::ops::Add;
 
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_python_ast::helpers::{find_keyword, SimpleCallArgs};
 use ruff_python_semantic::analyze::logging;
 use ruff_python_stdlib::logging::LoggingLevel;
@@ -171,10 +171,10 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             {
                 let mut diagnostic = Diagnostic::new(LoggingWarn, level_call_range);
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         "warning".to_string(),
                         level_call_range,
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -9,7 +9,7 @@ use rustpython_parser::ast::{
 };
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{create_expr, trailing_comment_start_offset, unparse_expr};
@@ -136,7 +136,9 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                 let mut diagnostic = Diagnostic::new(UnnecessaryPass, pass_stmt.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = trailing_comment_start_offset(pass_stmt, checker.locator) {
-                        diagnostic.set_fix(Edit::range_deletion(pass_stmt.range().add_end(index)));
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
+                            pass_stmt.range().add_end(index),
+                        )));
                     } else {
                         diagnostic.try_set_fix(|| {
                             delete_stmt(
@@ -414,10 +416,10 @@ pub fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                         .collect(),
                 });
 
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -439,7 +441,10 @@ pub fn reimplemented_list_builtin(checker: &mut Checker, expr: &Expr) {
             if elts.is_empty() {
                 let mut diagnostic = Diagnostic::new(ReimplementedListBuiltin, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement("list".to_string(), expr.range()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                        "list".to_string(),
+                        expr.range(),
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Expr, ExprKind, Operator};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::unparse_expr;
@@ -77,13 +77,13 @@ fn traverse_union<'a>(
             };
 
             // Replace the parent with its non-duplicate child.
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     if expr.node == left.node { right } else { left },
                     checker.stylist,
                 ),
                 parent.range(),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Arguments, Constant, Expr, ExprKind, Operator, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::context::Context;
 
@@ -298,10 +298,10 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
-                            ));
+                            )));
                         }
 
                         checker.diagnostics.push(diagnostic);
@@ -324,10 +324,10 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
-                            ));
+                            )));
                         }
 
                         checker.diagnostics.push(diagnostic);
@@ -353,10 +353,10 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
-                            ));
+                            )));
                         }
 
                         checker.diagnostics.push(diagnostic);
@@ -379,10 +379,10 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
-                            ));
+                            )));
                         }
 
                         checker.diagnostics.push(diagnostic);
@@ -410,7 +410,10 @@ pub fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr], value
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement("...".to_string(), value.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            "...".to_string(),
+            value.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -437,7 +440,10 @@ pub fn annotated_assignment_default_in_stub(
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement("...".to_string(), value.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            "...".to_string(),
+            value.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -9,7 +9,7 @@ use rustpython_parser::ast::{
     Boolop, Excepthandler, ExcepthandlerKind, Expr, ExprKind, Keyword, Stmt, StmtKind, Unaryop,
 };
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments_in, unparse_stmt, Truthiness};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -203,10 +203,10 @@ pub fn unittest_assertion(
                 );
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
-                        diagnostic.set_fix(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_stmt(&stmt, checker.stylist),
                             expr.range(),
-                        ));
+                        )));
                     }
                 }
                 Some(diagnostic)

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -3,7 +3,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ast::{Arguments, Expr, ExprKind, Keyword, Stmt, StmtKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
 use ruff_python_ast::helpers::collect_arg_names;
@@ -398,10 +398,10 @@ fn check_fixture_returns(checker: &mut Checker, stmt: &Stmt, name: &str, body: &
                             stmt.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "return".to_string(),
                                 TextRange::at(stmt.start(), "yield".text_len()),
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -470,7 +470,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let range = checker.locator.full_lines_range(expr.range());
-                    diagnostic.set_fix(Edit::range_deletion(range));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -486,7 +486,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let line_range = checker.locator.full_lines_range(expr.range());
-                    diagnostic.set_fix(Edit::range_deletion(line_range));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(line_range)));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::CallPath;
 
@@ -113,9 +113,9 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr, call_path:
     if !has_parameters {
         let mut diagnostic = Diagnostic::new(PytestUseFixturesWithoutParameters, decorator.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_deletion(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                 decorator.range().sub_start(TextSize::from(1)),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -148,7 +148,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             name_range,
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 format!(
                                     "({})",
                                     unparse_expr(
@@ -168,7 +168,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                                     )
                                 ),
                                 name_range,
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -181,7 +181,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             name_range,
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
                                         elts: names
@@ -198,7 +198,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                                     checker.stylist,
                                 ),
                                 name_range,
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -222,7 +222,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             expr.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
                                         elts: elts.clone(),
@@ -231,7 +231,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                                     checker.stylist,
                                 ),
                                 expr.range(),
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -244,7 +244,10 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
-                                diagnostic.set_fix(Edit::range_replacement(content, expr.range()));
+                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                                    content,
+                                    expr.range(),
+                                )));
                             }
                         }
                         checker.diagnostics.push(diagnostic);
@@ -268,7 +271,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             expr.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 format!(
                                     "({})",
                                     unparse_expr(
@@ -280,7 +283,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                                     )
                                 ),
                                 expr.range(),
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -293,7 +296,10 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
-                                diagnostic.set_fix(Edit::range_replacement(content, expr.range()));
+                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                                    content,
+                                    expr.range(),
+                                )));
                             }
                         }
                         checker.diagnostics.push(diagnostic);
@@ -366,10 +372,10 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&create_expr(value.node.clone()), checker.stylist),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -289,7 +289,10 @@ fn docstring(
         fixed_contents.push_str(&quote);
         fixed_contents.push_str(string_contents);
         fixed_contents.push_str(&quote);
-        diagnostic.set_fix(Edit::range_replacement(fixed_contents, range));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            fixed_contents,
+            range,
+        )));
     }
     Some(diagnostic)
 }
@@ -364,7 +367,10 @@ fn strings(
                 fixed_contents.push_str(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push_str(quote);
-                diagnostic.set_fix(Edit::range_replacement(fixed_contents, *range));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    fixed_contents,
+                    *range,
+                )));
             }
             diagnostics.push(diagnostic);
         } else {
@@ -427,7 +433,10 @@ fn strings(
 
                         fixed_contents.push(quote);
 
-                        diagnostic.set_fix(Edit::range_replacement(fixed_contents, *range));
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                            fixed_contents,
+                            *range,
+                        )));
                     }
                     diagnostics.push(diagnostic);
                 }
@@ -450,7 +459,10 @@ fn strings(
                     fixed_contents.push(quote);
                     fixed_contents.push_str(string_contents);
                     fixed_contents.push(quote);
-                    diagnostic.set_fix(Edit::range_replacement(fixed_contents, *range));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                        fixed_contents,
+                        *range,
+                    )));
                 }
                 diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::match_parens;
 
@@ -34,7 +34,7 @@ pub fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: &Expr) 
                 .expect("Expected call to include parentheses");
             let mut diagnostic = Diagnostic::new(UnnecessaryParenOnRaiseException, range);
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::deletion(func.end(), range.end()));
+                diagnostic.set_fix(Fix::unspecified(Edit::deletion(func.end(), range.end())));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -3,7 +3,7 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt, StmtKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::elif_else_range;
 use ruff_python_ast::helpers::is_const_none;
@@ -345,7 +345,10 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement("return".to_string(), stmt.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                "return".to_string(),
+                stmt.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }
@@ -359,10 +362,10 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(ImplicitReturnValue, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "return None".to_string(),
                 stmt.range(),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }
@@ -416,10 +419,10 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Edit::insertion(
+                        diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator),
-                        ));
+                        )));
                     }
                 }
                 checker.diagnostics.push(diagnostic);
@@ -454,10 +457,10 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
-                        diagnostic.set_fix(Edit::insertion(
+                        diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator),
-                        ));
+                        )));
                     }
                 }
                 checker.diagnostics.push(diagnostic);
@@ -493,10 +496,10 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     content.push_str(checker.stylist.line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
-                    diagnostic.set_fix(Edit::insertion(
+                    diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         content,
                         end_of_last_statement(stmt, checker.locator),
-                    ));
+                    )));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -7,7 +7,7 @@ use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Boolop, Cmpop, Expr, ExprContext, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{
@@ -366,10 +366,10 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                 // Populate the `Fix`. Replace the _entire_ `BoolOp`. Note that if we have
                 // multiple duplicates, the fixes will conflict.
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -468,10 +468,10 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
                     values: iter::once(in_expr).chain(unmatched).collect(),
                 })
             };
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(&in_expr, checker.stylist),
                 expr.range(),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }
@@ -519,7 +519,10 @@ pub fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement("False".to_string(), expr.range()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                        "False".to_string(),
+                        expr.range(),
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -569,7 +572,10 @@ pub fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement("True".to_string(), expr.range()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                        "True".to_string(),
+                        expr.range(),
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -116,10 +116,10 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             value: capital_env_var.into(),
             kind: kind.clone(),
         });
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&new_env_var, checker.stylist),
             slice.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -176,7 +176,10 @@ pub fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(expected, expr.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            expected,
+            expr.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprContext, ExprKind, Stmt, StmtKind};
 use unicode_width::UnicodeWidthStr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr, ComparableStmt};
 use ruff_python_ast::helpers::{
@@ -370,7 +370,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
     if fixable && checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
             // If the condition is a comparison, we can replace it with the condition.
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
                         value: Some(test.clone()),
@@ -378,11 +378,11 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     checker.stylist,
                 ),
                 stmt.range(),
-            ));
+            )));
         } else {
             // Otherwise, we need to wrap the condition in a call to `bool`. (We've already
             // verified, above, that `bool` is a builtin.)
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
                         value: Some(Box::new(create_expr(ExprKind::Call {
@@ -397,7 +397,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
                     checker.stylist,
                 ),
                 stmt.range(),
-            ));
+            )));
         };
     }
     checker.diagnostics.push(diagnostic);
@@ -528,7 +528,10 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
         stmt.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(contents, stmt.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            contents,
+            stmt.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -875,7 +878,10 @@ pub fn use_dict_get_with_default(
         stmt.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(contents, stmt.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            contents,
+            stmt.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -100,12 +100,12 @@ pub fn explicit_true_false_in_ifexpr(
     );
     if checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(&test.clone(), checker.stylist),
                 expr.range(),
-            ));
+            )));
         } else if checker.ctx.is_builtin("bool") {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     &create_expr(ExprKind::Call {
                         func: Box::new(create_expr(ExprKind::Name {
@@ -118,7 +118,7 @@ pub fn explicit_true_false_in_ifexpr(
                     checker.stylist,
                 ),
                 expr.range(),
-            ));
+            )));
         };
     }
     checker.diagnostics.push(diagnostic);
@@ -152,7 +152,7 @@ pub fn explicit_false_true_in_ifexpr(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::UnaryOp {
                     op: Unaryop::Not,
@@ -161,7 +161,7 @@ pub fn explicit_false_true_in_ifexpr(
                 checker.stylist,
             ),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -200,7 +200,7 @@ pub fn twisted_arms_in_ifexpr(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::IfExp {
                     test: Box::new(create_expr(orelse.node.clone())),
@@ -210,7 +210,7 @@ pub fn twisted_arms_in_ifexpr(
                 checker.stylist,
             ),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Stmt, StmtKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 use ruff_python_semantic::scope::ScopeKind;
@@ -107,7 +107,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
                     left: left.clone(),
@@ -117,7 +117,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
                 checker.stylist,
             ),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -157,7 +157,7 @@ pub fn negation_with_not_equal_op(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
                     left: left.clone(),
@@ -167,7 +167,7 @@ pub fn negation_with_not_equal_op(
                 checker.stylist,
             ),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -191,10 +191,10 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(operand, checker.stylist),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind};
 
 use ruff_diagnostics::Edit;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -91,7 +91,10 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: TextRang
         range,
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(value_content, right.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            value_content,
+            right.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -227,11 +227,11 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     stmt.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("any") {
-                    diagnostic.set_fix(Edit::replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,
                         stmt.start(),
                         loop_info.terminal,
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -308,11 +308,11 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     stmt.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("all") {
-                    diagnostic.set_fix(Edit::replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,
                         stmt.start(),
                         loop_info.terminal,
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -104,7 +104,10 @@ pub fn suppressible_exception(
                     );
                     let handler_line_begin = checker.locator.line_start(handler.start());
                     let remove_handler = Edit::deletion(handler_line_begin, handler.end());
-                    Ok(Fix::from_iter([import_edit, replace_try, remove_handler]))
+                    Ok(Fix::unspecified_edits(
+                        import_edit,
+                        [replace_try, remove_handler],
+                    ))
                 });
             }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use libcst_native::{Codegen, CodegenState, CompOp};
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_stdlib::str::{self};
@@ -161,7 +161,10 @@ pub fn yoda_conditions(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(suggestion, expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                suggestion,
+                expr.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     } else {

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::Stmt;
 use textwrap::indent;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{
     followed_by_multi_statement_line, preceded_by_multi_statement_line, trailing_lines_end,
@@ -148,10 +148,10 @@ pub fn organize_imports(
     } else {
         let mut diagnostic = Diagnostic::new(UnsortedImports, range);
         if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 indent(&expected, indentation),
                 range,
-            ));
+            )));
         }
         Some(diagnostic)
     }

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -70,7 +70,7 @@ pub fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 match type_name {
                     "unicode" => "str",
                     "long" => "int",
@@ -78,7 +78,7 @@ pub fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
                 }
                 .to_string(),
                 expr.range(),
-            ));
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -41,5 +41,5 @@ pub(super) fn convert_inplace_argument_to_assignment(
     )
     .ok()?;
 
-    Some(Fix::from_iter([insert_assignment, remove_argument]))
+    Some(Fix::unspecified_edits(insert_assignment, [remove_argument]))
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -3,7 +3,7 @@ use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::registry::Rule;
@@ -164,7 +164,7 @@ pub fn compound_statements(
                     let mut diagnostic =
                         Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
                     if autofix.into() && settings.rules.should_fix(Rule::UselessSemicolon) {
-                        diagnostic.set_fix(Edit::deletion(start, end));
+                        diagnostic.set_fix(Fix::unspecified(Edit::deletion(start, end)));
                     };
                     diagnostics.push(diagnostic);
                 }

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use log::error;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -108,10 +108,10 @@ pub fn invalid_escape_sequence(
             let range = TextRange::at(location, next_char.text_len() + TextSize::from(1));
             let mut diagnostic = Diagnostic::new(InvalidEscapeSequence(*next_char), range);
             if autofix {
-                diagnostic.set_fix(Edit::insertion(
+                diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     r"\".to_string(),
                     range.start() + TextSize::from(1),
-                ));
+                )));
             }
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_leading_content, has_trailing_content, unparse_stmt};
 use ruff_python_ast::newlines::StrExt;
@@ -103,7 +103,10 @@ pub fn lambda_assignment(
                         indented.push_str(&line);
                     }
                 }
-                diagnostic.set_fix(Edit::range_replacement(indented, stmt.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    indented,
+                    stmt.range(),
+                )));
             }
 
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -2,7 +2,7 @@ use itertools::izip;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Cmpop, Constant, Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 
@@ -270,7 +270,10 @@ pub fn literal_comparisons(
             .collect::<Vec<_>>();
         let content = compare(left, &ops, comparators, checker.stylist);
         for diagnostic in &mut diagnostics {
-            diagnostic.set_fix(Edit::range_replacement(content.to_string(), expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                content.to_string(),
+                expr.range(),
+            )));
         }
     }
 

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -1,7 +1,7 @@
 use super::LogicalLine;
 use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::Edit;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
 use ruff_text_size::{TextRange, TextSize};

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -86,7 +86,10 @@ pub(crate) fn missing_whitespace(
                     let mut diagnostic = Diagnostic::new(kind, TextRange::empty(token.start()));
 
                     if autofix {
-                        diagnostic.set_fix(Edit::insertion(" ".to_string(), token.end()));
+                        diagnostic.set_fix(Fix::unspecified(Edit::insertion(
+                            " ".to_string(),
+                            token.end(),
+                        )));
                     }
                     context.push_diagnostic(diagnostic);
                 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -1,6 +1,6 @@
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
 use ruff_text_size::{TextRange, TextSize};
@@ -63,7 +63,7 @@ pub(crate) fn whitespace_before_parameters(
             let mut diagnostic = Diagnostic::new(kind, TextRange::new(start, end));
 
             if autofix {
-                diagnostic.set_fix(Edit::deletion(start, end));
+                diagnostic.set_fix(Fix::unspecified(Edit::deletion(start, end)));
             }
             context.push_diagnostic(diagnostic);
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::{TextLen, TextRange};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -55,10 +55,10 @@ pub fn no_newline_at_end_of_file(
 
         let mut diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, range);
         if autofix {
-            diagnostic.set_fix(Edit::insertion(
+            diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                 stylist.line_ending().to_string(),
                 range.start(),
-            ));
+            )));
         }
         return Some(diagnostic);
     }

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Cmpop, Expr, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -99,10 +99,10 @@ pub fn not_tests(
                         if check_not_in {
                             let mut diagnostic = Diagnostic::new(NotInTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
-                                diagnostic.set_fix(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
                                     expr.range(),
-                                ));
+                                )));
                             }
                             checker.diagnostics.push(diagnostic);
                         }
@@ -111,10 +111,10 @@ pub fn not_tests(
                         if check_not_is {
                             let mut diagnostic = Diagnostic::new(NotIsTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
-                                diagnostic.set_fix(Edit::range_replacement(
+                                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     compare(left, &[Cmpop::IsNot], comparators, checker.stylist),
                                     expr.range(),
-                                ));
+                                )));
                             }
                             checker.diagnostics.push(diagnostic);
                         }

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::Line;
 
@@ -95,7 +95,7 @@ pub(crate) fn trailing_whitespace(
                 if matches!(autofix, flags::Autofix::Enabled)
                     && settings.rules.should_fix(Rule::BlankLineWithWhitespace)
                 {
-                    diagnostic.set_fix(Edit::range_deletion(range));
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                 }
                 return Some(diagnostic);
             }
@@ -104,7 +104,7 @@ pub(crate) fn trailing_whitespace(
             if matches!(autofix, flags::Autofix::Enabled)
                 && settings.rules.should_fix(Rule::TrailingWhitespace)
             {
-                diagnostic.set_fix(Edit::range_deletion(range));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
             }
             return Some(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 
@@ -82,11 +82,11 @@ pub fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
                 }
 
                 // Insert one blank line after the summary (replacing any existing lines).
-                diagnostic.set_fix(Edit::replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     summary_end,
                     blank_end,
-                ));
+                )));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 use ruff_text_size::{TextLen, TextRange};
@@ -94,10 +94,10 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
-                    diagnostic.set_fix(Edit::deletion(
+                    diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -116,11 +116,11 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
-                    diagnostic.set_fix(Edit::replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         checker.stylist.line_ending().to_string(),
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -163,11 +163,11 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
-                diagnostic.set_fix(Edit::replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     first_line_start,
                     blank_lines_end,
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use ruff_text_size::{TextLen, TextRange};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 
@@ -88,10 +88,10 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
-                diagnostic.set_fix(Edit::deletion(
+                diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                     blank_lines_start,
                     docstring.start() - docstring.indentation.text_len(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -149,7 +149,10 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
-                diagnostic.set_fix(Edit::deletion(first_line_end, blank_lines_end));
+                diagnostic.set_fix(Fix::unspecified(Edit::deletion(
+                    first_line_end,
+                    blank_lines_end,
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::{TextLen, TextRange};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -71,10 +71,10 @@ pub fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             capitalized_word,
             TextRange::at(body.start(), first_word.text_len()),
-        ));
+        )));
     }
 
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextLen;
 use strum::IntoEnumIterator;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 
@@ -64,10 +64,10 @@ pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
                 && !trimmed.ends_with(':')
                 && !trimmed.ends_with(';')
             {
-                diagnostic.set_fix(Edit::insertion(
+                diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         };

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextLen;
 use strum::IntoEnumIterator;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 
@@ -61,10 +61,10 @@ pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {
             let mut diagnostic = Diagnostic::new(EndsInPunctuation, docstring.range());
             // Best-effort autofix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
-                diagnostic.set_fix(Edit::insertion(
+                diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         };

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -1,5 +1,5 @@
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::whitespace;
@@ -90,10 +90,10 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(UnderIndentation, TextRange::empty(line.start()));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         whitespace::clean(docstring.indentation),
                         TextRange::at(line.start(), line_indent.text_len()),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -151,10 +151,10 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(OverIndentation, TextRange::empty(last.start()));
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         whitespace::clean(docstring.indentation),
                         TextRange::at(last.start(), line_indent.text_len()),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{NewlineWithTrailingNewline, UniversalNewlineIterator};
 use ruff_python_ast::str::{is_triple_quote, leading_quote};
@@ -67,10 +67,10 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                 // Delete until first non-whitespace char.
                 for line in content_lines {
                     if let Some(end_column) = line.find(|c: char| !c.is_whitespace()) {
-                        diagnostic.set_fix(Edit::deletion(
+                        diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                             first_line.end(),
                             line.start() + TextSize::try_from(end_column).unwrap(),
-                        ));
+                        )));
                         break;
                     }
                 }
@@ -123,7 +123,11 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );
 
-                    diagnostic.set_fix(Edit::replacement(repl, body.start(), first_line.end()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::replacement(
+                        repl,
+                        body.start(),
+                        first_line.end(),
+                    )));
                 }
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{NewlineWithTrailingNewline, StrExt};
 use ruff_python_ast::whitespace;
@@ -56,11 +56,11 @@ pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring
                             checker.stylist.line_ending().as_str(),
                             whitespace::clean(docstring.indentation)
                         );
-                        diagnostic.set_fix(Edit::replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                             content,
                             docstring.expr.end() - num_trailing_quotes - num_trailing_spaces,
                             docstring.expr.end() - num_trailing_quotes,
-                        ));
+                        )));
                     }
                     checker.diagnostics.push(diagnostic);
                 }

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_text_size::{TextLen, TextRange};
@@ -44,10 +44,10 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
         // characters, avoid applying the fix.
         if !trimmed.ends_with(quote) && !trimmed.starts_with(quote) && !ends_with_backslash(trimmed)
         {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 trimmed.to_string(),
                 TextRange::at(body.start(), line.text_len()),
-            ));
+            )));
         }
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::str::{leading_quote, trailing_quote};
@@ -49,10 +49,10 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                 if !trimmed.ends_with(trailing.chars().last().unwrap())
                     && !trimmed.starts_with(leading.chars().last().unwrap())
                 {
-                    diagnostic.set_fix(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.range(),
-                    ));
+                    )));
                 }
             }
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::StmtKind;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit};
+use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
@@ -373,7 +373,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and the underline.
-                        diagnostic.set_fix(Edit::range_deletion(range));
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -405,11 +405,11 @@ fn blanks_and_section_underline(
                             "-".repeat(context.section_name().len()),
                             checker.stylist.line_ending().as_str()
                         );
-                        diagnostic.set_fix(Edit::replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                             content,
                             blank_lines_end,
                             non_blank_line.full_end(),
-                        ));
+                        )));
                     };
                     checker.diagnostics.push(diagnostic);
                 }
@@ -435,10 +435,10 @@ fn blanks_and_section_underline(
                         );
 
                         // Replace the existing indentation with whitespace of the appropriate length.
-                        diagnostic.set_fix(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             whitespace::clean(docstring.indentation),
                             range,
-                        ));
+                        )));
                     };
                     checker.diagnostics.push(diagnostic);
                 }
@@ -478,10 +478,10 @@ fn blanks_and_section_underline(
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
-                            diagnostic.set_fix(Edit::deletion(
+                            diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                 line_after_dashes.start(),
                                 blank_lines_after_dashes_end,
-                            ));
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }
@@ -516,7 +516,10 @@ fn blanks_and_section_underline(
                         whitespace::clean(docstring.indentation),
                         "-".repeat(context.section_name().len()),
                     );
-                    diagnostic.set_fix(Edit::insertion(content, context.summary_range().end()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::insertion(
+                        content,
+                        context.summary_range().end(),
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -536,7 +539,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and content.
-                        diagnostic.set_fix(Edit::range_deletion(range));
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
                 }
@@ -565,7 +568,10 @@ fn blanks_and_section_underline(
                     "-".repeat(context.section_name().len()),
                 );
 
-                diagnostic.set_fix(Edit::insertion(content, context.summary_range().end()));
+                diagnostic.set_fix(Fix::unspecified(Edit::insertion(
+                    content,
+                    context.summary_range().end(),
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -599,10 +605,10 @@ fn common_section(
                 // Replace the section title with the capitalized variant. This requires
                 // locating the start and end of the section name.
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     capitalized_section_name.to_string(),
                     section_range,
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -622,11 +628,11 @@ fn common_section(
                 let content = whitespace::clean(docstring.indentation);
                 let fix_range = TextRange::at(context.range().start(), leading_space.text_len());
 
-                diagnostic.set_fix(if content.is_empty() {
+                diagnostic.set_fix(Fix::unspecified(if content.is_empty() {
                     Edit::range_deletion(fix_range)
                 } else {
                     Edit::range_replacement(content, fix_range)
-                });
+                }));
             };
             checker.diagnostics.push(diagnostic);
         }
@@ -649,7 +655,10 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline at the beginning of the next section.
-                    diagnostic.set_fix(Edit::insertion(line_end.to_string(), next.range().start()));
+                    diagnostic.set_fix(Fix::unspecified(Edit::insertion(
+                        line_end.to_string(),
+                        next.range().start(),
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -667,10 +676,10 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
-                    diagnostic.set_fix(Edit::insertion(
+                    diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         format!("{}{}", line_end, docstring.indentation),
                         context.range().end(),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }
@@ -691,10 +700,10 @@ fn common_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
-                diagnostic.set_fix(Edit::insertion(
+                diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     line_end.to_string(),
                     context.range().start(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -893,10 +902,10 @@ fn numpy_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 let section_range = context.section_name_range();
-                diagnostic.set_fix(Edit::range_deletion(TextRange::at(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     section_range.end(),
                     suffix.text_len(),
-                )));
+                ))));
             }
 
             checker.diagnostics.push(diagnostic);
@@ -930,10 +939,10 @@ fn google_section(
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix.
                 let section_name_range = context.section_name_range();
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     ":".to_string(),
                     TextRange::at(section_name_range.end(), suffix.text_len()),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -4,7 +4,7 @@ use once_cell::unsync::Lazy;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Cmpop, Expr};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers;
 
@@ -78,10 +78,10 @@ pub fn invalid_literal_comparison(
                             None
                         }
                     } {
-                        diagnostic.set_fix(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             content,
                             located_op.range() + location.start(),
-                        ));
+                        )));
                     }
                 } else {
                     error!("Failed to fix invalid comparison due to missing op");

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -46,10 +46,10 @@ pub fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     };
     let mut diagnostic = Diagnostic::new(RaiseNotImplemented, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "NotImplementedError".to_string(),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -3,7 +3,7 @@ use std::hash::{BuildHasherDefault, Hash};
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr};
 use ruff_python_ast::helpers::unparse_expr;
@@ -109,10 +109,10 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
-                                    diagnostic.set_fix(Edit::deletion(
+                                    diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                         values[i - 1].end(),
                                         values[i].end(),
-                                    ));
+                                    )));
                                 }
                             } else {
                                 seen_values.insert(comparable_value);
@@ -137,10 +137,10 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
-                                    diagnostic.set_fix(Edit::deletion(
+                                    diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                         values[i - 1].end(),
                                         values[i].end(),
-                                    ));
+                                    )));
                                 }
                             } else {
                                 seen_values.insert(comparable_value);

--- a/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
@@ -2,7 +2,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use ruff_diagnostics::AlwaysAutofixableViolation;
 use ruff_diagnostics::Edit;
-use ruff_diagnostics::{Diagnostic, DiagnosticKind};
+use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -197,7 +197,10 @@ pub fn invalid_string_characters(
 
         let mut diagnostic = Diagnostic::new(rule, range);
         if autofix {
-            diagnostic.set_fix(Edit::range_replacement(replacement.to_string(), range));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                replacement.to_string(),
+                range,
+            )));
         }
         diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Alias, AliasData, Located, Stmt, StmtKind};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_stmt, unparse_stmt};
 
@@ -53,7 +53,7 @@ pub fn manual_from_import(checker: &mut Checker, stmt: &Stmt, alias: &Alias, nam
         alias.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_stmt(
                 &create_stmt(StmtKind::ImportFrom {
                     module: Some(module.to_string()),
@@ -69,7 +69,7 @@ pub fn manual_from_import(checker: &mut Checker, stmt: &Stmt, alias: &Alias, nam
                 checker.stylist,
             ),
             stmt.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -54,7 +54,7 @@ pub fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
                     checker.locator,
                 )?;
                 let reference_edit = Edit::range_replacement(binding, func.range());
-                Ok(Fix::from_iter([import_edit, reference_edit]))
+                Ok(Fix::unspecified_edits(import_edit, [reference_edit]))
             });
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Alias;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -49,7 +49,10 @@ pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(asname.to_string(), alias.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            asname.to_string(),
+            alias.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
 
@@ -44,10 +44,10 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC { straight_import }, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if straight_import {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     "datetime.UTC".to_string(),
                     expr.range(),
-                ));
+                )));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Located, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -24,10 +24,10 @@ fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator.slice(node.range());
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, AliasData, Stmt};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::whitespace::indentation;
@@ -551,7 +551,10 @@ pub fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
-                diagnostic.set_fix(Edit::range_replacement(content, stmt.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    content,
+                    stmt.range(),
+                )));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -6,7 +6,7 @@ use libcst_native::{
 use log::error;
 use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -257,7 +257,10 @@ pub fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 value.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement("mock".to_string(), value.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    "mock".to_string(),
+                    value.range(),
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -300,8 +303,10 @@ pub fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             name.range(),
                         );
                         if let Some(content) = content.as_ref() {
-                            diagnostic
-                                .set_fix(Edit::range_replacement(content.clone(), stmt.range()));
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                                content.clone(),
+                                stmt.range(),
+                            )));
                         }
                         checker.diagnostics.push(diagnostic);
                     }

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -69,10 +69,10 @@ pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             format!("self.{target}"),
             expr.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -2,7 +2,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -142,11 +142,11 @@ pub fn extraneous_parentheses(
                 if autofix.into() && settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents =
                         locator.slice(TextRange::new(start_range.start(), end_range.end()));
-                    diagnostic.set_fix(Edit::replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         start_range.start(),
                         end_range.end(),
-                    ));
+                    )));
                 }
                 diagnostics.push(diagnostic);
             } else {

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -5,7 +5,7 @@ use rustpython_common::format::{
 };
 use rustpython_parser::ast::{Constant, Expr, ExprKind, KeywordData};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::{is_implicit_concatenation, leading_quote, trailing_quote};
 
@@ -273,7 +273,10 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
 
     let mut diagnostic = Diagnostic::new(FString, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(contents, expr.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            contents,
+            expr.range(),
+        )));
     };
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -145,7 +145,10 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
         if let Ok(contents) =
             generate_call(expr, &summary.indices, checker.locator, checker.stylist)
         {
-            diagnostic.set_fix(Edit::range_replacement(contents, expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                contents,
+                expr.range(),
+            )));
         };
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -67,7 +67,7 @@ pub fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list: &[Expr
                             checker.locator,
                         )?;
                         let reference_edit = Edit::range_replacement(binding, expr.range());
-                        Ok(Fix::from_iter([import_edit, reference_edit]))
+                        Ok(Fix::unspecified_edits(import_edit, [reference_edit]))
                     });
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 
@@ -48,10 +48,10 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
                 TextRange::new(func.end(), expr.end()),
             );
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(func, checker.stylist),
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::str::is_implicit_concatenation;
 
@@ -64,7 +64,7 @@ pub fn native_literals(
                 LiteralType::Bytes
             }}, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
                         content.push('b');
@@ -78,7 +78,7 @@ pub fn native_literals(
                         content
                     },
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
             return;
@@ -127,7 +127,10 @@ pub fn native_literals(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement(arg_code.to_string(), expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                arg_code.to_string(),
+                expr.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -38,7 +38,10 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
             .map_or(true, |binding| binding.kind.is_builtin());
         let mut diagnostic = Diagnostic::new(OpenAlias { fixable }, expr.range());
         if fixable && checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement("open".to_string(), func.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                "open".to_string(),
+                func.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, Expr, ExprContext, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::compose_call_path;
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
@@ -63,10 +63,10 @@ fn atom_diagnostic(checker: &mut Checker, target: &Expr) {
         target.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "OSError".to_string(),
             target.range(),
-        ));
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }
@@ -103,12 +103,12 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
         }
 
         if remaining.len() == 1 {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "OSError".to_string(),
                 target.range(),
-            ));
+            )));
         } else {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 format!(
                     "({})",
                     unparse_expr(
@@ -120,7 +120,7 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
                     )
                 ),
                 target.range(),
-            ));
+            )));
         }
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -7,7 +7,7 @@ use rustpython_common::cformat::{
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::str::{leading_quote, trailing_quote};
@@ -444,7 +444,10 @@ pub(crate) fn printf_string_formatting(
 
     let mut diagnostic = Diagnostic::new(PrintfStringFormatting, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(contents, expr.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            contents,
+            expr.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_text_size::TextRange;
 
@@ -23,7 +23,10 @@ impl AlwaysAutofixableViolation for QuotedAnnotation {
 pub fn quoted_annotation(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
     if checker.patch(Rule::QuotedAnnotation) {
-        diagnostic.set_fix(Edit::range_replacement(annotation.to_string(), range));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            annotation.to_string(),
+            range,
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Keyword};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 use ruff_python_ast::source_code::Locator;
@@ -116,10 +116,10 @@ fn create_check(
     );
     if patch {
         if let Some(content) = replacement_value {
-            diagnostic.set_fix(Edit::range_replacement(
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 content.to_string(),
                 mode_param.range(),
-            ));
+            )));
         } else {
             diagnostic.try_set_fix(|| create_remove_param_fix(locator, expr, mode_param));
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -38,7 +38,7 @@ fn generate_fix(
     } else {
         (stderr, stdout)
     };
-    Ok(Fix::new(vec![
+    Ok(Fix::unspecified(vec![
         Edit::range_replacement("capture_output=True".to_string(), first.range()),
         remove_argument(locator, func.start(), second.range(), args, keywords, false)?,
     ]))

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -38,10 +38,17 @@ fn generate_fix(
     } else {
         (stderr, stdout)
     };
-    Ok(Fix::unspecified(vec![
+    Ok(Fix::unspecified_edits(
         Edit::range_replacement("capture_output=True".to_string(), first.range()),
-        remove_argument(locator, func.start(), second.range(), args, keywords, false)?,
-    ]))
+        [remove_argument(
+            locator,
+            func.start(),
+            second.range(),
+            args,
+            keywords,
+            false,
+        )?],
+    ))
 }
 
 /// UP022

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::{TextLen, TextRange};
 use rustpython_parser::ast::{Expr, Keyword};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::find_keyword;
 
@@ -35,7 +35,10 @@ pub fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwargs: &[
         let range = TextRange::at(kwarg.start(), "universal_newlines".text_len());
         let mut diagnostic = Diagnostic::new(ReplaceUniversalNewlines, range);
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement("text".to_string(), range));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                "text".to_string(),
+                range,
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -46,7 +46,10 @@ pub fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr, args: 
     };
     let mut diagnostic = Diagnostic::new(TypeOfPrimitive { primitive }, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
-        diagnostic.set_fix(Edit::range_replacement(primitive.builtin(), expr.range()));
+        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            primitive.builtin(),
+            expr.range(),
+        )));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -31,7 +31,10 @@ pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
-            diagnostic.set_fix(Edit::range_replacement("str".to_string(), expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                "str".to_string(),
+                expr.range(),
+            )));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -27,10 +27,10 @@ pub fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, kind: Option<&str
         if const_kind.to_lowercase() == "u" {
             let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_deletion(TextRange::at(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     expr.start(),
                     TextSize::from(1),
-                )));
+                ))));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::Line;
 
@@ -30,7 +30,10 @@ pub(crate) fn unnecessary_coding_comment(line: &Line, autofix: bool) -> Option<D
     if CODING_COMMENT_REGEX.is_match(line.as_str()) {
         let mut diagnostic = Diagnostic::new(UTF8EncodingDeclaration, line.full_range());
         if autofix {
-            diagnostic.set_fix(Edit::deletion(line.start(), line.full_end()));
+            diagnostic.set_fix(Fix::unspecified(Edit::deletion(
+                line.start(),
+                line.full_end(),
+            )));
         }
         Some(diagnostic)
     } else {

--- a/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -101,7 +101,10 @@ pub fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr], valu
                 content.push('(');
                 content.push_str(&existing[1..existing.len() - 1]);
                 content.push(')');
-                diagnostic.set_fix(Edit::range_replacement(content, value.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    content,
+                    value.range(),
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::typing::AnnotationKind;
 
@@ -55,7 +55,10 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
         if fixable && checker.patch(diagnostic.kind.rule()) {
             let binding = binding.to_lowercase();
             if checker.ctx.is_builtin(&binding) {
-                diagnostic.set_fix(Edit::range_replacement(binding, expr.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    binding,
+                    expr.range(),
+                )));
             }
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Constant, Expr, ExprKind, Operator};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 use ruff_python_ast::typing::AnnotationKind;
@@ -112,10 +112,10 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
         TypingMember::Optional => {
             let mut diagnostic = Diagnostic::new(NonPEP604Annotation { fixable }, expr.range());
             if fixable && checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&optional(slice), checker.stylist),
                     expr.range(),
-                ));
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }
@@ -127,17 +127,17 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                         // Invalid type annotation.
                     }
                     ExprKind::Tuple { elts, .. } => {
-                        diagnostic.set_fix(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_expr(&union(elts), checker.stylist),
                             expr.range(),
-                        ));
+                        )));
                     }
                     _ => {
                         // Single argument.
-                        diagnostic.set_fix(Edit::range_replacement(
+                        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_expr(slice, checker.stylist),
                             expr.range(),
-                        ));
+                        )));
                     }
                 }
             }

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use rustpython_parser::ast::{Expr, ExprKind, Operator};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_expr;
 
@@ -93,10 +93,10 @@ pub fn use_pep604_isinstance(checker: &mut Checker, expr: &Expr, func: &Expr, ar
 
                 let mut diagnostic = Diagnostic::new(NonPEP604Isinstance { kind }, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
-                    diagnostic.set_fix(Edit::range_replacement(
+                    diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         unparse_expr(&union(elts), checker.stylist),
                         types.range(),
-                    ));
+                    )));
                 }
                 checker.diagnostics.push(diagnostic);
             }

--- a/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::RefEquality;
 use ruff_python_ast::visitor;
@@ -176,7 +176,10 @@ pub fn yield_in_for_loop(checker: &mut Checker, stmt: &Stmt) {
             if checker.patch(diagnostic.kind.rule()) {
                 let contents = checker.locator.slice(item.iter.range());
                 let contents = format!("yield from {contents}");
-                diagnostic.set_fix(Edit::range_replacement(contents, item.stmt.range()));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                    contents,
+                    item.stmt.range(),
+                )));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Edit};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -1725,10 +1725,10 @@ pub fn ambiguous_unicode_character(
                     );
                     if settings.rules.enabled(diagnostic.kind.rule()) {
                         if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
-                            diagnostic.set_fix(Edit::range_replacement(
+                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 (representant as char).to_string(),
                                 char_range,
-                            ));
+                            )));
                         }
                         diagnostics.push(diagnostic);
                     }

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Operator};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, has_comments, unparse_expr};
 
@@ -108,7 +108,10 @@ pub fn collection_literal_concatenation(checker: &mut Checker, expr: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if fixable {
-            diagnostic.set_fix(Edit::range_replacement(contents, expr.range()));
+            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                contents,
+                expr.range(),
+            )));
         }
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -56,7 +56,7 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
     // Detect autofixes that don't converge after multiple iterations.
     if diagnostics
         .iter()
-        .any(|diagnostic| !diagnostic.fix.is_empty())
+        .any(|diagnostic| diagnostic.fix.is_some())
     {
         let max_iterations = 10;
 

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -233,7 +233,7 @@ pub fn get(
                 messages.push(Message {
                     kind: header.kind,
                     range: header.range,
-                    fix: header.fix,
+                    fix: Some(header.fix),
                     file: source_file.clone(),
                     noqa_offset: header.noqa_row,
                 });

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -124,7 +124,7 @@ impl Serialize for SerializeMessage<'_> {
 struct MessageHeader {
     kind: DiagnosticKind,
     range: TextRange,
-    fix: Fix,
+    fix: Option<Fix>,
     file_id: usize,
     noqa_row: TextSize,
 }
@@ -233,7 +233,7 @@ pub fn get(
                 messages.push(Message {
                     kind: header.kind,
                     range: header.range,
-                    fix: Some(header.fix),
+                    fix: header.fix,
                     file: source_file.clone(),
                     noqa_offset: header.noqa_row,
                 });

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -24,7 +24,7 @@ pub struct DiagnosticKind {
 pub struct Diagnostic {
     pub kind: DiagnosticKind,
     pub range: TextRange,
-    pub fix: Fix,
+    pub fix: Option<Fix>,
     pub parent: Option<TextSize>,
 }
 
@@ -33,7 +33,7 @@ impl Diagnostic {
         Self {
             kind: kind.into(),
             range,
-            fix: Fix::empty(),
+            fix: None,
             parent: None,
         }
     }
@@ -41,7 +41,7 @@ impl Diagnostic {
     /// Set the [`Fix`] used to fix the diagnostic.
     #[inline]
     pub fn set_fix<T: Into<Fix>>(&mut self, fix: T) {
-        self.fix = fix.into();
+        self.fix = Some(fix.into());
     }
 
     /// Consumes `self` and returns a new `Diagnostic` with the given `fix`.
@@ -57,7 +57,7 @@ impl Diagnostic {
     #[inline]
     pub fn try_set_fix<T: Into<Fix>>(&mut self, func: impl FnOnce() -> Result<T>) {
         match func() {
-            Ok(fix) => self.fix = fix.into(),
+            Ok(fix) => self.fix = Some(fix.into()),
             Err(err) => error!("Failed to create fix: {}", err),
         }
     }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -12,14 +12,16 @@ pub struct Fix {
 }
 
 impl Fix {
-    /// Create a new [`Fix`] from a vector of [`Edit`] elements with an unspecified applicability.
-    pub fn unspecified(edits: Vec<Edit>) -> Self {
-        Self { edits }
+    /// Create a new [`Fix`] with an unspecified applicability from an [`Edit`] element.
+    pub fn unspecified(edit: Edit) -> Self {
+        Self { edits: vec![edit] }
     }
 
     /// Create a new [`Fix`] with unspecified applicability from multiple [`Edit`] elements.
     pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
-        Self::unspecified(std::iter::once(edit).chain(rest.into_iter()).collect())
+        Self {
+            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+        }
     }
 
     /// Create an empty [`Fix`].

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -39,14 +39,6 @@ impl Fix {
     }
 }
 
-impl FromIterator<Edit> for Fix {
-    fn from_iter<T: IntoIterator<Item = Edit>>(iter: T) -> Self {
-        Self {
-            edits: Vec::from_iter(iter),
-        }
-    }
-}
-
 impl From<Edit> for Fix {
     fn from(edit: Edit) -> Self {
         Self { edits: vec![edit] }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::edit::Edit;
 
 /// A collection of [`Edit`] elements to be applied to a source file.
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Fix {
     edits: Vec<Edit>,

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -24,16 +24,6 @@ impl Fix {
         }
     }
 
-    /// Create an empty [`Fix`].
-    pub const fn empty() -> Self {
-        Self { edits: Vec::new() }
-    }
-
-    /// Return `true` if the [`Fix`] contains no [`Edit`] elements.
-    pub fn is_empty(&self) -> bool {
-        self.edits.is_empty()
-    }
-
     /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`].
     pub fn min_start(&self) -> Option<TextSize> {
         self.edits.iter().map(Edit::start).min()

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -12,8 +12,8 @@ pub struct Fix {
 }
 
 impl Fix {
-    /// Create a new [`Fix`] from a vector of [`Edit`] elements.
-    pub fn new(edits: Vec<Edit>) -> Self {
+    /// Create a new [`Fix`] from a vector of [`Edit`] elements with an unspecified applicability.
+    pub fn unspecified(edits: Vec<Edit>) -> Self {
         Self { edits }
     }
 

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -17,6 +17,11 @@ impl Fix {
         Self { edits }
     }
 
+    /// Create a new [`Fix`] with unspecified applicability from multiple [`Edit`] elements.
+    pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+        Self::unspecified(std::iter::once(edit).chain(rest.into_iter()).collect())
+    }
+
     /// Create an empty [`Fix`].
     pub const fn empty() -> Self {
         Self { edits: Vec::new() }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -215,14 +215,10 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
                 message: message.kind.body,
                 location: start_location,
                 end_location,
-                fix: if message.fix.is_none() {
-                    None
-                } else {
-                    Some(ExpandedFix {
-                        message: message.kind.suggestion,
-                        edits: message.fix.unwrap().into_edits(),
-                    })
-                },
+                fix: message.fix.map(|fix| ExpandedFix {
+                    message: message.kind.suggestion,
+                    edits: fix.into_edits(),
+                }),
             }
         })
         .collect();

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -215,12 +215,12 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
                 message: message.kind.body,
                 location: start_location,
                 end_location,
-                fix: if message.fix.is_empty() {
+                fix: if message.fix.is_none() {
                     None
                 } else {
                     Some(ExpandedFix {
                         message: message.kind.suggestion,
-                        edits: message.fix.into_edits(),
+                        edits: message.fix.unwrap().into_edits(),
                     })
                 },
             }


### PR DESCRIPTION
Part of https://github.com/charliermarsh/ruff/issues/4181
Closes https://github.com/charliermarsh/ruff/issues/4182

Thanks for the well specified issue! This implements many of the noted changes (see commit messages). There are a couple of deviations:

- Removes `Fix::empty`
- Updates `Message::fix` to be `Option<Fix>`
- Updates `MessageHeader::fix` to be `Option<Fix>`
- Does not remove `From<Edit> for Fix` (see [discussion](https://github.com/charliermarsh/ruff/pull/4198#issuecomment-1537473767))

