### PR TITLE
Fix panic in pydocstyle D214 when docstring indentation is empty

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D214_module.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D214_module.py
@@ -1,0 +1,21 @@
+"""A module docstring with D214 violations
+
+    Returns
+-----
+    valid returns
+
+    Args
+-----
+    valid args
+"""
+
+import os
+from .expected import Expectation
+
+expectation = Expectation()
+expect = expectation.expect
+
+expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+       "D214: Section is over-indented ('Returns')")
+expect(os.path.normcase(__file__ if __file__[-1] != 'c' else __file__[:-1]),
+       "D214: Section is over-indented ('Args')")

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -68,6 +68,7 @@ mod tests {
     #[test_case(Rule::UndocumentedPublicPackage, Path::new("D104/__init__.py"); "D104_1")]
     #[test_case(Rule::SectionNameEndsInColon, Path::new("D.py"); "D416")]
     #[test_case(Rule::SectionNotOverIndented, Path::new("sections.py"); "D214")]
+    #[test_case(Rule::SectionNotOverIndented, Path::new("D214_module.py"); "D214_module")]
     #[test_case(Rule::SectionUnderlineAfterName, Path::new("sections.py"); "D408")]
     #[test_case(Rule::SectionUnderlineMatchesSectionLength, Path::new("sections.py"); "D409")]
     #[test_case(Rule::SectionUnderlineNotOverIndented, Path::new("sections.py"); "D215")]

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -620,15 +620,13 @@ fn common_section(
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the existing indentation with whitespace of the appropriate length.
                 let content = whitespace::clean(docstring.indentation);
-                if content.is_empty() {
-                    let start = context.range().start();
-                    diagnostic.set_fix(Edit::deletion(start, start + leading_space.text_len()));
+                let fix_range = TextRange::at(context.range().start(), leading_space.text_len());
+
+                diagnostic.set_fix(if content.is_empty() {
+                    Edit::range_deletion(fix_range)
                 } else {
-                    diagnostic.set_fix(Edit::range_replacement(
-                        content,
-                        TextRange::at(context.range().start(), leading_space.text_len()),
-                    ));
-                }
+                    Edit::range_replacement(content, fix_range)
+                });
             };
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -619,10 +619,16 @@ fn common_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the existing indentation with whitespace of the appropriate length.
-                diagnostic.set_fix(Edit::range_replacement(
-                    whitespace::clean(docstring.indentation),
-                    TextRange::at(context.range().start(), leading_space.text_len()),
-                ));
+                let content = whitespace::clean(docstring.indentation);
+                if content.is_empty() {
+                    let start = context.range().start();
+                    diagnostic.set_fix(Edit::deletion(start, start + leading_space.text_len()));
+                } else {
+                    diagnostic.set_fix(Edit::range_replacement(
+                        content,
+                        TextRange::at(context.range().start(), leading_space.text_len()),
+                    ));
+                }
             };
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_D214_module.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D214_D214_module.py.snap
@@ -1,0 +1,59 @@
+---
+source: crates/ruff/src/rules/pydocstyle/mod.rs
+---
+D214_module.py:1:1: D214 [*] Section is over-indented ("Returns")
+   |
+ 1 | / """A module docstring with D214 violations
+ 2 | | 
+ 3 | |     Returns
+ 4 | | -----
+ 5 | |     valid returns
+ 6 | | 
+ 7 | |     Args
+ 8 | | -----
+ 9 | |     valid args
+10 | | """
+   | |___^ D214
+11 |   
+12 |   import os
+   |
+   = help: Remove over-indentation from "Returns"
+
+ℹ Suggested fix
+1 1 | """A module docstring with D214 violations
+2 2 | 
+3   |-    Returns
+  3 |+Returns
+4 4 | -----
+5 5 |     valid returns
+6 6 | 
+
+D214_module.py:1:1: D214 [*] Section is over-indented ("Args")
+   |
+ 1 | / """A module docstring with D214 violations
+ 2 | | 
+ 3 | |     Returns
+ 4 | | -----
+ 5 | |     valid returns
+ 6 | | 
+ 7 | |     Args
+ 8 | | -----
+ 9 | |     valid args
+10 | | """
+   | |___^ D214
+11 |   
+12 |   import os
+   |
+   = help: Remove over-indentation from "Args"
+
+ℹ Suggested fix
+4 4 | -----
+5 5 |     valid returns
+6 6 | 
+7   |-    Args
+  7 |+Args
+8 8 | -----
+9 9 |     valid args
+10 10 | """
+
+


### PR DESCRIPTION
Closes https://github.com/charliermarsh/ruff/issues/4194
