### PR TITLE
List rule changes in ecosystem

### DIFF
--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -329,13 +329,11 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
             print()
             print("| Rule | Changes | Additions | Removals |")
             print("| ---- | ------- | --------- | -------- |")
-            for rule, (additions, removals) in dict(
-                sorted(
-                    rule_changes.items(),
-                    key=lambda x: (x[1][0] + x[1][1]),
-                    reverse=True,
-                ),
-            ).items():
+            for rule, (additions, removals) in sorted(
+                rule_changes.items(),
+                key=lambda x: (x[1][0] + x[1][1]),
+                reverse=True,
+            ):
                 print(f"| {rule} | {additions + removals} | {additions} | {removals} |")
 
     logger.debug(f"Finished {len(repositories)} repositories")

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -323,7 +323,8 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
             else:
                 continue
 
-        print(f"<details><summary>Rules changed: {len(rule_changes.keys())}</summary>")
+        print(f"Rules changed: {len(rule_changes.keys())}")
+        print()
         print("| Rule | Changes | Additions | Removals |")
         print("| ---- | ------- | --------- | -------- |")
         for rule, (additions, removals) in dict(
@@ -334,8 +335,6 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
             ),
         ).items():
             print(f"| {rule} | {additions + removals} | {additions} | {removals} |")
-
-        print("</details>")
 
     logger.debug(f"Finished {len(repositories)} repositories")
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -300,7 +300,14 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                 for line in diff_str.splitlines():
                     # Find rule change for current line or construction
                     # + <rule>/<path>:<line>:<column>: <rule_code> <message>
-                    rule_code = re.findall(r": [A-Z]{1,3}[0-9]{3,4}", line)[0][2:]
+                    matches = re.findall(r": [A-Z]{1,3}[0-9]{3,4}", line)
+                    if len(matches) == 0:
+                        # Handle case where there are no regex matches e.g.
+                        # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE" # noqa: E501, ERA001
+                        # Which was found in local testing
+                        continue
+
+                    rule_code = matches[0][2:]
 
                     # Get current additions and removals for this rule
                     current_changes = rule_changes.get(rule_code, (0, 0))

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -323,18 +323,19 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
             else:
                 continue
 
-        print(f"Rules changed: {len(rule_changes.keys())}")
-        print()
-        print("| Rule | Changes | Additions | Removals |")
-        print("| ---- | ------- | --------- | -------- |")
-        for rule, (additions, removals) in dict(
-            sorted(
-                rule_changes.items(),
-                key=lambda x: (x[1][0] + x[1][1]),
-                reverse=True,
-            ),
-        ).items():
-            print(f"| {rule} | {additions + removals} | {additions} | {removals} |")
+        if len(rule_changes.keys()) > 0:
+            print(f"Rules changed: {len(rule_changes.keys())}")
+            print()
+            print("| Rule | Changes | Additions | Removals |")
+            print("| ---- | ------- | --------- | -------- |")
+            for rule, (additions, removals) in dict(
+                sorted(
+                    rule_changes.items(),
+                    key=lambda x: (x[1][0] + x[1][1]),
+                    reverse=True,
+                ),
+            ).items():
+                print(f"| {rule} | {additions + removals} | {additions} | {removals} |")
 
     logger.debug(f"Finished {len(repositories)} repositories")
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -300,7 +300,7 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                 for line in diff_str.splitlines():
                     # Find rule change for current line or construction
                     # + <rule>/<path>:<line>:<column>: <rule_code> <message>
-                    matches = re.search(r": [A-Z]{1,3}[0-9]{3,4}", line)
+                    matches = re.search(r": ([A-Z]{1,3}[0-9]{3,4})", line)
 
                     if matches is None:
                         # Handle case where there are no regex matches e.g.
@@ -308,7 +308,7 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                         # Which was found in local testing
                         continue
 
-                    rule_code = matches.group(0)[2:]  # Trim leading ": "
+                    rule_code = matches.group(1)
 
                     # Get current additions and removals for this rule
                     current_changes = rule_changes.get(rule_code, (0, 0))

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -324,10 +324,16 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                 continue
 
         print(f"<details><summary>Rules changed: {len(rule_changes.keys())}</summary>")
