### PR TITLE
Remove special-casing for `flake8-builtins` rules

### DIFF
--- a/crates/ruff/src/rules/flake8_builtins/mod.rs
+++ b/crates/ruff/src/rules/flake8_builtins/mod.rs
@@ -1,17 +1,15 @@
 //! Rules from [flake8-builtins](https://pypi.org/project/flake8-builtins/).
 pub(crate) mod rules;
 pub mod settings;
-pub(crate) mod types;
 
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A001.py:1:1: A001 Variable `sum` is shadowing a python builtin
+A001.py:1:1: A001 Variable `sum` is shadowing a Python builtin
   |
 1 | import some as sum
   | ^^^^^^^^^^^^^^^^^^ A001
@@ -9,7 +9,7 @@ A001.py:1:1: A001 Variable `sum` is shadowing a python builtin
 3 | from directory import new as dir
   |
 
-A001.py:2:1: A001 Variable `int` is shadowing a python builtin
+A001.py:2:1: A001 Variable `int` is shadowing a Python builtin
   |
 2 | import some as sum
 3 | from some import other as int
@@ -17,7 +17,7 @@ A001.py:2:1: A001 Variable `int` is shadowing a python builtin
 4 | from directory import new as dir
   |
 
-A001.py:3:1: A001 Variable `dir` is shadowing a python builtin
+A001.py:3:1: A001 Variable `dir` is shadowing a Python builtin
   |
 3 | import some as sum
 4 | from some import other as int
@@ -27,7 +27,7 @@ A001.py:3:1: A001 Variable `dir` is shadowing a python builtin
 7 | print = 1
   |
 
-A001.py:5:1: A001 Variable `print` is shadowing a python builtin
+A001.py:5:1: A001 Variable `print` is shadowing a Python builtin
   |
 5 | from directory import new as dir
 6 | 
@@ -37,7 +37,7 @@ A001.py:5:1: A001 Variable `print` is shadowing a python builtin
 9 | (complex := 3)
   |
 
-A001.py:6:1: A001 Variable `copyright` is shadowing a python builtin
+A001.py:6:1: A001 Variable `copyright` is shadowing a Python builtin
   |
 6 | print = 1
 7 | copyright: 'annotation' = 2
@@ -46,7 +46,7 @@ A001.py:6:1: A001 Variable `copyright` is shadowing a python builtin
 9 | float = object = 4
   |
 
-A001.py:7:2: A001 Variable `complex` is shadowing a python builtin
+A001.py:7:2: A001 Variable `complex` is shadowing a Python builtin
    |
  7 | print = 1
  8 | copyright: 'annotation' = 2
@@ -56,7 +56,7 @@ A001.py:7:2: A001 Variable `complex` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:8:1: A001 Variable `float` is shadowing a python builtin
+A001.py:8:1: A001 Variable `float` is shadowing a Python builtin
    |
  8 | copyright: 'annotation' = 2
  9 | (complex := 3)
@@ -65,7 +65,7 @@ A001.py:8:1: A001 Variable `float` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:8:9: A001 Variable `object` is shadowing a python builtin
+A001.py:8:9: A001 Variable `object` is shadowing a Python builtin
    |
  8 | copyright: 'annotation' = 2
  9 | (complex := 3)
@@ -74,7 +74,7 @@ A001.py:8:9: A001 Variable `object` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:9:1: A001 Variable `min` is shadowing a python builtin
+A001.py:9:1: A001 Variable `min` is shadowing a Python builtin
    |
  9 | (complex := 3)
 10 | float = object = 4
@@ -84,7 +84,7 @@ A001.py:9:1: A001 Variable `min` is shadowing a python builtin
 13 | id = 4
    |
 
-A001.py:9:6: A001 Variable `max` is shadowing a python builtin
+A001.py:9:6: A001 Variable `max` is shadowing a Python builtin
    |
  9 | (complex := 3)
 10 | float = object = 4
