### PR TITLE
Ignore __debuggerskip__ in unused variable checks

### DIFF
--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -327,6 +327,7 @@ pub fn unused_variable(checker: &mut Checker, scope: ScopeId) {
             && name != &"__tracebackhide__"
             && name != &"__traceback_info__"
             && name != &"__traceback_supplement__"
+            && name != &"__debuggerskip__"
         {
             let mut diagnostic = Diagnostic::new(
                 UnusedVariable {


### PR DESCRIPTION
## Summary

This is used in [IPython](https://ipython.readthedocs.io/en/7.31.0/whatsnew/version7.html#ipython-7-29) to tell `pdb` to avoid stepping into certain functions, like decorators.

Closes #4228.