-        print("| Rule | Additions | Removals |")
-        print("| ---- | --------- | -------- |")
-        for rule, (additions, removals) in rule_changes.items():
-            print(f"| {rule} | {additions} | {removals} |")
+        print("| Rule | Changes | Additions | Removals |")
+        print("| ---- | ------- | --------- | -------- |")
+        for rule, (additions, removals) in dict(
+            sorted(
+                rule_changes.items(),
+                key=lambda x: (x[1][0] + x[1][1]),
+                reverse=True,
+            ),
+        ).items():
+            print(f"| {rule} | {additions + removals} | {additions} | {removals} |")
 
         print("</details>")
 

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -300,14 +300,15 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                 for line in diff_str.splitlines():
                     # Find rule change for current line or construction
                     # + <rule>/<path>:<line>:<column>: <rule_code> <message>
-                    matches = re.findall(r": [A-Z]{1,3}[0-9]{3,4}", line)
-                    if len(matches) == 0:
+                    matches = re.search(r": [A-Z]{1,3}[0-9]{3,4}", line)
+
+                    if matches is None:
                         # Handle case where there are no regex matches e.g.
                         # +                 "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE" # noqa: E501, ERA001
                         # Which was found in local testing
                         continue
 
-                    rule_code = matches[0][2:]  # Trim leading ": "
+                    rule_code = matches.group(0)[2:]  # Trim leading ": "
 
                     # Get current additions and removals for this rule
                     current_changes = rule_changes.get(rule_code, (0, 0))

--- a/scripts/check_ecosystem.py
+++ b/scripts/check_ecosystem.py
@@ -307,7 +307,7 @@ async def main(*, ruff1: Path, ruff2: Path, projects_jsonl: Optional[Path]) -> N
                         # Which was found in local testing
                         continue
 
-                    rule_code = matches[0][2:]
+                    rule_code = matches[0][2:]  # Trim leading ": "
 
                     # Get current additions and removals for this rule
                     current_changes = rule_changes.get(rule_code, (0, 0))


### PR DESCRIPTION
Currently, the ecosystem check lists all changes between two versions of ruff as a diff. This PR counts the changes for each rule so the impact of the change can be determined. 

A use case where this could be useful is when adding a set of new rules to determine if one rule will cause a particularly large number of new rule violations to be raised. For example, the addition of the new flake8-todo rules in #3921 raised [a discussion ](https://github.com/charliermarsh/ruff/pull/3921#discussion_r1190257550)about the impact of the rule TDO003 which checks that TODOs have links present.

## Example output

When comparing the current build to v0.0.264 the example output would be.

```bash
scripts/check_ecosystem.py env/bin/ruff target/release/ruff
```

ℹ️ ecosystem check **detected changes**. (+12, -0, 0 error(s))

<details><summary>typeshed (+12, -0)</summary>
<p>

```diff
+ stdlib/typing.pyi:735:1: PYI042 Type alias `_get_type_hints_obj_allowed_types` should be CamelCase
+ stubs/cffi/_cffi_backend.pyi:113:5: PYI042 Type alias `buffer` should be CamelCase
+ stubs/cffi/cffi/api.pyi:13:1: PYI042 Type alias `basestring` should be CamelCase
+ stubs/cffi/cffi/api.pyi:18:5: PYI042 Type alias `buffer` should be CamelCase
+ stubs/pika/pika/spec.pyi:9:1: PYI042 Type alias `_str` should be CamelCase
+ stubs/pywin32/pythoncom.pyi:10:1: PYI042 Type alias `error` should be CamelCase
+ stubs/pywin32/win32/odbc.pyi:9:1: PYI042 Type alias `_odbcError` should be CamelCase
+ stubs/pywin32/win32comext/adsi/adsi.pyi:7:1: PYI042 Type alias `error` should be CamelCase
+ stubs/pywin32/win32comext/propsys/propsys.pyi:6:1: PYI042 Type alias `error` should be CamelCase
+ stubs/pywin32/win32comext/shell/shell.pyi:7:1: PYI042 Type alias `error` should be CamelCase
+ stubs/redis/redis/typing.pyi:17:1: PYI043 Private type alias `_StringLikeT` should not be suffixed with `T` (the `T` suffix implies that an object is a `TypeVar`)
+ stubs/requests/requests/compat.pyi:22:1: PYI042 Type alias `builtin_str` should be CamelCase
```

</p>
</details>
Rules changed: 2

| Rule | Changes | Additions | Removals |
| ---- | ------- | --------- | -------- |
| PYI042 | 11 | 11 | 0 |
| PYI043 | 1 | 1 | 0 |