### PR TITLE
Remove deprecated `update-check` setting

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,5 +1,16 @@
 # Breaking Changes
 
+## 0.0.266
+
+### `update-check` is no longer a valid configuration option ([#4313](https://github.com/charliermarsh/ruff/pull/4313))
+
+The `update-check` functionality was deprecated in [#2530](https://github.com/charliermarsh/ruff/pull/2530),
+in that the behavior itself was removed, and Ruff was changed to warn when that option was enabled.
+
+Now, Ruff will throw an error when `update-check` is provided via a configuration file (e.g.,
+`update-check = false`) or through the command-line, since it has no effect. Users should remove
+this option from their configuration.
+
 ## 0.0.265
 
 ### `--fix-only` now exits with a zero exit code, unless `--exit-non-zero-on-fix` is specified ([#4146](https://github.com/charliermarsh/ruff/pull/4146))

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -65,7 +65,6 @@ pub struct Configuration {
     pub target_version: Option<PythonVersion>,
     pub task_tags: Option<Vec<String>>,
     pub typing_modules: Option<Vec<String>>,
-    pub update_check: Option<bool>,
     // Plugins
     pub flake8_annotations: Option<flake8_annotations::settings::Options>,
     pub flake8_bandit: Option<flake8_bandit::settings::Options>,
@@ -201,7 +200,6 @@ impl Configuration {
             target_version: options.target_version,
             task_tags: options.task_tags,
             typing_modules: options.typing_modules,
-            update_check: options.update_check,
             // Plugins
             flake8_annotations: options.flake8_annotations,
             flake8_bandit: options.flake8_bandit,
@@ -272,7 +270,6 @@ impl Configuration {
             target_version: self.target_version.or(config.target_version),
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
-            update_check: self.update_check.or(config.update_check),
             // Plugins
             flake8_annotations: self.flake8_annotations.or(config.flake8_annotations),
             flake8_bandit: self.flake8_bandit.or(config.flake8_bandit),

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -57,7 +57,6 @@ impl AllSettings {
                 fix_only: config.fix_only.unwrap_or(false),
                 format: config.format.unwrap_or_default(),
                 show_fixes: config.show_fixes.unwrap_or(false),
-                update_check: config.update_check.unwrap_or_default(),
             },
             lib: Settings::from_configuration(config, project_root)?,
         })
@@ -74,7 +73,6 @@ pub struct CliSettings {
     pub fix_only: bool,
     pub format: SerializationFormat,
     pub show_fixes: bool,
-    pub update_check: bool,
 }
 
 #[derive(Debug, CacheKey)]

--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -445,14 +445,6 @@ pub struct Options {
     )]
     /// A list of rule codes or prefixes to consider non-autofix-able.
     pub unfixable: Option<Vec<RuleSelector>>,
-    #[option(
-        default = "false",
-        value_type = "bool",
-        example = "update-check = true"
-    )]
-    /// Enable or disable automatic update checks (overridden by the
-    /// `--update-check` and `--no-update-check` command-line flags).
-    pub update_check: Option<bool>,
     #[option_group]
     /// Options for the `flake8-annotations` plugin.
     pub flake8_annotations: Option<flake8_annotations::settings::Options>,

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -240,16 +240,6 @@ pub struct CheckArgs {
     /// autofix, even if no lint violations remain.
     #[arg(long, help_heading = "Miscellaneous", conflicts_with = "exit_zero")]
     pub exit_non_zero_on_fix: bool,
-    /// Does nothing and will be removed in the future.
-    #[arg(
-        long,
-        overrides_with("no_update_check"),
-        help_heading = "Miscellaneous",
-        hide = true
-    )]
-    update_check: bool,
-    #[clap(long, overrides_with("update_check"), hide = true)]
-    no_update_check: bool,
     /// Show counts for every rule with at least one violation.
     #[arg(
         long,
@@ -402,7 +392,6 @@ impl CheckArgs {
                 force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
                 format: self.format,
                 show_fixes: resolve_bool_arg(self.show_fixes, self.no_show_fixes),
-                update_check: resolve_bool_arg(self.update_check, self.no_update_check),
             },
         )
     }
@@ -467,7 +456,6 @@ pub struct Overrides {
     pub force_exclude: Option<bool>,
     pub format: Option<SerializationFormat>,
     pub show_fixes: Option<bool>,
-    pub update_check: Option<bool>,
 }
 
 impl ConfigProcessor for &Overrides {
@@ -526,9 +514,6 @@ impl ConfigProcessor for &Overrides {
         }
         if let Some(target_version) = &self.target_version {
             config.target_version = Some(*target_version);
-        }
-        if let Some(update_check) = &self.update_check {
-            config.update_check = Some(*update_check);
         }
     }
 }

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -150,7 +150,6 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         fix_only,
         format,
         show_fixes,
-        update_check,
         ..
     } = pyproject_config.settings.cli;
 
@@ -309,13 +308,6 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
                 let mut stdout = BufWriter::new(io::stdout().lock());
                 printer.write_once(&diagnostics, &mut stdout)?;
             }
-        }
-
-        if update_check {
-            warn_user_once!(
-                "update-check has been removed; setting it will cause an error in a future \
-                 version."
-            );
         }
 
         if !cli.exit_zero {

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -127,7 +127,6 @@ pub fn defaultSettings() -> Result<JsValue, JsValue> {
         task_tags: None,
         typing_modules: None,
         unfixable: None,
-        update_check: None,
         // Use default options for all plugins.
         flake8_annotations: Some(flake8_annotations::settings::Settings::default().into()),
         flake8_bandit: Some(flake8_bandit::settings::Settings::default().into()),

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -531,13 +531,6 @@
       "items": {
         "$ref": "#/definitions/RuleSelector"
       }
-    },
-    "update-check": {
-      "description": "Enable or disable automatic update checks (overridden by the `--update-check` and `--no-update-check` command-line flags).",
-      "type": [
-        "boolean",
-        "null"
-      ]
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Breaking in that users with `update-check = false` in their configuration file should now remove it.