### PR TITLE
Move `show_source` onto CLI settings group

### DIFF
--- a/crates/ruff/src/settings/defaults.rs
+++ b/crates/ruff/src/settings/defaults.rs
@@ -79,7 +79,6 @@ impl Default for Settings {
             namespace_packages: vec![],
             per_file_ignores: vec![],
             respect_gitignore: true,
-            show_source: false,
             src: vec![path_dedot::CWD.clone()],
             project_root: path_dedot::CWD.clone(),
             target_version: TARGET_VERSION,

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -57,6 +57,7 @@ impl AllSettings {
                 fix_only: config.fix_only.unwrap_or(false),
                 format: config.format.unwrap_or_default(),
                 show_fixes: config.show_fixes.unwrap_or(false),
+                show_source: config.show_source.unwrap_or(false),
             },
             lib: Settings::from_configuration(config, project_root)?,
         })
@@ -65,14 +66,14 @@ impl AllSettings {
 
 #[derive(Debug, Default, Clone)]
 #[allow(clippy::struct_excessive_bools)]
-/// Settings that are not used by this library and
-/// only here so that `ruff_cli` can use them.
+/// Settings that are not used by this library and only here so that `ruff_cli` can use them.
 pub struct CliSettings {
     pub cache_dir: PathBuf,
     pub fix: bool,
     pub fix_only: bool,
     pub format: SerializationFormat,
     pub show_fixes: bool,
+    pub show_source: bool,
 }
 
 #[derive(Debug, CacheKey)]
@@ -81,7 +82,6 @@ pub struct Settings {
     pub rules: RuleTable,
     pub per_file_ignores: Vec<(GlobMatcher, GlobMatcher, RuleSet)>,
 
-    pub show_source: bool,
     pub target_version: PythonVersion,
 
     // Resolver settings
@@ -168,7 +168,6 @@ impl Settings {
                 config.per_file_ignores.unwrap_or_default(),
             )?,
             respect_gitignore: config.respect_gitignore.unwrap_or(true),
-            show_source: config.show_source.unwrap_or_default(),
             src: config
                 .src
                 .unwrap_or_else(|| vec![project_root.to_path_buf()]),
@@ -429,7 +428,7 @@ pub fn resolve_per_file_ignores(
 
 #[cfg(test)]
 mod tests {
-    use crate::codes::{self, Pycodestyle};
+    use crate::codes::Pycodestyle;
     use crate::registry::{Rule, RuleSet};
     use crate::settings::configuration::Configuration;
     use crate::settings::rule_table::RuleTable;
@@ -449,7 +448,7 @@ mod tests {
     #[test]
     fn rule_codes() {
         let actual = resolve_rules([RuleSelection {
-            select: Some(vec![codes::Pycodestyle::W.into()]),
+            select: Some(vec![Pycodestyle::W.into()]),
             ..RuleSelection::default()
         }]);
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -150,6 +150,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         fix_only,
         format,
         show_fixes,
+        show_source,
         ..
     } = pyproject_config.settings.cli;
 
@@ -181,8 +182,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
     if show_fixes {
         printer_flags |= PrinterFlags::SHOW_FIXES;
     }
-
-    if pyproject_config.settings.lib.show_source {
+    if show_source {
         printer_flags |= PrinterFlags::SHOW_SOURCE;
     }
 


### PR DESCRIPTION
Now that we _always_ compute source, we don't need it available as a library setting -- it's only relevant for the printer.