### PR TITLE
Refactor whitespace around operator

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E22.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E22.py
@@ -151,8 +151,8 @@ spam(-1)
 func1(lambda *args, **kw: (args, kw))
 func2(lambda a, b=h[:], c=0: (a, b, c))
 if not -5 < x < +5:
-    print >> sys.stderr, "x is out of range."
-print >>sys.stdout, "x is an integer."
+    print >>sys.stderr, "x is out of range."
+print >> sys.stdout, "x is an integer."
 x = x / 2 - 1
 x = 1 @ 2
 

--- a/crates/ruff/resources/test/fixtures/pycodestyle/E22.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E22.py
@@ -151,8 +151,8 @@ spam(-1)
 func1(lambda *args, **kw: (args, kw))
 func2(lambda a, b=h[:], c=0: (a, b, c))
 if not -5 < x < +5:
-    print >>sys.stderr, "x is out of range."
-print >> sys.stdout, "x is an integer."
+    print >> sys.stderr, "x is out of range."
+print >>sys.stdout, "x is an integer."
 x = x / 2 - 1
 x = 1 @ 2
 

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -22,7 +22,10 @@ pub(crate) fn missing_whitespace_after_keyword(
     line: &LogicalLine,
     context: &mut LogicalLinesContext,
 ) {
-    for (tok0, tok1) in line.tokens().iter().tuple_windows() {
+    for window in line.tokens().windows(2) {
+        let tok0 = &window[0];
+        let tok1 = &window[1];
+
         let tok0_kind = tok0.kind();
         let tok1_kind = tok1.kind();
 

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -1,11 +1,9 @@
-use itertools::Itertools;
-use ruff_text_size::TextRange;
-
 use crate::checkers::logical_lines::LogicalLinesContext;
 use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
+use ruff_text_size::TextRange;
 
 #[violation]
 pub struct MissingWhitespaceAfterKeyword;

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -1,11 +1,9 @@
 use crate::checkers::logical_lines::LogicalLinesContext;
-use itertools::PeekingNext;
+use crate::rules::pycodestyle::rules::logical_lines::{LogicalLine, LogicalLineToken};
 use ruff_diagnostics::{DiagnosticKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::{TextRange, TextSize};
-
-use crate::rules::pycodestyle::rules::logical_lines::{LogicalLine, LogicalLineToken};
+use ruff_text_size::TextRange;
 
 // E225
 #[violation]
@@ -57,16 +55,6 @@ pub(crate) fn missing_whitespace_around_operator(
     line: &LogicalLine,
     context: &mut LogicalLinesContext,
 ) {
-    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
-    enum NeedsSpace {
-        /// Needs a leading and trailing space
-        Yes,
-        /// Doesn't need a leading or trailing space
-        No,
-        /// Needs a trailing space if it has a leading space.
-        Optional,
-    }
-
     let mut parens = 0u32;
     let mut prev_token: Option<&LogicalLineToken> = None;
     let mut tokens = line.tokens().iter().peekable();
@@ -80,116 +68,120 @@ pub(crate) fn missing_whitespace_around_operator(
 
         match kind {
             TokenKind::Lpar | TokenKind::Lambda => parens += 1,
-            TokenKind::Rpar => parens -= 1,
+            TokenKind::Rpar => parens = parens.saturating_sub(1),
             _ => {}
         };
 
         let needs_space = if kind == TokenKind::Equal && parens > 0 {
             // Allow keyword args or defaults: foo(bar=None).
             NeedsSpace::No
-        } else if kind.is_whitespace_needed() {
-            NeedsSpace::Yes
-        } else if kind.is_unary() {
-            prev_token.map_or(NeedsSpace::No, |prev_token| {
-                let prev_kind = dbg!(prev_token.kind());
+        } else if kind == TokenKind::Slash {
+            // Tolerate the "/" operator in function definition
+            // For more info see PEP570
 
-                // Check if the operator is used as a binary operator
+            // `def f(a, /, b):` or `def f(a, b, /):` or `f = lambda a, /:`
+            //            ^                       ^                      ^
+            let slash_in_func = matches!(
+                tokens.peek().map(|t| t.kind()),
+                Some(TokenKind::Comma | TokenKind::Rpar | TokenKind::Colon)
+            );
+
+            NeedsSpace::from(!slash_in_func)
+        } else if kind.is_unary() || kind == TokenKind::DoubleStar {
+            prev_token.map_or(NeedsSpace::No, |prev_token| {
+                let prev_kind = prev_token.kind();
+
+                // Check if the operator is used as a binary operator.
                 // Allow unary operators: -123, -x, +1.
                 // Allow argument unpacking: foo(*args, **kwargs)
-                if matches!(
+                let is_binary = matches!(
                     prev_kind,
                     TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace
                 ) || !(prev_kind.is_operator()
                     || prev_kind.is_keyword()
-                    || prev_kind.is_soft_keyword())
-                {
-                    NeedsSpace::Optional
+                    || prev_kind.is_soft_keyword());
+
+                if is_binary {
+                    if kind == TokenKind::DoubleStar {
+                        // Enforce consistent spacing, but don't enforce whitespaces.
+                        NeedsSpace::Optional
+                    } else {
+                        NeedsSpace::Yes
+                    }
                 } else {
                     NeedsSpace::No
                 }
             })
-        } else if kind.is_whitespace_optional() {
-            NeedsSpace::Optional
+        } else if is_whitespace_needed(kind) {
+            NeedsSpace::Yes
         } else {
             NeedsSpace::No
         };
 
-        dbg!(needs_space, kind);
+        if needs_space != NeedsSpace::No {
+            let has_leading_trivia = prev_token.map_or(true, |prev| {
+                prev.end() < token.start() || prev.kind().is_trivia()
+            });
 
-        match needs_space {
-            NeedsSpace::Yes => {
-                // Assert leading whitespace
-                if prev_token.map_or(false, |prev| prev.end() == token.start()) {
-                    // A needed opening space was not found
+            let has_trailing_trivia = tokens.peek().map_or(true, |next| {
+                token.end() < next.start() || next.kind().is_trivia()
+            });
+
+            match (has_leading_trivia, has_trailing_trivia) {
+                // Operator with trailing but no leading space, enforce consistent spacing
+                (false, true) => {
                     context.push(
-                        diagnostic_kind_for_operator(kind),
+                        MissingWhitespaceAroundOperator,
                         TextRange::empty(token.start()),
                     );
                 }
-                // Assert trailing whitespace
-                else if let Some(next_token) = tokens.peek() {
-                    let next_kind = next_token.kind();
-
-                    // Tolerate the "<>" operator, even if running Python 3
-                    // Deal with Python 3's annotated return value "->"
-                    let not_equal_or_arrow = next_kind == TokenKind::Greater
-                        && matches!(kind, TokenKind::Less | TokenKind::Minus);
-
-                    // Tolerate the "/" operator in function definition
-                    // For more info see PEP570
-                    let is_slash_in_function_definition = matches!(
-                        (kind, next_kind),
-                        (
-                            TokenKind::Slash,
-                            TokenKind::Comma | TokenKind::Rpar | TokenKind::Colon
-                        ) | (TokenKind::Rpar, TokenKind::Colon)
+                // Operator with leading but no trailing space, enforce consistent spacing.
+                (true, false) => {
+                    context.push(
+                        MissingWhitespaceAroundOperator,
+                        TextRange::empty(token.end()),
                     );
-
-                    let has_trailing_trivia =
-                        next_token.start() > token.end() || next_kind.is_trivia();
-
-                    if !has_trailing_trivia
-                        && !not_equal_or_arrow
-                        && !is_slash_in_function_definition
-                    {
+                }
+                // Operator with no space, require spaces if it is required by the operator.
+                (false, false) => {
+                    if needs_space == NeedsSpace::Yes {
                         context.push(
                             diagnostic_kind_for_operator(kind),
-                            TextRange::empty(token.end()),
-                        );
-                    }
-                }
-            }
-
-            NeedsSpace::Optional => {
-                // Surrounding space is optional, but ensure that
-                // leading & trailing space matches opening space
-                let has_leading = prev_token.map_or(false, |prev| prev.end() < token.start());
-                let has_trailing = tokens.peek().map_or(false, |next| {
-                    token.end() < next.start() || next.kind().is_trivia()
-                });
-
-                // TODO why does this use MissingWhitespaceAroundOperator...always
-                match (has_leading, has_trailing) {
-                    (true, false) => {
-                        context.push(
-                            MissingWhitespaceAroundOperator,
-                            TextRange::empty(token.end()),
-                        );
-                    }
-                    (false, true) => {
-                        context.push(
-                            MissingWhitespaceAroundOperator,
                             TextRange::empty(token.start()),
                         );
                     }
-                    (false, false) | (true, true) => {}
+                }
+                (true, true) => {
+                    // Operator has leading and trailing space, all good
                 }
             }
-
-            NeedsSpace::No => {}
-        };
+        }
 
         prev_token = Some(token);
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum NeedsSpace {
+    /// Needs a leading and trailing space.
+    Yes,
+
+    /// Doesn't need a leading or trailing space. Or in other words, we don't care how many
+    /// leading or trailing spaces that token has.
+    No,
+
+    /// Needs consistent leading and trailing spacing. The operator needs spacing if
+    /// * it has a leading space
+    /// * it has a trailing space
+    Optional,
+}
+
+impl From<bool> for NeedsSpace {
+    fn from(value: bool) -> Self {
+        match value {
+            true => NeedsSpace::Yes,
+            false => NeedsSpace::No,
+        }
     }
 }
 
@@ -203,4 +195,38 @@ fn diagnostic_kind_for_operator(operator: TokenKind) -> DiagnosticKind {
     } else {
         DiagnosticKind::from(MissingWhitespaceAroundOperator)
     }
+}
+
+fn is_whitespace_needed(kind: TokenKind) -> bool {
+    matches!(
+        kind,
+        TokenKind::DoubleStarEqual
+            | TokenKind::StarEqual
+            | TokenKind::SlashEqual
+            | TokenKind::DoubleSlashEqual
+            | TokenKind::PlusEqual
+            | TokenKind::MinusEqual
+            | TokenKind::NotEqual
+            | TokenKind::Less
+            | TokenKind::Greater
+            | TokenKind::PercentEqual
+            | TokenKind::CircumflexEqual
+            | TokenKind::AmperEqual
+            | TokenKind::VbarEqual
+            | TokenKind::EqEqual
+            | TokenKind::LessEqual
+            | TokenKind::GreaterEqual
+            | TokenKind::LeftShiftEqual
+            | TokenKind::RightShiftEqual
+            | TokenKind::Equal
+            | TokenKind::And
+            | TokenKind::Or
+            | TokenKind::In
+            | TokenKind::Is
+            | TokenKind::Rarrow
+            | TokenKind::ColonEqual
+            | TokenKind::Slash
+            | TokenKind::Percent
+    ) || kind.is_arithmetic()
+        || kind.is_bitwise_or_shift()
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_around_operator.rs
@@ -88,30 +88,30 @@ pub(crate) fn missing_whitespace_around_operator(
 
             NeedsSpace::from(!slash_in_func)
         } else if kind.is_unary() || kind == TokenKind::DoubleStar {
-            prev_token.map_or(NeedsSpace::No, |prev_token| {
+            let is_binary = prev_token.map_or(false, |prev_token| {
                 let prev_kind = prev_token.kind();
 
                 // Check if the operator is used as a binary operator.
                 // Allow unary operators: -123, -x, +1.
                 // Allow argument unpacking: foo(*args, **kwargs)
-                let is_binary = matches!(
+                matches!(
                     prev_kind,
                     TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace
                 ) || !(prev_kind.is_operator()
                     || prev_kind.is_keyword()
-                    || prev_kind.is_soft_keyword());
+                    || prev_kind.is_soft_keyword())
+            });
 
-                if is_binary {
-                    if kind == TokenKind::DoubleStar {
-                        // Enforce consistent spacing, but don't enforce whitespaces.
-                        NeedsSpace::Optional
-                    } else {
-                        NeedsSpace::Yes
-                    }
+            if is_binary {
+                if kind == TokenKind::DoubleStar {
+                    // Enforce consistent spacing, but don't enforce whitespaces.
+                    NeedsSpace::Optional
                 } else {
-                    NeedsSpace::No
+                    NeedsSpace::Yes
                 }
-            })
+            } else {
+                NeedsSpace::No
+            }
         } else if is_whitespace_needed(kind) {
             NeedsSpace::Yes
         } else {
@@ -178,9 +178,10 @@ enum NeedsSpace {
 
 impl From<bool> for NeedsSpace {
     fn from(value: bool) -> Self {
-        match value {
-            true => NeedsSpace::Yes,
-            false => NeedsSpace::No,
+        if value {
+            NeedsSpace::Yes
+        } else {
+            NeedsSpace::No
         }
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
@@ -259,14 +259,14 @@ E22.py:100:7: E225 Missing whitespace around operator
 103 | #:
     |
 
-E22.py:155:9: E225 Missing whitespace around operator
+E22.py:154:13: E225 Missing whitespace around operator
     |
+154 | func2(lambda a, b=h[:], c=0: (a, b, c))
 155 | if not -5 < x < +5:
-156 |     print >> sys.stderr, "x is out of range."
-157 | print >>sys.stdout, "x is an integer."
-    |          E225
+156 |     print >>sys.stderr, "x is out of range."
+    |              E225
+157 | print >> sys.stdout, "x is an integer."
 158 | x = x / 2 - 1
-159 | x = 1 @ 2
     |
 
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
-assertion_line: 114
 ---
 E22.py:54:13: E225 Missing whitespace around operator
    |
@@ -171,6 +170,16 @@ E22.py:82:6: E225 Missing whitespace around operator
 86 | 1is 1
    |
 
+E22.py:84:2: E225 Missing whitespace around operator
+   |
+84 | i = 1or 0
+85 | #: E225
+86 | 1is 1
+   |   E225
+87 | #: E225
+88 | 1in []
+   |
+
 E22.py:86:2: E225 Missing whitespace around operator
    |
 86 | 1is 1
@@ -250,14 +259,14 @@ E22.py:100:7: E225 Missing whitespace around operator
 103 | #:
     |
 
-E22.py:154:13: E225 Missing whitespace around operator
+E22.py:155:9: E225 Missing whitespace around operator
     |
-154 | func2(lambda a, b=h[:], c=0: (a, b, c))
 155 | if not -5 < x < +5:
-156 |     print >>sys.stderr, "x is out of range."
-    |              E225
-157 | print >> sys.stdout, "x is an integer."
+156 |     print >> sys.stderr, "x is out of range."
+157 | print >>sys.stdout, "x is an integer."
+    |          E225
 158 | x = x / 2 - 1
+159 | x = 1 @ 2
     |
 
 

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E225_E22.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
+assertion_line: 114
 ---
 E22.py:54:13: E225 Missing whitespace around operator
    |
@@ -8,6 +9,16 @@ E22.py:54:13: E225 Missing whitespace around operator
    |              E225
 56 | #: E225
 57 | submitted+= 1
+   |
+
+E22.py:56:10: E225 Missing whitespace around operator
+   |
+56 | submitted +=1
+57 | #: E225
+58 | submitted+= 1
+   |           E225
+59 | #: E225
+60 | c =-1
    |
 
 E22.py:58:4: E225 Missing whitespace around operator
@@ -100,12 +111,12 @@ E22.py:74:12: E225 Missing whitespace around operator
 78 | i=i+ 1
    |
 
-E22.py:76:3: E225 Missing whitespace around operator
+E22.py:76:2: E225 Missing whitespace around operator
    |
 76 | _1kB = _1MB>> 10
 77 | #: E225 E225
 78 | i=i+ 1
-   |    E225
+   |   E225
 79 | #: E225 E225
 80 | i=i +1
    |
@@ -120,12 +131,12 @@ E22.py:76:4: E225 Missing whitespace around operator
 80 | i=i +1
    |
 
-E22.py:78:3: E225 Missing whitespace around operator
+E22.py:78:2: E225 Missing whitespace around operator
    |
 78 | i=i+ 1
 79 | #: E225 E225
 80 | i=i +1
-   |    E225
+   |   E225
 81 | #: E225
 82 | i = 1and 1
    |
@@ -138,6 +149,36 @@ E22.py:78:6: E225 Missing whitespace around operator
    |       E225
 81 | #: E225
 82 | i = 1and 1
+   |
+
+E22.py:80:6: E225 Missing whitespace around operator
+   |
+80 | i=i +1
+81 | #: E225
+82 | i = 1and 1
+   |       E225
+83 | #: E225
+84 | i = 1or 0
+   |
+
+E22.py:82:6: E225 Missing whitespace around operator
+   |
+82 | i = 1and 1
+83 | #: E225
+84 | i = 1or 0
+   |       E225
+85 | #: E225
+86 | 1is 1
+   |
+
+E22.py:86:2: E225 Missing whitespace around operator
+   |
+86 | 1is 1
+87 | #: E225
+88 | 1in []
+   |   E225
+89 | #: E225
+90 | i = 1 @2
    |
 
 E22.py:88:8: E225 Missing whitespace around operator
@@ -160,12 +201,12 @@ E22.py:90:6: E225 Missing whitespace around operator
 94 | i=i+1
    |
 
-E22.py:92:3: E225 Missing whitespace around operator
+E22.py:92:2: E225 Missing whitespace around operator
    |
 92 | i = 1@ 2
 93 | #: E225 E226
 94 | i=i+1
-   |    E225
+   |   E225
 95 | #: E225 E226
 96 | i =i+1
    |
@@ -179,6 +220,16 @@ E22.py:94:4: E225 Missing whitespace around operator
 97 | #: E225 E226
 98 | i= i+1
    |
+
+E22.py:96:2: E225 Missing whitespace around operator
+    |
+ 96 | i =i+1
+ 97 | #: E225 E226
+ 98 | i= i+1
+    |   E225
+ 99 | #: E225 E226
+100 | c = (a +b)*(a - b)
+    |
 
 E22.py:98:9: E225 Missing whitespace around operator
     |

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E226_E22.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E226_E22.py.snap
@@ -50,6 +50,15 @@ E22.py:100:11: E226 Missing whitespace around arithmetic operator
 103 | #:
     |
 
+E22.py:104:6: E226 Missing whitespace around arithmetic operator
+    |
+104 | #: E226
+105 | z = 2//30
+    |       E226
+106 | #: E226 E226
+107 | c = (a+b) * (a-b)
+    |
+
 E22.py:106:7: E226 Missing whitespace around arithmetic operator
     |
 106 | z = 2//30
@@ -118,6 +127,16 @@ E22.py:116:12: E226 Missing whitespace around arithmetic operator
     |             E226
 119 | #: E226
 120 | def halves(n):
+    |
+
+E22.py:119:14: E226 Missing whitespace around arithmetic operator
+    |
+119 | #: E226
+120 | def halves(n):
+121 |     return (i//2 for i in range(n))
+    |               E226
+122 | #: E227
+123 | _1kB = _1MB>>10
     |
 
 

--- a/crates/ruff_python_ast/src/token_kind.rs
+++ b/crates/ruff_python_ast/src/token_kind.rs
@@ -168,56 +168,8 @@ pub enum TokenKind {
 
 impl TokenKind {
     #[inline]
-    pub const fn is_whitespace_needed(&self) -> bool {
-        matches!(
-            self,
-            TokenKind::DoubleStarEqual
-                | TokenKind::StarEqual
-                | TokenKind::SlashEqual
-                | TokenKind::DoubleSlashEqual
-                | TokenKind::PlusEqual
-                | TokenKind::MinusEqual
-                | TokenKind::NotEqual
-                | TokenKind::Less
-                | TokenKind::Greater
-                | TokenKind::PercentEqual
-                | TokenKind::CircumflexEqual
-                | TokenKind::AmperEqual
-                | TokenKind::VbarEqual
-                | TokenKind::EqEqual
-                | TokenKind::LessEqual
-                | TokenKind::GreaterEqual
-                | TokenKind::LeftShiftEqual
-                | TokenKind::RightShiftEqual
-                | TokenKind::Equal
-                | TokenKind::And
-                | TokenKind::Or
-                | TokenKind::In
-                | TokenKind::Is
-                | TokenKind::Rarrow
-                | TokenKind::Percent
-        )
-    }
-
-    #[inline]
-    pub const fn is_whitespace_optional(&self) -> bool {
-        self.is_arithmetic()
-            || matches!(
-                self,
-                TokenKind::CircumFlex
-                    | TokenKind::Amper
-                    | TokenKind::Vbar
-                    | TokenKind::LeftShift
-                    | TokenKind::Percent
-            )
-    }
-
-    #[inline]
     pub const fn is_unary(&self) -> bool {
-        matches!(
-            self,
-            TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::DoubleStar
-        )
+        matches!(self, TokenKind::Plus | TokenKind::Minus | TokenKind::Star)
     }
 
     #[inline]
@@ -311,6 +263,11 @@ impl TokenKind {
                 | TokenKind::Ellipsis
                 | TokenKind::ColonEqual
                 | TokenKind::Colon
+                | TokenKind::And
+                | TokenKind::Or
+                | TokenKind::Not
+                | TokenKind::In
+                | TokenKind::Is
         )
     }
 
@@ -340,6 +297,7 @@ impl TokenKind {
                 | TokenKind::Plus
                 | TokenKind::Minus
                 | TokenKind::Slash
+                | TokenKind::DoubleSlash
                 | TokenKind::At
         )
     }

--- a/crates/ruff_python_ast/src/token_kind.rs
+++ b/crates/ruff_python_ast/src/token_kind.rs
@@ -195,6 +195,7 @@ impl TokenKind {
                 | TokenKind::In
                 | TokenKind::Is
                 | TokenKind::Rarrow
+                | TokenKind::Percent
         )
     }
 
@@ -207,7 +208,6 @@ impl TokenKind {
                     | TokenKind::Amper
                     | TokenKind::Vbar
                     | TokenKind::LeftShift
-                    | TokenKind::RightShift
                     | TokenKind::Percent
             )
     }
@@ -216,11 +216,7 @@ impl TokenKind {
     pub const fn is_unary(&self) -> bool {
         matches!(
             self,
-            TokenKind::Plus
-                | TokenKind::Minus
-                | TokenKind::Star
-                | TokenKind::DoubleStar
-                | TokenKind::RightShift
+            TokenKind::Plus | TokenKind::Minus | TokenKind::Star | TokenKind::DoubleStar
         )
     }
 
@@ -324,7 +320,7 @@ impl TokenKind {
     }
 
     #[inline]
-    pub const fn is_skip_comment(&self) -> bool {
+    pub const fn is_trivia(&self) -> bool {
         matches!(
             self,
             TokenKind::Newline
@@ -345,6 +341,24 @@ impl TokenKind {
                 | TokenKind::Minus
                 | TokenKind::Slash
                 | TokenKind::At
+        )
+    }
+
+    #[inline]
+    pub const fn is_bitwise_or_shift(&self) -> bool {
+        matches!(
+            self,
+            TokenKind::LeftShift
+                | TokenKind::LeftShiftEqual
+                | TokenKind::RightShift
+                | TokenKind::RightShiftEqual
+                | TokenKind::Amper
+                | TokenKind::AmperEqual
+                | TokenKind::Vbar
+                | TokenKind::VbarEqual
+                | TokenKind::CircumFlex
+                | TokenKind::CircumflexEqual
+                | TokenKind::Tilde
         )
     }
 


### PR DESCRIPTION
This PR refactors the pycodestyle missing whitespace around operator rule and fixes a few bug where our implementation didn't match the behavior of the pycodestyle rule. My main motivation for the refactor was that I simply didn't understood the rule and failed to set the right diagnostic ranges in #4113. I find the new logic easier to understand because it only uses token specific state, but some may disagree with that. 

The rule itself isn't too complicated: It ensures that operators have consistent leading and trailing spaces (an operator either has leading and trailing spaces or not) and enforces mandatory spaces around some operators. 

The misunderstanding that I had for a long time is that we would want to use the Modulo diagnostic whenever some spacing with the `%` operator is off (and the same for bitwise operations and arithmetic operations). But that's not the case. The logic is:

* Use `MissingWhitespaceAroundOperator` if the leading and trailing spaces are not consistent regardless of the operator
* Use `MissingWhitespaceAroundAritmeticOperator`, `MissingWhitespaceAroundBitwiseOrShiftOperator`, or `MissingWhitespaceAroundModuloOperator` if the operator has no spacing and the operator is an arithmetic operator, a bitwise or shift operator, or the modulo operator (enforce spaces). 
* Use `MissingWhitespaceAroundOperator` otherwise. 

That means the logic is staged: first test for consistent spacing, and only then enforce missing whitespace with the operator-specific violation. 



