### PR TITLE
Move black excludes from pre-commit config to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,11 +63,6 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-        exclude: |
-          (?x)^(
-            crates/ruff/resources/.*|
-            crates/ruff_python_formatter/resources/.*
-          )$
 
 ci:
   skip: [cargo-fmt, clippy, dev-generate-all]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,11 @@ bindings = "bin"
 manifest-path = "crates/ruff_cli/Cargo.toml"
 python-source = "python"
 strip = true
+
+[tool.black]
+force-exclude = '''
+/(
+  | crates/ruff/resources
+  | crates/ruff_python_formatter/resources
+)/
+'''


### PR DESCRIPTION
Currently, when black is run for the project with `black .`, it tries to format files in:
- `crates/ruff/resources/test/fixtures` 
- `crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases`. 

This behaviour differs from when running black with pre-commit as these files are excluded. 

The files that black is attempting to format should not be formatted as they are test fixtures.

This PR moves the exclusion from the pre-commit config to a black specific config in `pyproject.toml`.