### PR TITLE
Add docs for flake8-simplify rules

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -26,6 +26,27 @@ impl AlwaysAutofixableViolation for UncapitalizedEnvironmentVariables {
     }
 }
 
+/// ## What it does
+/// Check for `None` passed as the default value in `dict.get()`.
+///
+/// ## Why is this bad?
+/// `None` is the default value for `dict.get()`, so it is redundant to pass it
+/// explicitly.
+///
+/// ## Example
+/// ```python
+/// ages = {"Tom": 23, "Maria": 23, "Loca": 11}
+/// age = ages.get("Hodge", None)  # None
+/// ```
+///
+/// Use instead:
+/// ```python
+/// ages = {"Tom": 23, "Maria": 23, "Loca": 11}
+/// age = ages.get("Hodge")  # None
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/library/stdtypes.html#dict.get)
 #[violation]
 pub struct DictGetWithNoneDefault {
     expected: String,

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -35,14 +35,14 @@ impl AlwaysAutofixableViolation for UncapitalizedEnvironmentVariables {
 ///
 /// ## Example
 /// ```python
-/// ages = {"Tom": 23, "Maria": 23, "Loca": 11}
-/// age = ages.get("Hodge", None)  # None
+/// ages = {"Tom": 23, "Maria": 23, "Dog": 11}
+/// age = ages.get("Cat", None)  # None
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// ages = {"Tom": 23, "Maria": 23, "Loca": 11}
-/// age = ages.get("Hodge")  # None
+/// ages = {"Tom": 23, "Maria": 23, "Dog": 11}
+/// age = ages.get("Cat")  # None
 /// ```
 ///
 /// ## References

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -27,7 +27,7 @@ impl AlwaysAutofixableViolation for UncapitalizedEnvironmentVariables {
 }
 
 /// ## What it does
-/// Check for `None` passed as the default value in `dict.get()`.
+/// Check for `dict.get()` calls that pass `None` as the default value.
 ///
 /// ## Why is this bad?
 /// `None` is the default value for `dict.get()`, so it is redundant to pass it

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -6,29 +6,29 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for usages of the builtin `open()` function without a context handler.
+/// Checks for usages of the builtin `open()` function without an associated context
+/// manager.
 ///
 /// ## Why is this bad?
-/// If a file is opened without a context handler, it is not guaranteed that the
-/// file will be closed (e.g., if an exception is raised). This can cause
+/// If a file is opened without a context manager, it is not guaranteed that
+/// the file will be closed (e.g., if an exception is raised), which can cause
 /// resource leaks.
 ///
 /// ## Example
 /// ```python
 /// file = open("foo.txt")
-/// ...  # do something with file
+/// ...
 /// file.close()
 /// ```
 ///
 /// Use instead:
 /// ```python
 /// with open("foo.txt") as file:
-///     ...  # do something with file
+///     ...
 /// ```
 ///
 /// # References
 /// - [Python documentation](https://docs.python.org/3/library/functions.html#open)
-/// - [Python documentation](https://docs.python.org/3/reference/compound_stmts.html#the-with-statement)
 #[violation]
 pub struct OpenFileWithContextHandler;
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -5,6 +5,30 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for usages of the builtin `open()` function without a context handler.
+///
+/// ## Why is this bad?
+/// If a file is opened without a context handler, it is not guaranteed that the
+/// file will be closed (e.g., if an exception is raised). This can cause
+/// resource leaks.
+///
+/// ## Example
+/// ```python
+/// file = open("foo.txt")
+/// ...  # do something with file
+/// file.close()
+/// ```
+///
+/// Use instead:
+/// ```python
+/// with open("foo.txt") as file:
+///     ...  # do something with file
+/// ```
+///
+/// # References
+/// - [Python documentation](https://docs.python.org/3/library/functions.html#open)
+/// - [Python documentation](https://docs.python.org/3/reference/compound_stmts.html#the-with-statement)
 #[violation]
 pub struct OpenFileWithContextHandler;
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -5,6 +5,40 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for `return` statements in `try`/`except` and `finally` blocks.
+///
+/// ## Why is this bad?
+/// The `return` statement in `finally` blocks will always be executed, even if
+/// an exception is raised in the `try` or `except` blocks. This can lead to
+/// unexpected behavior.
+///
+/// ## Example
+/// ```python
+/// def squared(n):  # always returns -1
+///     try:
+///         sqr = n**2
+///         return sqr
+///     except Exception:
+///         return "An exception occurred"
+///     finally:
+///         return -1
+/// ```
+///
+/// Use instead:
+/// ```python
+/// def squared(n):
+///     try:
+///         return_value = n**2
+///     except Exception:
+///         return_value = "An exception occurred"
+///     finally:
+///         return_value = -1
+///     return return_value
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/tutorial/errors.html#defining-clean-up-actions)
 #[violation]
 pub struct ReturnInTryExceptFinally;
 

--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM107_SIM107.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM107_SIM107.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_simplify/mod.rs
 ---
-SIM107.py:9:9: SIM107 Don't use `return` in `try`/`except` and `finally`
+SIM107.py:9:9: SIM107 Don't use `return` in `try`-`except` and `finally`
    |
  9 |         return "2"
 10 |     finally:


### PR DESCRIPTION
Adds docs for three flake8-simplify rules: `SIM107`, `SIM115`, and `SIM910`. This should complete all flake8-simplify rules that do not have auto-fix support (presumably the rules that users of ruff would appreciate documentation for the most).

Related to #2646.