### PR TITLE
Add .git-rewrite folder to default ignored folder paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ exclude = [
     ".direnv",
     ".eggs",
     ".git",
+    ".git-rewrite",
     ".hg",
     ".mypy_cache",
     ".nox",

--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -38,6 +38,7 @@ pub static EXCLUDE: Lazy<Vec<FilePattern>> = Lazy::new(|| {
         FilePattern::Builtin(".direnv"),
         FilePattern::Builtin(".eggs"),
         FilePattern::Builtin(".git"),
+        FilePattern::Builtin(".git-rewrite"),
         FilePattern::Builtin(".hg"),
         FilePattern::Builtin(".mypy_cache"),
         FilePattern::Builtin(".nox"),

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -71,7 +71,7 @@ pub struct Options {
     /// default expression matches `_`, `__`, and `_var`, but not `_var_`.
     pub dummy_variable_rgx: Option<String>,
     #[option(
-        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
+        default = r#"[".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "build", "dist", "node_modules", "venv"]"#,
         value_type = "list[str]",
         example = r#"
             exclude = [".venv"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ exclude = [
     ".direnv",
     ".eggs",
     ".git",
+    ".git-rewrite",
     ".hg",
     ".mypy_cache",
     ".nox",
@@ -303,7 +304,7 @@ extend = "../pyproject.toml"
 line-length = 100
 ```
 
-All of the above rules apply equivalently to `ruff.toml` and `.ruff.toml`  files. If Ruff detects
+All of the above rules apply equivalently to `ruff.toml` and `.ruff.toml` files. If Ruff detects
 multiple configuration files in the same directory, the `.ruff.toml` file will take precedence over
 the `ruff.toml` file, and the `ruff.toml` file will take precedence over the `pyproject.toml` file.
 


### PR DESCRIPTION
The .git-rewrite folder is generated by the git-filter-branch command, and very unlikely to be something ruff wants to touch.

git-filter-branch is a git command which allows running commands over an entire git history. ruff is a good candidate for the type of commands that may be run, so it's sensible to add this in the defaults.

See git-filter-branch(1) for more info