### PR TITLE
Fail lint tests if the fix creates a syntax error

### DIFF
--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use itertools::Itertools;
+use ruff_diagnostics::Diagnostic;
 use rustc_hash::FxHashMap;
 use rustpython_parser::lexer::LexResult;
 
@@ -15,6 +16,7 @@ use crate::directives;
 use crate::linter::{check_path, LinterResult};
 use crate::message::{Emitter, EmitterContext, Message, TextEmitter};
 use crate::packaging::detect_package_root;
+use crate::rules::pycodestyle::rules::syntax_error;
 use crate::settings::{flags, Settings};
 
 pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
@@ -24,6 +26,8 @@ pub fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
 /// A convenient wrapper around [`check_path`], that additionally
 /// asserts that autofixes converge after 10 iterations.
 pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Message>> {
+    static MAX_ITERATIONS: usize = 10;
+
     let path = test_resource_path("fixtures").join(path);
     let contents = std::fs::read_to_string(&path)?;
     let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&contents);
@@ -38,7 +42,7 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
     );
     let LinterResult {
         data: (diagnostics, _imports),
-        ..
+        error,
     } = check_path(
         &path,
         path.parent()
@@ -53,19 +57,32 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
         flags::Autofix::Enabled,
     );
 
+    let source_has_errors = error.is_some();
+
     // Detect autofixes that don't converge after multiple iterations.
+    let mut iterations = 0;
+
     if diagnostics
         .iter()
         .any(|diagnostic| !diagnostic.fix.is_empty())
     {
-        let max_iterations = 10;
-
+        let mut diagnostics = diagnostics.clone();
         let mut contents = contents.clone();
-        let mut iterations = 0;
 
-        loop {
-            let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&contents);
-            let locator = Locator::new(&contents);
+        while let Some((fixed_contents, _)) = fix_file(&diagnostics, &Locator::new(&contents)) {
+            if iterations < MAX_ITERATIONS {
+                iterations += 1;
+            } else {
+                let output = print_diagnostics(diagnostics, &path, &contents);
+
+                panic!(
+                        "Failed to converge after {MAX_ITERATIONS} iterations. This likely \
+                         indicates a bug in the implementation of the fix. Last diagnostics:\n{output}"
+                    );
+            }
+
+            let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&fixed_contents);
+            let locator = Locator::new(&fixed_contents);
             let stylist = Stylist::from_tokens(&tokens, &locator);
             let indexer = Indexer::from_tokens(&tokens, &locator);
             let directives = directives::extract_directives(
@@ -74,9 +91,10 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
                 &locator,
                 &indexer,
             );
+
             let LinterResult {
-                data: (diagnostics, _imports),
-                ..
+                data: (fixed_diagnostics, _),
+                error: fixed_error,
             } = check_path(
                 &path,
                 None,
@@ -89,47 +107,30 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
                 flags::Noqa::Enabled,
                 flags::Autofix::Enabled,
             );
-            if let Some((fixed_contents, _)) = fix_file(&diagnostics, &locator) {
-                if iterations < max_iterations {
-                    iterations += 1;
-                    contents = fixed_contents.to_string();
-                } else {
-                    let source_code = SourceFileBuilder::new(
-                        path.file_name().unwrap().to_string_lossy().as_ref(),
-                        contents,
-                    )
-                    .finish();
 
-                    let messages: Vec<_> = diagnostics
-                        .into_iter()
-                        .map(|diagnostic| {
-                            // Not strictly necessary but adds some coverage for this code path
-                            let noqa = directives.noqa_line_for.resolve(diagnostic.start());
+            if let Some(fixed_error) = fixed_error {
+                if !source_has_errors {
+                    // Previous fix introduced a syntax error, abort
+                    let fixes = print_diagnostics(diagnostics, &path, &contents);
 
-                            Message::from_diagnostic(diagnostic, source_code.clone(), noqa)
-                        })
-                        .collect();
+                    let mut syntax_diagnostics = Vec::new();
+                    syntax_error(&mut syntax_diagnostics, &fixed_error, &locator);
+                    let syntax_errors =
+                        print_diagnostics(syntax_diagnostics, &path, &fixed_contents);
 
-                    let mut output: Vec<u8> = Vec::new();
-                    TextEmitter::default()
-                        .with_show_fix(true)
-                        .with_show_source(true)
-                        .emit(
-                            &mut output,
-                            &messages,
-                            &EmitterContext::new(&FxHashMap::default()),
-                        )
-                        .unwrap();
-
-                    let output_str = String::from_utf8(output).unwrap();
                     panic!(
-                        "Failed to converge after {max_iterations} iterations. This likely \
-                         indicates a bug in the implementation of the fix. Last diagnostics:\n{output_str}"
+                        r#"Fixed source has a syntax error where the source document does not. This is a bug in one of the generated fixes:
+{syntax_errors}
+Last generated fixes:
+{fixes}
+Source with applied fixes:
+{fixed_contents}"#
                     );
                 }
-            } else {
-                break;
             }
+
+            diagnostics = fixed_diagnostics;
+            contents = fixed_contents.to_string();
         }
     }
 
@@ -149,6 +150,25 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
         })
         .sorted()
         .collect())
