### PR TITLE
Include positional- and keyword-only arguments in too-many-arguments

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/too_many_arguments.py
+++ b/crates/ruff/resources/test/fixtures/pylint/too_many_arguments.py
@@ -22,13 +22,13 @@ def f(x=1, y=1, z=1):  # OK
     pass
 
 
-def f(x, y, z, /, u, v, w):  # OK
+def f(x, y, z, /, u, v, w):  # Too many arguments (6/5)
     pass
 
 
-def f(x, y, z, *, u, v, w):  # OK
+def f(x, y, z, *, u, v, w):  # Too many arguments (6/5)
     pass
 
 
-def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (6/5)
+def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (9/5)
     pass

--- a/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_arguments.rs
@@ -25,6 +25,8 @@ pub fn too_many_arguments(checker: &mut Checker, args: &Arguments, stmt: &Stmt) 
     let num_args = args
         .args
         .iter()
+        .chain(args.kwonlyargs.iter())
+        .chain(args.posonlyargs.iter())
         .filter(|arg| !checker.settings.dummy_variable_rgx.is_match(&arg.node.arg))
         .count();
     if num_args > checker.settings.pylint.max_args {

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLR0913_too_many_arguments.py.snap
@@ -15,9 +15,23 @@ too_many_arguments.py:17:5: PLR0913 Too many arguments to function call (6 > 5)
 18 |     pass
    |
 
-too_many_arguments.py:33:5: PLR0913 Too many arguments to function call (6 > 5)
+too_many_arguments.py:25:5: PLR0913 Too many arguments to function call (6 > 5)
    |
-33 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (6/5)
+25 | def f(x, y, z, /, u, v, w):  # Too many arguments (6/5)
+   |     ^ PLR0913
+26 |     pass
+   |
+
+too_many_arguments.py:29:5: PLR0913 Too many arguments to function call (6 > 5)
+   |
+29 | def f(x, y, z, *, u, v, w):  # Too many arguments (6/5)
+   |     ^ PLR0913
+30 |     pass
+   |
+
+too_many_arguments.py:33:5: PLR0913 Too many arguments to function call (9 > 5)
+   |
+33 | def f(x, y, z, a, b, c, *, u, v, w):  # Too many arguments (9/5)
    |     ^ PLR0913
 34 |     pass
    |


### PR DESCRIPTION
See: https://github.com/pylint-dev/pylint/issues/8667.

Closes #4037.