### PR TITLE
Refactor code to use the new RustPython `is` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ dependencies = [
  "regex",
  "ruff_text_size",
  "rustc-hash",
- "rustpython-literal 0.2.0 (git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666)",
+ "rustpython-literal 0.2.0 (git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec)",
  "rustpython-parser",
  "serde",
  "smallvec",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666#2af98056629fbe75ccc0d90c4ee05dfeb403d666"
+source = "git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec#947fb53d0b41fec465db3d8e725bdb2eec1299ec"
 dependencies = [
  "schemars",
  "serde",
@@ -2201,8 +2201,9 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666#2af98056629fbe75ccc0d90c4ee05dfeb403d666"
+source = "git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec#947fb53d0b41fec465db3d8e725bdb2eec1299ec"
 dependencies = [
+ "is-macro",
  "num-bigint",
  "rustpython-parser-core",
 ]
@@ -2234,7 +2235,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666#2af98056629fbe75ccc0d90c4ee05dfeb403d666"
+source = "git+https://github.com/youknowone/RustPython-parser.git?rev=5b2af304a2baa53598e594097824165d4ac7a119#5b2af304a2baa53598e594097824165d4ac7a119"
 dependencies = [
  "hexf-parse",
  "lexical-parse-float",
@@ -2245,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/youknowone/RustPython-parser.git?rev=5b2af304a2baa53598e594097824165d4ac7a119#5b2af304a2baa53598e594097824165d4ac7a119"
+source = "git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec#947fb53d0b41fec465db3d8e725bdb2eec1299ec"
 dependencies = [
  "hexf-parse",
  "lexical-parse-float",
@@ -2256,7 +2257,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666#2af98056629fbe75ccc0d90c4ee05dfeb403d666"
+source = "git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec#947fb53d0b41fec465db3d8e725bdb2eec1299ec"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2278,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=2af98056629fbe75ccc0d90c4ee05dfeb403d666#2af98056629fbe75ccc0d90c4ee05dfeb403d666"
+source = "git+https://github.com/RustPython/Parser.git?rev=947fb53d0b41fec465db3d8e725bdb2eec1299ec#947fb53d0b41fec465db3d8e725bdb2eec1299ec"
 dependencies = [
  "itertools",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ path-absolutize = { version = "3.0.14" }
 proc-macro2 = { version = "1.0.51" }
 quote = { version = "1.0.23" }
 regex = { version = "1.7.1" }
-ruff_text_size = { git = "https://github.com/RustPython/Parser.git", rev = "2af98056629fbe75ccc0d90c4ee05dfeb403d666" }
+ruff_text_size = { git = "https://github.com/RustPython/Parser.git", rev = "947fb53d0b41fec465db3d8e725bdb2eec1299ec" }
 rustc-hash = { version = "1.1.0" }
 rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "f3e4d3409253660bd4fa7f3d24d3db747e7dca61" }
-rustpython-literal = { git = "https://github.com/RustPython/Parser.git", rev = "2af98056629fbe75ccc0d90c4ee05dfeb403d666" }
-rustpython-parser = { git = "https://github.com/RustPython/Parser.git", rev = "2af98056629fbe75ccc0d90c4ee05dfeb403d666" , default-features = false}
+rustpython-literal = { git = "https://github.com/RustPython/Parser.git", rev = "947fb53d0b41fec465db3d8e725bdb2eec1299ec" }
+rustpython-parser = { git = "https://github.com/RustPython/Parser.git", rev = "947fb53d0b41fec465db3d8e725bdb2eec1299ec" , default-features = false}
 schemars = { version = "0.8.12" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", features = ["preserve_order"] }

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{self, Constant, Expr, ExprKind, Stmt};
+use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -420,10 +420,7 @@ fn is_none_returning(body: &[Stmt]) -> bool {
     for expr in visitor.returns.into_iter().flatten() {
         if !matches!(
             expr.node,
-            ExprKind::Constant(ast::ExprConstant {
-                value: Constant::None,
-                ..
-            })
+            ExprKind::Constant(ref constant) if constant.value.is_none()
         ) {
             return false;
         }

--- a/crates/ruff/src/rules/flake8_blind_except/rules.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules.rs
@@ -59,9 +59,8 @@ pub fn blind_except(
                 if let StmtKind::Expr(ast::StmtExpr { value }) = &stmt.node {
                     if let ExprKind::Call(ast::ExprCall { func, keywords, .. }) = &value.node {
                         if logging::is_logger_candidate(&checker.ctx, func) {
-                            if let ExprKind::Attribute(ast::ExprAttribute { attr, .. }) = &func.node
-                            {
-                                let attr = attr.as_str();
+                            if let Some(attribute) = func.node.as_attribute_expr() {
+                                let attr = attribute.attr.as_str();
                                 if attr == "exception" {
                                     return true;
                                 }

--- a/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/rules.rs
@@ -120,7 +120,7 @@ pub fn check_positional_boolean_in_def(
 
         // check for both bool (python class) and 'bool' (string annotation)
         let hint = match &expr.node {
-            ExprKind::Name(ast::ExprName { id, .. }) => id == "bool",
+            ExprKind::Name(name) => &name.id == "bool",
             ExprKind::Constant(ast::ExprConstant {
                 value: Constant::Str(value),
                 ..

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{Expr, ExprKind};
+use rustpython_parser::ast::Expr;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -45,7 +45,7 @@ pub fn unnecessary_list_call(checker: &mut Checker, expr: &Expr, func: &Expr, ar
     if !checker.ctx.is_builtin("list") {
         return;
     }
-    if !matches!(argument, ExprKind::ListComp(_)) {
+    if !argument.is_list_comp_expr() {
         return;
     }
     let mut diagnostic = Diagnostic::new(UnnecessaryListCall, expr.range());

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{Expr, ExprKind, Keyword};
+use rustpython_parser::ast::{Expr, Keyword};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
@@ -53,7 +53,7 @@ pub fn unnecessary_list_comprehension_set(
     if !checker.ctx.is_builtin("set") {
         return;
     }
-    if let ExprKind::ListComp(_) = &argument {
+    if argument.is_list_comp_expr() {
         let mut diagnostic = Diagnostic::new(UnnecessaryListComprehensionSet, expr.range());
         if checker.patch(diagnostic.kind.rule()) {
             #[allow(deprecated)]

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -65,10 +65,7 @@ pub(super) fn is_empty_or_null_string(expr: &Expr) -> bool {
             value: Constant::Str(string),
             ..
         }) => string.is_empty(),
-        ExprKind::Constant(ast::ExprConstant {
-            value: Constant::None,
-            ..
-        }) => true,
+        ExprKind::Constant(constant) if constant.value.is_none() => true,
         ExprKind::JoinedStr(ast::ExprJoinedStr { values }) => {
             values.iter().all(is_empty_or_null_string)
         }

--- a/crates/ruff/src/rules/flake8_return/helpers.rs
+++ b/crates/ruff/src/rules/flake8_return/helpers.rs
@@ -1,5 +1,5 @@
 use ruff_text_size::TextSize;
-use rustpython_parser::ast::{self, Constant, Expr, ExprKind, Stmt};
+use rustpython_parser::ast::{Expr, ExprKind, Stmt};
 
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::source_code::Locator;
@@ -11,10 +11,7 @@ pub fn result_exists(returns: &[(&Stmt, Option<&Expr>)]) -> bool {
         expr.map(|expr| {
             !matches!(
                 expr.node,
-                ExprKind::Constant(ast::ExprConstant {
-                    value: Constant::None,
-                    ..
-                })
+                ExprKind::Constant(ref constant) if constant.value.is_none()
             )
         })
         .unwrap_or(false)


### PR DESCRIPTION
Related parser patch https://github.com/RustPython/Parser/pull/20

I made a few changes as example.