@@ -94,7 +94,7 @@ A001.py:9:6: A001 Variable `max` is shadowing a python builtin
 13 | id = 4
    |
 
-A001.py:11:1: A001 Variable `id` is shadowing a python builtin
+A001.py:11:1: A001 Variable `id` is shadowing a Python builtin
    |
 11 | min, max = 5, 6
 12 | 
@@ -104,7 +104,7 @@ A001.py:11:1: A001 Variable `id` is shadowing a python builtin
 15 | def bytes():
    |
 
-A001.py:13:1: A001 Variable `bytes` is shadowing a python builtin
+A001.py:13:1: A001 Variable `bytes` is shadowing a Python builtin
    |
 13 |   id = 4
 14 |   
@@ -115,7 +115,7 @@ A001.py:13:1: A001 Variable `bytes` is shadowing a python builtin
 18 |   class slice:
    |
 
-A001.py:16:1: A001 Variable `slice` is shadowing a python builtin
+A001.py:16:1: A001 Variable `slice` is shadowing a Python builtin
    |
 16 |       pass
 17 |   
@@ -126,7 +126,7 @@ A001.py:16:1: A001 Variable `slice` is shadowing a python builtin
 21 |   try:
    |
 
-A001.py:21:1: A001 Variable `ValueError` is shadowing a python builtin
+A001.py:21:1: A001 Variable `ValueError` is shadowing a Python builtin
    |
 21 |   try:
 22 |       ...
@@ -137,7 +137,7 @@ A001.py:21:1: A001 Variable `ValueError` is shadowing a python builtin
 26 |   for memoryview, *bytearray in []:
    |
 
-A001.py:24:5: A001 Variable `memoryview` is shadowing a python builtin
+A001.py:24:5: A001 Variable `memoryview` is shadowing a Python builtin
    |
 24 |     ...
 25 | 
@@ -146,7 +146,7 @@ A001.py:24:5: A001 Variable `memoryview` is shadowing a python builtin
 27 |     pass
    |
 
-A001.py:24:18: A001 Variable `bytearray` is shadowing a python builtin
+A001.py:24:18: A001 Variable `bytearray` is shadowing a Python builtin
    |
 24 |     ...
 25 | 
@@ -155,7 +155,7 @@ A001.py:24:18: A001 Variable `bytearray` is shadowing a python builtin
 27 |     pass
    |
 
-A001.py:27:22: A001 Variable `str` is shadowing a python builtin
+A001.py:27:22: A001 Variable `str` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -164,7 +164,7 @@ A001.py:27:22: A001 Variable `str` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:27:45: A001 Variable `all` is shadowing a python builtin
+A001.py:27:45: A001 Variable `all` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -173,7 +173,7 @@ A001.py:27:45: A001 Variable `all` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:27:50: A001 Variable `any` is shadowing a python builtin
+A001.py:27:50: A001 Variable `any` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -182,7 +182,7 @@ A001.py:27:50: A001 Variable `any` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:30:8: A001 Variable `sum` is shadowing a python builtin
+A001.py:30:8: A001 Variable `sum` is shadowing a Python builtin
    |
 30 |     pass
 31 | 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A001_A001.py_builtins_ignorelist.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A001.py:1:1: A001 Variable `sum` is shadowing a python builtin
+A001.py:1:1: A001 Variable `sum` is shadowing a Python builtin
   |
 1 | import some as sum
   | ^^^^^^^^^^^^^^^^^^ A001
@@ -9,7 +9,7 @@ A001.py:1:1: A001 Variable `sum` is shadowing a python builtin
 3 | from directory import new as dir
   |
 
-A001.py:2:1: A001 Variable `int` is shadowing a python builtin
+A001.py:2:1: A001 Variable `int` is shadowing a Python builtin
   |
 2 | import some as sum
 3 | from some import other as int
@@ -17,7 +17,7 @@ A001.py:2:1: A001 Variable `int` is shadowing a python builtin
 4 | from directory import new as dir
   |
 
