### PR TITLE
Update `mkdocs` unformatted example error message

### DIFF
--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -103,8 +103,8 @@ def format_file(
     if contents != new_contents:
         rule_name = file.name.split(".")[0]
         print(
-            f"Rule `{rule_name}` docs are not formatted. This section should be "
-            f"rewritten to:",
+            f"Rule `{rule_name}` docs are not formatted. The example section "
+            f"should be rewritten to:",
         )
 
         # Add indentation so that snipped can be copied directly to docs


### PR DESCRIPTION
In #3979 it became clear that the error message could be clearer that only the example section of the documentation should be updated. This PR clarifies this.