### PR TITLE
Write diagnostic name when failing to create fix

### DIFF
--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -65,7 +65,7 @@ impl Diagnostic {
     pub fn try_set_fix(&mut self, func: impl FnOnce() -> Result<Fix>) {
         match func() {
             Ok(fix) => self.fix = Some(fix),
-            Err(err) => error!("Failed to create fix: {}", err),
+            Err(err) => error!("Failed to create fix for {}: {}", self.kind.name, err),
         }
     }
 
@@ -76,7 +76,7 @@ impl Diagnostic {
     pub fn try_set_fix_from_edit(&mut self, func: impl FnOnce() -> Result<Edit>) {
         match func() {
             Ok(edit) => self.fix = Some(Fix::unspecified(edit)),
-            Err(err) => error!("Failed to create fix: {}", err),
+            Err(err) => error!("Failed to create fix for {}: {}", self.kind.name, err),
         }
     }
 


### PR DESCRIPTION
Tweak to debug some opaque "error: Failed to create fix: Unable to split parenthesized condition" errors i've seen.