### PR TITLE
Tweak package metadata URLs, add changelog URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Software Development :: Quality Assurance",
 ]
-urls = { repository = "https://github.com/charliermarsh/ruff" }
+
+[project.urls]
+Repository = "https://github.com/charliermarsh/ruff"
+Changelog = "https://github.com/charliermarsh/ruff/releases"
 
 [tool.maturin]
 bindings = "bin"


### PR DESCRIPTION
These links are visible on the package's PyPI page. The lowercase "repository" is currently a bit awkward.

> ![image](https://user-images.githubusercontent.com/137616/237045248-e00245ba-58db-4788-bf99-9abd3355c94a.png)

Added "Changelog" URL, which is handy for users and is also used by tools like Renovate bot to provide direct access to the changelog for a dependency update.