-A001.py:5:1: A001 Variable `print` is shadowing a python builtin
+A001.py:5:1: A001 Variable `print` is shadowing a Python builtin
   |
 5 | from directory import new as dir
 6 | 
@@ -27,7 +27,7 @@ A001.py:5:1: A001 Variable `print` is shadowing a python builtin
 9 | (complex := 3)
   |
 
-A001.py:6:1: A001 Variable `copyright` is shadowing a python builtin
+A001.py:6:1: A001 Variable `copyright` is shadowing a Python builtin
   |
 6 | print = 1
 7 | copyright: 'annotation' = 2
@@ -36,7 +36,7 @@ A001.py:6:1: A001 Variable `copyright` is shadowing a python builtin
 9 | float = object = 4
   |
 
-A001.py:7:2: A001 Variable `complex` is shadowing a python builtin
+A001.py:7:2: A001 Variable `complex` is shadowing a Python builtin
    |
  7 | print = 1
  8 | copyright: 'annotation' = 2
@@ -46,7 +46,7 @@ A001.py:7:2: A001 Variable `complex` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:8:1: A001 Variable `float` is shadowing a python builtin
+A001.py:8:1: A001 Variable `float` is shadowing a Python builtin
    |
  8 | copyright: 'annotation' = 2
  9 | (complex := 3)
@@ -55,7 +55,7 @@ A001.py:8:1: A001 Variable `float` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:8:9: A001 Variable `object` is shadowing a python builtin
+A001.py:8:9: A001 Variable `object` is shadowing a Python builtin
    |
  8 | copyright: 'annotation' = 2
  9 | (complex := 3)
@@ -64,7 +64,7 @@ A001.py:8:9: A001 Variable `object` is shadowing a python builtin
 11 | min, max = 5, 6
    |
 
-A001.py:9:1: A001 Variable `min` is shadowing a python builtin
+A001.py:9:1: A001 Variable `min` is shadowing a Python builtin
    |
  9 | (complex := 3)
 10 | float = object = 4
@@ -74,7 +74,7 @@ A001.py:9:1: A001 Variable `min` is shadowing a python builtin
 13 | id = 4
    |
 
-A001.py:9:6: A001 Variable `max` is shadowing a python builtin
+A001.py:9:6: A001 Variable `max` is shadowing a Python builtin
    |
  9 | (complex := 3)
 10 | float = object = 4
@@ -84,7 +84,7 @@ A001.py:9:6: A001 Variable `max` is shadowing a python builtin
 13 | id = 4
    |
 
-A001.py:13:1: A001 Variable `bytes` is shadowing a python builtin
+A001.py:13:1: A001 Variable `bytes` is shadowing a Python builtin
    |
 13 |   id = 4
 14 |   
@@ -95,7 +95,7 @@ A001.py:13:1: A001 Variable `bytes` is shadowing a python builtin
 18 |   class slice:
    |
 
-A001.py:16:1: A001 Variable `slice` is shadowing a python builtin
+A001.py:16:1: A001 Variable `slice` is shadowing a Python builtin
    |
 16 |       pass
 17 |   
@@ -106,7 +106,7 @@ A001.py:16:1: A001 Variable `slice` is shadowing a python builtin
 21 |   try:
    |
 
-A001.py:21:1: A001 Variable `ValueError` is shadowing a python builtin
+A001.py:21:1: A001 Variable `ValueError` is shadowing a Python builtin
    |
 21 |   try:
 22 |       ...
@@ -117,7 +117,7 @@ A001.py:21:1: A001 Variable `ValueError` is shadowing a python builtin
 26 |   for memoryview, *bytearray in []:
    |
 
-A001.py:24:5: A001 Variable `memoryview` is shadowing a python builtin
+A001.py:24:5: A001 Variable `memoryview` is shadowing a Python builtin
    |
 24 |     ...
 25 | 
