### PR TITLE
u32-backed OneIndexed

### DIFF
--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -55,8 +55,9 @@ impl Display for Diff<'_> {
             .map(|op| (op.old_range().start, op.new_range().start))
             .unwrap_or_default();
 
-        let digit_with =
-            calculate_print_width(OneIndexed::from_zero_indexed(largest_new.max(largest_old)));
+        let digit_with = calculate_print_width(
+            OneIndexed::try_from_zero_indexed(largest_new.max(largest_old)).unwrap(),
+        );
 
         for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
             if idx > 0 {
@@ -72,8 +73,12 @@ impl Display for Diff<'_> {
 
                     let line_style = LineStyle::from(change.tag());
 
-                    let old_index = change.old_index().map(OneIndexed::from_zero_indexed);
-                    let new_index = change.new_index().map(OneIndexed::from_zero_indexed);
+                    let old_index = change
+                        .old_index()
+                        .map(|i| OneIndexed::try_from_zero_indexed(i).unwrap());
+                    let new_index = change
+                        .new_index()
+                        .map(|i| OneIndexed::try_from_zero_indexed(i).unwrap());
 
                     write!(
                         f,

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -5,7 +5,7 @@ use ruff_python_ast::source_code::{OneIndexed, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
 use std::fmt::{Display, Formatter};
-use std::num::NonZeroUsize;
+use std::num::NonZeroU32;
 
 /// Renders a diff that shows the code fixes.
 ///
@@ -158,7 +158,7 @@ impl From<ChangeTag> for LineStyle {
 
 struct Line {
     index: Option<OneIndexed>,
-    width: NonZeroUsize,
+    width: NonZeroU32,
 }
 
 impl Display for Line {
@@ -170,13 +170,13 @@ impl Display for Line {
                 }
                 Ok(())
             }
-            Some(idx) => write!(f, "{:<width$}", idx, width = self.width.get()),
+            Some(idx) => write!(f, "{:<width$}", idx, width = self.width.get() as usize),
         }
     }
 }
 
 /// Calculate the length of the string representation of `value`
-pub(super) fn calculate_print_width(mut value: OneIndexed) -> NonZeroUsize {
+pub(super) fn calculate_print_width(mut value: OneIndexed) -> NonZeroU32 {
     const TEN: OneIndexed = OneIndexed::from_zero_indexed(9);
 
     let mut width = OneIndexed::ONE;
@@ -187,4 +187,10 @@ pub(super) fn calculate_print_width(mut value: OneIndexed) -> NonZeroUsize {
     }
 
     width
+}
+
+/// Calculate the length of the padding to print string representation of `value`
+pub(super) fn calculate_padding_width(length: NonZeroU32, value: OneIndexed) -> usize {
+    let padding = length.get() - calculate_print_width(value).get();
+    padding as _
 }

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -184,7 +184,7 @@ impl Display for Line {
 pub(super) fn calculate_print_width(mut value: OneIndexed) -> NonZeroU32 {
     const TEN: OneIndexed = OneIndexed::from_zero_indexed(9);
 
-    let mut width = OneIndexed::ONE;
+    let mut width = NonZeroU32::new(1).unwrap();
 
     while value >= TEN {
         value = OneIndexed::new(value.get() / 10).unwrap_or(OneIndexed::MIN);

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -105,11 +105,11 @@ impl Display for DisplayGroupedMessage<'_> {
             write!(
                 f,
                 "cell {cell}{sep}",
-                cell = jupyter_index.row_to_cell[start_location.row.to_one_indexed()],
+                cell = jupyter_index.row_to_cell[start_location.row.to_usize()],
                 sep = ":".cyan()
             )?;
             (
-                jupyter_index.row_to_row_in_cell[start_location.row.to_one_indexed()],
+                jupyter_index.row_to_row_in_cell[start_location.row.to_usize()],
                 start_location.column.get(),
             )
         } else {

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -96,7 +96,7 @@ impl Serialize for ExpandedEdits<'_> {
 fn to_zero_indexed_column(location: &SourceLocation) -> Value {
     json!({
         "row": location.row,
-        "column": location.column.to_zero_indexed()
+        "column": location.column.to_zero_indexed_usize()
     })
 }
 

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -71,13 +71,13 @@ impl Emitter for TextEmitter {
                     write!(
                         writer,
                         "cell {cell}{sep}",
-                        cell = jupyter_index.row_to_cell[start_location.row.get()],
+                        cell = jupyter_index.row_to_cell[start_location.row.to_one_indexed()],
                         sep = ":".cyan(),
                     )?;
 
                     SourceLocation {
                         row: OneIndexed::new(
-                            jupyter_index.row_to_row_in_cell[start_location.row.get()] as usize,
+                            jupyter_index.row_to_row_in_cell[start_location.row.to_one_indexed()],
                         )
                         .unwrap(),
                         column: start_location.column,
@@ -219,7 +219,7 @@ impl Display for MessageCodeFrame<'_> {
             title: None,
             slices: vec![Slice {
                 source: &source.text,
-                line_start: content_start_index.get(),
+                line_start: content_start_index.to_one_indexed(),
                 annotations: vec![SourceAnnotation {
                     label: &label,
                     annotation_type: AnnotationType::Error,

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -71,13 +71,13 @@ impl Emitter for TextEmitter {
                     write!(
                         writer,
                         "cell {cell}{sep}",
-                        cell = jupyter_index.row_to_cell[start_location.row.to_one_indexed()],
+                        cell = jupyter_index.row_to_cell[start_location.row.to_usize()],
                         sep = ":".cyan(),
                     )?;
 
                     SourceLocation {
                         row: OneIndexed::new(
-                            jupyter_index.row_to_row_in_cell[start_location.row.to_one_indexed()],
+                            jupyter_index.row_to_row_in_cell[start_location.row.to_usize()],
                         )
                         .unwrap(),
                         column: start_location.column,
@@ -188,7 +188,7 @@ impl Display for MessageCodeFrame<'_> {
         let content_end_index = source_code.line_index(range.end());
         let mut end_index = content_end_index
             .saturating_add(2)
-            .min(OneIndexed::from_zero_indexed(source_code.line_count()));
+            .min(OneIndexed::try_from_zero_indexed(source_code.line_count()).unwrap());
 
         // Trim trailing empty lines
         while end_index > content_end_index {
@@ -219,7 +219,7 @@ impl Display for MessageCodeFrame<'_> {
             title: None,
             slices: vec![Slice {
                 source: &source.text,
-                line_start: content_start_index.to_one_indexed(),
+                line_start: content_start_index.to_usize(),
                 annotations: vec![SourceAnnotation {
                     label: &label,
                     annotation_type: AnnotationType::Error,

--- a/crates/ruff_python_ast/src/source_code/line_index.rs
+++ b/crates/ruff_python_ast/src/source_code/line_index.rs
@@ -268,7 +268,7 @@ impl OneIndexed {
     /// The largest value that can be represented by this integer type
     pub const MAX: Self = unwrap(Self::new(u32::MAX));
 
-    pub const ONE: NonZeroU32 = unwrap(NonZeroU32::new(1));
+    const ONE: NonZeroU32 = unwrap(NonZeroU32::new(1));
 
     /// Creates a non-zero if the given value is not zero.
     pub const fn new(value: u32) -> Option<Self> {


### PR DESCRIPTION
I tried to minimize diagnostic side code changes.

The key change of interface is `to_one_indexed`. By adding this method, the interface consistently requires to use `one_indexed` or `zero_indexed` to convert `OneIndexed` to usize or vice versa.