### PR TITLE
Respect `__all__` imports when determining definition visibility

### DIFF
--- a/crates/ruff/resources/test/fixtures/pydocstyle/all.py
+++ b/crates/ruff/resources/test/fixtures/pydocstyle/all.py
@@ -1,0 +1,18 @@
+def public_func():
+    pass
+
+
+def private_func():
+    pass
+
+
+class PublicClass:
+    class PublicNestedClass:
+        pass
+
+
+class PrivateClass:
+    pass
+
+
+__all__ = ("public_func", "PublicClass")

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -168,4 +168,23 @@ mod tests {
         assert_messages!(diagnostics);
         Ok(())
     }
+
+    #[test]
+    fn all() -> Result<()> {
+        let diagnostics = test_path(
+            Path::new("pydocstyle/all.py"),
+            &settings::Settings::for_rules([
+                Rule::UndocumentedPublicModule,
+                Rule::UndocumentedPublicClass,
+                Rule::UndocumentedPublicMethod,
+                Rule::UndocumentedPublicFunction,
+                Rule::UndocumentedPublicPackage,
+                Rule::UndocumentedMagicMethod,
+                Rule::UndocumentedPublicNestedClass,
+                Rule::UndocumentedPublicInit,
+            ]),
+        )?;
+        assert_messages!(diagnostics);
+        Ok(())
+    }
 }

--- a/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__all.snap
+++ b/crates/ruff/src/rules/pydocstyle/snapshots/ruff__rules__pydocstyle__tests__all.snap
@@ -1,0 +1,34 @@
+---
+source: crates/ruff/src/rules/pydocstyle/mod.rs
+---
+all.py:1:1: D100 Missing docstring in public module
+  |
+1 | def public_func():
+  |  D100
+2 |     pass
+  |
+
+all.py:1:5: D103 Missing docstring in public function
+  |
+1 | def public_func():
+  |     ^^^^^^^^^^^ D103
+2 |     pass
+  |
+
+all.py:9:7: D101 Missing docstring in public class
+   |
+ 9 | class PublicClass:
+   |       ^^^^^^^^^^^ D101
+10 |     class PublicNestedClass:
+11 |         pass
+   |
+
+all.py:10:11: D106 Missing docstring in public nested class
+   |
+10 | class PublicClass:
+11 |     class PublicNestedClass:
+   |           ^^^^^^^^^^^^^^^^^ D106
+12 |         pass
+   |
+
+


### PR DESCRIPTION
## Summary

When determining whether a function, method, etc. is public or private, we need to take `__all__` into account. This PR leverages our new delayed-visibility logic to respect `__all__` exports.

For more context, see #4339.

Closes #993.
