### PR TITLE
Add a `Snapshot` abstraction for deferring and restoring visitor context

### DIFF
--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -2,26 +2,20 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::Expr;
 
 use ruff_python_semantic::analyze::visibility::{Visibility, VisibleScope};
-use ruff_python_semantic::node::NodeId;
-use ruff_python_semantic::scope::ScopeId;
+use ruff_python_semantic::context::Snapshot;
 
-use crate::checkers::ast::AnnotationContext;
 use crate::docstrings::definition::Definition;
-
-/// A snapshot of the current scope and statement, which will be restored when visiting any
-/// deferred definitions.
-type Context<'a> = (ScopeId, Option<NodeId>);
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all
 /// module-level definitions have been analyzed.
 #[derive(Default)]
 pub struct Deferred<'a> {
-    pub definitions: Vec<(Definition<'a>, Visibility, Context<'a>)>,
-    pub string_type_definitions: Vec<(TextRange, &'a str, AnnotationContext, Context<'a>)>,
-    pub type_definitions: Vec<(&'a Expr, AnnotationContext, Context<'a>)>,
-    pub functions: Vec<(Context<'a>, VisibleScope)>,
-    pub lambdas: Vec<(&'a Expr, Context<'a>)>,
-    pub for_loops: Vec<Context<'a>>,
-    pub assignments: Vec<Context<'a>>,
+    pub definitions: Vec<(Definition<'a>, Visibility, Snapshot)>,
+    pub string_type_definitions: Vec<(TextRange, &'a str, Snapshot)>,
+    pub type_definitions: Vec<(&'a Expr, Snapshot)>,
+    pub functions: Vec<(Snapshot, VisibleScope)>,
+    pub lambdas: Vec<(&'a Expr, Snapshot)>,
+    pub for_loops: Vec<Snapshot>,
+    pub assignments: Vec<Snapshot>,
 }

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -19,6 +19,15 @@ use crate::binding::{
 use crate::node::{NodeId, Nodes};
 use crate::scope::{Scope, ScopeId, ScopeKind, Scopes};
 
+/// A snapshot of the [`Context`] at a given point in the AST traversal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Snapshot {
+    scope_id: ScopeId,
+    stmt_id: Option<NodeId>,
+    in_annotation: bool,
+    in_type_checking_block: bool,
+}
+
 #[allow(clippy::struct_excessive_bools)]
 pub struct Context<'a> {
     pub typing_modules: &'a [String],
@@ -434,5 +443,23 @@ impl<'a> Context<'a> {
             exceptions.insert(*exception);
         }
         exceptions
+    }
+
+    /// Generate a [`Snapshot`] of the current context.
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            scope_id: self.scope_id,
+            stmt_id: self.stmt_id,
+            in_annotation: self.in_annotation,
+            in_type_checking_block: self.in_type_checking_block,
+        }
+    }
+
+    /// Restore the context to the given [`Snapshot`].
+    pub fn restore(&mut self, snapshot: Snapshot) {
+        self.scope_id = snapshot.scope_id;
+        self.stmt_id = snapshot.stmt_id;
+        self.in_annotation = snapshot.in_annotation;
+        self.in_type_checking_block = snapshot.in_type_checking_block;
     }
 }

--- a/crates/ruff_python_semantic/src/node.rs
+++ b/crates/ruff_python_semantic/src/node.rs
@@ -30,6 +30,7 @@ impl From<NodeId> for usize {
     }
 }
 
+/// A [`Node`] represents a statement in a program, along with a pointer to its parent (if any).
 #[derive(Debug)]
 struct Node<'a> {
     /// The statement this node represents.


### PR DESCRIPTION
## Summary

In the `Checker`, a common pattern we have is that we see something like a function definition, then we add it to a queue for deferred processing (since, e.g., we don't parse function bodies until we've parsed the rest of the containing scope). When we defer these traversals, we have to save some of the `Checker` state (e.g., the current scope), which we then restore later on.

This PR formalizes that pattern using a `Snapshot` struct, along with `Context::snapshot` and `Context::restore` methods.

Honestly, there's more state that we _should_ be saving and restoring in the `Snapshot`, namely all of the boolean flags. We should revisit those omissions, but it's no different than on `main` and it tends not to matter in practice.
