### PR TITLE
UP011: Fix typo in rule description

### DIFF
--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -14,11 +14,11 @@ pub struct LRUCacheWithoutParameters;
 impl AlwaysAutofixableViolation for LRUCacheWithoutParameters {
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!("Unnecessary parameters to `functools.lru_cache`")
+        format!("Unnecessary parentheses to `functools.lru_cache`")
     }
 
     fn autofix_title(&self) -> String {
-        "Remove unnecessary parameters".to_string()
+        "Remove unnecessary parentheses".to_string()
     }
 }
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP011.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP011.py.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-UP011.py:5:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
+UP011.py:5:21: UP011 [*] Unnecessary parentheses to `functools.lru_cache`
   |
 5 | @functools.lru_cache()
   |                     ^^ UP011
 6 | def fixme():
 7 |     pass
   |
-  = help: Remove unnecessary parameters
+  = help: Remove unnecessary parentheses
 
 ℹ Suggested fix
 2 2 | from functools import lru_cache
@@ -20,14 +20,14 @@ UP011.py:5:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
 7 7 |     pass
 8 8 | 
 
-UP011.py:10:11: UP011 [*] Unnecessary parameters to `functools.lru_cache`
+UP011.py:10:11: UP011 [*] Unnecessary parentheses to `functools.lru_cache`
    |
 10 | @lru_cache()
    |           ^^ UP011
 11 | def fixme():
 12 |     pass
    |
-   = help: Remove unnecessary parameters
+   = help: Remove unnecessary parentheses
 
 ℹ Suggested fix
 7  7  |     pass
@@ -39,7 +39,7 @@ UP011.py:10:11: UP011 [*] Unnecessary parameters to `functools.lru_cache`
 12 12 |     pass
 13 13 | 
 
-UP011.py:16:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
+UP011.py:16:21: UP011 [*] Unnecessary parentheses to `functools.lru_cache`
    |
 16 | @other_decorator
 17 | @functools.lru_cache()
@@ -47,7 +47,7 @@ UP011.py:16:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
 18 | def fixme():
 19 |     pass
    |
-   = help: Remove unnecessary parameters
+   = help: Remove unnecessary parentheses
 
 ℹ Suggested fix
 13 13 | 
@@ -59,14 +59,14 @@ UP011.py:16:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
 18 18 |     pass
 19 19 | 
 
-UP011.py:21:21: UP011 [*] Unnecessary parameters to `functools.lru_cache`
+UP011.py:21:21: UP011 [*] Unnecessary parentheses to `functools.lru_cache`
    |
 21 | @functools.lru_cache()
    |                     ^^ UP011
 22 | @other_decorator
 23 | def fixme():
    |
-   = help: Remove unnecessary parameters
+   = help: Remove unnecessary parentheses
 
 ℹ Suggested fix
 18 18 |     pass


### PR DESCRIPTION
This rule is about removing the extra parentheses, not parameters :)

Reference:
https://github.com/asottile/pyupgrade#remove-parentheses-from-functoolslru_cache