@@ -126,7 +126,7 @@ A001.py:24:5: A001 Variable `memoryview` is shadowing a python builtin
 27 |     pass
    |
 
-A001.py:24:18: A001 Variable `bytearray` is shadowing a python builtin
+A001.py:24:18: A001 Variable `bytearray` is shadowing a Python builtin
    |
 24 |     ...
 25 | 
@@ -135,7 +135,7 @@ A001.py:24:18: A001 Variable `bytearray` is shadowing a python builtin
 27 |     pass
    |
 
-A001.py:27:22: A001 Variable `str` is shadowing a python builtin
+A001.py:27:22: A001 Variable `str` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -144,7 +144,7 @@ A001.py:27:22: A001 Variable `str` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:27:45: A001 Variable `all` is shadowing a python builtin
+A001.py:27:45: A001 Variable `all` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -153,7 +153,7 @@ A001.py:27:45: A001 Variable `all` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:27:50: A001 Variable `any` is shadowing a python builtin
+A001.py:27:50: A001 Variable `any` is shadowing a Python builtin
    |
 27 |     pass
 28 | 
@@ -162,7 +162,7 @@ A001.py:27:50: A001 Variable `any` is shadowing a python builtin
 30 |     pass
    |
 
-A001.py:30:8: A001 Variable `sum` is shadowing a python builtin
+A001.py:30:8: A001 Variable `sum` is shadowing a Python builtin
    |
 30 |     pass
 31 | 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A002_A002.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A002_A002.py.snap
@@ -1,49 +1,49 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A002.py:1:11: A002 Argument `str` is shadowing a python builtin
+A002.py:1:11: A002 Argument `str` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |           ^^^ A002
 2 |     pass
   |
 
-A002.py:1:19: A002 Argument `type` is shadowing a python builtin
+A002.py:1:19: A002 Argument `type` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                   ^^^^ A002
 2 |     pass
   |
 
-A002.py:1:26: A002 Argument `complex` is shadowing a python builtin
+A002.py:1:26: A002 Argument `complex` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                          ^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:1:35: A002 Argument `Exception` is shadowing a python builtin
+A002.py:1:35: A002 Argument `Exception` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                                   ^^^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:1:48: A002 Argument `getattr` is shadowing a python builtin
+A002.py:1:48: A002 Argument `getattr` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                                                ^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:5:17: A002 Argument `bytes` is shadowing a python builtin
+A002.py:5:17: A002 Argument `bytes` is shadowing a Python builtin
   |
 5 | async def func2(bytes):
   |                 ^^^^^ A002
 6 |     pass
   |
 
-A002.py:8:17: A002 Argument `id` is shadowing a python builtin
+A002.py:8:17: A002 Argument `id` is shadowing a Python builtin
    |
  8 |     pass
  9 | 
@@ -52,7 +52,7 @@ A002.py:8:17: A002 Argument `id` is shadowing a python builtin
 11 |     pass
    |
 
-A002.py:8:21: A002 Argument `dir` is shadowing a python builtin
+A002.py:8:21: A002 Argument `dir` is shadowing a Python builtin
    |
  8 |     pass
  9 | 
@@ -61,7 +61,7 @@ A002.py:8:21: A002 Argument `dir` is shadowing a python builtin
 11 |     pass
    |
 
-A002.py:11:16: A002 Argument `float` is shadowing a python builtin
+A002.py:11:16: A002 Argument `float` is shadowing a Python builtin
    |
 11 |     pass
 12 | 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A002_A002.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A002_A002.py_builtins_ignorelist.snap
@@ -1,49 +1,49 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A002.py:1:11: A002 Argument `str` is shadowing a python builtin
+A002.py:1:11: A002 Argument `str` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |           ^^^ A002
 2 |     pass
   |
 
-A002.py:1:19: A002 Argument `type` is shadowing a python builtin
+A002.py:1:19: A002 Argument `type` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                   ^^^^ A002
 2 |     pass
   |
 
