### PR TITLE
Use `NodeId` for `Binding` source

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -24,7 +24,6 @@ use serde::{Deserialize, Serialize};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::types::RefEquality;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{helpers, visitor};
 
@@ -108,12 +107,7 @@ where
 }
 
 /// B007
-pub fn unused_loop_control_variable(
-    checker: &mut Checker,
-    stmt: &Stmt,
-    target: &Expr,
-    body: &[Stmt],
-) {
+pub fn unused_loop_control_variable(checker: &mut Checker, target: &Expr, body: &[Stmt]) {
     let control_names = {
         let mut finder = NameFinder::new();
         finder.visit_expr(target);
@@ -168,9 +162,9 @@ pub fn unused_loop_control_variable(
                 let scope = checker.ctx.scope();
                 let binding = scope.bindings_for_name(name).find_map(|index| {
                     let binding = &checker.ctx.bindings[*index];
-                    binding.source.and_then(|source| {
-                        (RefEquality(source) == RefEquality(stmt)).then_some(binding)
-                    })
+                    binding
+                        .source
+                        .and_then(|source| (Some(source) == checker.ctx.stmt_id).then_some(binding))
                 });
                 if let Some(binding) = binding {
                     if binding.kind.is_loop_var() {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -328,7 +328,8 @@ pub fn unused_variable(checker: &mut Checker, scope: ScopeId) {
                 binding.range,
             );
             if checker.patch(diagnostic.kind.rule()) {
-                if let Some(stmt) = binding.source {
+                if let Some(source) = binding.source {
+                    let stmt = checker.ctx.stmts[source];
                     if let Some((kind, fix)) = remove_unused_variable(stmt, binding.range, checker)
                     {
                         if matches!(kind, DeletionKind::Whole) {

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -1,5 +1,3 @@
-use rustpython_parser::ast::Stmt;
-
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
@@ -55,9 +53,9 @@ pub fn global_statement(checker: &mut Checker, name: &str) {
     if let Some(index) = scope.get(name) {
         let binding = &checker.ctx.bindings[*index];
         if binding.kind.is_global() {
-            let source: &Stmt = binding
+            let source = checker.ctx.stmts[binding
                 .source
-                .expect("`global` bindings should always have a `source`");
+                .expect("`global` bindings should always have a `source`")];
             let diagnostic = Diagnostic::new(
                 GlobalStatement {
                     name: name.to_string(),

--- a/crates/ruff_python_semantic/src/analyze/branch_detection.rs
+++ b/crates/ruff_python_semantic/src/analyze/branch_detection.rs
@@ -1,47 +1,41 @@
 use std::cmp::Ordering;
 
-use ruff_python_ast::types::RefEquality;
 use rustpython_parser::ast::ExcepthandlerKind::ExceptHandler;
 use rustpython_parser::ast::{Stmt, StmtKind};
 
-use crate::node::Nodes;
+use crate::node::{NodeId, Nodes};
 
 /// Return the common ancestor of `left` and `right` below `stop`, or `None`.
-fn common_ancestor<'a>(
-    left: &'a Stmt,
-    right: &'a Stmt,
-    stop: Option<&'a Stmt>,
-    node_tree: &Nodes<'a>,
-) -> Option<&'a Stmt> {
-    if stop.map_or(false, |stop| {
-        RefEquality(left) == RefEquality(stop) || RefEquality(right) == RefEquality(stop)
-    }) {
+fn common_ancestor(
+    left: NodeId,
+    right: NodeId,
+    stop: Option<NodeId>,
+    node_tree: &Nodes,
+) -> Option<NodeId> {
+    if stop.map_or(false, |stop| left == stop || right == stop) {
         return None;
     }
 
-    if RefEquality(left) == RefEquality(right) {
+    if left == right {
         return Some(left);
     }
 
-    let left_id = node_tree.node_id(left)?;
-    let right_id = node_tree.node_id(right)?;
-
-    let left_depth = node_tree.depth(left_id);
-    let right_depth = node_tree.depth(right_id);
+    let left_depth = node_tree.depth(left);
+    let right_depth = node_tree.depth(right);
 
     match left_depth.cmp(&right_depth) {
         Ordering::Less => {
-            let right_id = node_tree.parent_id(right_id)?;
-            common_ancestor(left, node_tree[right_id], stop, node_tree)
+            let right = node_tree.parent_id(right)?;
+            common_ancestor(left, right, stop, node_tree)
         }
         Ordering::Equal => {
-            let left_id = node_tree.parent_id(left_id)?;
-            let right_id = node_tree.parent_id(right_id)?;
-            common_ancestor(node_tree[left_id], node_tree[right_id], stop, node_tree)
+            let left = node_tree.parent_id(left)?;
+            let right = node_tree.parent_id(right)?;
+            common_ancestor(left, right, stop, node_tree)
         }
         Ordering::Greater => {
-            let left_id = node_tree.parent_id(left_id)?;
-            common_ancestor(node_tree[left_id], right, stop, node_tree)
+            let left = node_tree.parent_id(left)?;
+            common_ancestor(left, right, stop, node_tree)
         }
     }
 }
@@ -78,21 +72,23 @@ fn alternatives(stmt: &Stmt) -> Vec<Vec<&Stmt>> {
 
 /// Return `true` if `stmt` is a descendent of any of the nodes in `ancestors`.
 fn descendant_of<'a>(
-    stmt: &'a Stmt,
+    stmt: NodeId,
     ancestors: &[&'a Stmt],
-    stop: &'a Stmt,
+    stop: NodeId,
     node_tree: &Nodes<'a>,
 ) -> bool {
-    ancestors
-        .iter()
-        .any(|ancestor| common_ancestor(stmt, ancestor, Some(stop), node_tree).is_some())
+    ancestors.iter().any(|ancestor| {
+        node_tree.node_id(ancestor).map_or(false, |ancestor| {
+            common_ancestor(stmt, ancestor, Some(stop), node_tree).is_some()
+        })
+    })
 }
 
 /// Return `true` if `left` and `right` are on different branches of an `if` or
 /// `try` statement.
-pub fn different_forks<'a>(left: &'a Stmt, right: &'a Stmt, node_tree: &Nodes<'a>) -> bool {
+pub fn different_forks(left: NodeId, right: NodeId, node_tree: &Nodes) -> bool {
     if let Some(ancestor) = common_ancestor(left, right, None, node_tree) {
-        for items in alternatives(ancestor) {
+        for items in alternatives(node_tree[ancestor]) {
             let l = descendant_of(left, &items, ancestor, node_tree);
             let r = descendant_of(right, &items, ancestor, node_tree);
             if l ^ r {

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -3,8 +3,8 @@ use std::ops::{Deref, Index, IndexMut};
 
 use bitflags::bitflags;
 use ruff_text_size::TextRange;
-use rustpython_parser::ast::Stmt;
 
+use crate::node::NodeId;
 use crate::scope::ScopeId;
 
 #[derive(Debug, Clone)]
@@ -14,7 +14,7 @@ pub struct Binding<'a> {
     /// The context in which the binding was created.
     pub context: ExecutionContext,
     /// The statement in which the [`Binding`] was defined.
-    pub source: Option<&'a Stmt>,
+    pub source: Option<NodeId>,
     /// Tuple of (scope index, range) indicating the scope and range at which
     /// the binding was last used in a runtime context.
     pub runtime_usage: Option<(ScopeId, TextRange)>,

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -252,7 +252,9 @@ impl<'a> Context<'a> {
                                 .take(scope_index)
                                 .all(|scope| scope.get(name).is_none())
                             {
-                                return Some((binding.source.unwrap(), format!("{name}.{member}")));
+                                if let Some(source) = binding.source {
+                                    return Some((self.stmts[source], format!("{name}.{member}")));
+                                }
                             }
                         }
                     }
@@ -268,7 +270,9 @@ impl<'a> Context<'a> {
                                     .take(scope_index)
                                     .all(|scope| scope.get(name).is_none())
                                 {
-                                    return Some((binding.source.unwrap(), (*name).to_string()));
+                                    if let Some(source) = binding.source {
+                                        return Some((self.stmts[source], (*name).to_string()));
+                                    }
                                 }
                             }
                         }
@@ -283,7 +287,9 @@ impl<'a> Context<'a> {
                                 .take(scope_index)
                                 .all(|scope| scope.get(name).is_none())
                             {
-                                return Some((binding.source.unwrap(), format!("{name}.{member}")));
+                                if let Some(source) = binding.source {
+                                    return Some((self.stmts[source], format!("{name}.{member}")));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Rather than storing the source as a `&Stmt`, we can instead store the `NodeId` for the corresponding `Stmt` and look it up as needed.

This does require lookups in a few additional spots, but it also simplifies some of the logic, e.g., in `branch_detection.rs`.
