### PR TITLE
Always generate fixes

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -63,7 +63,6 @@ pub struct Checker<'a> {
     module_path: Option<Vec<String>>,
     package: Option<&'a Path>,
     is_stub: bool,
-    autofix: flags::Autofix,
     noqa: flags::Noqa,
     pub settings: &'a Settings,
     pub noqa_line_for: &'a NoqaMapping,
@@ -85,7 +84,6 @@ impl<'a> Checker<'a> {
     pub fn new(
         settings: &'a Settings,
         noqa_line_for: &'a NoqaMapping,
-        autofix: flags::Autofix,
         noqa: flags::Noqa,
         path: &'a Path,
         package: Option<&'a Path>,
@@ -98,7 +96,6 @@ impl<'a> Checker<'a> {
         Checker {
             settings,
             noqa_line_for,
-            autofix,
             noqa,
             path,
             package,
@@ -121,7 +118,7 @@ impl<'a> Checker<'a> {
     /// Return `true` if a patch should be generated under the given autofix
     /// `Mode`.
     pub fn patch(&self, code: Rule) -> bool {
-        self.autofix.into() && self.settings.rules.should_fix(code)
+        self.settings.rules.should_fix(code)
     }
 
     /// Return `true` if a `Rule` is disabled by a `noqa` directive.
@@ -5674,7 +5671,6 @@ pub fn check_ast(
     indexer: &Indexer,
     noqa_line_for: &NoqaMapping,
     settings: &Settings,
-    autofix: flags::Autofix,
     noqa: flags::Noqa,
     path: &Path,
     package: Option<&Path>,
@@ -5682,7 +5678,6 @@ pub fn check_ast(
     let mut checker = Checker::new(
         settings,
         noqa_line_for,
-        autofix,
         noqa,
         path,
         package,

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -15,7 +15,7 @@ use crate::directives::IsortDirectives;
 use crate::registry::Rule;
 use crate::rules::isort;
 use crate::rules::isort::track::{Block, ImportTracker};
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) -> Option<ImportMap> {
     let Some(package) = package else {
@@ -79,7 +79,6 @@ pub fn check_imports(
     directives: &IsortDirectives,
     settings: &Settings,
     stylist: &Stylist,
-    autofix: flags::Autofix,
     path: &Path,
     package: Option<&Path>,
 ) -> (Vec<Diagnostic>, Option<ImportMap>) {
@@ -99,7 +98,7 @@ pub fn check_imports(
         for block in &blocks {
             if !block.imports.is_empty() {
                 if let Some(diagnostic) = isort::rules::organize_imports(
-                    block, locator, stylist, indexer, settings, autofix, package,
+                    block, locator, stylist, indexer, settings, package,
                 ) {
                     diagnostics.push(diagnostic);
                 }
@@ -108,7 +107,7 @@ pub fn check_imports(
     }
     if settings.rules.enabled(Rule::MissingRequiredImport) {
         diagnostics.extend(isort::rules::add_required_imports(
-            &blocks, python_ast, locator, stylist, settings, autofix, is_stub,
+            &blocks, python_ast, locator, stylist, settings, is_stub,
         ));
     }
 

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -12,7 +12,7 @@ use crate::rules::pycodestyle::rules::logical_lines::{
     whitespace_around_named_parameter_equals, whitespace_before_comment,
     whitespace_before_parameters, LogicalLines, TokenFlags,
 };
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 /// Return the amount of indentation, expanding tabs to the next multiple of 8.
 fn expand_indent(line: &str) -> usize {
@@ -35,20 +35,18 @@ pub fn check_logical_lines(
     locator: &Locator,
     stylist: &Stylist,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<Diagnostic> {
     let mut context = LogicalLinesContext::new(settings);
 
     #[cfg(feature = "logical_lines")]
-    let should_fix_missing_whitespace =
-        autofix.into() && settings.rules.should_fix(Rule::MissingWhitespace);
+    let should_fix_missing_whitespace = settings.rules.should_fix(Rule::MissingWhitespace);
 
     #[cfg(not(feature = "logical_lines"))]
     let should_fix_missing_whitespace = false;
 
     #[cfg(feature = "logical_lines")]
     let should_fix_whitespace_before_parameters =
-        autofix.into() && settings.rules.should_fix(Rule::WhitespaceBeforeParameters);
+        settings.rules.should_fix(Rule::WhitespaceBeforeParameters);
 
     #[cfg(not(feature = "logical_lines"))]
     let should_fix_whitespace_before_parameters = false;

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -11,7 +11,7 @@ use crate::noqa::{Directive, FileExemption, NoqaDirectives, NoqaMapping};
 use crate::registry::{AsRule, Rule};
 use crate::rule_redirects::get_redirect_target;
 use crate::rules::ruff::rules::{UnusedCodes, UnusedNOQA};
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 pub fn check_noqa(
     diagnostics: &mut Vec<Diagnostic>,
@@ -19,7 +19,6 @@ pub fn check_noqa(
     comment_ranges: &[TextRange],
     noqa_line_for: &NoqaMapping,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<usize> {
     let enforce_noqa = settings.rules.enabled(Rule::UnusedNOQA);
 
@@ -101,7 +100,7 @@ pub fn check_noqa(
                     if line.matches.is_empty() {
                         let mut diagnostic =
                             Diagnostic::new(UnusedNOQA { codes: None }, *noqa_range);
-                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+                        if settings.rules.should_fix(diagnostic.kind.rule()) {
                             #[allow(deprecated)]
                             diagnostic.set_fix_from_edit(delete_noqa(
                                 *leading_spaces,
@@ -170,7 +169,7 @@ pub fn check_noqa(
                             },
                             *range,
                         );
-                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+                        if settings.rules.should_fix(diagnostic.kind.rule()) {
                             if valid_codes.is_empty() {
                                 #[allow(deprecated)]
                                 diagnostic.set_fix_from_edit(delete_noqa(

--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -19,7 +19,7 @@ use crate::rules::pycodestyle::rules::{
 use crate::rules::pygrep_hooks::rules::{blanket_noqa, blanket_type_ignore};
 use crate::rules::pylint;
 use crate::rules::pyupgrade::rules::unnecessary_coding_comment;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 pub fn check_physical_lines(
     path: &Path,
@@ -28,7 +28,6 @@ pub fn check_physical_lines(
     indexer: &Indexer,
     doc_lines: &[TextSize],
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
     let mut has_any_shebang = false;
@@ -51,10 +50,8 @@ pub fn check_physical_lines(
         settings.rules.enabled(Rule::BlankLineWithWhitespace);
     let enforce_tab_indentation = settings.rules.enabled(Rule::TabIndentation);
 
-    let fix_unnecessary_coding_comment =
-        autofix.into() && settings.rules.should_fix(Rule::UTF8EncodingDeclaration);
-    let fix_shebang_whitespace =
-        autofix.into() && settings.rules.should_fix(Rule::ShebangLeadingWhitespace);
+    let fix_unnecessary_coding_comment = settings.rules.should_fix(Rule::UTF8EncodingDeclaration);
+    let fix_shebang_whitespace = settings.rules.should_fix(Rule::ShebangLeadingWhitespace);
 
     let mut commented_lines_iter = indexer.comment_ranges().iter().peekable();
     let mut doc_lines_iter = doc_lines.iter().peekable();
@@ -148,7 +145,7 @@ pub fn check_physical_lines(
         }
 
         if enforce_trailing_whitespace || enforce_blank_line_contains_whitespace {
-            if let Some(diagnostic) = trailing_whitespace(&line, settings, autofix) {
+            if let Some(diagnostic) = trailing_whitespace(&line, settings) {
                 diagnostics.push(diagnostic);
             }
         }
@@ -164,7 +161,7 @@ pub fn check_physical_lines(
         if let Some(diagnostic) = no_newline_at_end_of_file(
             locator,
             stylist,
-            autofix.into() && settings.rules.should_fix(Rule::MissingNewlineAtEndOfFile),
+            settings.rules.should_fix(Rule::MissingNewlineAtEndOfFile),
         ) {
             diagnostics.push(diagnostic);
         }
@@ -188,7 +185,7 @@ mod tests {
     use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 
     use crate::registry::Rule;
-    use crate::settings::{flags, Settings};
+    use crate::settings::Settings;
 
     use super::check_physical_lines;
 
@@ -211,7 +208,6 @@ mod tests {
                     line_length,
                     ..Settings::for_rule(Rule::LineTooLong)
                 },
-                flags::Autofix::Enabled,
             )
         };
         assert_eq!(check_with_max_line_length(8), vec![]);

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -125,7 +125,7 @@ impl Display for DisplayGroupedMessage<'_> {
                 self.column_length.get() - calculate_print_width(start_location.column).get()
             ),
             code_and_body = RuleCodeAndBody {
-                message: &message,
+                message,
                 show_fix_status: self.show_fix_status
             },
         )?;

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -125,7 +125,7 @@ impl Display for DisplayGroupedMessage<'_> {
                 self.column_length.get() - calculate_print_width(start_location.column).get()
             ),
             code_and_body = RuleCodeAndBody {
-                message_kind: &message.kind,
+                message: &message,
                 show_fix_status: self.show_fix_status
             },
         )?;

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -182,10 +182,10 @@ def fibonacci(n):
             },
             TextRange::new(TextSize::from(7), TextSize::from(9)),
         )
-        .with_fix(Fix::new(vec![Edit::range_deletion(TextRange::new(
+        .with_fix(Fix::suggested(Edit::range_deletion(TextRange::new(
             TextSize::from(0),
             TextSize::from(10),
-        ))]));
+        ))));
 
         let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
 

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -181,7 +181,11 @@ def fibonacci(n):
                 multiple: false,
             },
             TextRange::new(TextSize::from(7), TextSize::from(9)),
-        );
+        )
+        .with_fix(Fix::new(vec![Edit::range_deletion(TextRange::new(
+            TextSize::from(0),
+            TextSize::from(10),
+        ))]));
 
         let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
 

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -6,7 +6,22 @@ expression: content
   {
     "code": "F401",
     "message": "`os` imported but unused",
-    "fix": null,
+    "fix": {
+      "message": "Remove unused import: `os`",
+      "edits": [
+        {
+          "content": "",
+          "location": {
+            "row": 1,
+            "column": 0
+          },
+          "end_location": {
+            "row": 2,
+            "column": 0
+          }
+        }
+      ]
+    },
     "location": {
       "row": 1,
       "column": 8

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -92,7 +92,7 @@ impl Emitter for TextEmitter {
                 col = diagnostic_location.column,
                 sep = ":".cyan(),
                 code_and_body = RuleCodeAndBody {
-                    message: &message,
+                    message,
                     show_fix_status: self.flags.contains(EmitterFlags::SHOW_FIX_STATUS)
                 }
             )?;
@@ -121,7 +121,7 @@ impl Display for RuleCodeAndBody<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let kind = &self.message.kind;
 
-        if self.show_fix_status && !self.message.fix.is_empty() {
+        if self.show_fix_status && self.message.fix.is_some() {
             write!(
                 f,
                 "{code} {autofix}{body}",

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -5,7 +5,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 use super::detection::comment_contains_code;
 
@@ -50,7 +50,6 @@ pub fn commented_out_code(
     locator: &Locator,
     range: TextRange,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Option<Diagnostic> {
     let line = locator.full_lines(range);
 
@@ -58,7 +57,7 @@ pub fn commented_out_code(
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, range);
 
-        if autofix.into() && settings.rules.should_fix(Rule::CommentedOutCode) {
+        if settings.rules.should_fix(Rule::CommentedOutCode) {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                 locator.full_lines_range(range),

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B007_B007.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B007.py:6:5: B007 [*] Loop control variable `i` not used within loop body
+B007.py:6:5: B007 Loop control variable `i` not used within loop body
   |
 6 | print(i)  # name no longer defined on Python 3; no warning yet
 7 | 
@@ -31,7 +31,7 @@ B007.py:18:13: B007 [*] Loop control variable `k` not used within loop body
 20 20 | 
 21 21 | 
 
-B007.py:30:5: B007 [*] Loop control variable `i` not used within loop body
+B007.py:30:5: B007 Loop control variable `i` not used within loop body
    |
 30 | for i, (j, (k, l)) in strange_generator():  # i, k not used
    |     ^ B007
@@ -116,7 +116,7 @@ B007.py:52:14: B007 [*] Loop control variable `bar` not used within loop body
 54 54 |             break
 55 55 | 
 
-B007.py:59:14: B007 [*] Loop control variable `bar` not used within loop body
+B007.py:59:14: B007 Loop control variable `bar` not used within loop body
    |
 59 | def f():
 60 |     # Unfixable due to usage of `bar` outside of loop.

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -9,7 +9,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 /// Simplified token type.
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -223,7 +223,6 @@ pub fn trailing_commas(
     tokens: &[LexResult],
     locator: &Locator,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
@@ -324,7 +323,7 @@ pub fn trailing_commas(
         if comma_prohibited {
             let comma = prev.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
-            if autofix.into() && settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
+            if settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(diagnostic.range())));
             }
@@ -360,7 +359,7 @@ pub fn trailing_commas(
                 MissingTrailingComma,
                 TextRange::empty(missing_comma.1.end()),
             );
-            if autofix.into() && settings.rules.should_fix(Rule::MissingTrailingComma) {
+            if settings.rules.should_fix(Rule::MissingTrailingComma) {
                 // Create a replacement that includes the final bracket (or other token),
                 // rather than just inserting a comma at the end. This prevents the UP034 autofix
                 // removing any brackets in the same linter pass - doing both at the same time could

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
-use ruff_diagnostics::AlwaysAutofixableViolation;
-use ruff_diagnostics::Diagnostic;
+use ruff_diagnostics::Violation;
+use ruff_diagnostics::{AutofixKind, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::any_over_expr;
 
@@ -42,14 +42,16 @@ use crate::rules::flake8_comprehensions::fixes;
 #[violation]
 pub struct UnnecessaryComprehensionAnyAll;
 
-impl AlwaysAutofixableViolation for UnnecessaryComprehensionAnyAll {
+impl Violation for UnnecessaryComprehensionAnyAll {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Unnecessary list comprehension.")
     }
 
-    fn autofix_title(&self) -> String {
-        "Remove unnecessary list comprehension".to_string()
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|_| "Remove unnecessary list comprehension".to_string())
     }
 }
 

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C417_C417.py.snap
@@ -249,7 +249,7 @@ C417.py:16:8: C417 [*] Unnecessary `map` usage (rewrite using a `dict` comprehen
 18 18 | # Error, but unfixable.
 19 19 | # For simple expressions, this could be: `(x if x else 1 for x in nums)`.
 
-C417.py:21:1: C417 [*] Unnecessary `map` usage (rewrite using a generator expression)
+C417.py:21:1: C417 Unnecessary `map` usage (rewrite using a generator expression)
    |
 21 | # For simple expressions, this could be: `(x if x else 1 for x in nums)`.
 22 | # For more complex expressions, this would differ: `(x + 2 if x else 3 for x in nums)`.

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C419_C419.py.snap
@@ -77,7 +77,7 @@ C419.py:7:5: C419 [*] Unnecessary list comprehension.
 9 9 | any({x.id for x in bar})
 10 10 | 
 
-C419.py:9:5: C419 [*] Unnecessary list comprehension.
+C419.py:9:5: C419 Unnecessary list comprehension.
    |
  9 |     [x.id for x in bar],  # second comment
 10 | )  # third comment

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -2,8 +2,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
-use ruff_diagnostics::{Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -18,16 +17,20 @@ pub struct PytestParametrizeNamesWrongType {
     pub expected: types::ParametrizeNameType,
 }
 
-impl AlwaysAutofixableViolation for PytestParametrizeNamesWrongType {
+impl Violation for PytestParametrizeNamesWrongType {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let PytestParametrizeNamesWrongType { expected } = self;
         format!("Wrong name(s) type in `@pytest.mark.parametrize`, expected `{expected}`")
     }
 
-    fn autofix_title(&self) -> String {
-        let PytestParametrizeNamesWrongType { expected } = self;
-        format!("Use a `{expected}` for parameter names")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|violation| {
+            let PytestParametrizeNamesWrongType { expected } = violation;
+            format!("Use a `{expected}` for parameter names")
+        })
     }
 }
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_csv.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT006_csv.snap
@@ -77,7 +77,7 @@ PT006.py:39:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
 41 41 |     ...
 42 42 | 
 
-PT006.py:44:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expected `csv`
+PT006.py:44:26: PT006 Wrong name(s) type in `@pytest.mark.parametrize`, expected `csv`
    |
 44 | @pytest.mark.parametrize([some_expr, another_expr], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ PT006
@@ -86,7 +86,7 @@ PT006.py:44:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expe
    |
    = help: Use a `csv` for parameter names
 
-PT006.py:49:26: PT006 [*] Wrong name(s) type in `@pytest.mark.parametrize`, expected `csv`
+PT006.py:49:26: PT006 Wrong name(s) type in `@pytest.mark.parametrize`, expected `csv`
    |
 49 | @pytest.mark.parametrize([some_expr, "param2"], [1, 2, 3])
    |                          ^^^^^^^^^^^^^^^^^^^^^ PT006

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT009.snap
@@ -106,7 +106,7 @@ PT009.py:15:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
 17 17 |         self.assertTrue(**{"expr": expr, "msg": msg})  # Error, unfixable
 18 18 |         self.assertTrue(msg=msg, expr=expr, unexpected_arg=False)  # Error, unfixable
 
-PT009.py:16:9: PT009 [*] Use a regular `assert` instead of unittest-style `assertTrue`
+PT009.py:16:9: PT009 Use a regular `assert` instead of unittest-style `assertTrue`
    |
 16 |         self.assertTrue(expr=expr, msg=msg)  # Error
 17 |         self.assertTrue(msg=msg, expr=expr)  # Error
@@ -117,7 +117,7 @@ PT009.py:16:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-PT009.py:17:9: PT009 [*] Use a regular `assert` instead of unittest-style `assertTrue`
+PT009.py:17:9: PT009 Use a regular `assert` instead of unittest-style `assertTrue`
    |
 17 |         self.assertTrue(msg=msg, expr=expr)  # Error
 18 |         self.assertTrue(*(expr, msg))  # Error, unfixable
@@ -128,7 +128,7 @@ PT009.py:17:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-PT009.py:18:9: PT009 [*] Use a regular `assert` instead of unittest-style `assertTrue`
+PT009.py:18:9: PT009 Use a regular `assert` instead of unittest-style `assertTrue`
    |
 18 |         self.assertTrue(*(expr, msg))  # Error, unfixable
 19 |         self.assertTrue(**{"expr": expr, "msg": msg})  # Error, unfixable
@@ -139,7 +139,7 @@ PT009.py:18:9: PT009 [*] Use a regular `assert` instead of unittest-style `asser
    |
    = help: Replace `assertTrue(...)` with `assert ...`
 
-PT009.py:19:9: PT009 [*] Use a regular `assert` instead of unittest-style `assertTrue`
+PT009.py:19:9: PT009 Use a regular `assert` instead of unittest-style `assertTrue`
    |
 19 |         self.assertTrue(**{"expr": expr, "msg": msg})  # Error, unfixable
 20 |         self.assertTrue(msg=msg, expr=expr, unexpected_arg=False)  # Error, unfixable

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
@@ -250,7 +250,7 @@ PT018.py:33:5: PT018 Assertion should be broken down into multiple parts
 37 |     assert (
    |
 
-PT018.py:35:5: PT018 [*] Assertion should be broken down into multiple parts
+PT018.py:35:5: PT018 Assertion should be broken down into multiple parts
    |
 35 |       assert not (something or something_else and something_third)
 36 |       # detected, but no autofix for parenthesized conditions

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::source_code::Locator;
 
 use crate::lex::docstring_detection::StateMachine;
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 use super::settings::Quote;
 
@@ -255,12 +255,7 @@ impl<'a> From<&'a str> for Trivia<'a> {
 }
 
 /// Q003
-fn docstring(
-    locator: &Locator,
-    range: TextRange,
-    settings: &Settings,
-    autofix: flags::Autofix,
-) -> Option<Diagnostic> {
+fn docstring(locator: &Locator, range: TextRange, settings: &Settings) -> Option<Diagnostic> {
     let quotes_settings = &settings.flake8_quotes;
 
     let text = locator.slice(range);
@@ -279,7 +274,7 @@ fn docstring(
         },
         range,
     );
-    if autofix.into() && settings.rules.should_fix(Rule::BadQuotesDocstring) {
+    if settings.rules.should_fix(Rule::BadQuotesDocstring) {
         let quote_count = if trivia.is_multiline { 3 } else { 1 };
         let string_contents = &trivia.raw_text[quote_count..trivia.raw_text.len() - quote_count];
         let quote = good_docstring(quotes_settings.docstring_quotes).repeat(quote_count);
@@ -299,12 +294,7 @@ fn docstring(
 }
 
 /// Q001, Q002
-fn strings(
-    locator: &Locator,
-    sequence: &[TextRange],
-    settings: &Settings,
-    autofix: flags::Autofix,
-) -> Vec<Diagnostic> {
+fn strings(locator: &Locator, sequence: &[TextRange], settings: &Settings) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
     let quotes_settings = &settings.flake8_quotes;
@@ -358,7 +348,7 @@ fn strings(
                 *range,
             );
 
-            if autofix.into() && settings.rules.should_fix(Rule::BadQuotesMultilineString) {
+            if settings.rules.should_fix(Rule::BadQuotesMultilineString) {
                 let string_contents = &trivia.raw_text[3..trivia.raw_text.len() - 3];
                 let quote = good_multiline(quotes_settings.multiline_quotes);
                 let mut fixed_contents = String::with_capacity(
@@ -391,7 +381,7 @@ fn strings(
                     && !string_contents.contains(bad_single(quotes_settings.inline_quotes))
                 {
                     let mut diagnostic = Diagnostic::new(AvoidableEscapedQuote, *range);
-                    if autofix.into() && settings.rules.should_fix(Rule::AvoidableEscapedQuote) {
+                    if settings.rules.should_fix(Rule::AvoidableEscapedQuote) {
                         let quote = bad_single(quotes_settings.inline_quotes);
 
                         let mut fixed_contents =
@@ -454,7 +444,7 @@ fn strings(
                     },
                     *range,
                 );
-                if autofix.into() && settings.rules.should_fix(Rule::BadQuotesInlineString) {
+                if settings.rules.should_fix(Rule::BadQuotesInlineString) {
                     let quote = good_single(quotes_settings.inline_quotes);
                     let mut fixed_contents =
                         String::with_capacity(trivia.prefix.len() + string_contents.len() + 2);
@@ -477,12 +467,7 @@ fn strings(
 }
 
 /// Generate `flake8-quote` diagnostics from a token stream.
-pub fn from_tokens(
-    lxr: &[LexResult],
-    locator: &Locator,
-    settings: &Settings,
-    autofix: flags::Autofix,
-) -> Vec<Diagnostic> {
+pub fn from_tokens(lxr: &[LexResult], locator: &Locator, settings: &Settings) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
     // Keep track of sequences of strings, which represent implicit string
@@ -496,10 +481,10 @@ pub fn from_tokens(
         // docstring, then move on.
         if is_docstring {
             if !sequence.is_empty() {
-                diagnostics.extend(strings(locator, &sequence, settings, autofix));
+                diagnostics.extend(strings(locator, &sequence, settings));
                 sequence.clear();
             }
-            if let Some(diagnostic) = docstring(locator, range, settings, autofix) {
+            if let Some(diagnostic) = docstring(locator, range, settings) {
                 diagnostics.push(diagnostic);
             }
         } else {
@@ -509,7 +494,7 @@ pub fn from_tokens(
             } else if !matches!(tok, Tok::Comment(..) | Tok::NonLogicalNewline) {
                 // Otherwise, consume the sequence.
                 if !sequence.is_empty() {
-                    diagnostics.extend(strings(locator, &sequence, settings, autofix));
+                    diagnostics.extend(strings(locator, &sequence, settings));
                     sequence.clear();
                 }
             }
@@ -518,7 +503,7 @@ pub fn from_tokens(
 
     // If we have an unterminated sequence, consume it.
     if !sequence.is_empty() {
-        diagnostics.extend(strings(locator, &sequence, settings, autofix));
+        diagnostics.extend(strings(locator, &sequence, settings));
         sequence.clear();
     }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprKind};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix, Violation};
+use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -13,16 +13,20 @@ pub struct UncapitalizedEnvironmentVariables {
     original: String,
 }
 
-impl AlwaysAutofixableViolation for UncapitalizedEnvironmentVariables {
+impl Violation for UncapitalizedEnvironmentVariables {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let UncapitalizedEnvironmentVariables { expected, original } = self;
         format!("Use capitalized environment variable `{expected}` instead of `{original}`")
     }
 
-    fn autofix_title(&self) -> String {
-        let UncapitalizedEnvironmentVariables { expected, original } = self;
-        format!("Replace `{original}` with `{expected}`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|violation| {
+            let UncapitalizedEnvironmentVariables { expected, original } = violation;
+            format!("Replace `{original}` with `{expected}`")
+        })
     }
 }
 
@@ -53,11 +57,16 @@ pub struct DictGetWithNoneDefault {
     original: String,
 }
 
-impl Violation for DictGetWithNoneDefault {
+impl AlwaysAutofixableViolation for DictGetWithNoneDefault {
     #[derive_message_formats]
     fn message(&self) -> String {
         let DictGetWithNoneDefault { expected, original } = self;
         format!("Use `{expected}` instead of `{original}`")
+    }
+
+    fn autofix_title(&self) -> String {
+        let DictGetWithNoneDefault { expected, original } = self;
+        format!("Replace `{original}` with `{expected}`")
     }
 }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Constant, Expr, ExprContext, ExprKind, Unaryop};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, unparse_expr};
 
@@ -12,16 +12,20 @@ pub struct IfExprWithTrueFalse {
     expr: String,
 }
 
-impl AlwaysAutofixableViolation for IfExprWithTrueFalse {
+impl Violation for IfExprWithTrueFalse {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let IfExprWithTrueFalse { expr } = self;
         format!("Use `bool({expr})` instead of `True if {expr} else False`")
     }
 
-    fn autofix_title(&self) -> String {
-        let IfExprWithTrueFalse { expr } = self;
-        format!("Replace with `not {expr}")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|violation| {
+            let IfExprWithTrueFalse { expr } = violation;
+            format!("Replace with `not {expr}")
+        })
     }
 }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{create_expr, create_stmt, unparse_stmt};
 use ruff_python_ast::source_code::Stylist;
@@ -17,16 +17,20 @@ pub struct ReimplementedBuiltin {
     repl: String,
 }
 
-impl AlwaysAutofixableViolation for ReimplementedBuiltin {
+impl Violation for ReimplementedBuiltin {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let ReimplementedBuiltin { repl } = self;
         format!("Use `{repl}` instead of `for` loop")
     }
 
-    fn autofix_title(&self) -> String {
-        let ReimplementedBuiltin { repl } = self;
-        format!("Replace with `{repl}`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|violation| {
+            let ReimplementedBuiltin { repl } = violation;
+            format!("Replace with `{repl}`")
+        })
     }
 }
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM110.py.snap
@@ -192,7 +192,7 @@ SIM110.py:83:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
 89 85 | 
 90 86 | 
 
-SIM110.py:124:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead of `for` loop
+SIM110.py:124:5: SIM110 Use `return any(check(x) for x in iterable)` instead of `for` loop
     |
 124 |           pass
 125 |   
@@ -205,7 +205,7 @@ SIM110.py:124:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead
     |
     = help: Replace with `return any(check(x) for x in iterable)`
 
-SIM110.py:134:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` instead of `for` loop
+SIM110.py:134:5: SIM110 Use `return all(not check(x) for x in iterable)` instead of `for` loop
     |
 134 |           pass
 135 |   

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM110_SIM111.py.snap
@@ -192,7 +192,7 @@ SIM111.py:83:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` inst
 89 85 | 
 90 86 | 
 
-SIM111.py:124:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead of `for` loop
+SIM111.py:124:5: SIM110 Use `return any(check(x) for x in iterable)` instead of `for` loop
     |
 124 |           pass
 125 |   
@@ -205,7 +205,7 @@ SIM111.py:124:5: SIM110 [*] Use `return any(check(x) for x in iterable)` instead
     |
     = help: Replace with `return any(check(x) for x in iterable)`
 
-SIM111.py:134:5: SIM110 [*] Use `return all(not check(x) for x in iterable)` instead of `for` loop
+SIM111.py:134:5: SIM110 Use `return all(not check(x) for x in iterable)` instead of `for` loop
     |
 134 |           pass
 135 |   

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM112_SIM112.py.snap
@@ -21,7 +21,7 @@ SIM112.py:4:12: SIM112 [*] Use capitalized environment variable `FOO` instead of
 6 6 | os.environ.get('foo')
 7 7 | 
 
-SIM112.py:6:16: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
+SIM112.py:6:16: SIM112 Use capitalized environment variable `FOO` instead of `foo`
    |
  6 | os.environ['foo']
  7 | 
@@ -32,7 +32,7 @@ SIM112.py:6:16: SIM112 [*] Use capitalized environment variable `FOO` instead of
    |
    = help: Replace `foo` with `FOO`
 
-SIM112.py:8:16: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
+SIM112.py:8:16: SIM112 Use capitalized environment variable `FOO` instead of `foo`
    |
  8 | os.environ.get('foo')
  9 | 
@@ -43,7 +43,7 @@ SIM112.py:8:16: SIM112 [*] Use capitalized environment variable `FOO` instead of
    |
    = help: Replace `foo` with `FOO`
 
-SIM112.py:10:11: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
+SIM112.py:10:11: SIM112 Use capitalized environment variable `FOO` instead of `foo`
    |
 10 | os.environ.get('foo', 'bar')
 11 | 
@@ -54,7 +54,7 @@ SIM112.py:10:11: SIM112 [*] Use capitalized environment variable `FOO` instead o
    |
    = help: Replace `foo` with `FOO`
 
-SIM112.py:12:22: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
+SIM112.py:12:22: SIM112 Use capitalized environment variable `FOO` instead of `foo`
    |
 12 | os.getenv('foo')
 13 | 
@@ -86,7 +86,7 @@ SIM112.py:14:18: SIM112 [*] Use capitalized environment variable `FOO` instead o
 16 16 | if env := os.environ.get('foo'):
 17 17 |     pass
 
-SIM112.py:16:26: SIM112 [*] Use capitalized environment variable `FOO` instead of `foo`
+SIM112.py:16:26: SIM112 Use capitalized environment variable `FOO` instead of `foo`
    |
 16 | env = os.environ['foo']
 17 | 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM210_SIM210.py.snap
@@ -58,7 +58,7 @@ SIM210.py:5:5: SIM210 [*] Use `bool(b + c)` instead of `True if b + c else False
 7 7 | a = False if b else True  # OK
 8 8 | 
 
-SIM210.py:15:9: SIM210 [*] Use `bool(b)` instead of `True if b else False`
+SIM210.py:15:9: SIM210 Use `bool(b)` instead of `True if b else False`
    |
 15 |         return False
 16 | 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
@@ -9,6 +9,7 @@ SIM910.py:2:1: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 4 | 
 5 | # SIM910
   |
+  = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 1 1 | # SIM910
@@ -26,6 +27,7 @@ SIM910.py:5:1: SIM910 [*] Use `{}.get("key")` instead of `{}.get("key", None)`
 7 | 
 8 | # OK
   |
+  = help: Replace `{}.get("key", None)` with `{}.get("key")`
 
 ℹ Suggested fix
 2 2 | {}.get(key, None)
@@ -44,6 +46,7 @@ SIM910.py:20:9: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
    |         ^^^^^^^^^^^^^^^^^ SIM910
 22 |     pass
    |
+   = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 17 17 | {}.get("key", False)
@@ -63,6 +66,7 @@ SIM910.py:24:5: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
 26 | 
 27 | # SIM910
    |
+   = help: Replace `{}.get(key, None)` with `{}.get(key)`
 
 ℹ Suggested fix
 21 21 |     pass
@@ -80,6 +84,7 @@ SIM910.py:27:1: SIM910 [*] Use `({}).get(key)` instead of `({}).get(key, None)`
 28 | ({}).get(key, None)
    | ^^^^^^^^^^^^^^^^^^^ SIM910
    |
+   = help: Replace `({}).get(key, None)` with `({}).get(key)`
 
 ℹ Suggested fix
 24 24 | a = {}.get(key, None)

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM910_SIM910.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_simplify/mod.rs
 ---
-SIM910.py:2:1: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:2:1: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
   |
 2 | # SIM910
 3 | {}.get(key, None)
@@ -18,7 +18,7 @@ SIM910.py:2:1: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
 4 4 | # SIM910
 5 5 | {}.get("key", None)
 
-SIM910.py:5:1: SIM910 Use `{}.get("key")` instead of `{}.get("key", None)`
+SIM910.py:5:1: SIM910 [*] Use `{}.get("key")` instead of `{}.get("key", None)`
   |
 5 | # SIM910
 6 | {}.get("key", None)
@@ -37,7 +37,7 @@ SIM910.py:5:1: SIM910 Use `{}.get("key")` instead of `{}.get("key", None)`
 7 7 | # OK
 8 8 | {}.get(key)
 
-SIM910.py:20:9: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:20:9: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
    |
 20 | # SIM910
 21 | if a := {}.get(key, None):
@@ -55,7 +55,7 @@ SIM910.py:20:9: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
 22 22 | 
 23 23 | # SIM910
 
-SIM910.py:24:5: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
+SIM910.py:24:5: SIM910 [*] Use `{}.get(key)` instead of `{}.get(key, None)`
    |
 24 | # SIM910
 25 | a = {}.get(key, None)
@@ -74,7 +74,7 @@ SIM910.py:24:5: SIM910 Use `{}.get(key)` instead of `{}.get(key, None)`
 26 26 | # SIM910
 27 27 | ({}).get(key, None)
 
-SIM910.py:27:1: SIM910 Use `({}).get(key)` instead of `({}).get(key, None)`
+SIM910.py:27:1: SIM910 [*] Use `({}).get(key)` instead of `({}).get(key, None)`
    |
 27 | # SIM910
 28 | ({}).get(key, None)

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_all_imports.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_all_imports.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
 ---
-TID252.py:7:1: TID252 [*] Relative imports are banned
+TID252.py:7:1: TID252 Relative imports are banned
    |
  7 | # TID252
  8 | from . import sibling
@@ -11,7 +11,7 @@ TID252.py:7:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:8:1: TID252 [*] Relative imports are banned
+TID252.py:8:1: TID252 Relative imports are banned
    |
  8 | # TID252
  9 | from . import sibling
@@ -22,7 +22,7 @@ TID252.py:8:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:9:1: TID252 [*] Relative imports are banned
+TID252.py:9:1: TID252 Relative imports are banned
    |
  9 | from . import sibling
 10 | from .sibling import example
@@ -33,7 +33,7 @@ TID252.py:9:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:10:1: TID252 [*] Relative imports are banned
+TID252.py:10:1: TID252 Relative imports are banned
    |
 10 | from .sibling import example
 11 | from .. import parent
@@ -44,7 +44,7 @@ TID252.py:10:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:11:1: TID252 [*] Relative imports are banned
+TID252.py:11:1: TID252 Relative imports are banned
    |
 11 | from .. import parent
 12 | from ..parent import example
@@ -55,7 +55,7 @@ TID252.py:11:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:12:1: TID252 [*] Relative imports are banned
+TID252.py:12:1: TID252 Relative imports are banned
    |
 12 | from ..parent import example
 13 | from ... import grandparent
@@ -66,7 +66,7 @@ TID252.py:12:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:13:1: TID252 [*] Relative imports are banned
+TID252.py:13:1: TID252 Relative imports are banned
    |
 13 | from ... import grandparent
 14 | from ...grandparent import example
@@ -77,7 +77,7 @@ TID252.py:13:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:14:1: TID252 [*] Relative imports are banned
+TID252.py:14:1: TID252 Relative imports are banned
    |
 14 |   from ...grandparent import example
 15 |   from  .parent import hello
@@ -90,7 +90,7 @@ TID252.py:14:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:17:1: TID252 [*] Relative imports are banned
+TID252.py:17:1: TID252 Relative imports are banned
    |
 17 |       parent import \
 18 |           hello_world
@@ -104,7 +104,7 @@ TID252.py:17:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:21:1: TID252 [*] Relative imports are banned
+TID252.py:21:1: TID252 Relative imports are banned
    |
 21 |     import \
 22 |     world_hello
@@ -115,7 +115,7 @@ TID252.py:21:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:22:1: TID252 [*] Relative imports are banned
+TID252.py:22:1: TID252 Relative imports are banned
    |
 22 |     world_hello
 23 | from ..... import ultragrantparent
@@ -126,7 +126,7 @@ TID252.py:22:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:23:1: TID252 [*] Relative imports are banned
+TID252.py:23:1: TID252 Relative imports are banned
    |
 23 | from ..... import ultragrantparent
 24 | from ...... import ultragrantparent
@@ -137,7 +137,7 @@ TID252.py:23:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:24:1: TID252 [*] Relative imports are banned
+TID252.py:24:1: TID252 Relative imports are banned
    |
 24 | from ...... import ultragrantparent
 25 | from ....... import ultragrantparent
@@ -148,7 +148,7 @@ TID252.py:24:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:25:1: TID252 [*] Relative imports are banned
+TID252.py:25:1: TID252 Relative imports are banned
    |
 25 | from ....... import ultragrantparent
 26 | from ......... import ultragrantparent
@@ -159,7 +159,7 @@ TID252.py:25:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:26:1: TID252 [*] Relative imports are banned
+TID252.py:26:1: TID252 Relative imports are banned
    |
 26 | from ......... import ultragrantparent
 27 | from ........................... import ultragrantparent
@@ -170,7 +170,7 @@ TID252.py:26:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:27:1: TID252 [*] Relative imports are banned
+TID252.py:27:1: TID252 Relative imports are banned
    |
 27 | from ........................... import ultragrantparent
 28 | from .....parent import ultragrantparent
@@ -180,7 +180,7 @@ TID252.py:27:1: TID252 [*] Relative imports are banned
    |
    = help: Replace relative imports with absolute imports
 
-TID252.py:28:1: TID252 [*] Relative imports are banned
+TID252.py:28:1: TID252 Relative imports are banned
    |
 28 | from .....parent import ultragrantparent
 29 | from .........parent import ultragrantparent

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
 ---
-TID252.py:9:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:9:1: TID252 Relative imports from parent modules are banned
    |
  9 | from . import sibling
 10 | from .sibling import example
@@ -12,7 +12,7 @@ TID252.py:9:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:10:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:10:1: TID252 Relative imports from parent modules are banned
    |
 10 | from .sibling import example
 11 | from .. import parent
@@ -23,7 +23,7 @@ TID252.py:10:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:11:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:11:1: TID252 Relative imports from parent modules are banned
    |
 11 | from .. import parent
 12 | from ..parent import example
@@ -34,7 +34,7 @@ TID252.py:11:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:12:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:12:1: TID252 Relative imports from parent modules are banned
    |
 12 | from ..parent import example
 13 | from ... import grandparent
@@ -45,7 +45,7 @@ TID252.py:12:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:17:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:17:1: TID252 Relative imports from parent modules are banned
    |
 17 |       parent import \
 18 |           hello_world
@@ -59,7 +59,7 @@ TID252.py:17:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:21:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:21:1: TID252 Relative imports from parent modules are banned
    |
 21 |     import \
 22 |     world_hello
@@ -70,7 +70,7 @@ TID252.py:21:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:22:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:22:1: TID252 Relative imports from parent modules are banned
    |
 22 |     world_hello
 23 | from ..... import ultragrantparent
@@ -81,7 +81,7 @@ TID252.py:22:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:23:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:23:1: TID252 Relative imports from parent modules are banned
    |
 23 | from ..... import ultragrantparent
 24 | from ...... import ultragrantparent
@@ -92,7 +92,7 @@ TID252.py:23:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:24:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:24:1: TID252 Relative imports from parent modules are banned
    |
 24 | from ...... import ultragrantparent
 25 | from ....... import ultragrantparent
@@ -103,7 +103,7 @@ TID252.py:24:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:25:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:25:1: TID252 Relative imports from parent modules are banned
    |
 25 | from ....... import ultragrantparent
 26 | from ......... import ultragrantparent
@@ -114,7 +114,7 @@ TID252.py:25:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:26:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:26:1: TID252 Relative imports from parent modules are banned
    |
 26 | from ......... import ultragrantparent
 27 | from ........................... import ultragrantparent
@@ -125,7 +125,7 @@ TID252.py:26:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:27:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:27:1: TID252 Relative imports from parent modules are banned
    |
 27 | from ........................... import ultragrantparent
 28 | from .....parent import ultragrantparent
@@ -135,7 +135,7 @@ TID252.py:27:1: TID252 [*] Relative imports from parent modules are banned
    |
    = help: Replace relative imports from parent modules with absolute imports
 
-TID252.py:28:1: TID252 [*] Relative imports from parent modules are banned
+TID252.py:28:1: TID252 Relative imports from parent modules are banned
    |
 28 | from .....parent import ultragrantparent
 29 | from .........parent import ultragrantparent

--- a/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
+++ b/crates/ruff/src/rules/flake8_tidy_imports/snapshots/ruff__rules__flake8_tidy_imports__relative_imports__tests__ban_parent_imports_package.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
 ---
-application.py:5:1: TID252 [*] Relative imports from parent modules are banned
+application.py:5:1: TID252 Relative imports from parent modules are banned
   |
 5 | import attrs
 6 | 

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -12,7 +12,7 @@ use ruff_python_ast::source_code::{Locator, Stylist};
 use crate::importer::Importer;
 use crate::registry::Rule;
 use crate::rules::isort::track::Block;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 /// ## What it does
 /// Adds any required imports, as specified by the user, to the top of the
@@ -92,7 +92,6 @@ fn add_required_import(
     locator: &Locator,
     stylist: &Stylist,
     settings: &Settings,
-    autofix: flags::Autofix,
     is_stub: bool,
 ) -> Option<Diagnostic> {
     // If the import is already present in a top-level block, don't add it.
@@ -119,7 +118,7 @@ fn add_required_import(
         MissingRequiredImport(required_import.to_string()),
         TextRange::default(),
     );
-    if autofix.into() && settings.rules.should_fix(Rule::MissingRequiredImport) {
+    if settings.rules.should_fix(Rule::MissingRequiredImport) {
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(
             Importer::new(python_ast, locator, stylist)
@@ -136,7 +135,6 @@ pub fn add_required_imports(
     locator: &Locator,
     stylist: &Stylist,
     settings: &Settings,
-    autofix: flags::Autofix,
     is_stub: bool,
 ) -> Vec<Diagnostic> {
     settings
@@ -178,7 +176,6 @@ pub fn add_required_imports(
                             locator,
                             stylist,
                             settings,
-                            autofix,
                             is_stub,
                         )
                     })
@@ -198,7 +195,6 @@ pub fn add_required_imports(
                             locator,
                             stylist,
                             settings,
-                            autofix,
                             is_stub,
                         )
                     })

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -5,7 +5,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::Stmt;
 use textwrap::indent;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{
     followed_by_multi_statement_line, preceded_by_multi_statement_line, trailing_lines_end,
@@ -40,14 +40,16 @@ use super::super::{comments, format_imports};
 #[violation]
 pub struct UnsortedImports;
 
-impl AlwaysAutofixableViolation for UnsortedImports {
+impl Violation for UnsortedImports {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Import block is un-sorted or un-formatted")
     }
 
-    fn autofix_title(&self) -> String {
-        "Organize imports".to_string()
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|_| "Organize imports".to_string())
     }
 }
 

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -14,7 +14,7 @@ use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 use ruff_python_ast::whitespace::leading_space;
 
 use crate::registry::AsRule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 use super::super::track::Block;
 use super::super::{comments, format_imports};
@@ -82,7 +82,6 @@ pub fn organize_imports(
     stylist: &Stylist,
     indexer: &Indexer,
     settings: &Settings,
-    autofix: flags::Autofix,
     package: Option<&Path>,
 ) -> Option<Diagnostic> {
     let indentation = locator.slice(extract_indentation_range(&block.imports, locator));
@@ -147,7 +146,7 @@ pub fn organize_imports(
         None
     } else {
         let mut diagnostic = Diagnostic::new(UnsortedImports, range);
-        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+        if settings.rules.should_fix(diagnostic.kind.rule()) {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 indent(&expected, indentation),

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__leading_prefix.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__leading_prefix.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/isort/mod.rs
 ---
-leading_prefix.py:1:8: I001 [*] Import block is un-sorted or un-formatted
+leading_prefix.py:1:8: I001 Import block is un-sorted or un-formatted
   |
 1 |   x = 1; import sys
   |  ________^
@@ -12,7 +12,7 @@ leading_prefix.py:1:8: I001 [*] Import block is un-sorted or un-formatted
   |
   = help: Organize imports
 
-leading_prefix.py:5:12: I001 [*] Import block is un-sorted or un-formatted
+leading_prefix.py:5:12: I001 Import block is un-sorted or un-formatted
   |
 5 |   if True:
 6 |       x = 1; import sys
@@ -24,7 +24,7 @@ leading_prefix.py:5:12: I001 [*] Import block is un-sorted or un-formatted
   |
   = help: Organize imports
 
-leading_prefix.py:10:9: I001 [*] Import block is un-sorted or un-formatted
+leading_prefix.py:10:9: I001 Import block is un-sorted or un-formatted
    |
 10 | if True:
 11 |     x = 1; \
@@ -35,7 +35,7 @@ leading_prefix.py:10:9: I001 [*] Import block is un-sorted or un-formatted
    |
    = help: Organize imports
 
-leading_prefix.py:13:1: I001 [*] Import block is un-sorted or un-formatted
+leading_prefix.py:13:1: I001 Import block is un-sorted or un-formatted
    |
 13 | x = 1; \
 14 | import os

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__trailing_suffix.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__trailing_suffix.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/isort/mod.rs
 ---
-trailing_suffix.py:1:1: I001 [*] Import block is un-sorted or un-formatted
+trailing_suffix.py:1:1: I001 Import block is un-sorted or un-formatted
   |
 1 | / import sys
 2 | | import os; x = 1
@@ -11,7 +11,7 @@ trailing_suffix.py:1:1: I001 [*] Import block is un-sorted or un-formatted
   |
   = help: Organize imports
 
-trailing_suffix.py:5:5: I001 [*] Import block is un-sorted or un-formatted
+trailing_suffix.py:5:5: I001 Import block is un-sorted or un-formatted
   |
 5 |   if True:
 6 |       import sys

--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -47,7 +47,6 @@ mod tests {
             &directives,
             &settings,
             flags::Noqa::Enabled,
-            flags::Autofix::Enabled,
         );
         let actual: Vec<Rule> = diagnostics
             .into_iter()

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -7,7 +7,7 @@ use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 /// ## What it does
 /// Checks for compound statements (multiple statements on the same line).
@@ -99,11 +99,7 @@ impl AlwaysAutofixableViolation for UselessSemicolon {
 }
 
 /// E701, E702, E703
-pub fn compound_statements(
-    lxr: &[LexResult],
-    settings: &Settings,
-    autofix: flags::Autofix,
-) -> Vec<Diagnostic> {
+pub fn compound_statements(lxr: &[LexResult], settings: &Settings) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
     // Track the last seen instance of a variety of tokens.
@@ -163,7 +159,7 @@ pub fn compound_statements(
                 if let Some((start, end)) = semi {
                     let mut diagnostic =
                         Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
-                    if autofix.into() && settings.rules.should_fix(Rule::UselessSemicolon) {
+                    if settings.rules.should_fix(Rule::UselessSemicolon) {
                         #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::deletion(start, end)));
                     };

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -5,7 +5,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::Line;
 
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 /// ## What it does
 /// Checks for superfluous trailing whitespace.
@@ -75,11 +75,7 @@ impl AlwaysAutofixableViolation for BlankLineWithWhitespace {
 }
 
 /// W291, W293
-pub(crate) fn trailing_whitespace(
-    line: &Line,
-    settings: &Settings,
-    autofix: flags::Autofix,
-) -> Option<Diagnostic> {
+pub(crate) fn trailing_whitespace(line: &Line, settings: &Settings) -> Option<Diagnostic> {
     let whitespace_len: TextSize = line
         .chars()
         .rev()
@@ -92,9 +88,7 @@ pub(crate) fn trailing_whitespace(
         if range == line.range() {
             if settings.rules.enabled(Rule::BlankLineWithWhitespace) {
                 let mut diagnostic = Diagnostic::new(BlankLineWithWhitespace, range);
-                if matches!(autofix, flags::Autofix::Enabled)
-                    && settings.rules.should_fix(Rule::BlankLineWithWhitespace)
-                {
+                if settings.rules.should_fix(Rule::BlankLineWithWhitespace) {
                     #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                 }
@@ -102,9 +96,7 @@ pub(crate) fn trailing_whitespace(
             }
         } else if settings.rules.enabled(Rule::TrailingWhitespace) {
             let mut diagnostic = Diagnostic::new(TrailingWhitespace, range);
-            if matches!(autofix, flags::Autofix::Enabled)
-                && settings.rules.should_fix(Rule::TrailingWhitespace)
-            {
+            if settings.rules.should_fix(Rule::TrailingWhitespace) {
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
             }

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_text_size::{TextLen, TextRange};
@@ -11,14 +11,16 @@ use crate::rules::pydocstyle::helpers::ends_with_backslash;
 #[violation]
 pub struct SurroundingWhitespace;
 
-impl AlwaysAutofixableViolation for SurroundingWhitespace {
+impl Violation for SurroundingWhitespace {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("No whitespaces allowed surrounding docstring text")
     }
 
-    fn autofix_title(&self) -> String {
-        "Trim surrounding whitespace".to_string()
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|_| "Trim surrounding whitespace".to_string())
     }
 }
 

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::str::{leading_quote, trailing_quote};
@@ -10,14 +10,16 @@ use crate::registry::AsRule;
 #[violation]
 pub struct FitsOnOneLine;
 
-impl AlwaysAutofixableViolation for FitsOnOneLine {
+impl Violation for FitsOnOneLine {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("One-line docstring should fit on one line")
     }
 
-    fn autofix_title(&self) -> String {
-        "Reformat to one line".to_string()
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|_| "Reformat to one line".to_string())
     }
 }
 

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D200_D.py.snap
@@ -73,7 +73,7 @@ D.py:606:5: D200 [*] One-line docstring should fit on one line
 610 608 | 
 611 609 | @expect('D200: One-line docstring should fit on one line with quotes '
 
-D.py:615:5: D200 [*] One-line docstring should fit on one line
+D.py:615:5: D200 One-line docstring should fit on one line
     |
 615 |   @expect('D212: Multi-line docstring summary should start at the first line')
 616 |   def one_liner():
@@ -85,7 +85,7 @@ D.py:615:5: D200 [*] One-line docstring should fit on one line
     |
     = help: Reformat to one line
 
-D.py:624:5: D200 [*] One-line docstring should fit on one line
+D.py:624:5: D200 One-line docstring should fit on one line
     |
 624 |   @expect('D212: Multi-line docstring summary should start at the first line')
 625 |   def one_liner():

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D210_D.py.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__D210_D.py.snap
@@ -62,7 +62,7 @@ D.py:299:5: D210 [*] No whitespaces allowed surrounding docstring text
 301 301 |     This is the end.
 302 302 |     """
 
-D.py:581:5: D210 [*] No whitespaces allowed surrounding docstring text
+D.py:581:5: D210 No whitespaces allowed surrounding docstring text
     |
 581 |         "or exclamation point (not '\"')")
 582 | def endswith_quote():

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -276,7 +276,6 @@ mod tests {
             &directives,
             &settings,
             flags::Noqa::Enabled,
-            flags::Autofix::Enabled,
         );
         diagnostics.sort_by_key(Diagnostic::start);
         let actual = diagnostics

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -4,7 +4,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::{ExprKind, Located, Stmt, StmtKind};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::source_code::Locator;
@@ -48,16 +48,20 @@ pub struct UnusedVariable {
     pub name: String,
 }
 
-impl AlwaysAutofixableViolation for UnusedVariable {
+impl Violation for UnusedVariable {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         let UnusedVariable { name } = self;
         format!("Local variable `{name}` is assigned to but never used")
     }
 
-    fn autofix_title(&self) -> String {
-        let UnusedVariable { name } = self;
-        format!("Remove assignment to unused variable `{name}`")
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|violation| {
+            let UnusedVariable { name } = violation;
+            format!("Remove assignment to unused variable `{name}`")
+        })
     }
 }
 

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_0.py.snap
@@ -57,7 +57,7 @@ F841_0.py:20:5: F841 [*] Local variable `foo` is assigned to but never used
 22 21 | 
 23 22 |     bar = (1, 2)
 
-F841_0.py:21:6: F841 [*] Local variable `a` is assigned to but never used
+F841_0.py:21:6: F841 Local variable `a` is assigned to but never used
    |
 21 | def f():
 22 |     foo = (1, 2)
@@ -68,7 +68,7 @@ F841_0.py:21:6: F841 [*] Local variable `a` is assigned to but never used
    |
    = help: Remove assignment to unused variable `a`
 
-F841_0.py:21:9: F841 [*] Local variable `b` is assigned to but never used
+F841_0.py:21:9: F841 Local variable `b` is assigned to but never used
    |
 21 | def f():
 22 |     foo = (1, 2)
@@ -200,7 +200,7 @@ F841_0.py:115:5: F841 [*] Local variable `Baz` is assigned to but never used
 117 117 |     match x:
 118 118 |         case (Foo.A):
 
-F841_0.py:122:14: F841 [*] Local variable `y` is assigned to but never used
+F841_0.py:122:14: F841 Local variable `y` is assigned to but never used
     |
 122 |         case [Bar.A, *_]:
 123 |             print("A")
@@ -210,7 +210,7 @@ F841_0.py:122:14: F841 [*] Local variable `y` is assigned to but never used
     |
     = help: Remove assignment to unused variable `y`
 
-F841_0.py:127:21: F841 [*] Local variable `value` is assigned to but never used
+F841_0.py:127:21: F841 Local variable `value` is assigned to but never used
     |
 127 | def f():
 128 |     if any((key := (value := x)) for x in ["ok"]):

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_1.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pyflakes/mod.rs
 ---
-F841_1.py:6:5: F841 [*] Local variable `x` is assigned to but never used
+F841_1.py:6:5: F841 Local variable `x` is assigned to but never used
   |
 6 | def f():
 7 |     x, y = 1, 2  # this triggers F841 as it's just a simple assignment where unpacking isn't needed
@@ -9,7 +9,7 @@ F841_1.py:6:5: F841 [*] Local variable `x` is assigned to but never used
   |
   = help: Remove assignment to unused variable `x`
 
-F841_1.py:6:8: F841 [*] Local variable `y` is assigned to but never used
+F841_1.py:6:8: F841 Local variable `y` is assigned to but never used
   |
 6 | def f():
 7 |     x, y = 1, 2  # this triggers F841 as it's just a simple assignment where unpacking isn't needed
@@ -53,7 +53,7 @@ F841_1.py:20:5: F841 [*] Local variable `coords` is assigned to but never used
 22 22 | 
 23 23 | def f():
 
-F841_1.py:24:6: F841 [*] Local variable `a` is assigned to but never used
+F841_1.py:24:6: F841 Local variable `a` is assigned to but never used
    |
 24 | def f():
 25 |     (a, b) = (x, y) = 1, 2  # this triggers F841 on everything
@@ -61,7 +61,7 @@ F841_1.py:24:6: F841 [*] Local variable `a` is assigned to but never used
    |
    = help: Remove assignment to unused variable `a`
 
-F841_1.py:24:9: F841 [*] Local variable `b` is assigned to but never used
+F841_1.py:24:9: F841 Local variable `b` is assigned to but never used
    |
 24 | def f():
 25 |     (a, b) = (x, y) = 1, 2  # this triggers F841 on everything
@@ -69,7 +69,7 @@ F841_1.py:24:9: F841 [*] Local variable `b` is assigned to but never used
    |
    = help: Remove assignment to unused variable `b`
 
-F841_1.py:24:15: F841 [*] Local variable `x` is assigned to but never used
+F841_1.py:24:15: F841 Local variable `x` is assigned to but never used
    |
 24 | def f():
 25 |     (a, b) = (x, y) = 1, 2  # this triggers F841 on everything
@@ -77,7 +77,7 @@ F841_1.py:24:15: F841 [*] Local variable `x` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x`
 
-F841_1.py:24:18: F841 [*] Local variable `y` is assigned to but never used
+F841_1.py:24:18: F841 Local variable `y` is assigned to but never used
    |
 24 | def f():
 25 |     (a, b) = (x, y) = 1, 2  # this triggers F841 on everything

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F841_F841_3.py.snap
@@ -156,7 +156,7 @@ F841_3.py:27:46: F841 [*] Local variable `z3` is assigned to but never used
 29 29 | 
 30 30 | 
 
-F841_3.py:32:6: F841 [*] Local variable `x1` is assigned to but never used
+F841_3.py:32:6: F841 Local variable `x1` is assigned to but never used
    |
 32 | def f():
 33 |     (x1, y1) = (1, 2)
@@ -166,7 +166,7 @@ F841_3.py:32:6: F841 [*] Local variable `x1` is assigned to but never used
    |
    = help: Remove assignment to unused variable `x1`
 
-F841_3.py:32:10: F841 [*] Local variable `y1` is assigned to but never used
+F841_3.py:32:10: F841 Local variable `y1` is assigned to but never used
    |
 32 | def f():
 33 |     (x1, y1) = (1, 2)

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__f841_dummy_variable_rgx.snap
@@ -38,7 +38,7 @@ F841_0.py:20:5: F841 [*] Local variable `foo` is assigned to but never used
 22 21 | 
 23 22 |     bar = (1, 2)
 
-F841_0.py:21:6: F841 [*] Local variable `a` is assigned to but never used
+F841_0.py:21:6: F841 Local variable `a` is assigned to but never used
    |
 21 | def f():
 22 |     foo = (1, 2)
@@ -49,7 +49,7 @@ F841_0.py:21:6: F841 [*] Local variable `a` is assigned to but never used
    |
    = help: Remove assignment to unused variable `a`
 
-F841_0.py:21:9: F841 [*] Local variable `b` is assigned to but never used
+F841_0.py:21:9: F841 Local variable `b` is assigned to but never used
    |
 21 | def f():
 22 |     foo = (1, 2)
@@ -238,7 +238,7 @@ F841_0.py:115:5: F841 [*] Local variable `Baz` is assigned to but never used
 117 117 |     match x:
 118 118 |         case (Foo.A):
 
-F841_0.py:122:14: F841 [*] Local variable `y` is assigned to but never used
+F841_0.py:122:14: F841 Local variable `y` is assigned to but never used
     |
 122 |         case [Bar.A, *_]:
 123 |             print("A")
@@ -248,7 +248,7 @@ F841_0.py:122:14: F841 [*] Local variable `y` is assigned to but never used
     |
     = help: Remove assignment to unused variable `y`
 
-F841_0.py:127:21: F841 [*] Local variable `value` is assigned to but never used
+F841_0.py:127:21: F841 Local variable `value` is assigned to but never used
     |
 127 | def f():
 128 |     if any((key := (value := x)) for x in ["ok"]):

--- a/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
@@ -171,11 +171,7 @@ impl AlwaysAutofixableViolation for InvalidCharacterZeroWidthSpace {
 }
 
 /// PLE2510, PLE2512, PLE2513, PLE2514, PLE2515
-pub fn invalid_string_characters(
-    locator: &Locator,
-    range: TextRange,
-    autofix: bool,
-) -> Vec<Diagnostic> {
+pub fn invalid_string_characters(locator: &Locator, range: TextRange) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     let text = locator.slice(range);
 
@@ -195,15 +191,10 @@ pub fn invalid_string_characters(
         let location = range.start() + TextSize::try_from(column).unwrap();
         let range = TextRange::at(location, c.text_len());
 
-        let mut diagnostic = Diagnostic::new(rule, range);
-        if autofix {
-            #[allow(deprecated)]
-            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                replacement.to_string(),
-                range,
-            )));
-        }
-        diagnostics.push(diagnostic);
+        #[allow(deprecated)]
+        diagnostics.push(Diagnostic::new(rule, range).with_fix(Fix::unspecified(
+            Edit::range_replacement(replacement.to_string(), range),
+        )));
     }
 
     diagnostics

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Expr, ExprKind, Keyword};
 
-use ruff_diagnostics::{Diagnostic, Edit, Fix, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments, unparse_expr};
 use ruff_python_semantic::context::Context;
@@ -21,6 +21,8 @@ pub struct NestedMinMax {
 }
 
 impl Violation for NestedMinMax {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Nested `{}` calls can be flattened", self.func)

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_1.py.snap
@@ -76,7 +76,7 @@ sys_exit_alias_1.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
 11 11 | 
 12 12 | def main():
 
-sys_exit_alias_1.py:15:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
+sys_exit_alias_1.py:15:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
 15 |     sys = 1
 16 | 
@@ -86,7 +86,7 @@ sys_exit_alias_1.py:15:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
    |
    = help: Replace `exit` with `sys.exit()`
 
-sys_exit_alias_1.py:16:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
+sys_exit_alias_1.py:16:5: PLR1722 Use `sys.exit()` instead of `quit`
    |
 16 |     exit(1)
 17 |     quit(1)

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_3.py.snap
@@ -38,7 +38,7 @@ sys_exit_alias_3.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
 11 11 | 
 12 12 | def main():
 
-sys_exit_alias_3.py:16:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
+sys_exit_alias_3.py:16:5: PLR1722 Use `sys.exit()` instead of `quit`
    |
 16 |     exit(1)
 17 |     quit(1)

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR1722_sys_exit_alias_5.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pylint/mod.rs
 ---
-sys_exit_alias_5.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
+sys_exit_alias_5.py:3:1: PLR1722 Use `sys.exit()` instead of `exit`
   |
 3 | from sys import *
 4 | 
@@ -11,7 +11,7 @@ sys_exit_alias_5.py:3:1: PLR1722 [*] Use `sys.exit()` instead of `exit`
   |
   = help: Replace `exit` with `sys.exit()`
 
-sys_exit_alias_5.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
+sys_exit_alias_5.py:4:1: PLR1722 Use `sys.exit()` instead of `quit`
   |
 4 | exit(0)
 5 | quit(0)
@@ -19,7 +19,7 @@ sys_exit_alias_5.py:4:1: PLR1722 [*] Use `sys.exit()` instead of `quit`
   |
   = help: Replace `quit` with `sys.exit()`
 
-sys_exit_alias_5.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
+sys_exit_alias_5.py:8:5: PLR1722 Use `sys.exit()` instead of `exit`
    |
  8 | def main():
  9 |     exit(1)
@@ -28,7 +28,7 @@ sys_exit_alias_5.py:8:5: PLR1722 [*] Use `sys.exit()` instead of `exit`
    |
    = help: Replace `exit` with `sys.exit()`
 
-sys_exit_alias_5.py:9:5: PLR1722 [*] Use `sys.exit()` instead of `quit`
+sys_exit_alias_5.py:9:5: PLR1722 Use `sys.exit()` instead of `quit`
    |
  9 | def main():
 10 |     exit(1)

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -7,7 +7,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
 use crate::registry::Rule;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 #[violation]
 pub struct ExtraneousParentheses;
@@ -121,7 +121,6 @@ pub fn extraneous_parentheses(
     tokens: &[LexResult],
     locator: &Locator,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
     let mut i = 0;
@@ -139,7 +138,7 @@ pub fn extraneous_parentheses(
                     ExtraneousParentheses,
                     TextRange::new(start_range.start(), end_range.end()),
                 );
-                if autofix.into() && settings.rules.should_fix(Rule::ExtraneousParentheses) {
+                if settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents =
                         locator.slice(TextRange::new(start_range.start(), end_range.end()));
                     #[allow(deprecated)]

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -4,7 +4,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::Expr;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -16,14 +16,16 @@ use crate::rules::pyflakes::format::FormatSummary;
 #[violation]
 pub struct FormatLiterals;
 
-impl AlwaysAutofixableViolation for FormatLiterals {
+impl Violation for FormatLiterals {
+    const AUTOFIX: AutofixKind = AutofixKind::Sometimes;
+
     #[derive_message_formats]
     fn message(&self) -> String {
         format!("Use implicit references for positional format fields")
     }
 
-    fn autofix_title(&self) -> String {
-        "Remove explicit positional indices".to_string()
+    fn autofix_title_formatter(&self) -> Option<fn(&Self) -> String> {
+        Some(|_| "Remove explicit positional indices".to_string())
     }
 }
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_0.py.snap
@@ -197,7 +197,7 @@ UP030_0.py:22:1: UP030 [*] Use implicit references for positional format fields
 24 24 | '{' '0}'.format(1)
 25 25 | 
 
-UP030_0.py:24:1: UP030 [*] Use implicit references for positional format fields
+UP030_0.py:24:1: UP030 Use implicit references for positional format fields
    |
 24 | "\N{snowman} {0}".format(1)
 25 | 
@@ -208,7 +208,7 @@ UP030_0.py:24:1: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-UP030_0.py:29:5: UP030 [*] Use implicit references for positional format fields
+UP030_0.py:29:5: UP030 Use implicit references for positional format fields
    |
 29 |   # https://github.com/Instagram/LibCST/issues/846
 30 |   print(
@@ -220,7 +220,7 @@ UP030_0.py:29:5: UP030 [*] Use implicit references for positional format fields
    |
    = help: Remove explicit positional indices
 
-UP030_0.py:34:5: UP030 [*] Use implicit references for positional format fields
+UP030_0.py:34:5: UP030 Use implicit references for positional format fields
    |
 34 |   print(
 35 |       'foo{0}'  # ohai\n"

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP030_2.py.snap
@@ -85,7 +85,7 @@ UP030_2.py:12:1: UP030 [*] Use implicit references for positional format fields
 14 14 | "{1}_{0}".format(*args)
 15 15 | 
 
-UP030_2.py:14:1: UP030 [*] Use implicit references for positional format fields
+UP030_2.py:14:1: UP030 Use implicit references for positional format fields
    |
 14 | "{0}_{1}".format(1, *args)
 15 | 

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::source_code::Locator;
 use crate::registry::AsRule;
 use crate::rules::ruff::rules::confusables::CONFUSABLES;
 use crate::rules::ruff::rules::Context;
-use crate::settings::{flags, Settings};
+use crate::settings::Settings;
 
 #[violation]
 pub struct AmbiguousUnicodeCharacterString {
@@ -98,7 +98,6 @@ pub fn ambiguous_unicode_character(
     range: TextRange,
     context: Context,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> Vec<Diagnostic> {
     let mut diagnostics = vec![];
 
@@ -135,7 +134,7 @@ pub fn ambiguous_unicode_character(
                         char_range,
                     );
                     if settings.rules.enabled(diagnostic.kind.rule()) {
-                        if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+                        if settings.rules.should_fix(diagnostic.kind.rule()) {
                             #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 (representant as char).to_string(),

--- a/crates/ruff/src/settings/flags.rs
+++ b/crates/ruff/src/settings/flags.rs
@@ -1,5 +1,3 @@
-use ruff_macros::CacheKey;
-
 #[derive(Debug, Copy, Clone, Hash)]
 pub enum FixMode {
     Generate,
@@ -14,21 +12,6 @@ impl From<bool> for FixMode {
             Self::Apply
         } else {
             Self::None
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, CacheKey, result_like::BoolLike)]
-pub enum Autofix {
-    Enabled,
-    Disabled,
-}
-
-impl From<FixMode> for Autofix {
-    fn from(value: FixMode) -> Self {
-        match value {
-            FixMode::Generate | FixMode::Diff | FixMode::Apply => Self::Enabled,
-            FixMode::None => Self::Disabled,
         }
     }
 }

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -54,7 +54,6 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
         &directives,
         settings,
         flags::Noqa::Enabled,
-        flags::Autofix::Enabled,
     );
 
     let source_has_errors = error.is_some();
@@ -105,7 +104,6 @@ pub fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Mess
                 &directives,
                 settings,
                 flags::Noqa::Enabled,
-                flags::Autofix::Enabled,
             );
 
             if let Some(fixed_error) = fixed_error {

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use itertools::Itertools;
-use ruff_diagnostics::Diagnostic;
+use ruff_diagnostics::{AutofixKind, Diagnostic};
 use rustc_hash::FxHashMap;
 use rustpython_parser::lexer::LexResult;
 
@@ -16,6 +16,7 @@ use crate::directives;
 use crate::linter::{check_path, LinterResult};
 use crate::message::{Emitter, EmitterContext, Message, TextEmitter};
 use crate::packaging::detect_package_root;
+use crate::registry::AsRule;
 use crate::rules::pycodestyle::rules::syntax_error;
 use crate::settings::{flags, Settings};
 
@@ -141,6 +142,24 @@ Source with applied fixes:
     Ok(diagnostics
         .into_iter()
         .map(|diagnostic| {
+            let rule = diagnostic.kind.rule();
+            let fixable = diagnostic.fix.is_some();
+
+            match (fixable, rule.autofixable()) {
+                (true, AutofixKind::Sometimes | AutofixKind::Always)
+                | (false, AutofixKind::None | AutofixKind::Sometimes) => {
+                    // Ok
+                }
+                (true, AutofixKind::None) => {
+                    panic!("Rule {rule:?} is marked as non-fixable but it created a fix. Change the `Violation::AUTOFIX` to either `AutofixKind::Sometimes` or `AutofixKind::Always`");
+                },
+                (false, AutofixKind::Always) => {
+                    panic!("Rule {rule:?} is marked to always-fixable but the diagnostic has no fix. Either ensure you always emit a fix or change `Violation::AUTOFIX` to either `AutofixKind::Sometimes` or `AutofixKind::None")
+                }
+            }
+
+            assert!(!(fixable && diagnostic.kind.suggestion.is_none()), "Diagnostic emitted by {rule:?} is fixable but `Violation::autofix_title` returns `None`.`");
+
             // Not strictly necessary but adds some coverage for this code path
             let noqa = directives.noqa_line_for.resolve(diagnostic.start());
 

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -61,7 +61,6 @@ fn benchmark_linter(mut group: BenchmarkGroup<WallTime>, settings: &Settings) {
                         None,
                         settings,
                         flags::Noqa::Enabled,
-                        flags::Autofix::Enabled,
                     );
 
                     // Assert that file contains no parse errors

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -9,7 +9,7 @@ use filetime::FileTime;
 use log::error;
 use path_absolutize::Absolutize;
 use ruff::message::Message;
-use ruff::settings::{flags, AllSettings, Settings};
+use ruff::settings::{AllSettings, Settings};
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_diagnostics::{DiagnosticKind, Fix};
 use ruff_python_ast::imports::ImportMap;
@@ -145,7 +145,6 @@ fn cache_key(
     package: Option<&Path>,
     metadata: &fs::Metadata,
     settings: &Settings,
-    autofix: flags::Autofix,
 ) -> u64 {
     let mut hasher = CacheKeyHasher::new();
     CARGO_PKG_VERSION.cache_key(&mut hasher);
@@ -158,7 +157,6 @@ fn cache_key(
     #[cfg(unix)]
     metadata.permissions().mode().cache_key(&mut hasher);
     settings.cache_key(&mut hasher);
-    autofix.cache_key(&mut hasher);
     hasher.finish()
 }
 
@@ -204,11 +202,10 @@ pub fn get(
     package: Option<&Path>,
     metadata: &fs::Metadata,
     settings: &AllSettings,
-    autofix: flags::Autofix,
 ) -> Option<(Vec<Message>, ImportMap)> {
     let encoded = read_sync(
         &settings.cli.cache_dir,
-        cache_key(path, package, metadata, &settings.lib, autofix),
+        cache_key(path, package, metadata, &settings.lib),
     )
     .ok()?;
     match bincode::deserialize::<CheckResult>(&encoded[..]) {
@@ -254,14 +251,13 @@ pub fn set(
     package: Option<&Path>,
     metadata: &fs::Metadata,
     settings: &AllSettings,
-    autofix: flags::Autofix,
     messages: &[Message],
     imports: &ImportMap,
 ) {
     let check_result = CheckResultRef { imports, messages };
     if let Err(e) = write_sync(
         &settings.cli.cache_dir,
-        cache_key(path, package, metadata, &settings.lib, autofix),
+        cache_key(path, package, metadata, &settings.lib),
         &bincode::serialize(&check_result).unwrap(),
     ) {
         error!("Failed to write to cache: {e:?}");
@@ -269,15 +265,9 @@ pub fn set(
 }
 
 /// Delete a value from the cache.
-pub fn del(
-    path: &Path,
-    package: Option<&Path>,
-    metadata: &fs::Metadata,
-    settings: &AllSettings,
-    autofix: flags::Autofix,
-) {
+pub fn del(path: &Path, package: Option<&Path>, metadata: &fs::Metadata, settings: &AllSettings) {
     drop(del_sync(
         &settings.cli.cache_dir,
-        cache_key(path, package, metadata, &settings.lib, autofix),
+        cache_key(path, package, metadata, &settings.lib),
     ));
 }

--- a/crates/ruff_cli/src/diagnostics.rs
+++ b/crates/ruff_cli/src/diagnostics.rs
@@ -119,9 +119,7 @@ pub fn lint_path(
         && matches!(autofix, flags::FixMode::None | flags::FixMode::Generate)
     {
         let metadata = path.metadata()?;
-        if let Some((messages, imports)) =
-            cache::get(path, package, &metadata, settings, autofix.into())
-        {
+        if let Some((messages, imports)) = cache::get(path, package, &metadata, settings) {
             debug!("Cache hit for: {}", path.display());
             return Ok(Diagnostics::new(messages, imports));
         }
@@ -172,26 +170,12 @@ pub fn lint_path(
             (result, fixed)
         } else {
             // If we fail to autofix, lint the original source code.
-            let result = lint_only(
-                &contents,
-                path,
-                package,
-                &settings.lib,
-                noqa,
-                autofix.into(),
-            );
+            let result = lint_only(&contents, path, package, &settings.lib, noqa);
             let fixed = FxHashMap::default();
             (result, fixed)
         }
     } else {
-        let result = lint_only(
-            &contents,
-            path,
-            package,
-            &settings.lib,
-            noqa,
-            autofix.into(),
-        );
+        let result = lint_only(&contents, path, package, &settings.lib, noqa);
         let fixed = FxHashMap::default();
         (result, fixed)
     };
@@ -209,20 +193,12 @@ pub fn lint_path(
 
         // Purge the cache.
         if let Some(metadata) = metadata {
-            cache::del(path, package, &metadata, settings, autofix.into());
+            cache::del(path, package, &metadata, settings);
         }
     } else {
         // Re-populate the cache.
         if let Some(metadata) = metadata {
-            cache::set(
-                path,
-                package,
-                &metadata,
-                settings,
-                autofix.into(),
-                &messages,
-                &imports,
-            );
+            cache::set(path, package, &metadata, settings, &messages, &imports);
         }
     }
 
@@ -305,7 +281,6 @@ pub fn lint_stdin(
                 package,
                 settings,
                 noqa,
-                autofix.into(),
             );
             let fixed = FxHashMap::default();
 
@@ -323,7 +298,6 @@ pub fn lint_stdin(
             package,
             settings,
             noqa,
-            autofix.into(),
         );
         let fixed = FxHashMap::default();
         (result, fixed)

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -118,7 +118,7 @@ impl Printer {
                     let num_fixable = diagnostics
                         .messages
                         .iter()
-                        .filter(|message| !message.fix.is_empty())
+                        .filter(|message| message.fix.is_some())
                         .count();
                     if num_fixable > 0 {
                         writeln!(
@@ -236,7 +236,7 @@ impl Printer {
                 (
                     message.kind.rule(),
                     &message.kind.body,
-                    !message.fix.is_empty(),
+                    message.fix.is_some(),
                 )
             })
             .sorted()

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -118,7 +118,7 @@ impl Printer {
                     let num_fixable = diagnostics
                         .messages
                         .iter()
-                        .filter(|message| message.kind.fixable)
+                        .filter(|message| !message.fix.is_empty())
                         .count();
                     if num_fixable > 0 {
                         writeln!(
@@ -236,7 +236,7 @@ impl Printer {
                 (
                     message.kind.rule(),
                     &message.kind.body,
-                    message.kind.fixable,
+                    !message.fix.is_empty(),
                 )
             })
             .sorted()

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -16,8 +16,6 @@ pub struct DiagnosticKind {
     pub body: String,
     /// The message to display to the user, to explain the suggested fix.
     pub suggestion: Option<String>,
-    /// Whether the diagnostic is automatically fixable.
-    pub fixable: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/ruff_macros/src/violation.rs
+++ b/crates/ruff_macros/src/violation.rs
@@ -59,7 +59,6 @@ pub fn violation(violation: &ItemStruct) -> Result<TokenStream> {
 
                     Self {
                         body: Violation::message(&value),
-                        fixable: value.autofix_title_formatter().is_some(),
                         suggestion: value.autofix_title_formatter().map(|f| f(&value)),
                         name: stringify!(#ident).to_string(),
                     }
@@ -83,7 +82,6 @@ pub fn violation(violation: &ItemStruct) -> Result<TokenStream> {
 
                     Self {
                         body: Violation::message(&value),
-                        fixable: value.autofix_title_formatter().is_some(),
                         suggestion: value.autofix_title_formatter().map(|f| f(&value)),
                         name: stringify!(#ident).to_string(),
                     }

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -198,7 +198,6 @@ pub fn check(contents: &str, options: JsValue) -> Result<JsValue, JsValue> {
         &directives,
         &settings,
         flags::Noqa::Enabled,
-        flags::Autofix::Enabled,
     );
 
     let source_code = locator.to_source_code();


### PR DESCRIPTION
This PR removes `autofx` and instead always generates the fixes. This allows us to rely on `fix.is_empty` (or `fix.is_some` after #4198) to determine whether a violation is fixable. 

This will also allow us to always render the fix suggestions in the future. 

I fixed a few violations that incorrectly returned an autofix title even when the violation wasn't fixable or the other way around. 

## Are you sure?

Not entirely. Having the functionality to conditionally generate `Fix`es seems useful. For example, we could avoid generating fixes when we've seen a suppression comment, or if we've seen a large number of `Diagnostic`s and aren't running in verbose mode. I think we can still support this by consistently using `checker.patch` or refactor our rules into two: 

* Part 1: Generates the `Violations`
* Part 2: Creates the fixes (code actions) when necessary

This would have the added advantage that code authors don't need to know when to emit fixes (not as today) and are instead guided by the infrastructure/API.

## Performance

This change slightly regresses performance for projects with many (500k) diagnostics. 

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 220.9 ± 3.2 | 216.8 | 226.8 | 1.15 ± 0.03 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache  ` | 221.1 ± 3.5 | 216.3 | 226.5 | 1.15 ± 0.03 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 1544.1 ± 27.6 | 1492.2 | 1586.2 | 8.04 ± 0.23 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL ` | 1482.7 ± 22.2 | 1454.3 | 1529.2 | 7.72 ± 0.21 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache   -s` | 192.1 ± 4.4 | 185.0 | 200.0 | 1.00 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache   -s` | 193.7 ± 10.2 | 187.3 | 228.7 | 1.01 ± 0.06 |
| `./target/release/ruff ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL  -s` | 1302.3 ± 25.2 | 1262.6 | 1334.4 | 6.78 ± 0.20 |
| `./ruff-main ./crates/ruff/resources/test/cpython/ -e --no-cache --select=ALL  -s` | 1241.5 ± 20.3 | 1220.6 | 1280.7 | 6.46 ± 0.18 |
