### PR TITLE
Show settings path in `--show-settings` output

### DIFF
--- a/crates/ruff/src/packaging.rs
+++ b/crates/ruff/src/packaging.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use rustc_hash::FxHashMap;
 
-use crate::resolver::{PyprojectDiscovery, Resolver};
+use crate::resolver::{PyprojectConfig, Resolver};
 
 // If we have a Python package layout like:
 // - root/
@@ -82,7 +82,7 @@ fn detect_package_root_with_cache<'a>(
 pub fn detect_package_roots<'a>(
     files: &[&'a Path],
     resolver: &'a Resolver,
-    pyproject_strategy: &'a PyprojectDiscovery,
+    pyproject_config: &'a PyprojectConfig,
 ) -> FxHashMap<&'a Path, Option<&'a Path>> {
     // Pre-populate the module cache, since the list of files could (but isn't
     // required to) contain some `__init__.py` files.
@@ -98,9 +98,7 @@ pub fn detect_package_roots<'a>(
     // Search for the package root for each file.
     let mut package_roots: FxHashMap<&Path, Option<&Path>> = FxHashMap::default();
     for file in files {
-        let namespace_packages = &resolver
-            .resolve(file, pyproject_strategy)
-            .namespace_packages;
+        let namespace_packages = &resolver.resolve(file, pyproject_config).namespace_packages;
         if let Some(package) = file.parent() {
             if package_roots.contains_key(package) {
                 continue;

--- a/crates/ruff/src/resolver.rs
+++ b/crates/ruff/src/resolver.rs
@@ -166,7 +166,11 @@ pub fn resolve_scoped_settings(
 ) -> Result<(PathBuf, AllSettings)> {
     let configuration = resolve_configuration(pyproject, relativity, processor)?;
     let project_root = relativity.resolve(pyproject);
-    let settings = AllSettings::from_configuration(configuration, &project_root)?;
+    let settings = AllSettings::from_configuration(
+        configuration,
+        &project_root,
+        Some(pyproject.to_path_buf()),
+    )?;
     Ok((project_root, settings))
 }
 

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -13,7 +13,6 @@ use strum::IntoEnumIterator;
 use ruff_cache::cache_dir;
 use ruff_macros::CacheKey;
 
-use crate::fs;
 use crate::registry::{Rule, RuleNamespace, RuleSet, INCOMPATIBLE_CODES};
 use crate::rule_selector::{RuleSelector, Specificity};
 use crate::rules::{
@@ -44,15 +43,10 @@ const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct AllSettings {
     pub cli: CliSettings,
     pub lib: Settings,
-    settings_path: Option<PathBuf>,
 }
 
 impl AllSettings {
-    pub fn from_configuration(
-        config: Configuration,
-        project_root: &Path,
-        settings_path: Option<PathBuf>,
-    ) -> Result<Self> {
+    pub fn from_configuration(config: Configuration, project_root: &Path) -> Result<Self> {
         Ok(Self {
             cli: CliSettings {
                 cache_dir: config
@@ -66,12 +60,7 @@ impl AllSettings {
                 update_check: config.update_check.unwrap_or_default(),
             },
             lib: Settings::from_configuration(config, project_root)?,
-            settings_path: settings_path.map(fs::normalize_path),
         })
-    }
-
-    pub fn settings_path(&self) -> Option<&Path> {
-        self.settings_path.as_deref()
     }
 }
 

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -13,6 +13,7 @@ use strum::IntoEnumIterator;
 use ruff_cache::cache_dir;
 use ruff_macros::CacheKey;
 
+use crate::fs;
 use crate::registry::{Rule, RuleNamespace, RuleSet, INCOMPATIBLE_CODES};
 use crate::rule_selector::{RuleSelector, Specificity};
 use crate::rules::{
@@ -43,10 +44,15 @@ const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct AllSettings {
     pub cli: CliSettings,
     pub lib: Settings,
+    settings_path: Option<PathBuf>,
 }
 
 impl AllSettings {
-    pub fn from_configuration(config: Configuration, project_root: &Path) -> Result<Self> {
+    pub fn from_configuration(
+        config: Configuration,
+        project_root: &Path,
+        settings_path: Option<PathBuf>,
+    ) -> Result<Self> {
         Ok(Self {
             cli: CliSettings {
                 cache_dir: config
@@ -60,7 +66,12 @@ impl AllSettings {
                 update_check: config.update_check.unwrap_or_default(),
             },
             lib: Settings::from_configuration(config, project_root)?,
+            settings_path: settings_path.map(fs::normalize_path),
         })
+    }
+
+    pub fn settings_path(&self) -> Option<&Path> {
+        self.settings_path.as_deref()
     }
 }
 

--- a/crates/ruff_cli/src/commands/add_noqa.rs
+++ b/crates/ruff_cli/src/commands/add_noqa.rs
@@ -7,7 +7,7 @@ use log::{debug, error};
 use rayon::prelude::*;
 
 use ruff::linter::add_noqa_to_path;
-use ruff::resolver::PyprojectDiscovery;
+use ruff::resolver::PyprojectConfig;
 use ruff::{packaging, resolver, warn_user_once};
 
 use crate::args::Overrides;
@@ -15,12 +15,12 @@ use crate::args::Overrides;
 /// Add `noqa` directives to a collection of files.
 pub fn add_noqa(
     files: &[PathBuf],
-    pyproject_strategy: &PyprojectDiscovery,
+    pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
 ) -> Result<usize> {
     // Collect all the files to check.
     let start = Instant::now();
-    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
+    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_config, overrides)?;
     let duration = start.elapsed();
     debug!("Identified files to lint in: {:?}", duration);
 
@@ -37,7 +37,7 @@ pub fn add_noqa(
             .map(ignore::DirEntry::path)
             .collect::<Vec<_>>(),
         &resolver,
-        pyproject_strategy,
+        pyproject_config,
     );
 
     let start = Instant::now();
@@ -50,7 +50,7 @@ pub fn add_noqa(
                 .parent()
                 .and_then(|parent| package_roots.get(parent))
                 .and_then(|package| *package);
-            let settings = resolver.resolve(path, pyproject_strategy);
+            let settings = resolver.resolve(path, pyproject_config);
             match add_noqa_to_path(path, package, settings) {
                 Ok(count) => Some(count),
                 Err(e) => {

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -238,7 +238,11 @@ mod test {
 
         let diagnostics = run(
             &[root_path.join("valid.ipynb")],
-            &PyprojectDiscovery::Fixed(AllSettings::from_configuration(configuration, &root_path)?),
+            &PyprojectDiscovery::Fixed(AllSettings::from_configuration(
+                configuration,
+                &root_path,
+                None,
+            )?),
             &overrides,
             Cache::Disabled,
             Noqa::Enabled,

--- a/crates/ruff_cli/src/commands/run_stdin.rs
+++ b/crates/ruff_cli/src/commands/run_stdin.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use anyhow::Result;
 
-use ruff::resolver::PyprojectDiscovery;
+use ruff::resolver::PyprojectConfig;
 use ruff::settings::flags;
 use ruff::{packaging, resolver};
 
@@ -20,22 +20,28 @@ fn read_from_stdin() -> Result<String> {
 /// Run the linter over a single file, read from `stdin`.
 pub fn run_stdin(
     filename: Option<&Path>,
-    pyproject_strategy: &PyprojectDiscovery,
+    pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
     noqa: flags::Noqa,
     autofix: flags::FixMode,
 ) -> Result<Diagnostics> {
     if let Some(filename) = filename {
-        if !resolver::python_file_at_path(filename, pyproject_strategy, overrides)? {
+        if !resolver::python_file_at_path(filename, pyproject_config, overrides)? {
             return Ok(Diagnostics::default());
         }
     }
-    let settings = pyproject_strategy.top_level_settings();
-    let package_root = filename
-        .and_then(Path::parent)
-        .and_then(|path| packaging::detect_package_root(path, &settings.lib.namespace_packages));
+    let package_root = filename.and_then(Path::parent).and_then(|path| {
+        packaging::detect_package_root(path, &pyproject_config.settings.lib.namespace_packages)
+    });
     let stdin = read_from_stdin()?;
-    let mut diagnostics = lint_stdin(filename, package_root, &stdin, &settings.lib, noqa, autofix)?;
+    let mut diagnostics = lint_stdin(
+        filename,
+        package_root,
+        &stdin,
+        &pyproject_config.settings.lib,
+        noqa,
+        autofix,
+    )?;
     diagnostics.messages.sort_unstable();
     Ok(diagnostics)
 }

--- a/crates/ruff_cli/src/commands/show_files.rs
+++ b/crates/ruff_cli/src/commands/show_files.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use itertools::Itertools;
 
-use ruff::resolver::PyprojectDiscovery;
+use ruff::resolver::PyprojectConfig;
 use ruff::{resolver, warn_user_once};
 
 use crate::args::Overrides;
@@ -12,11 +12,11 @@ use crate::args::Overrides;
 /// Show the list of files to be checked based on current settings.
 pub fn show_files(
     files: &[PathBuf],
-    pyproject_strategy: &PyprojectDiscovery,
+    pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
-    let (paths, _resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
+    let (paths, _resolver) = resolver::python_files_in_path(files, pyproject_config, overrides)?;
 
     if paths.is_empty() {
         warn_user_once!("No Python files found under the given path(s)");

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -5,18 +5,18 @@ use anyhow::{bail, Result};
 use itertools::Itertools;
 
 use ruff::resolver;
-use ruff::resolver::PyprojectDiscovery;
+use ruff::resolver::PyprojectConfig;
 
 use crate::args::Overrides;
 
 /// Print the user-facing configuration settings.
 pub fn show_settings(
     files: &[PathBuf],
-    pyproject_strategy: &PyprojectDiscovery,
+    pyproject_config: &PyprojectConfig,
     overrides: &Overrides,
 ) -> Result<()> {
     // Collect all files in the hierarchy.
-    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_strategy, overrides)?;
+    let (paths, resolver) = resolver::python_files_in_path(files, pyproject_config, overrides)?;
 
     // Print the list of files.
     let Some(entry) = paths
@@ -26,11 +26,11 @@ pub fn show_settings(
         bail!("No files found under the given path");
     };
     let path = entry.path();
-    let settings = resolver.resolve(path, pyproject_strategy);
+    let settings = resolver.resolve(path, pyproject_config);
 
     let mut stdout = BufWriter::new(io::stdout().lock());
     writeln!(stdout, "Resolved settings for: {path:?}")?;
-    if let Some(settings_path) = pyproject_strategy.top_level_settings().settings_path() {
+    if let Some(settings_path) = pyproject_config.path.as_ref() {
         writeln!(stdout, "Settings path: {settings_path:?}")?;
     }
     writeln!(stdout, "{settings:#?}")?;

--- a/crates/ruff_cli/src/commands/show_settings.rs
+++ b/crates/ruff_cli/src/commands/show_settings.rs
@@ -30,6 +30,9 @@ pub fn show_settings(
 
     let mut stdout = BufWriter::new(io::stdout().lock());
     writeln!(stdout, "Resolved settings for: {path:?}")?;
+    if let Some(settings_path) = pyproject_strategy.top_level_settings().settings_path() {
+        writeln!(stdout, "Settings path: {settings_path:?}")?;
+    }
     writeln!(stdout, "{settings:#?}")?;
 
     Ok(())

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -97,7 +97,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
 
     // Construct the "default" settings. These are used when no `pyproject.toml`
     // files are present, or files are injected from outside of the hierarchy.
-    let pyproject_strategy = resolve::resolve(
+    let pyproject_config = resolve::resolve(
         cli.isolated,
         cli.config.as_deref(),
         &overrides,
@@ -105,15 +105,13 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
     )?;
 
     if cli.show_settings {
-        commands::show_settings::show_settings(&cli.files, &pyproject_strategy, &overrides)?;
+        commands::show_settings::show_settings(&cli.files, &pyproject_config, &overrides)?;
         return Ok(ExitStatus::Success);
     }
     if cli.show_files {
-        commands::show_files::show_files(&cli.files, &pyproject_strategy, &overrides)?;
+        commands::show_files::show_files(&cli.files, &pyproject_config, &overrides)?;
         return Ok(ExitStatus::Success);
     }
-
-    let top_level_settings = pyproject_strategy.top_level_settings();
 
     // Extract options that are included in `Settings`, but only apply at the top
     // level.
@@ -124,7 +122,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         show_fixes,
         update_check,
         ..
-    } = top_level_settings.cli.clone();
+    } = pyproject_config.settings.cli;
 
     // Autofix rules are as follows:
     // - If `--fix` or `--fix-only` is set, always apply fixes to the filesystem (or
@@ -155,7 +153,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         printer_flags |= PrinterFlags::SHOW_FIXES;
     }
 
-    if top_level_settings.lib.show_source {
+    if pyproject_config.settings.lib.show_source {
         printer_flags |= PrinterFlags::SHOW_SOURCE;
     }
 
@@ -171,7 +169,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
             warn_user_once!("--fix is incompatible with --add-noqa.");
         }
         let modifications =
-            commands::add_noqa::add_noqa(&cli.files, &pyproject_strategy, &overrides)?;
+            commands::add_noqa::add_noqa(&cli.files, &pyproject_config, &overrides)?;
         if modifications > 0 && log_level >= LogLevel::Default {
             let s = if modifications == 1 { "" } else { "s" };
             #[allow(clippy::print_stderr)]
@@ -195,7 +193,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
 
         let messages = commands::run::run(
             &cli.files,
-            &pyproject_strategy,
+            &pyproject_config,
             &overrides,
             cache.into(),
             noqa.into(),
@@ -225,7 +223,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
 
                         let messages = commands::run::run(
                             &cli.files,
-                            &pyproject_strategy,
+                            &pyproject_config,
                             &overrides,
                             cache.into(),
                             noqa.into(),
@@ -244,7 +242,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         let diagnostics = if is_stdin {
             commands::run_stdin::run_stdin(
                 cli.stdin_filename.map(fs::normalize_path).as_deref(),
-                &pyproject_strategy,
+                &pyproject_config,
                 &overrides,
                 noqa.into(),
                 autofix,
@@ -252,7 +250,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         } else {
             commands::run::run(
                 &cli.files,
-                &pyproject_strategy,
+                &pyproject_config,
                 &overrides,
                 cache.into(),
                 noqa.into(),

--- a/crates/ruff_cli/src/resolve.rs
+++ b/crates/ruff_cli/src/resolve.rs
@@ -23,7 +23,7 @@ pub fn resolve(
     if isolated {
         let mut config = Configuration::default();
         overrides.process_config(&mut config);
-        let settings = AllSettings::from_configuration(config, &path_dedot::CWD)?;
+        let settings = AllSettings::from_configuration(config, &path_dedot::CWD, None)?;
         return Ok(PyprojectDiscovery::Fixed(settings));
     }
 
@@ -68,6 +68,6 @@ pub fn resolve(
     // as the "default" settings.)
     let mut config = Configuration::default();
     overrides.process_config(&mut config);
-    let settings = AllSettings::from_configuration(config, &path_dedot::CWD)?;
+    let settings = AllSettings::from_configuration(config, &path_dedot::CWD, None)?;
     Ok(PyprojectDiscovery::Hierarchical(settings))
 }

--- a/crates/ruff_cli/src/resolve.rs
+++ b/crates/ruff_cli/src/resolve.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use path_absolutize::path_dedot;
 
 use ruff::resolver::{
-    resolve_settings_with_processor, ConfigProcessor, PyprojectDiscovery, Relativity,
+    resolve_settings_with_processor, ConfigProcessor, PyprojectConfig, PyprojectDiscoveryStrategy,
+    Relativity,
 };
 use ruff::settings::configuration::Configuration;
 use ruff::settings::{pyproject, AllSettings};
@@ -18,13 +19,17 @@ pub fn resolve(
     config: Option<&Path>,
     overrides: &Overrides,
     stdin_filename: Option<&Path>,
-) -> Result<PyprojectDiscovery> {
+) -> Result<PyprojectConfig> {
     // First priority: if we're running in isolated mode, use the default settings.
     if isolated {
         let mut config = Configuration::default();
         overrides.process_config(&mut config);
-        let settings = AllSettings::from_configuration(config, &path_dedot::CWD, None)?;
-        return Ok(PyprojectDiscovery::Fixed(settings));
+        let settings = AllSettings::from_configuration(config, &path_dedot::CWD)?;
+        return Ok(PyprojectConfig::new(
+            PyprojectDiscoveryStrategy::Fixed,
+            settings,
+            None,
+        ));
     }
 
     // Second priority: the user specified a `pyproject.toml` file. Use that
@@ -36,7 +41,11 @@ pub fn resolve(
         .transpose()?
     {
         let settings = resolve_settings_with_processor(&pyproject, &Relativity::Cwd, overrides)?;
-        return Ok(PyprojectDiscovery::Fixed(settings));
+        return Ok(PyprojectConfig::new(
+            PyprojectDiscoveryStrategy::Fixed,
+            settings,
+            Some(pyproject),
+        ));
     }
 
     // Third priority: find a `pyproject.toml` file in either an ancestor of
@@ -50,7 +59,11 @@ pub fn resolve(
             .unwrap_or(&path_dedot::CWD.as_path()),
     )? {
         let settings = resolve_settings_with_processor(&pyproject, &Relativity::Parent, overrides)?;
-        return Ok(PyprojectDiscovery::Hierarchical(settings));
+        return Ok(PyprojectConfig::new(
+            PyprojectDiscoveryStrategy::Hierarchical,
+            settings,
+            Some(pyproject),
+        ));
     }
 
     // Fourth priority: find a user-specific `pyproject.toml`, but resolve all paths
@@ -59,7 +72,11 @@ pub fn resolve(
     // these act as the "default" settings.)
     if let Some(pyproject) = pyproject::find_user_settings_toml() {
         let settings = resolve_settings_with_processor(&pyproject, &Relativity::Cwd, overrides)?;
-        return Ok(PyprojectDiscovery::Hierarchical(settings));
+        return Ok(PyprojectConfig::new(
+            PyprojectDiscoveryStrategy::Hierarchical,
+            settings,
+            Some(pyproject),
+        ));
     }
 
     // Fallback: load Ruff's default settings, and resolve all paths relative to the
@@ -68,6 +85,10 @@ pub fn resolve(
     // as the "default" settings.)
     let mut config = Configuration::default();
     overrides.process_config(&mut config);
-    let settings = AllSettings::from_configuration(config, &path_dedot::CWD, None)?;
-    Ok(PyprojectDiscovery::Hierarchical(settings))
+    let settings = AllSettings::from_configuration(config, &path_dedot::CWD)?;
+    Ok(PyprojectConfig::new(
+        PyprojectDiscoveryStrategy::Hierarchical,
+        settings,
+        None,
+    ))
 }


### PR DESCRIPTION
## Summary

Create a new struct called `PyprojectConfig` which holds all the `pyproject.toml` configuration related information. This includes the discovery strategy used (`Fixed` or `Hierarchical`), the settings itself and absolute path to the `pyproject.toml` file.

Using `PyprojectConfig::new` will try to resolve the given config path to absolute.

## Test Plan

***Project structure:***

```
.
├── pyproject.toml
├── src
│   └── ...
└── test
    ├── foo
    │   └── __init__.py
    └── pyproject.toml
```

<details><summary><b>Using `--isolated` (no config path):</b></summary>
<p>

```console
$ ~/contributing/astral/ruff/target/debug/ruff check --show-settings --isolated . | head -n8  
Resolved settings for: "/Users/dhruv/playground/python/ruff-play/src/B031.py"
Settings {
    rules: RuleTable {
        enabled: {
            MixedSpacesAndTabs,
            MultipleImportsOnOneLine,
            ModuleImportNotAtTopOfFile,
            LineTooLong,
```

</p>
</details> 

<details><summary><b>Using <code>--config pyproject.toml</code></b></summary>
<p>

```console
$ ~/contributing/astral/ruff/target/debug/ruff check --show-settings --config=pyproject.toml . | head -n8
Resolved settings for: "/Users/dhruv/playground/python/ruff-play/src/B031.py"
Settings path: "/Users/dhruv/playground/python/ruff-play/pyproject.toml"
Settings {
    rules: RuleTable {
        enabled: {
            UnnecessaryCallAroundSorted,
            UnnecessaryCollectionCall,
            UnnecessaryComprehension,
```

</p>
</details> 

<details><summary><b>Using <code>--config ../pyproject.toml</code></b></summary>
<p>

```console
$ ~/contributing/astral/ruff/target/debug/ruff check --show-settings --config=../pyproject.toml . | head -n8 
Resolved settings for: "/Users/dhruv/playground/python/ruff-play/test/foo/__init__.py"
Settings path: "/Users/dhruv/playground/python/ruff-play/pyproject.toml"
Settings {
    rules: RuleTable {
        enabled: {
            UnnecessaryCallAroundSorted,
            UnnecessaryCollectionCall,
            UnnecessaryComprehension,
```

</p>
</details> 

<details><summary><b>Using hierarchical strategy to find config file</b></summary>
<p>

```console
$ ~/contributing/astral/ruff/target/debug/ruff check --show-settings . | head -n8          
Resolved settings for: "/Users/dhruv/playground/python/ruff-play/src/B031.py"
Settings path: "/Users/dhruv/playground/python/ruff-play/pyproject.toml"
Settings {
    rules: RuleTable {
        enabled: {
            UnnecessaryCallAroundSorted,
            UnnecessaryCollectionCall,
            UnnecessaryComprehension,
```

</p>
</details> 

<details><summary><b>No config file (commented out <code>[tool.ruff]</code> section)</b></summary>
<p>

```console
$ ~/contributing/astral/ruff/target/debug/ruff check --show-settings . | head -n8  
Resolved settings for: "/Users/dhruv/playground/python/ruff-play/src/B031.py"
Settings {
    rules: RuleTable {
        enabled: {
            MixedSpacesAndTabs,
            MultipleImportsOnOneLine,
            ModuleImportNotAtTopOfFile,
            LineTooLong,
```

</p>
</details> 

resolves: #3202