### PR TITLE
Consider Flask app logger as logger candidate

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
+++ b/crates/ruff/resources/test/fixtures/flake8_logging_format/G001.py
@@ -7,3 +7,12 @@ foo.info("Hello {}".format("World!"))
 logging.log(logging.INFO, msg="Hello {}".format("World!"))
 logging.log(level=logging.INFO, msg="Hello {}".format("World!"))
 logging.log(msg="Hello {}".format("World!"), level=logging.INFO)
+
+# Flask support
+import flask
+from flask import current_app
+from flask import current_app as app
+
+flask.current_app.logger.info("Hello {}".format("World!"))
+current_app.logger.info("Hello {}".format("World!"))
+app.logger.log(logging.INFO, "Hello {}".format("World!"))

--- a/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
+++ b/crates/ruff/src/rules/flake8_logging_format/snapshots/ruff__rules__flake8_logging_format__tests__G001.py.snap
@@ -55,6 +55,34 @@ G001.py:9:17: G001 Logging statement uses `string.format()`
 10 | logging.log(level=logging.INFO, msg="Hello {}".format("World!"))
 11 | logging.log(msg="Hello {}".format("World!"), level=logging.INFO)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ G001
+12 | 
+13 | # Flask support
+   |
+
+G001.py:16:31: G001 Logging statement uses `string.format()`
+   |
+16 | from flask import current_app as app
+17 | 
+18 | flask.current_app.logger.info("Hello {}".format("World!"))
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ G001
+19 | current_app.logger.info("Hello {}".format("World!"))
+20 | app.logger.log(logging.INFO, "Hello {}".format("World!"))
+   |
+
+G001.py:17:25: G001 Logging statement uses `string.format()`
+   |
+17 | flask.current_app.logger.info("Hello {}".format("World!"))
+18 | current_app.logger.info("Hello {}".format("World!"))
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ G001
+19 | app.logger.log(logging.INFO, "Hello {}".format("World!"))
+   |
+
+G001.py:18:30: G001 Logging statement uses `string.format()`
+   |
+18 | flask.current_app.logger.info("Hello {}".format("World!"))
+19 | current_app.logger.info("Hello {}".format("World!"))
+20 | app.logger.log(logging.INFO, "Hello {}".format("World!"))
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ G001
    |
 
 

--- a/crates/ruff_python_semantic/src/analyze/logging.rs
+++ b/crates/ruff_python_semantic/src/analyze/logging.rs
@@ -19,7 +19,7 @@ use crate::context::Context;
 pub fn is_logger_candidate(context: &Context, func: &Expr) -> bool {
     if let ExprKind::Attribute { value, .. } = &func.node {
         let Some(call_path) = (if let Some(call_path) = context.resolve_call_path(value) {
-            if call_path.first().map_or(false, |module| *module == "logging") {
+            if call_path.first().map_or(false, |module| *module == "logging") || call_path.as_slice() == ["flask", "current_app", "logger"] {
                 Some(call_path)
             } else {
                 None


### PR DESCRIPTION
For future reference, the logger can also be invoked directly through the `app` variable as mentioned below. But, this requires type inference.

```python
from flask import Flask

app = Flask(__name__)
app.logger.info("...")
```

fixes: #4251