### PR TITLE
Add `Fix::applicability` to JSON output

### DIFF
--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -39,8 +39,9 @@ impl Serialize for ExpandedMessages<'_> {
 
             let fix = message.fix.as_ref().map(|fix| {
                 json!({
-                        "message": message.kind.suggestion.as_deref(),
-                        "edits": &ExpandedEdits { edits: fix.edits(), source_code: &source_code },
+                    "applicability": fix.applicability(),
+                    "message": message.kind.suggestion.as_deref(),
+                    "edits": &ExpandedEdits { edits: fix.edits(), source_code: &source_code },
                 })
             });
 

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -189,14 +189,13 @@ def fibonacci(n):
 
         let fib_source = SourceFileBuilder::new("fib.py", fib).finish();
 
-        #[allow(deprecated)]
         let unused_variable = Diagnostic::new(
             UnusedVariable {
                 name: "x".to_string(),
             },
             TextRange::new(TextSize::from(94), TextSize::from(95)),
         )
-        .with_fix(Fix::unspecified(Edit::deletion(
+        .with_fix(Fix::suggested(Edit::deletion(
             TextSize::from(94),
             TextSize::from(99),
         )));

--- a/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__json__tests__output.snap
@@ -7,6 +7,7 @@ expression: content
     "code": "F401",
     "message": "`os` imported but unused",
     "fix": {
+      "applicability": "Suggested",
       "message": "Remove unused import: `os`",
       "edits": [
         {
@@ -37,6 +38,7 @@ expression: content
     "code": "F841",
     "message": "Local variable `x` is assigned to but never used",
     "fix": {
+      "applicability": "Suggested",
       "message": "Remove assignment to unused variable `x`",
       "edits": [
         {

--- a/crates/ruff_cli/tests/integration_test.rs
+++ b/crates/ruff_cli/tests/integration_test.rs
@@ -93,6 +93,7 @@ fn test_stdin_json() -> Result<()> {
     "code": "F401",
     "message": "`os` imported but unused",
     "fix": {{
+      "applicability": "Unspecified",
       "message": "Remove unused import: `os`",
       "edits": [
         {{


### PR DESCRIPTION
Add the `Fix::applicability` to the JSON output. I'll use the presence of the new field to detect whether this ruff version emits
one-based indices for edits or not.

Closes #4340