### PR TITLE
Add `Applicability` to `Fix`

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -108,6 +108,7 @@ mod tests {
     use crate::autofix::apply_fixes;
     use crate::rules::pycodestyle::rules::MissingNewlineAtEndOfFile;
 
+    #[allow(deprecated)]
     fn create_diagnostics(edit: impl IntoIterator<Item = Edit>) -> Vec<Diagnostic> {
         edit.into_iter()
             .map(|edit| Diagnostic {

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -5340,7 +5340,9 @@ impl<'a> Checker<'a> {
                         if matches!(child.node, StmtKind::ImportFrom { .. }) {
                             diagnostic.set_parent(child.start());
                         }
+
                         if let Some(edit) = &fix {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(edit.clone()));
                         }
                         diagnostics.push(diagnostic);

--- a/crates/ruff/src/checkers/noqa.rs
+++ b/crates/ruff/src/checkers/noqa.rs
@@ -180,6 +180,7 @@ pub fn check_noqa(
                                     locator,
                                 ));
                             } else {
+                                #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     format!("# noqa: {}", valid_codes.join(", ")),
                                     *range,

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -1,6 +1,6 @@
 use crate::message::Message;
 use colored::{Color, ColoredString, Colorize, Styles};
-use ruff_diagnostics::Fix;
+use ruff_diagnostics::{Fix, Applicability};
 use ruff_python_ast::source_code::{OneIndexed, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
@@ -47,8 +47,14 @@ impl Display for Diff<'_> {
 
         let diff = TextDiff::from_lines(self.source_code.source_text(), &output);
 
-        writeln!(f, "{}", "ℹ Suggested fix".blue())?;
-
+        let message = match self.fix.applicability() {
+            Applicability::Automatic => "Fix",
+            Applicability::Suggested => "Suggested fix",
+            Applicability::Manual => "Possible fix",
+            _ => "Suggested fix",  // For backwards compatibility, unspecified fixes are 'suggested'
+        };
+        writeln!(f, "ℹ {}", message.blue())?;
+        
         let (largest_old, largest_new) = diff
             .ops()
             .last()

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -51,7 +51,7 @@ impl Display for Diff<'_> {
             Applicability::Automatic => "Fix",
             Applicability::Suggested => "Suggested fix",
             Applicability::Manual => "Possible fix",
-            _ => "Suggested fix", // For backwards compatibility, unspecified fixes are 'suggested'
+            Applicability::Unspecified => "Suggested fix", // For backwards compatibility, unspecified fixes are 'suggested'
         };
         writeln!(f, "ℹ {}", message.blue())?;
 

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -1,6 +1,6 @@
 use crate::message::Message;
 use colored::{Color, ColoredString, Colorize, Styles};
-use ruff_diagnostics::{Fix, Applicability};
+use ruff_diagnostics::{Applicability, Fix};
 use ruff_python_ast::source_code::{OneIndexed, SourceFile};
 use ruff_text_size::{TextRange, TextSize};
 use similar::{ChangeTag, TextDiff};
@@ -51,10 +51,10 @@ impl Display for Diff<'_> {
             Applicability::Automatic => "Fix",
             Applicability::Suggested => "Suggested fix",
             Applicability::Manual => "Possible fix",
-            _ => "Suggested fix",  // For backwards compatibility, unspecified fixes are 'suggested'
+            _ => "Suggested fix", // For backwards compatibility, unspecified fixes are 'suggested'
         };
         writeln!(f, "ℹ {}", message.blue())?;
-        
+
         let (largest_old, largest_new) = diff
             .ops()
             .last()

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -185,6 +185,7 @@ def fibonacci(n):
 
         let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
 
+        #[allow(deprecated)]
         let unused_variable = Diagnostic::new(
             UnusedVariable {
                 name: "x".to_string(),

--- a/crates/ruff/src/rules/eradicate/rules.rs
+++ b/crates/ruff/src/rules/eradicate/rules.rs
@@ -57,7 +57,9 @@ pub fn commented_out_code(
     // Verify that the comment is on its own line, and that it contains code.
     if is_standalone_comment(line) && comment_contains_code(line, &settings.task_tags[..]) {
         let mut diagnostic = Diagnostic::new(CommentedOutCode, range);
+
         if autofix.into() && settings.rules.should_fix(Rule::CommentedOutCode) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                 locator.full_lines_range(range),
             )));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -63,6 +63,7 @@ pub fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg: Option
 
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_stmt(&assertion_error(msg), checker.stylist),
             stmt.range(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -96,6 +96,7 @@ fn duplicate_handler_exceptions<'a>(
                 expr.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if unique_elts.len() == 1 {
                         unparse_expr(unique_elts[0], checker.stylist)

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -64,6 +64,7 @@ pub fn getattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     let mut diagnostic = Diagnostic::new(GetAttrWithConstant, expr.range());
 
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&attribute(obj, value), checker.stylist),
             expr.range(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -47,6 +47,7 @@ pub fn redundant_tuple_in_exception_handler(checker: &mut Checker, handlers: &[E
             type_.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(elt, checker.stylist),
                 type_.range(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -79,6 +79,7 @@ pub fn setattr_with_constant(checker: &mut Checker, expr: &Expr, func: &Expr, ar
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());
 
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     assignment(obj, name, value, checker.stylist),
                     expr.range(),

--- a/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/unused_loop_control_variable.rs
@@ -169,6 +169,7 @@ pub fn unused_loop_control_variable(checker: &mut Checker, target: &Expr, body: 
                 if let Some(binding) = binding {
                     if binding.kind.is_loop_var() {
                         if !binding.used() {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 rename,
                                 expr.range(),

--- a/crates/ruff/src/rules/flake8_commas/rules.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules.rs
@@ -325,6 +325,7 @@ pub fn trailing_commas(
             let comma = prev.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
             if autofix.into() && settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(diagnostic.range())));
             }
             diagnostics.push(diagnostic);
@@ -365,6 +366,7 @@ pub fn trailing_commas(
                 // removing any brackets in the same linter pass - doing both at the same time could
                 // lead to a syntax error.
                 let contents = locator.slice(missing_comma.1);
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     format!("{contents},"),
                     missing_comma.1,

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -203,6 +203,7 @@ fn generate_fix(stylist: &Stylist, stmt: &Stmt, exc_arg: &Expr, indentation: &st
         }),
         stylist,
     );
+    #[allow(deprecated)]
     Fix::unspecified_edits(
         Edit::insertion(
             format!(

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_whitespace.rs
@@ -32,6 +32,7 @@ pub fn shebang_whitespace(
                 TextRange::at(range.start(), *n_spaces),
             );
             if autofix {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     range.start(),
                     *n_spaces,

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -171,6 +171,7 @@ pub fn logging_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords:
             {
                 let mut diagnostic = Diagnostic::new(LoggingWarn, level_call_range);
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         "warning".to_string(),
                         level_call_range,

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -137,7 +137,6 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = trailing_comment_start_offset(pass_stmt, checker.locator) {
                         #[allow(deprecated)]
-                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                             pass_stmt.range().add_end(index),
                         )));

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -136,6 +136,8 @@ pub fn no_unnecessary_pass(checker: &mut Checker, body: &[Stmt]) {
                 let mut diagnostic = Diagnostic::new(UnnecessaryPass, pass_stmt.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     if let Some(index) = trailing_comment_start_offset(pass_stmt, checker.locator) {
+                        #[allow(deprecated)]
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                             pass_stmt.range().add_end(index),
                         )));
@@ -417,7 +419,7 @@ pub fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                         })
                         .collect(),
                 });
-
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.range(),
@@ -443,6 +445,7 @@ pub fn reimplemented_list_builtin(checker: &mut Checker, expr: &Expr) {
             if elts.is_empty() {
                 let mut diagnostic = Diagnostic::new(ReimplementedListBuiltin, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         "list".to_string(),
                         expr.range(),

--- a/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -77,6 +77,7 @@ fn traverse_union<'a>(
             };
 
             // Replace the parent with its non-duplicate child.
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     if expr.node == left.node { right } else { left },

--- a/crates/ruff/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -23,6 +23,7 @@ impl AlwaysAutofixableViolation for QuotedAnnotationInStub {
 pub fn quoted_annotation_in_stub(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotationInStub, range);
     if checker.patch(Rule::QuotedAnnotationInStub) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             annotation.to_string(),
             range,

--- a/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/simple_defaults.rs
@@ -298,6 +298,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
@@ -324,6 +325,7 @@ pub fn typed_argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(TypedArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
@@ -353,6 +355,7 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
@@ -379,6 +382,7 @@ pub fn argument_simple_defaults(checker: &mut Checker, args: &Arguments) {
                             Diagnostic::new(ArgumentDefaultInStub, default.range());
 
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "...".to_string(),
                                 default.range(),
@@ -410,6 +414,7 @@ pub fn assignment_default_in_stub(checker: &mut Checker, targets: &[Expr], value
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "...".to_string(),
             value.range(),
@@ -440,6 +445,7 @@ pub fn annotated_assignment_default_in_stub(
 
     let mut diagnostic = Diagnostic::new(AssignmentDefaultInStub, value.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "...".to_string(),
             value.range(),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -204,6 +204,8 @@ pub fn unittest_assertion(
                 );
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
+                        #[allow(deprecated)]
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_stmt(&stmt, checker.stylist),
                             expr.range(),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -205,7 +205,6 @@ pub fn unittest_assertion(
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
                         #[allow(deprecated)]
-                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_stmt(&stmt, checker.stylist),
                             expr.range(),

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -292,6 +292,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 && args.is_empty()
                 && keywords.is_empty()
             {
+                #[allow(deprecated)]
                 let fix = Fix::unspecified(Edit::deletion(func.end(), decorator.end()));
                 pytest_fixture_parentheses(
                     checker,
@@ -354,6 +355,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
                 && checker.settings.flake8_pytest_style.fixture_parentheses
             {
+                #[allow(deprecated)]
                 let fix = Fix::unspecified(Edit::insertion(
                     Parentheses::Empty.to_string(),
                     decorator.end(),
@@ -423,6 +425,7 @@ fn check_fixture_returns(checker: &mut Checker, stmt: &Stmt, name: &str, body: &
                             stmt.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 "return".to_string(),
                                 TextRange::at(stmt.start(), "yield".text_len()),
@@ -495,6 +498,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let range = checker.locator.full_lines_range(expr.range());
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                 }
                 checker.diagnostics.push(diagnostic);
@@ -511,6 +515,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
                     let line_range = checker.locator.full_lines_range(expr.range());
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(line_range)));
                 }
                 checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -84,12 +84,14 @@ fn check_mark_parentheses(checker: &mut Checker, decorator: &Expr, call_path: &C
                 && args.is_empty()
                 && keywords.is_empty()
             {
+                #[allow(deprecated)]
                 let fix = Fix::unspecified(Edit::deletion(func.end(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "", "()");
             }
         }
         _ => {
             if checker.settings.flake8_pytest_style.mark_parentheses {
+                #[allow(deprecated)]
                 let fix = Fix::unspecified(Edit::insertion("()".to_string(), decorator.end()));
                 pytest_mark_parentheses(checker, decorator, call_path, fix, "()", "");
             }
@@ -113,6 +115,7 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr, call_path:
     if !has_parameters {
         let mut diagnostic = Diagnostic::new(PytestUseFixturesWithoutParameters, decorator.range());
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(
                 decorator.range().sub_start(TextSize::from(1)),
             )));

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -148,6 +148,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             name_range,
                         );
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 format!(
                                     "({})",
@@ -181,6 +182,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             name_range,
                         );
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
@@ -222,6 +224,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             expr.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 unparse_expr(
                                     &create_expr(ExprKind::List {
@@ -244,6 +247,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
+                                #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     content,
                                     expr.range(),
@@ -271,6 +275,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             expr.range(),
                         );
                         if checker.patch(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 format!(
                                     "({})",
@@ -296,6 +301,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             if let Some(content) = elts_to_csv(elts, checker) {
+                                #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     content,
                                     expr.range(),
@@ -372,6 +378,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&create_expr(value.node.clone()), checker.stylist),
             expr.range(),

--- a/crates/ruff/src/rules/flake8_quotes/rules.rs
+++ b/crates/ruff/src/rules/flake8_quotes/rules.rs
@@ -289,6 +289,7 @@ fn docstring(
         fixed_contents.push_str(&quote);
         fixed_contents.push_str(string_contents);
         fixed_contents.push_str(&quote);
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             fixed_contents,
             range,
@@ -367,6 +368,7 @@ fn strings(
                 fixed_contents.push_str(quote);
                 fixed_contents.push_str(string_contents);
                 fixed_contents.push_str(quote);
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     fixed_contents,
                     *range,
@@ -433,6 +435,7 @@ fn strings(
 
                         fixed_contents.push(quote);
 
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             fixed_contents,
                             *range,
@@ -459,6 +462,7 @@ fn strings(
                     fixed_contents.push(quote);
                     fixed_contents.push_str(string_contents);
                     fixed_contents.push(quote);
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         fixed_contents,
                         *range,

--- a/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -34,6 +34,7 @@ pub fn unnecessary_paren_on_raise_exception(checker: &mut Checker, expr: &Expr) 
                 .expect("Expected call to include parentheses");
             let mut diagnostic = Diagnostic::new(UnnecessaryParenOnRaiseException, range);
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::deletion(func.end(), range.end())));
             }
             checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -341,6 +341,7 @@ fn unnecessary_return_none(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryReturnNone, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "return".to_string(),
                 stmt.range(),
@@ -358,6 +359,7 @@ fn implicit_return_value(checker: &mut Checker, stack: &Stack) {
         }
         let mut diagnostic = Diagnostic::new(ImplicitReturnValue, stmt.range());
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "return None".to_string(),
                 stmt.range(),
@@ -415,6 +417,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator),
@@ -453,6 +456,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                         content.push_str(checker.stylist.line_ending().as_str());
                         content.push_str(indent);
                         content.push_str("return None");
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                             content,
                             end_of_last_statement(stmt, checker.locator),
@@ -492,6 +496,7 @@ fn implicit_return(checker: &mut Checker, stmt: &Stmt) {
                     content.push_str(checker.stylist.line_ending().as_str());
                     content.push_str(indent);
                     content.push_str("return None");
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         content,
                         end_of_last_statement(stmt, checker.locator),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -366,6 +366,7 @@ pub fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
 
                 // Populate the `Fix`. Replace the _entire_ `BoolOp`. Note that if we have
                 // multiple duplicates, the fixes will conflict.
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&bool_op, checker.stylist),
                     expr.range(),
@@ -468,6 +469,7 @@ pub fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
                     values: iter::once(in_expr).chain(unmatched).collect(),
                 })
             };
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(&in_expr, checker.stylist),
                 expr.range(),
@@ -519,6 +521,7 @@ pub fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         "False".to_string(),
                         expr.range(),
@@ -572,6 +575,7 @@ pub fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
                     expr.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         "True".to_string(),
                         expr.range(),
@@ -695,6 +699,7 @@ pub fn expr_or_true(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(edit));
         }
         checker.diagnostics.push(diagnostic);
@@ -714,6 +719,7 @@ pub fn expr_and_false(checker: &mut Checker, expr: &Expr) {
             edit.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(edit));
         }
         checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -116,6 +116,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
             value: capital_env_var.into(),
             kind: kind.clone(),
         });
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(&new_env_var, checker.stylist),
             slice.range(),
@@ -176,6 +177,7 @@ pub fn dict_get_with_none_default(checker: &mut Checker, expr: &Expr) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             expected,
             expr.range(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -304,6 +304,7 @@ pub fn nested_if_statements(
                     .universal_newlines()
                     .all(|line| line.width() <= checker.settings.line_length)
                 {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(edit));
                 }
             }
@@ -370,6 +371,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
     if fixable && checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
             // If the condition is a comparison, we can replace it with the condition.
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
@@ -382,6 +384,7 @@ pub fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
         } else {
             // Otherwise, we need to wrap the condition in a call to `bool`. (We've already
             // verified, above, that `bool` is a builtin.)
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_stmt(
                     &create_stmt(StmtKind::Return {
@@ -528,6 +531,7 @@ pub fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: Option<&
         stmt.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents,
             stmt.range(),
@@ -878,6 +882,7 @@ pub fn use_dict_get_with_default(
         stmt.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents,
             stmt.range(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -100,11 +100,13 @@ pub fn explicit_true_false_in_ifexpr(
     );
     if checker.patch(diagnostic.kind.rule()) {
         if matches!(test.node, ExprKind::Compare { .. }) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(&test.clone(), checker.stylist),
                 expr.range(),
             )));
         } else if checker.ctx.is_builtin("bool") {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     &create_expr(ExprKind::Call {
@@ -152,6 +154,7 @@ pub fn explicit_false_true_in_ifexpr(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::UnaryOp {
@@ -200,6 +203,7 @@ pub fn twisted_arms_in_ifexpr(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::IfExp {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -107,6 +107,7 @@ pub fn negation_with_equal_op(checker: &mut Checker, expr: &Expr, op: &Unaryop, 
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
@@ -157,6 +158,7 @@ pub fn negation_with_not_equal_op(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_expr(
                 &create_expr(ExprKind::Compare {
@@ -192,11 +194,13 @@ pub fn double_negation(checker: &mut Checker, expr: &Expr, op: &Unaryop, operand
     );
     if checker.patch(diagnostic.kind.rule()) {
         if checker.ctx.in_boolean_test {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(operand, checker.stylist),
                 expr.range(),
             )));
         } else if checker.ctx.is_builtin("bool") {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     &create_expr(ExprKind::Call {

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_with.rs
@@ -118,6 +118,7 @@ pub fn multiple_with_statements(
                         .universal_newlines()
                         .all(|line| line.width() <= checker.settings.line_length)
                     {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(edit));
                     }
                 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -91,6 +91,7 @@ fn key_in_dict(checker: &mut Checker, left: &Expr, right: &Expr, range: TextRang
         range,
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             value_content,
             right.range(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -227,6 +227,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     stmt.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("any") {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,
                         stmt.start(),
@@ -308,6 +309,7 @@ pub fn convert_for_loop_to_any_all(checker: &mut Checker, stmt: &Stmt, sibling: 
                     stmt.range(),
                 );
                 if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("all") {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,
                         stmt.start(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -105,6 +105,7 @@ pub fn suppressible_exception(
                     );
                     let handler_line_begin = checker.locator.line_start(handler.start());
                     let remove_handler = Edit::deletion(handler_line_begin, handler.end());
+                    #[allow(deprecated)]
                     Ok(Fix::unspecified_edits(
                         import_edit,
                         [replace_try, remove_handler],

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -161,6 +161,7 @@ pub fn yoda_conditions(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 suggestion,
                 expr.range(),

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -112,7 +112,7 @@ fn fix_banned_relative_import(
         }),
         stylist,
     );
-
+    #[allow(deprecated)]
     Some(Fix::unspecified(Edit::range_replacement(
         content,
         stmt.range(),

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -74,6 +74,7 @@ pub fn empty_type_checking_block<'a, 'b>(
                     if edit.is_deletion() || edit.content() == Some("pass") {
                         checker.deletions.insert(RefEquality(stmt));
                     }
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(edit));
                 }
                 Err(e) => error!("Failed to remove empty type-checking block: {e}"),

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -87,6 +87,7 @@ pub fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner: &str) 
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents,
             expr.range(),

--- a/crates/ruff/src/rules/isort/rules/add_required_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/add_required_imports.rs
@@ -120,6 +120,7 @@ fn add_required_import(
         TextRange::default(),
     );
     if autofix.into() && settings.rules.should_fix(Rule::MissingRequiredImport) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(
             Importer::new(python_ast, locator, stylist)
                 .add_import(required_import, TextSize::default()),

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -148,6 +148,7 @@ pub fn organize_imports(
     } else {
         let mut diagnostic = Diagnostic::new(UnsortedImports, range);
         if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 indent(&expected, indentation),
                 range,

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -70,6 +70,7 @@ pub fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 match type_name {
                     "unicode" => "str",

--- a/crates/ruff/src/rules/pandas_vet/fixes.rs
+++ b/crates/ruff/src/rules/pandas_vet/fixes.rs
@@ -40,6 +40,6 @@ pub(super) fn convert_inplace_argument_to_assignment(
         false,
     )
     .ok()?;
-
+    #[allow(deprecated)]
     Some(Fix::unspecified_edits(insert_assignment, [remove_argument]))
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -164,6 +164,7 @@ pub fn compound_statements(
                     let mut diagnostic =
                         Diagnostic::new(UselessSemicolon, TextRange::new(start, end));
                     if autofix.into() && settings.rules.should_fix(Rule::UselessSemicolon) {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::deletion(start, end)));
                     };
                     diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/invalid_escape_sequence.rs
@@ -108,6 +108,7 @@ pub fn invalid_escape_sequence(
             let range = TextRange::at(location, next_char.text_len() + TextSize::from(1));
             let mut diagnostic = Diagnostic::new(InvalidEscapeSequence(*next_char), range);
             if autofix {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     r"\".to_string(),
                     range.start() + TextSize::from(1),

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -103,6 +103,7 @@ pub fn lambda_assignment(
                         indented.push_str(&line);
                     }
                 }
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     indented,
                     stmt.range(),

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -277,6 +277,7 @@ pub fn literal_comparisons(
             .collect::<Vec<_>>();
         let content = compare(left, &ops, comparators, checker.stylist);
         for diagnostic in &mut diagnostics {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 content.to_string(),
                 expr.range(),

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -86,6 +86,7 @@ pub(crate) fn missing_whitespace(
                     let mut diagnostic = Diagnostic::new(kind, TextRange::empty(token.start()));
 
                     if autofix {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                             " ".to_string(),
                             token.end(),

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -63,6 +63,7 @@ pub(crate) fn whitespace_before_parameters(
             let mut diagnostic = Diagnostic::new(kind, TextRange::new(start, end));
 
             if autofix {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::deletion(start, end)));
             }
             context.push_diagnostic(diagnostic);

--- a/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/missing_newline_at_end_of_file.rs
@@ -55,6 +55,7 @@ pub fn no_newline_at_end_of_file(
 
         let mut diagnostic = Diagnostic::new(MissingNewlineAtEndOfFile, range);
         if autofix {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                 stylist.line_ending().to_string(),
                 range.start(),

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -99,6 +99,7 @@ pub fn not_tests(
                         if check_not_in {
                             let mut diagnostic = Diagnostic::new(NotInTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
+                                #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
                                     expr.range(),
@@ -111,6 +112,7 @@ pub fn not_tests(
                         if check_not_is {
                             let mut diagnostic = Diagnostic::new(NotIsTest, operand.range());
                             if checker.patch(diagnostic.kind.rule()) {
+                                #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                     compare(left, &[Cmpop::IsNot], comparators, checker.stylist),
                                     expr.range(),

--- a/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/trailing_whitespace.rs
@@ -95,6 +95,7 @@ pub(crate) fn trailing_whitespace(
                 if matches!(autofix, flags::Autofix::Enabled)
                     && settings.rules.should_fix(Rule::BlankLineWithWhitespace)
                 {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                 }
                 return Some(diagnostic);
@@ -104,6 +105,7 @@ pub(crate) fn trailing_whitespace(
             if matches!(autofix, flags::Autofix::Enabled)
                 && settings.rules.should_fix(Rule::TrailingWhitespace)
             {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
             }
             return Some(diagnostic);

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_after_summary.rs
@@ -82,6 +82,7 @@ pub fn blank_after_summary(checker: &mut Checker, docstring: &Docstring) {
                 }
 
                 // Insert one blank line after the summary (replacing any existing lines).
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     summary_end,

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -94,6 +94,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Delete the blank line before the class.
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                         blank_lines_start,
                         docstring.start() - docstring.indentation.text_len(),
@@ -116,6 +117,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Insert one blank line before the class.
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         checker.stylist.line_ending().to_string(),
                         blank_lines_start,
@@ -163,6 +165,7 @@ pub fn blank_before_after_class(checker: &mut Checker, docstring: &Docstring) {
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Insert a blank line before the class (replacing any existing lines).
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                     checker.stylist.line_ending().to_string(),
                     first_line_start,

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -88,6 +88,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line before the docstring.
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                     blank_lines_start,
                     docstring.start() - docstring.indentation.text_len(),
@@ -149,6 +150,7 @@ pub fn blank_before_after_function(checker: &mut Checker, docstring: &Docstring)
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete the blank line after the docstring.
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                     first_line_end,
                     blank_lines_end,

--- a/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/capitalized.rs
@@ -71,6 +71,7 @@ pub fn capitalized(checker: &mut Checker, docstring: &Docstring) {
     );
 
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             capitalized_word,
             TextRange::at(body.start(), first_word.text_len()),

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_period.rs
@@ -64,6 +64,7 @@ pub fn ends_with_period(checker: &mut Checker, docstring: &Docstring) {
                 && !trimmed.ends_with(':')
                 && !trimmed.ends_with(';')
             {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),

--- a/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/ends_with_punctuation.rs
@@ -61,6 +61,7 @@ pub fn ends_with_punctuation(checker: &mut Checker, docstring: &Docstring) {
             let mut diagnostic = Diagnostic::new(EndsInPunctuation, docstring.range());
             // Best-effort autofix: avoid adding a period after other punctuation marks.
             if checker.patch(diagnostic.kind.rule()) && !trimmed.ends_with([':', ';']) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     ".".to_string(),
                     line.start() + trimmed.text_len(),

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -90,6 +90,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(UnderIndentation, TextRange::empty(line.start()));
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         whitespace::clean(docstring.indentation),
                         TextRange::at(line.start(), line_indent.text_len()),
@@ -138,6 +139,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                     } else {
                         Edit::range_replacement(new_indent, over_indented)
                     };
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(edit));
                 }
                 checker.diagnostics.push(diagnostic);
@@ -151,6 +153,7 @@ pub fn indent(checker: &mut Checker, docstring: &Docstring) {
                 let mut diagnostic =
                     Diagnostic::new(OverIndentation, TextRange::empty(last.start()));
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         whitespace::clean(docstring.indentation),
                         TextRange::at(last.start(), line_indent.text_len()),

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -67,6 +67,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                 // Delete until first non-whitespace char.
                 for line in content_lines {
                     if let Some(end_column) = line.find(|c: char| !c.is_whitespace()) {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                             first_line.end(),
                             line.start() + TextSize::try_from(end_column).unwrap(),
@@ -123,6 +124,7 @@ pub fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstring) {
                         first_line.strip_prefix(prefix).unwrap().trim_start()
                     );
 
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         repl,
                         body.start(),

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -56,6 +56,7 @@ pub fn newline_after_last_paragraph(checker: &mut Checker, docstring: &Docstring
                             checker.stylist.line_ending().as_str(),
                             whitespace::clean(docstring.indentation)
                         );
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                             content,
                             docstring.expr.end() - num_trailing_quotes - num_trailing_spaces,

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -44,6 +44,7 @@ pub fn no_surrounding_whitespace(checker: &mut Checker, docstring: &Docstring) {
         // characters, avoid applying the fix.
         if !trimmed.ends_with(quote) && !trimmed.starts_with(quote) && !ends_with_backslash(trimmed)
         {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 trimmed.to_string(),
                 TextRange::at(body.start(), line.text_len()),

--- a/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/one_liner.rs
@@ -49,6 +49,7 @@ pub fn one_liner(checker: &mut Checker, docstring: &Docstring) {
                 if !trimmed.ends_with(trailing.chars().last().unwrap())
                     && !trimmed.starts_with(leading.chars().last().unwrap())
                 {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         format!("{leading}{trimmed}{trailing}"),
                         docstring.range(),

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -373,6 +373,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and the underline.
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
@@ -405,6 +406,7 @@ fn blanks_and_section_underline(
                             "-".repeat(context.section_name().len()),
                             checker.stylist.line_ending().as_str()
                         );
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                             content,
                             blank_lines_end,
@@ -435,6 +437,7 @@ fn blanks_and_section_underline(
                         );
 
                         // Replace the existing indentation with whitespace of the appropriate length.
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             whitespace::clean(docstring.indentation),
                             range,
@@ -478,6 +481,7 @@ fn blanks_and_section_underline(
                         );
                         if checker.patch(diagnostic.kind.rule()) {
                             // Delete any blank lines between the header and content.
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                 line_after_dashes.start(),
                                 blank_lines_after_dashes_end,
@@ -516,6 +520,7 @@ fn blanks_and_section_underline(
                         whitespace::clean(docstring.indentation),
                         "-".repeat(context.section_name().len()),
                     );
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         content,
                         context.summary_range().end(),
@@ -539,6 +544,7 @@ fn blanks_and_section_underline(
                         let range =
                             TextRange::new(context.following_range().start(), blank_lines_end);
                         // Delete any blank lines between the header and content.
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(range)));
                     }
                     checker.diagnostics.push(diagnostic);
@@ -568,6 +574,7 @@ fn blanks_and_section_underline(
                     "-".repeat(context.section_name().len()),
                 );
 
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     content,
                     context.summary_range().end(),
@@ -605,6 +612,7 @@ fn common_section(
                 // Replace the section title with the capitalized variant. This requires
                 // locating the start and end of the section name.
                 let section_range = context.section_name_range();
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     capitalized_section_name.to_string(),
                     section_range,
@@ -628,6 +636,7 @@ fn common_section(
                 let content = whitespace::clean(docstring.indentation);
                 let fix_range = TextRange::at(context.range().start(), leading_space.text_len());
 
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(if content.is_empty() {
                     Edit::range_deletion(fix_range)
                 } else {
@@ -655,6 +664,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline at the beginning of the next section.
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         line_end.to_string(),
                         next.range().start(),
@@ -676,6 +686,7 @@ fn common_section(
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     // Add a newline after the section.
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                         format!("{}{}", line_end, docstring.indentation),
                         context.range().end(),
@@ -700,6 +711,7 @@ fn common_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 // Add a blank line before the section.
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::insertion(
                     line_end.to_string(),
                     context.range().start(),
@@ -902,6 +914,7 @@ fn numpy_section(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 let section_range = context.section_name_range();
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     section_range.end(),
                     suffix.text_len(),
@@ -939,6 +952,7 @@ fn google_section(
             if checker.patch(diagnostic.kind.rule()) {
                 // Replace the suffix.
                 let section_name_range = context.section_name_range();
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     ":".to_string(),
                     TextRange::at(section_name_range.end(), suffix.text_len()),

--- a/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/f_string_missing_placeholders.rs
@@ -89,6 +89,7 @@ fn fix_f_string_missing_placeholders(
     checker: &mut Checker,
 ) -> Fix {
     let content = &checker.locator.contents()[TextRange::new(prefix_range.end(), tok_range.end())];
+    #[allow(deprecated)]
     Fix::unspecified(Edit::replacement(
         unescape_f_string(content),
         prefix_range.start(),

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -78,6 +78,7 @@ pub fn invalid_literal_comparison(
                             None
                         }
                     } {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             content,
                             located_op.range() + location.start(),

--- a/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/raise_not_implemented.rs
@@ -46,6 +46,7 @@ pub fn raise_not_implemented(checker: &mut Checker, expr: &Expr) {
     };
     let mut diagnostic = Diagnostic::new(RaiseNotImplemented, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "NotImplementedError".to_string(),
             expr.range(),

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -109,6 +109,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
+                                    #[allow(deprecated)]
                                     diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                         values[i - 1].end(),
                                         values[i].end(),
@@ -137,6 +138,7 @@ pub fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values: &[Exp
                             );
                             if is_duplicate_value {
                                 if checker.patch(diagnostic.kind.rule()) {
+                                    #[allow(deprecated)]
                                     diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                                         values[i - 1].end(),
                                         values[i].end(),

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -204,6 +204,7 @@ fn remove_unused_variable(
                 {
                     // If the expression is complex (`x = foo()`), remove the assignment,
                     // but preserve the right-hand side.
+                    #[allow(deprecated)]
                     Some((
                         DeletionKind::Partial,
                         Fix::unspecified(Edit::deletion(
@@ -224,6 +225,7 @@ fn remove_unused_variable(
                         checker.indexer,
                         checker.stylist,
                     ) {
+                        #[allow(deprecated)]
                         Ok(fix) => Some((DeletionKind::Whole, Fix::unspecified(fix))),
                         Err(err) => {
                             error!("Failed to delete unused variable: {}", err);
@@ -246,6 +248,7 @@ fn remove_unused_variable(
             return if contains_effect(value, |id| checker.ctx.is_builtin(id)) {
                 // If the expression is complex (`x = foo()`), remove the assignment,
                 // but preserve the right-hand side.
+                #[allow(deprecated)]
                 Some((
                     DeletionKind::Partial,
                     Fix::unspecified(Edit::deletion(
@@ -265,6 +268,7 @@ fn remove_unused_variable(
                     checker.indexer,
                     checker.stylist,
                 ) {
+                    #[allow(deprecated)]
                     Ok(edit) => Some((DeletionKind::Whole, Fix::unspecified(edit))),
                     Err(err) => {
                         error!("Failed to delete unused variable: {}", err);
@@ -282,6 +286,7 @@ fn remove_unused_variable(
         for item in items {
             if let Some(optional_vars) = &item.optional_vars {
                 if optional_vars.range() == range {
+                    #[allow(deprecated)]
                     return Some((
                         DeletionKind::Partial,
                         Fix::unspecified(Edit::deletion(

--- a/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_string_characters.rs
@@ -197,6 +197,7 @@ pub fn invalid_string_characters(
 
         let mut diagnostic = Diagnostic::new(rule, range);
         if autofix {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 replacement.to_string(),
                 range,

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -53,6 +53,7 @@ pub fn manual_from_import(checker: &mut Checker, stmt: &Stmt, alias: &Alias, nam
         alias.range(),
     );
     if fixable && checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             unparse_stmt(
                 &create_stmt(StmtKind::ImportFrom {

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -121,6 +121,7 @@ pub fn nested_min_max(
                     keywords: keywords.to_owned(),
                 },
             );
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(&flattened_expr, checker.stylist),
                 expr.range(),

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -55,6 +55,7 @@ pub fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
                     checker.locator,
                 )?;
                 let reference_edit = Edit::range_replacement(binding, func.range());
+                #[allow(deprecated)]
                 Ok(Fix::unspecified_edits(import_edit, [reference_edit]))
             });
         }

--- a/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_import_alias.rs
@@ -49,6 +49,7 @@ pub fn useless_import_alias(checker: &mut Checker, alias: &Alias) {
 
     let mut diagnostic = Diagnostic::new(UselessImportAlias, alias.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             asname.to_string(),
             alias.range(),

--- a/crates/ruff/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_return.rs
@@ -120,6 +120,7 @@ pub fn useless_return<'a>(
                 if edit.is_deletion() || edit.content() == Some("pass") {
                     checker.deletions.insert(RefEquality(last_stmt));
                 }
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(edit));
             }
             Err(e) => {

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -163,6 +163,7 @@ fn convert_to_class(
     base_class: &Expr,
     stylist: &Stylist,
 ) -> Fix {
+    #[allow(deprecated)]
     Fix::unspecified(Edit::range_replacement(
         unparse_stmt(&create_class_def_stmt(typename, body, base_class), stylist),
         stmt.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -210,6 +210,7 @@ fn convert_to_class(
     base_class: &Expr,
     stylist: &Stylist,
 ) -> Fix {
+    #[allow(deprecated)]
     Fix::unspecified(Edit::range_replacement(
         unparse_stmt(
             &create_class_def_stmt(class_name, body, total_keyword, base_class),

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -44,6 +44,7 @@ pub fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
         let mut diagnostic = Diagnostic::new(DatetimeTimezoneUTC { straight_import }, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             if straight_import {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     "datetime.UTC".to_string(),
                     expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_c_element_tree.rs
@@ -24,6 +24,7 @@ fn add_check_for_node<T>(checker: &mut Checker, node: &Located<T>) {
     let mut diagnostic = Diagnostic::new(DeprecatedCElementTree, node.range());
     if checker.patch(diagnostic.kind.rule()) {
         let contents = checker.locator.slice(node.range());
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents.replacen("cElementTree", "ElementTree", 1),
             node.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -551,6 +551,7 @@ pub fn deprecated_import(
         );
         if checker.patch(Rule::DeprecatedImport) {
             if let Some(content) = fix {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     content,
                     stmt.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -257,6 +257,7 @@ pub fn deprecated_mock_attribute(checker: &mut Checker, expr: &Expr) {
                 value.range(),
             );
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     "mock".to_string(),
                     value.range(),
@@ -303,6 +304,7 @@ pub fn deprecated_mock_import(checker: &mut Checker, stmt: &Stmt) {
                             name.range(),
                         );
                         if let Some(content) = content.as_ref() {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 content.clone(),
                                 stmt.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_unittest_alias.rs
@@ -69,6 +69,7 @@ pub fn deprecated_unittest_alias(checker: &mut Checker, expr: &Expr) {
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             format!("self.{target}"),
             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -142,6 +142,7 @@ pub fn extraneous_parentheses(
                 if autofix.into() && settings.rules.should_fix(Rule::ExtraneousParentheses) {
                     let contents =
                         locator.slice(TextRange::new(start_range.start(), end_range.end()));
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents[1..contents.len() - 1].to_string(),
                         start_range.start(),

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -277,6 +277,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
 
     let mut diagnostic = Diagnostic::new(FString, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents,
             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -145,6 +145,7 @@ pub(crate) fn format_literals(checker: &mut Checker, summary: &FormatSummary, ex
         if let Ok(contents) =
             generate_call(expr, &summary.indices, checker.locator, checker.stylist)
         {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 contents,
                 expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -68,6 +68,7 @@ pub fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list: &[Expr
                             checker.locator,
                         )?;
                         let reference_edit = Edit::range_replacement(binding, expr.range());
+                        #[allow(deprecated)]
                         Ok(Fix::unspecified_edits(import_edit, [reference_edit]))
                     });
                 }

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -48,6 +48,7 @@ pub fn lru_cache_without_parameters(checker: &mut Checker, decorator_list: &[Exp
                 TextRange::new(func.end(), expr.end()),
             );
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(func, checker.stylist),
                     expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -64,7 +64,8 @@ pub fn native_literals(
                 LiteralType::Bytes
             }}, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
-                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                #[allow(deprecated)]
+diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
                         content.push('b');
@@ -127,6 +128,7 @@ pub fn native_literals(
             expr.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 arg_code.to_string(),
                 expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -65,7 +65,7 @@ pub fn native_literals(
             }}, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
-diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if id == "bytes" {
                         let mut content = String::with_capacity(3);
                         content.push('b');

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -38,6 +38,7 @@ pub fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
             .map_or(true, |binding| binding.kind.is_builtin());
         let mut diagnostic = Diagnostic::new(OpenAlias { fixable }, expr.range());
         if fixable && checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "open".to_string(),
                 func.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -63,6 +63,7 @@ fn atom_diagnostic(checker: &mut Checker, target: &Expr) {
         target.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             "OSError".to_string(),
             target.range(),
@@ -103,11 +104,13 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
         }
 
         if remaining.len() == 1 {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "OSError".to_string(),
                 target.range(),
             )));
         } else {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 format!(
                     "({})",

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -177,6 +177,7 @@ fn fix_py2_block(
         ) {
             Ok(edit) => {
                 checker.deletions.insert(RefEquality(defined_by));
+                #[allow(deprecated)]
                 Some(Fix::unspecified(edit))
             }
             Err(err) => {
@@ -193,6 +194,7 @@ fn fix_py2_block(
 
         if indentation(checker.locator, start).is_none() {
             // Inline `else` block (e.g., `else: x = 1`).
+            #[allow(deprecated)]
             Some(Fix::unspecified(Edit::range_replacement(
                 checker
                     .locator
@@ -212,6 +214,7 @@ fn fix_py2_block(
                     .ok()
                 })
                 .map(|contents| {
+                    #[allow(deprecated)]
                     Fix::unspecified(Edit::replacement(
                         contents,
                         checker.locator.line_start(stmt.start()),
@@ -233,6 +236,7 @@ fn fix_py2_block(
                 end_location = body.last().unwrap().end();
             }
         }
+        #[allow(deprecated)]
         Some(Fix::unspecified(Edit::deletion(stmt.start(), end_location)))
     }
 }
@@ -254,6 +258,7 @@ fn fix_py3_block(
 
             if indentation(checker.locator, start).is_none() {
                 // Inline `if` block (e.g., `if ...: x = 1`).
+                #[allow(deprecated)]
                 Some(Fix::unspecified(Edit::range_replacement(
                     checker
                         .locator
@@ -273,6 +278,7 @@ fn fix_py3_block(
                         .ok()
                     })
                     .map(|contents| {
+                        #[allow(deprecated)]
                         Fix::unspecified(Edit::replacement(
                             contents,
                             checker.locator.line_start(stmt.start()),
@@ -286,6 +292,7 @@ fn fix_py3_block(
             // the rest.
             let end = body.last().unwrap();
             let text = checker.locator.slice(TextRange::new(test.end(), end.end()));
+            #[allow(deprecated)]
             Some(Fix::unspecified(Edit::range_replacement(
                 format!("else{text}"),
                 stmt.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -444,6 +444,7 @@ pub(crate) fn printf_string_formatting(
 
     let mut diagnostic = Diagnostic::new(PrintfStringFormatting, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             contents,
             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -23,6 +23,7 @@ impl AlwaysAutofixableViolation for QuotedAnnotation {
 pub fn quoted_annotation(checker: &mut Checker, annotation: &str, range: TextRange) {
     let mut diagnostic = Diagnostic::new(QuotedAnnotation, range);
     if checker.patch(Rule::QuotedAnnotation) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             annotation.to_string(),
             range,

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -116,6 +116,7 @@ fn create_check(
     );
     if patch {
         if let Some(content) = replacement_value {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 content.to_string(),
                 mode_param.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -38,6 +38,7 @@ fn generate_fix(
     } else {
         (stderr, stdout)
     };
+    #[allow(deprecated)]
     Ok(Fix::unspecified_edits(
         Edit::range_replacement("capture_output=True".to_string(), first.range()),
         [remove_argument(

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -35,6 +35,7 @@ pub fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwargs: &[
         let range = TextRange::at(kwarg.start(), "universal_newlines".text_len());
         let mut diagnostic = Diagnostic::new(ReplaceUniversalNewlines, range);
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "text".to_string(),
                 range,

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -97,6 +97,7 @@ pub fn super_call_with_parameters(checker: &mut Checker, expr: &Expr, func: &Exp
     let mut diagnostic = Diagnostic::new(SuperCallWithParameters, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
         if let Some(edit) = fixes::remove_super_arguments(checker.locator, checker.stylist, expr) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(edit));
         }
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -46,6 +46,7 @@ pub fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr, args: 
     };
     let mut diagnostic = Diagnostic::new(TypeOfPrimitive { primitive }, expr.range());
     if checker.patch(diagnostic.kind.rule()) {
+        #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
             primitive.builtin(),
             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -31,6 +31,7 @@ pub fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     {
         let mut diagnostic = Diagnostic::new(TypingTextStrAlias, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 "str".to_string(),
                 expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unicode_kind_prefix.rs
@@ -27,6 +27,7 @@ pub fn unicode_kind_prefix(checker: &mut Checker, expr: &Expr, kind: Option<&str
         if const_kind.to_lowercase() == "u" {
             let mut diagnostic = Diagnostic::new(UnicodeKindPrefix, expr.range());
             if checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::at(
                     expr.start(),
                     TextSize::from(1),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -125,6 +125,7 @@ pub fn unnecessary_builtin_import(
                 if edit.is_deletion() || edit.content() == Some("pass") {
                     checker.deletions.insert(RefEquality(defined_by));
                 }
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(edit));
             }
             Err(e) => error!("Failed to remove builtin import: {e}"),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_coding_comment.rs
@@ -30,6 +30,7 @@ pub(crate) fn unnecessary_coding_comment(line: &Line, autofix: bool) -> Option<D
     if CODING_COMMENT_REGEX.is_match(line.as_str()) {
         let mut diagnostic = Diagnostic::new(UTF8EncodingDeclaration, line.full_range());
         if autofix {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::deletion(
                 line.start(),
                 line.full_end(),

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_encode_utf8.rs
@@ -129,6 +129,7 @@ fn replace_with_bytes_literal(locator: &Locator, expr: &Expr, constant: &Expr) -
         }
         prev = Some(range.end());
     }
+    #[allow(deprecated)]
     Fix::unspecified(Edit::range_replacement(replacement, expr.range()))
 }
 

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -105,6 +105,7 @@ pub fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, names: &[Lo
                 if fix.is_deletion() || fix.content() == Some("pass") {
                     checker.deletions.insert(RefEquality(defined_by));
                 }
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(fix));
             }
             Err(e) => error!("Failed to remove `__future__` import: {e}"),

--- a/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unpacked_list_comprehension.rs
@@ -101,6 +101,7 @@ pub fn unpacked_list_comprehension(checker: &mut Checker, targets: &[Expr], valu
                 content.push('(');
                 content.push_str(&existing[1..existing.len() - 1]);
                 content.push(')');
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     content,
                     value.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -55,6 +55,7 @@ pub fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
         if fixable && checker.patch(diagnostic.kind.rule()) {
             let binding = binding.to_lowercase();
             if checker.ctx.is_builtin(&binding) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     binding,
                     expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -112,6 +112,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
         TypingMember::Optional => {
             let mut diagnostic = Diagnostic::new(NonPEP604Annotation { fixable }, expr.range());
             if fixable && checker.patch(diagnostic.kind.rule()) {
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     unparse_expr(&optional(slice), checker.stylist),
                     expr.range(),
@@ -127,6 +128,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                         // Invalid type annotation.
                     }
                     ExprKind::Tuple { elts, .. } => {
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_expr(&union(elts), checker.stylist),
                             expr.range(),
@@ -134,6 +136,7 @@ pub fn use_pep604_annotation(checker: &mut Checker, expr: &Expr, value: &Expr, s
                     }
                     _ => {
                         // Single argument.
+                        #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                             unparse_expr(slice, checker.stylist),
                             expr.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -93,6 +93,7 @@ pub fn use_pep604_isinstance(checker: &mut Checker, expr: &Expr, func: &Expr, ar
 
                 let mut diagnostic = Diagnostic::new(NonPEP604Isinstance { kind }, expr.range());
                 if checker.patch(diagnostic.kind.rule()) {
+                    #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                         unparse_expr(&union(elts), checker.stylist),
                         types.range(),

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -65,6 +65,7 @@ pub fn useless_metaclass_type(checker: &mut Checker, stmt: &Stmt, value: &Expr, 
                 if edit.is_deletion() || edit.content() == Some("pass") {
                     checker.deletions.insert(RefEquality(defined_by));
                 }
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(edit));
             }
             Err(e) => error!("Failed to fix remove metaclass type: {e}"),

--- a/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -176,6 +176,7 @@ pub fn yield_in_for_loop(checker: &mut Checker, stmt: &Stmt) {
             if checker.patch(diagnostic.kind.rule()) {
                 let contents = checker.locator.slice(item.iter.range());
                 let contents = format!("yield from {contents}");
+                #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     contents,
                     item.stmt.range(),

--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -136,6 +136,7 @@ pub fn ambiguous_unicode_character(
                     );
                     if settings.rules.enabled(diagnostic.kind.rule()) {
                         if autofix.into() && settings.rules.should_fix(diagnostic.kind.rule()) {
+                            #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                                 (representant as char).to_string(),
                                 char_range,

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -108,6 +108,7 @@ pub fn collection_literal_concatenation(checker: &mut Checker, expr: &Expr) {
     );
     if checker.patch(diagnostic.kind.rule()) {
         if fixable {
+            #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 contents,
                 expr.range(),

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -47,6 +47,7 @@ impl Diagnostic {
     /// Set the [`Fix`] used to fix the diagnostic.
     #[inline]
     #[deprecated(note = "Use `Diagnostic::set_fix` instead.")]
+    #[allow(deprecated)]
     pub fn set_fix_from_edit(&mut self, edit: Edit) {
         self.fix = Some(Fix::unspecified(edit));
     }
@@ -62,6 +63,7 @@ impl Diagnostic {
     /// Set the [`Fix`] used to fix the diagnostic, if the provided function returns `Ok`.
     /// Otherwise, log the error.
     #[inline]
+    #[allow(deprecated)]
     pub fn try_set_fix(&mut self, func: impl FnOnce() -> Result<Fix>) {
         match func() {
             Ok(fix) => self.fix = Some(fix),
@@ -73,6 +75,7 @@ impl Diagnostic {
     /// Otherwise, log the error.
     #[inline]
     #[deprecated(note = "Use Diagnostic::try_set_fix instead")]
+    #[allow(deprecated)]
     pub fn try_set_fix_from_edit(&mut self, func: impl FnOnce() -> Result<Edit>) {
         match func() {
             Ok(edit) => self.fix = Some(Fix::unspecified(edit)),

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -58,7 +58,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with automatic applicability from an [`Edit`] element.
+    /// Create a new [`Fix`] with [automatic applicability](Applicability::Automatic) from an [`Edit`] element.
     pub fn automatic(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
@@ -66,7 +66,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with automatic applicability from multiple [`Edit`] elements.
+    /// Create a new [`Fix`] with [automatic applicability](Applicability::Automatic) from multiple [`Edit`] elements.
     pub fn automatic_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
@@ -74,7 +74,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with suggsted applicability from an [`Edit`] element.
+    /// Create a new [`Fix`] with [suggested applicability](Applicability::Suggested) from an [`Edit`] element.
     pub fn suggested(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
@@ -82,7 +82,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with suggsted applicability from multiple [`Edit`] elements.
+    /// Create a new [`Fix`] with [suggested applicability](Applicability::Suggested) from multiple [`Edit`] elements.
     pub fn suggested_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
@@ -90,7 +90,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with manual applicability from an [`Edit`] element.
+    /// Create a new [`Fix`] with [manual applicability](Applicability::Manual) from an [`Edit`] element.
     pub fn manual(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
@@ -98,7 +98,7 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with manual applicability from multiple [`Edit`] elements.
+    /// Create a new [`Fix`] with [manual applicability](Applicability::Manual) from multiple [`Edit`] elements.
     pub fn manual_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -39,11 +39,43 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with unspecified applicability from multiple [`Edit`] elements.
+    /// Create a new [`Fix`] with an unspecified applicability from multiple [`Edit`] elements.
     pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
             applicability: Applicability::Unspecified,
+        }
+    }
+
+    /// Create a new [`Fix`] with safe applicability from an [`Edit`] element.
+    pub fn safe(edit: Edit) -> Self {
+        Self {
+            edits: vec![edit],
+            applicability: Applicability::safe,
+        }
+    }
+
+    /// Create a new [`Fix`] with safe applicability from multiple [`Edit`] elements.
+    pub fn safe_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+        Self {
+            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            applicability: Applicability::safe,
+        }
+    }
+
+    /// Create a new [`Fix`] with maybe incorrect applicability from an [`Edit`] element.
+    pub fn maybe_incorrect(edit: Edit) -> Self {
+        Self {
+            edits: vec![edit],
+            applicability: Applicability::MaybeIncorrect,
+        }
+    }
+
+    /// Create a new [`Fix`] with maybe incorrect applicability from multiple [`Edit`] elements.
+    pub fn maybe_incorrect_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+        Self {
+            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            applicability: Applicability::MaybeIncorrect,
         }
     }
 

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -7,7 +7,6 @@ use crate::edit::Edit;
 /// Indicates confidence in the correctness of a suggested fix.
 #[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[non_exhaustive]
 pub enum Applicability {
     /// The fix is definitely what the user intended, or maintains the exact meaning of the code.
     /// This fix should be automatically applied.

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -4,6 +4,23 @@ use serde::{Deserialize, Serialize};
 
 use crate::edit::Edit;
 
+/// Indicates confidence in the correctness of a suggested fix.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
+pub enum Applicability {
+    /// The suggestion is definitely what the user intended, or maintains the exact meaning of the code.
+    /// This suggestion should be automatically applied.
+    Safe,
+
+    /// The suggestion may be what the user intended, but it is uncertain.
+    /// The suggestion should result in valid code if it is applied.
+    MaybeIncorrect,
+
+    /// The applicability of the suggestion is unknown.
+    Unspecified,
+}
+
 /// A collection of [`Edit`] elements to be applied to a source file.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -124,5 +124,4 @@ impl Fix {
     pub fn applicability(&self) -> Applicability {
         self.applicability
     }
-
 }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -120,4 +120,9 @@ impl Fix {
     pub fn into_edits(self) -> Vec<Edit> {
         self.edits
     }
+
+    pub fn applicability(&self) -> Applicability {
+        self.applicability
+    }
+
 }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -38,6 +38,9 @@ pub struct Fix {
 
 impl Fix {
     /// Create a new [`Fix`] with an unspecified applicability from an [`Edit`] element.
+    #[deprecated(
+        note = "Use `Fix::automatic`, `Fix::suggested`, or `Fix::manual` instead to specify an applicability."
+    )]
     pub fn unspecified(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
@@ -46,6 +49,9 @@ impl Fix {
     }
 
     /// Create a new [`Fix`] with an unspecified applicability from multiple [`Edit`] elements.
+    #[deprecated(
+        note = "Use `Fix::automatic_edits`, `Fix::suggested_edits`, or `Fix::manual_edits` instead to specify an applicability."
+    )]
     pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
@@ -85,7 +91,6 @@ impl Fix {
         }
     }
 
-
     /// Create a new [`Fix`] with manual applicability from an [`Edit`] element.
     pub fn manual(edit: Edit) -> Self {
         Self {
@@ -101,7 +106,6 @@ impl Fix {
             applicability: Applicability::Manual,
         }
     }
-
 
     /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`].
     pub fn min_start(&self) -> Option<TextSize> {

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::edit::Edit;
 
 /// Indicates confidence in the correctness of a suggested fix.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum Applicability {
@@ -18,6 +18,7 @@ pub enum Applicability {
     MaybeIncorrect,
 
     /// The applicability of the suggestion is unknown.
+    #[default]
     Unspecified,
 }
 
@@ -26,18 +27,23 @@ pub enum Applicability {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Fix {
     edits: Vec<Edit>,
+    applicability: Applicability,
 }
 
 impl Fix {
     /// Create a new [`Fix`] with an unspecified applicability from an [`Edit`] element.
     pub fn unspecified(edit: Edit) -> Self {
-        Self { edits: vec![edit] }
+        Self {
+            edits: vec![edit],
+            applicability: Applicability::Unspecified,
+        }
     }
 
     /// Create a new [`Fix`] with unspecified applicability from multiple [`Edit`] elements.
     pub fn unspecified_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            applicability: Applicability::Unspecified,
         }
     }
 

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -9,15 +9,21 @@ use crate::edit::Edit;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[non_exhaustive]
 pub enum Applicability {
-    /// The suggestion is definitely what the user intended, or maintains the exact meaning of the code.
-    /// This suggestion should be automatically applied.
-    Safe,
+    /// The fix is definitely what the user intended, or maintains the exact meaning of the code.
+    /// This fix should be automatically applied.
+    Automatic,
 
-    /// The suggestion may be what the user intended, but it is uncertain.
-    /// The suggestion should result in valid code if it is applied.
-    MaybeIncorrect,
+    /// The fix may be what the user intended, but it is uncertain.
+    /// The fix should result in valid code if it is applied.
+    /// The fix can be applied with user opt-in.
+    Suggested,
 
-    /// The applicability of the suggestion is unknown.
+    /// The fix has a good chance of being incorrect or the code be incomplete.
+    /// The fix may result in invalid code if it is applied.
+    /// The fix should only be manually applied by the user.
+    Manual,
+
+    /// The applicability of the fix is unknown.
     #[default]
     Unspecified,
 }
@@ -47,37 +53,55 @@ impl Fix {
         }
     }
 
-    /// Create a new [`Fix`] with safe applicability from an [`Edit`] element.
-    pub fn safe(edit: Edit) -> Self {
+    /// Create a new [`Fix`] with automatic applicability from an [`Edit`] element.
+    pub fn automatic(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
-            applicability: Applicability::safe,
+            applicability: Applicability::Automatic,
         }
     }
 
-    /// Create a new [`Fix`] with safe applicability from multiple [`Edit`] elements.
-    pub fn safe_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+    /// Create a new [`Fix`] with automatic applicability from multiple [`Edit`] elements.
+    pub fn automatic_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
-            applicability: Applicability::safe,
+            applicability: Applicability::Automatic,
         }
     }
 
-    /// Create a new [`Fix`] with maybe incorrect applicability from an [`Edit`] element.
-    pub fn maybe_incorrect(edit: Edit) -> Self {
+    /// Create a new [`Fix`] with suggsted applicability from an [`Edit`] element.
+    pub fn suggested(edit: Edit) -> Self {
         Self {
             edits: vec![edit],
-            applicability: Applicability::MaybeIncorrect,
+            applicability: Applicability::Suggested,
         }
     }
 
-    /// Create a new [`Fix`] with maybe incorrect applicability from multiple [`Edit`] elements.
-    pub fn maybe_incorrect_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+    /// Create a new [`Fix`] with suggsted applicability from multiple [`Edit`] elements.
+    pub fn suggested_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
         Self {
             edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
-            applicability: Applicability::MaybeIncorrect,
+            applicability: Applicability::Suggested,
         }
     }
+
+
+    /// Create a new [`Fix`] with manual applicability from an [`Edit`] element.
+    pub fn manual(edit: Edit) -> Self {
+        Self {
+            edits: vec![edit],
+            applicability: Applicability::Manual,
+        }
+    }
+
+    /// Create a new [`Fix`] with manual applicability from multiple [`Edit`] elements.
+    pub fn manual_edits(edit: Edit, rest: impl IntoIterator<Item = Edit>) -> Self {
+        Self {
+            edits: std::iter::once(edit).chain(rest.into_iter()).collect(),
+            applicability: Applicability::Manual,
+        }
+    }
+
 
     /// Return the [`TextSize`] of the first [`Edit`] in the [`Fix`].
     pub fn min_start(&self) -> Option<TextSize> {

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 pub use diagnostic::{Diagnostic, DiagnosticKind};
 pub use edit::Edit;
-pub use fix::Fix;
+pub use fix::{Fix, Applicability};
 pub use violation::{AlwaysAutofixableViolation, AutofixKind, Violation};
 
 mod diagnostic;

--- a/crates/ruff_diagnostics/src/lib.rs
+++ b/crates/ruff_diagnostics/src/lib.rs
@@ -1,6 +1,6 @@
 pub use diagnostic::{Diagnostic, DiagnosticKind};
 pub use edit::Edit;
-pub use fix::{Fix, Applicability};
+pub use fix::{Applicability, Fix};
 pub use violation::{AlwaysAutofixableViolation, AutofixKind, Violation};
 
 mod diagnostic;


### PR DESCRIPTION
Adds `Applicability` levels to `Fix` with corresponding factory methods and deprecates the `unspecified` fix methods.

Updates `Diff` output to include "Fix", "Suggested fix", and "Possible fix" depending on the applicability. 

Closes #4183
