### PR TITLE
Fix panic when applying fixes with unsorted edits

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -62,7 +62,7 @@ fn apply_fixes<'a>(
             continue;
         }
 
-        for edit in fix.edits() {
+        for edit in fix.edits().iter().sorted_unstable_by_key(|e| e.start()) {
             // Add all contents from `last_pos` to `fix.location`.
             let slice = locator.slice(TextRange::new(last_pos.unwrap_or_default(), edit.start()));
             output.push_str(slice);


### PR DESCRIPTION
I'm undecided whether this is the proper fix or if we should rather change `Fix` to store a `BTreeSet` and sort the edits by the start location. But even then, there's still the possibility that two edits in a single `Fix` overlap, causing a panic. 

Fixes #4208

## Test Plan

Tested that running ruff with the example from #4208 no longer panics