-A002.py:1:26: A002 Argument `complex` is shadowing a python builtin
+A002.py:1:26: A002 Argument `complex` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                          ^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:1:35: A002 Argument `Exception` is shadowing a python builtin
+A002.py:1:35: A002 Argument `Exception` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                                   ^^^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:1:48: A002 Argument `getattr` is shadowing a python builtin
+A002.py:1:48: A002 Argument `getattr` is shadowing a Python builtin
   |
 1 | def func1(str, /, type, *complex, Exception, **getattr):
   |                                                ^^^^^^^ A002
 2 |     pass
   |
 
-A002.py:5:17: A002 Argument `bytes` is shadowing a python builtin
+A002.py:5:17: A002 Argument `bytes` is shadowing a Python builtin
   |
 5 | async def func2(bytes):
   |                 ^^^^^ A002
 6 |     pass
   |
 
-A002.py:11:16: A002 Argument `float` is shadowing a python builtin
+A002.py:11:16: A002 Argument `float` is shadowing a Python builtin
    |
 11 |     pass
 12 | 

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A003.py:2:5: A003 Class attribute `ImportError` is shadowing a python builtin
+A003.py:2:5: A003 Class attribute `ImportError` is shadowing a Python builtin
   |
 2 | class MyClass:
 3 |     ImportError = 4
@@ -10,7 +10,7 @@ A003.py:2:5: A003 Class attribute `ImportError` is shadowing a python builtin
 5 |     dir = "/"
   |
 
-A003.py:3:5: A003 Class attribute `id` is shadowing a python builtin
+A003.py:3:5: A003 Class attribute `id` is shadowing a Python builtin
   |
 3 | class MyClass:
 4 |     ImportError = 4
@@ -19,7 +19,7 @@ A003.py:3:5: A003 Class attribute `id` is shadowing a python builtin
 6 |     dir = "/"
   |
 
-A003.py:4:5: A003 Class attribute `dir` is shadowing a python builtin
+A003.py:4:5: A003 Class attribute `dir` is shadowing a Python builtin
   |
 4 |     ImportError = 4
 5 |     id = 5
@@ -29,7 +29,7 @@ A003.py:4:5: A003 Class attribute `dir` is shadowing a python builtin
 8 |     def __init__(self):
   |
 
-A003.py:11:5: A003 Class attribute `str` is shadowing a python builtin
+A003.py:11:5: A003 Class attribute `str` is shadowing a Python builtin
    |
 11 |           self.dir = "."
 12 |   

--- a/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
+++ b/crates/ruff/src/rules/flake8_builtins/snapshots/ruff__rules__flake8_builtins__tests__A003_A003.py_builtins_ignorelist.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/flake8_builtins/mod.rs
 ---
-A003.py:2:5: A003 Class attribute `ImportError` is shadowing a python builtin
+A003.py:2:5: A003 Class attribute `ImportError` is shadowing a Python builtin
   |
 2 | class MyClass:
 3 |     ImportError = 4
@@ -10,7 +10,7 @@ A003.py:2:5: A003 Class attribute `ImportError` is shadowing a python builtin
 5 |     dir = "/"
   |
 
-A003.py:11:5: A003 Class attribute `str` is shadowing a python builtin
+A003.py:11:5: A003 Class attribute `str` is shadowing a Python builtin
    |
 11 |           self.dir = "."
 12 |   

--- a/crates/ruff/src/rules/flake8_builtins/types.rs
+++ b/crates/ruff/src/rules/flake8_builtins/types.rs
@@ -1,6 +1,0 @@
-#[derive(Clone, Copy)]
-pub enum ShadowingType {
-    Variable,
-    Argument,
-    Attribute,
-}


### PR DESCRIPTION
## Summary

This PR modifies the `flake8-builtins` rules to follow some of our more conventional patterns (namely, by removing special-purpose methods on `Checker`). The updated patterns aren't necessarily _better_, but they're more consistent and will be useful if we migrate to a more declarative visitor-based approach.