### PR TITLE
Enable autofix for split-assertions at top level

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_pytest_style/PT018.py
+++ b/crates/ruff/resources/test/fixtures/flake8_pytest_style/PT018.py
@@ -39,3 +39,8 @@ def test_error():
 message
 """
     )
+
+
+assert something  # OK
+assert something and something_else  # Error
+assert something and something_else and something_third  # Error

--- a/crates/ruff/src/cst/matchers.rs
+++ b/crates/ruff/src/cst/matchers.rs
@@ -14,7 +14,7 @@ pub(crate) fn match_module(module_text: &str) -> Result<Module> {
 pub(crate) fn match_expression(expression_text: &str) -> Result<Expression> {
     match libcst_native::parse_expression(expression_text) {
         Ok(expression) => Ok(expression),
-        Err(_) => bail!("Failed to extract CST from source"),
+        Err(_) => bail!("Failed to extract expression from source"),
     }
 }
 

--- a/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
+++ b/crates/ruff/src/rules/flake8_pytest_style/snapshots/ruff__rules__flake8_pytest_style__tests__PT018.snap
@@ -269,4 +269,39 @@ PT018.py:35:5: PT018 Assertion should be broken down into multiple parts
    |
    = help: Break down assertion into multiple parts
 
+PT018.py:45:1: PT018 [*] Assertion should be broken down into multiple parts
+   |
+45 | assert something  # OK
+46 | assert something and something_else  # Error
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT018
+47 | assert something and something_else and something_third  # Error
+   |
+   = help: Break down assertion into multiple parts
+
+ℹ Suggested fix
+42 42 | 
+43 43 | 
+44 44 | assert something  # OK
+45    |-assert something and something_else  # Error
+   45 |+assert something
+   46 |+assert something_else
+46 47 | assert something and something_else and something_third  # Error
+
+PT018.py:46:1: PT018 [*] Assertion should be broken down into multiple parts
+   |
+46 | assert something  # OK
+47 | assert something and something_else  # Error
+48 | assert something and something_else and something_third  # Error
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PT018
+   |
+   = help: Break down assertion into multiple parts
+
+ℹ Suggested fix
+43 43 | 
+44 44 | assert something  # OK
+45 45 | assert something and something_else  # Error
+46    |-assert something and something_else and something_third  # Error
+   46 |+assert something and something_else
+   47 |+assert something_third
+
 


### PR DESCRIPTION
It looks like the `PT018` fix _assumed_ that the assertions would be within a function or otherwise not at the top level. This PR addresses that oversight, borrowing patterns from other existing autofixes.

Closes #4403.