### PR TITLE
Add a specialized `StatementVisitor`

### DIFF
--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -8,7 +8,7 @@ use ruff_diagnostics::Diagnostic;
 use ruff_python_ast::helpers::to_module_path;
 use ruff_python_ast::imports::{ImportMap, ModuleImport};
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_stdlib::path::is_python_stub_file;
 
 use crate::directives::IsortDirectives;

--- a/crates/ruff/src/doc_lines.rs
+++ b/crates/ruff/src/doc_lines.rs
@@ -10,8 +10,7 @@ use rustpython_parser::Tok;
 
 use ruff_python_ast::newlines::UniversalNewlineIterator;
 use ruff_python_ast::source_code::Locator;
-use ruff_python_ast::visitor;
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 
 /// Extract doc lines (standalone comments) from a token sequence.
 pub fn doc_lines_from_tokens<'a>(lxr: &'a [LexResult], locator: &'a Locator<'a>) -> DocLines<'a> {
@@ -75,7 +74,7 @@ struct StringLinesVisitor<'a> {
     locator: &'a Locator<'a>,
 }
 
-impl Visitor<'_> for StringLinesVisitor<'_> {
+impl StatementVisitor<'_> for StringLinesVisitor<'_> {
     fn visit_stmt(&mut self, stmt: &Stmt) {
         if let StmtKind::Expr { value } = &stmt.node {
             if let ExprKind::Constant {
@@ -91,7 +90,7 @@ impl Visitor<'_> for StringLinesVisitor<'_> {
                 }
             }
         }
-        visitor::walk_stmt(self, stmt);
+        walk_stmt(self, stmt);
     }
 }
 

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::ReturnStatementVisitor;
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::{cast, helpers};
 use ruff_python_semantic::analyze::visibility;
 use ruff_python_semantic::analyze::visibility::Visibility;
@@ -416,9 +416,7 @@ impl Violation for AnyType {
 
 fn is_none_returning(body: &[Stmt]) -> bool {
     let mut visitor = ReturnStatementVisitor::default();
-    for stmt in body {
-        visitor.visit_stmt(stmt);
-    }
+    visitor.visit_body(body);
     for expr in visitor.returns.into_iter().flatten() {
         if !matches!(
             expr.node,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/raise_without_from_inside_except.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{ExprKind, Stmt};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::RaiseStatementVisitor;
-use ruff_python_ast::visitor;
+use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_stdlib::str::is_lower;
 
 use crate::checkers::ast::Checker;
@@ -25,7 +25,7 @@ impl Violation for RaiseWithoutFromInsideExcept {
 pub fn raise_without_from_inside_except(checker: &mut Checker, body: &[Stmt]) {
     let raises = {
         let mut visitor = RaiseStatementVisitor::default();
-        visitor::walk_body(&mut visitor, body);
+        visitor.visit_body(body);
         visitor.raises
     };
 

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -7,9 +7,8 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::unparse_expr;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::types::Node;
-use ruff_python_ast::visitor;
-use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::context::Context;
 
 use crate::checkers::ast::Checker;
@@ -146,7 +145,7 @@ struct InnerForWithAssignTargetsVisitor<'a> {
     assignment_targets: Vec<ExprWithInnerBindingKind<'a>>,
 }
 
-impl<'a, 'b> Visitor<'b> for InnerForWithAssignTargetsVisitor<'a>
+impl<'a, 'b> StatementVisitor<'b> for InnerForWithAssignTargetsVisitor<'a>
 where
     'b: 'a,
 {
@@ -225,7 +224,7 @@ where
             StmtKind::FunctionDef { .. } => {}
             // Otherwise, do recurse.
             _ => {
-                visitor::walk_stmt(self, stmt);
+                walk_stmt(self, stmt);
             }
         }
     }

--- a/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
+++ b/crates/ruff/src/rules/pylint/rules/too_many_return_statements.rs
@@ -4,7 +4,7 @@ use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{identifier_range, ReturnStatementVisitor};
 use ruff_python_ast::source_code::Locator;
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::StatementVisitor;
 
 #[violation]
 pub struct TooManyReturnStatements {

--- a/crates/ruff/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_return.rs
@@ -4,8 +4,8 @@ use rustpython_parser::ast::{Constant, Expr, ExprKind, Stmt, StmtKind};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{is_const_none, ReturnStatementVisitor};
+use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::types::RefEquality;
-use ruff_python_ast::visitor::Visitor;
 
 use crate::autofix::actions::delete_stmt;
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/yield_in_for_loop.rs
@@ -3,9 +3,10 @@ use rustpython_parser::ast::{Expr, ExprContext, ExprKind, Stmt, StmtKind};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::statement_visitor::StatementVisitor;
 use ruff_python_ast::types::RefEquality;
-use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::{statement_visitor, visitor};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -59,7 +60,7 @@ struct YieldFromVisitor<'a> {
     yields: Vec<YieldFrom<'a>>,
 }
 
-impl<'a> Visitor<'a> for YieldFromVisitor<'a> {
+impl<'a> StatementVisitor<'a> for YieldFromVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match &stmt.node {
             StmtKind::For {
@@ -97,20 +98,7 @@ impl<'a> Visitor<'a> for YieldFromVisitor<'a> {
             | StmtKind::ClassDef { .. } => {
                 // Don't recurse into anything that defines a new scope.
             }
-            _ => visitor::walk_stmt(self, stmt),
-        }
-    }
-
-    fn visit_expr(&mut self, expr: &'a Expr) {
-        match &expr.node {
-            ExprKind::ListComp { .. }
-            | ExprKind::SetComp { .. }
-            | ExprKind::DictComp { .. }
-            | ExprKind::GeneratorExp { .. }
-            | ExprKind::Lambda { .. } => {
-                // Don't recurse into anything that defines a new scope.
-            }
-            _ => visitor::walk_expr(self, expr),
+            _ => statement_visitor::walk_stmt(self, stmt),
         }
     }
 }

--- a/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_within_try.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{Excepthandler, Stmt, StmtKind};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::visitor::{self, Visitor};
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 
 use crate::checkers::ast::Checker;
 
@@ -58,7 +58,7 @@ struct RaiseStatementVisitor<'a> {
     raises: Vec<&'a Stmt>,
 }
 
-impl<'a, 'b> Visitor<'b> for RaiseStatementVisitor<'a>
+impl<'a, 'b> StatementVisitor<'b> for RaiseStatementVisitor<'a>
 where
     'b: 'a,
 {
@@ -66,7 +66,7 @@ where
         match stmt.node {
             StmtKind::Raise { .. } => self.raises.push(stmt),
             StmtKind::Try { .. } | StmtKind::TryStar { .. } => (),
-            _ => visitor::walk_stmt(self, stmt),
+            _ => walk_stmt(self, stmt),
         }
     }
 }
@@ -79,9 +79,7 @@ pub fn raise_within_try(checker: &mut Checker, body: &[Stmt], handlers: &[Except
 
     let raises = {
         let mut visitor = RaiseStatementVisitor::default();
-        for stmt in body {
-            visitor.visit_stmt(stmt);
-        }
+        visitor.visit_body(body);
         visitor.raises
     };
 

--- a/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/reraise_no_cause.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{ExprKind, Stmt};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::RaiseStatementVisitor;
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::StatementVisitor;
 
 use crate::checkers::ast::Checker;
 
@@ -50,9 +50,7 @@ impl Violation for ReraiseNoCause {
 pub fn reraise_no_cause(checker: &mut Checker, body: &[Stmt]) {
     let raises = {
         let mut visitor = RaiseStatementVisitor::default();
-        for stmt in body {
-            visitor.visit_stmt(stmt);
-        }
+        visitor.visit_body(body);
         visitor.raises
     };
 

--- a/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -2,8 +2,7 @@ use rustpython_parser::ast::{Expr, ExprKind, Stmt, StmtKind};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_ast::visitor;
-use ruff_python_ast::visitor::Visitor;
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 
 use crate::checkers::ast::Checker;
 
@@ -51,7 +50,7 @@ struct ControlFlowVisitor<'a> {
     continues: Vec<&'a Stmt>,
 }
 
-impl<'a, 'b> Visitor<'b> for ControlFlowVisitor<'a>
+impl<'a, 'b> StatementVisitor<'b> for ControlFlowVisitor<'a>
 where
     'b: 'a,
 {
@@ -65,19 +64,7 @@ where
             StmtKind::Return { .. } => self.returns.push(stmt),
             StmtKind::Break => self.breaks.push(stmt),
             StmtKind::Continue => self.continues.push(stmt),
-            _ => visitor::walk_stmt(self, stmt),
-        }
-    }
-
-    fn visit_expr(&mut self, expr: &'b Expr) {
-        match &expr.node {
-            ExprKind::ListComp { .. }
-            | ExprKind::DictComp { .. }
-            | ExprKind::SetComp { .. }
-            | ExprKind::GeneratorExp { .. } => {
-                // Don't recurse.
-            }
-            _ => visitor::walk_expr(self, expr),
+            _ => walk_stmt(self, stmt),
         }
     }
 }

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -1,7 +1,7 @@
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use ruff_benchmark::{TestCase, TestCaseSpeed, TestFile, TestFileDownloadError};
-use ruff_python_ast::visitor::{walk_stmt, Visitor};
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use rustpython_parser::ast::Stmt;
 use std::time::Duration;
 
@@ -40,7 +40,7 @@ struct CountVisitor {
     count: usize,
 }
 
-impl<'a> Visitor<'a> for CountVisitor {
+impl<'a> StatementVisitor<'a> for CountVisitor {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         walk_stmt(self, stmt);
         self.count += 1;

--- a/crates/ruff_python_ast/src/lib.rs
+++ b/crates/ruff_python_ast/src/lib.rs
@@ -8,6 +8,7 @@ pub mod imports;
 pub mod newlines;
 pub mod relocate;
 pub mod source_code;
+pub mod statement_visitor;
 pub mod str;
 pub mod token_kind;
 pub mod types;

--- a/crates/ruff_python_ast/src/statement_visitor.rs
+++ b/crates/ruff_python_ast/src/statement_visitor.rs
@@ -1,0 +1,111 @@
+//! Specialized AST visitor trait and walk functions that only visit statements.
+
+use rustpython_parser::ast::{Excepthandler, ExcepthandlerKind, MatchCase, Stmt, StmtKind};
+
+/// A trait for AST visitors that only need to visit statements.
+pub trait StatementVisitor<'a> {
+    fn visit_body(&mut self, body: &'a [Stmt]) {
+        walk_body(self, body);
+    }
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        walk_stmt(self, stmt);
+    }
+    fn visit_excepthandler(&mut self, excepthandler: &'a Excepthandler) {
+        walk_excepthandler(self, excepthandler);
+    }
+    fn visit_match_case(&mut self, match_case: &'a MatchCase) {
+        walk_match_case(self, match_case);
+    }
+}
+
+pub fn walk_body<'a, V: StatementVisitor<'a> + ?Sized>(visitor: &mut V, body: &'a [Stmt]) {
+    for stmt in body {
+        visitor.visit_stmt(stmt);
+    }
+}
+
+pub fn walk_stmt<'a, V: StatementVisitor<'a> + ?Sized>(visitor: &mut V, stmt: &'a Stmt) {
+    match &stmt.node {
+        StmtKind::FunctionDef { body, .. } => {
+            visitor.visit_body(body);
+        }
+        StmtKind::AsyncFunctionDef { body, .. } => {
+            visitor.visit_body(body);
+        }
+        StmtKind::For { body, orelse, .. } => {
+            visitor.visit_body(body);
+            visitor.visit_body(orelse);
+        }
+        StmtKind::ClassDef { body, .. } => {
+            visitor.visit_body(body);
+        }
+        StmtKind::AsyncFor { body, orelse, .. } => {
+            visitor.visit_body(body);
+            visitor.visit_body(orelse);
+        }
+        StmtKind::While { body, orelse, .. } => {
+            visitor.visit_body(body);
+            visitor.visit_body(orelse);
+        }
+        StmtKind::If { body, orelse, .. } => {
+            visitor.visit_body(body);
+            visitor.visit_body(orelse);
+        }
+        StmtKind::With { body, .. } => {
+            visitor.visit_body(body);
+        }
+        StmtKind::AsyncWith { body, .. } => {
+            visitor.visit_body(body);
+        }
+        StmtKind::Match { cases, .. } => {
+            for match_case in cases {
+                visitor.visit_match_case(match_case);
+            }
+        }
+        StmtKind::Try {
+            body,
+            handlers,
+            orelse,
+            finalbody,
+        } => {
+            visitor.visit_body(body);
+            for excepthandler in handlers {
+                visitor.visit_excepthandler(excepthandler);
+            }
+            visitor.visit_body(orelse);
+            visitor.visit_body(finalbody);
+        }
+        StmtKind::TryStar {
+            body,
+            handlers,
+            orelse,
+            finalbody,
+        } => {
+            visitor.visit_body(body);
+            for excepthandler in handlers {
+                visitor.visit_excepthandler(excepthandler);
+            }
+            visitor.visit_body(orelse);
+            visitor.visit_body(finalbody);
+        }
+        _ => {}
+    }
+}
+
+pub fn walk_excepthandler<'a, V: StatementVisitor<'a> + ?Sized>(
+    visitor: &mut V,
+    excepthandler: &'a Excepthandler,
+) {
+    match &excepthandler.node {
+        ExcepthandlerKind::ExceptHandler { body, .. } => {
+            visitor.visit_body(body);
+        }
+    }
+}
+
+pub fn walk_match_case<'a, V: StatementVisitor<'a> + ?Sized>(
+    visitor: &mut V,
+    match_case: &'a MatchCase,
+) {
+    visitor.visit_body(&match_case.body);
+}

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -1,9 +1,15 @@
+//! AST visitor trait and walk functions.
+
 use rustpython_parser::ast::{
     Alias, Arg, Arguments, Boolop, Cmpop, Comprehension, Constant, Excepthandler,
     ExcepthandlerKind, Expr, ExprContext, ExprKind, Keyword, MatchCase, Operator, Pattern,
     PatternKind, Stmt, StmtKind, Unaryop, Withitem,
 };
 
+/// A trait for AST visitors. Visits all nodes in the AST recursively.
+///
+/// Prefer [`crate::statement_visitor::StatementVisitor`] for visitors that only need to visit
+/// statements.
 pub trait Visitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         walk_stmt(self, stmt);


### PR DESCRIPTION
## Summary

This PR adds a specialized `StatementVisitor` trait that structs can implement in lieu of the generic `Visitor` when they only care about visiting statements (recursively). In many cases, we only care about visiting statements, and visiting the entire AST is thus quite wasteful, as expressions can't contain statements.
