### PR TITLE
Fix jemalloc page size on aarch64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -191,6 +191,8 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
+            # see https://github.com/charliermarsh/ruff/issues/3791
+            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,10 @@ jobs:
         with:
           target: x86_64
           args: --release --out dist --sdist
-      - name: "Install built wheel - x86_64"
+      - name: "Test wheel - x86_64"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -68,9 +69,10 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           args: --release --universal2 --out dist
-      - name: "Install built wheel - universal2"
+      - name: "Test wheel - universal2"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
+          ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -113,11 +115,12 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-      - name: "Install built wheel"
+      - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
         run: |
           python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -158,10 +161,11 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: auto
           args: --release --out dist
-      - name: "Install built wheel"
+      - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -187,6 +191,7 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
           - target: s390x-unknown-linux-gnu
@@ -195,6 +200,7 @@ jobs:
             arch: ppc64le
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -207,10 +213,11 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           manylinux: auto
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --out dist
       - uses: uraimo/run-on-arch-action@v2
         if: matrix.platform.arch != 'ppc64'
-        name: Install built wheel
+        name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
           distro: ubuntu20.04
@@ -221,6 +228,7 @@ jobs:
             pip3 install -U pip
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -260,7 +268,7 @@ jobs:
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
           args: --release --out dist
-      - name: "Install built wheel"
+      - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: addnab/docker-run-action@v3
         with:
@@ -269,6 +277,7 @@ jobs:
           run: |
             apk add py3-pip
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
+            ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:
@@ -294,8 +303,10 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-musl
             arch: aarch64
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-musleabihf
             arch: armv7
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -309,8 +320,9 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
           args: --release --out dist
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
       - uses: uraimo/run-on-arch-action@v2
-        name: Install built wheel
+        name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
           distro: alpine_latest
@@ -319,6 +331,7 @@ jobs:
             apk add py3-pip
           run: |
             pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            ruff check --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This pr sets the jemalloc large page size on aarch64 to fix a panic during start.

I changed the `Install wheel` step to a `Test wheel` step that installs the wheel and runs `ruff --help`. Just to make sure we never publish something that's installable but doesn't run at all.

## Test Plan

* I triggered a [run](https://github.com/charliermarsh/ruff/actions/runs/4895523055/jobs/8741206236) that uses a page size of three and verified that it fails (ensures that it uses the environment variable)
* I triggered a [run](https://github.com/charliermarsh/ruff/actions/runs/4895642681/jobs/8741465153) that uses the correct page size of 16


@v1c77 Would you mind downloading the [binaries](https://github.com/charliermarsh/ruff/suites/12705945862/artifacts/682048513) from the GitHub Action run, try to run the aarch64 (musl or non musl) binary, and let me know if it runs on your machine?

