### PR TITLE
Specify exact command in incorrect parentheses suggestion

### DIFF
--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_default.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_default.snap
@@ -8,7 +8,7 @@ PT001.py:9:2: PT001 [*] Use `@pytest.fixture()` over `@pytest.fixture`
 10 | def no_parentheses():
 11 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Suggested fix
 6  6  | # `import pytest`
@@ -27,7 +27,7 @@ PT001.py:34:2: PT001 [*] Use `@pytest.fixture()` over `@pytest.fixture`
 35 | def imported_from_no_parentheses():
 36 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Suggested fix
 31 31 | # `from pytest import fixture`
@@ -46,7 +46,7 @@ PT001.py:59:2: PT001 [*] Use `@pytest.fixture()` over `@pytest.fixture`
 60 | def aliased_no_parentheses():
 61 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Add parentheses
 
 ℹ Suggested fix
 56 56 | # `from pytest import fixture as aliased`

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_no_parentheses.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT001_no_parentheses.snap
@@ -8,7 +8,7 @@ PT001.py:14:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 15 | def parentheses_no_params():
 16 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 11 11 |     return 42
@@ -30,7 +30,7 @@ PT001.py:24:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 27 |   def parentheses_no_params_multiline():
 28 |       return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 21 21 |     return 42
@@ -51,7 +51,7 @@ PT001.py:39:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 40 | def imported_from_parentheses_no_params():
 41 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 36 36 |     return 42
@@ -73,7 +73,7 @@ PT001.py:49:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 52 |   def imported_from_parentheses_no_params_multiline():
 53 |       return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 46 46 |     return 42
@@ -94,7 +94,7 @@ PT001.py:64:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 65 | def aliased_parentheses_no_params():
 66 |     return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 61 61 |     return 42
@@ -116,7 +116,7 @@ PT001.py:74:2: PT001 [*] Use `@pytest.fixture` over `@pytest.fixture()`
 77 |   def aliased_parentheses_no_params_multiline():
 78 |       return 42
    |
-   = help: Add/remove parentheses
+   = help: Remove parentheses
 
 ℹ Suggested fix
 71 71 |     return 42


### PR DESCRIPTION
We now specify whether the parentheses should be added or removed, rather than using a generic message.