### PR TITLE
Avoid `D403` if first char cannot be uppercased

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/D403.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/D403.py
@@ -13,3 +13,6 @@ def another_function():
 
 def utf8_function():
     """éste docstring is capitalized."""
+
+def uppercase_char_not_possible():
+    """'args' is not capitalized."""

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -59,6 +59,15 @@ pub fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     if first_char.is_uppercase() {
         return;
     };
+    if first_char
+        .to_uppercase()
+        .next()
+        .map_or(false, |uppercase_first_char| {
+            uppercase_first_char == first_char
+        })
+    {
+        return;
+    }
 
     let capitalized_word = first_char.to_uppercase().to_string() + first_word_chars.as_str();
 


### PR DESCRIPTION
fixes: #4280 