+}
+
+fn print_diagnostics(diagnostics: Vec<Diagnostic>, file_path: &Path, source: &str) -> String {
+    let source_file = SourceFileBuilder::new(
+        file_path.file_name().unwrap().to_string_lossy().as_ref(),
+        source,
+    )
+    .finish();
+
+    let messages: Vec<_> = diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            let noqa_start = diagnostic.start();
+
+            Message::from_diagnostic(diagnostic, source_file.clone(), noqa_start)
+        })
+        .collect();
+
+    print_messages(&messages)
 }
 
 pub(crate) fn print_messages(messages: &[Message]) -> String {


### PR DESCRIPTION
This PR adds a check to `test_path` that ensures that the source after the fixes are applied does not contain any syntax errors and aborts by printing the last applied fixes, the syntax error, and the fixed document's source if there are any syntax errors. 

This should help narrowing down syntax errors when developing fixes. 

Example output

```

Fixed source has a syntax error where the source document does not. This is a bug in one of the generated fixes:
FLY001.py:10:5: E999 SyntaxError: f-string: unterminated string
   |
10 | x = f"foobar"
11 | y = "foobar"
12 | f"{\"{'Finally'}, \" + f'{greeting}'}{subject}"
   |     ^ E999
   |


Last generated fixes:
FLY001.py:4:8: FLY001 [*] Consider `f"Finally, {greeting}"` instead of concatenation
  |
4 | subject = "World"
5 | msg = greeting + " " + subject
6 | msg2 = "Finally, " + greeting + " " + subject
  |        ^^^^^^^^^^^^^^^^^^^^^^ FLY001
7 | msg3 = f"Finally, {greeting} " + subject
8 | msg4 = "Finally, " + f"{greeting} {subject}"
  |
  = help: Replace with `f"Finally, {greeting}"`

ℹ Suggested fix
1 1 | greeting = "Hello"
2 2 | subject = "World"
3 3 | msg = greeting + " " + subject
4   |-msg2 = "Finally, " + greeting + " " + subject
  4 |+msg2 = f"Finally, {greeting}" + " " + subject
5 5 | msg3 = f"Finally, {greeting} " + subject
6 6 | msg4 = "Finally, " + f"{greeting} {subject}"
7 7 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error

FLY001.py:5:8: FLY001 [*] Consider `f"Finally, {greeting} {subject}"` instead of concatenation
  |
5 | msg = greeting + " " + subject
6 | msg2 = "Finally, " + greeting + " " + subject
7 | msg3 = f"Finally, {greeting} " + subject
  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FLY001
8 | msg4 = "Finally, " + f"{greeting} {subject}"
9 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
  |
  = help: Replace with `f"Finally, {greeting} {subject}"`

ℹ Suggested fix
2 2 | subject = "World"
3 3 | msg = greeting + " " + subject
4 4 | msg2 = "Finally, " + greeting + " " + subject
5   |-msg3 = f"Finally, {greeting} " + subject
  5 |+msg3 = f"Finally, {greeting} {subject}"
6 6 | msg4 = "Finally, " + f"{greeting} {subject}"
7 7 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8 8 | x = f"foo" + f"bar"

FLY001.py:6:8: FLY001 [*] Consider `f"Finally, {greeting} {subject}"` instead of concatenation
   |
 6 | msg2 = "Finally, " + greeting + " " + subject
 7 | msg3 = f"Finally, {greeting} " + subject
 8 | msg4 = "Finally, " + f"{greeting} {subject}"
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FLY001
 9 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
10 | x = f"foo" + f"bar"
   |
   = help: Replace with `f"Finally, {greeting} {subject}"`

ℹ Suggested fix
3 3 | msg = greeting + " " + subject
4 4 | msg2 = "Finally, " + greeting + " " + subject
5 5 | msg3 = f"Finally, {greeting} " + subject
6   |-msg4 = "Finally, " + f"{greeting} {subject}"
  6 |+msg4 = f"Finally, {greeting} {subject}"
7 7 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8 8 | x = f"foo" + f"bar"
9 9 | y = "foo" + "bar"

FLY001.py:8:5: FLY001 [*] Consider `f"foobar"` instead of concatenation
   |
 8 | msg4 = "Finally, " + f"{greeting} {subject}"
 9 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
10 | x = f"foo" + f"bar"
   |     ^^^^^^^^^^^^^^^ FLY001
11 | y = "foo" + "bar"
12 | "{'Finally'}, " + f"{greeting}" + f"{subject}"
   |
   = help: Replace with `f"foobar"`

ℹ Suggested fix
5 5 | msg3 = f"Finally, {greeting} " + subject
6 6 | msg4 = "Finally, " + f"{greeting} {subject}"
7 7 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8   |-x = f"foo" + f"bar"
  8 |+x = f"foobar"
9 9 | y = "foo" + "bar"
10 10 | "{'Finally'}, " + f"{greeting}" + f"{subject}"

FLY001.py:9:5: FLY001 [*] Consider `"foobar"` instead of concatenation
   |
 9 | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
10 | x = f"foo" + f"bar"
11 | y = "foo" + "bar"
   |     ^^^^^^^^^^^^^ FLY001
12 | "{'Finally'}, " + f"{greeting}" + f"{subject}"
   |
   = help: Replace with `"foobar"`

ℹ Suggested fix
6  6  | msg4 = "Finally, " + f"{greeting} {subject}"
7  7  | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8  8  | x = f"foo" + f"bar"
9     |-y = "foo" + "bar"
   9  |+y = "foobar"
10 10 | "{'Finally'}, " + f"{greeting}" + f"{subject}"

FLY001.py:10:1: FLY001 [*] Consider `f"{\"{'Finally'}, \" + f'{greeting}'}{subject}"` instead of concatenation
   |
10 | x = f"foo" + f"bar"
11 | y = "foo" + "bar"
12 | "{'Finally'}, " + f"{greeting}" + f"{subject}"
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FLY001
   |
   = help: Replace with `f"{\"{'Finally'}, \" + f'{greeting}'}{subject}"`

ℹ Suggested fix
7  7  | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8  8  | x = f"foo" + f"bar"
9  9  | y = "foo" + "bar"
10    |-"{'Finally'}, " + f"{greeting}" + f"{subject}"
   10 |+f"{\"{'Finally'}, \" + f'{greeting}'}{subject}"

FLY001.py:10:1: FLY001 [*] Consider `f"{{'Finally'}}, {greeting}"` instead of concatenation
   |
10 | x = f"foo" + f"bar"
11 | y = "foo" + "bar"
12 | "{'Finally'}, " + f"{greeting}" + f"{subject}"
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FLY001
   |
   = help: Replace with `f"{{'Finally'}}, {greeting}"`

ℹ Suggested fix
7  7  | # msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
8  8  | x = f"foo" + f"bar"
9  9  | y = "foo" + "bar"
10    |-"{'Finally'}, " + f"{greeting}" + f"{subject}"
   10 |+f"{{'Finally'}}, {greeting}" + f"{subject}"


Source with applied fixes:
greeting = "Hello"
subject = "World"
msg = greeting + " " + subject
msg2 = f"Finally, {greeting}" + " " + subject
msg3 = f"Finally, {greeting} {subject}"
msg4 = f"Finally, {greeting} {subject}"
# msg5 = "{'Finally'}, " + f"{greeting}" + f"{subject}"  # TODO: autofix syntax error
x = f"foobar"
y = "foobar"
f"{\"{'Finally'}, \" + f'{greeting}'}{subject}"
```