### PR TITLE
Enable automatic rewrites of `typing.Deque` and `typing.DefaultDict`

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP006.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP006.py
@@ -56,3 +56,11 @@ def f(x: "List['Li' 'st[str]']") -> None:
 
 def f(x: "Li" "st['List[str]']") -> None:
     ...
+
+
+def f(x: typing.Deque[str]) -> None:
+    ...
+
+
+def f(x: typing.DefaultDict[str, str]) -> None:
+    ...

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2351,7 +2351,6 @@ where
                                 || (self.settings.target_version >= PythonVersion::Py37
                                     && self.ctx.future_annotations()
                                     && self.ctx.in_annotation()))
-                            && analyze::typing::is_pep585_builtin(expr, &self.ctx)
                         {
                             pyupgrade::rules::use_pep585_annotation(self, expr);
                         }
@@ -2413,7 +2412,6 @@ where
                         || (self.settings.target_version >= PythonVersion::Py37
                             && self.ctx.future_annotations()
                             && self.ctx.in_annotation()))
-                    && analyze::typing::is_pep585_builtin(expr, &self.ctx)
                 {
                     pyupgrade::rules::use_pep585_annotation(self, expr);
                 }

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -2257,26 +2257,40 @@ where
         match &expr.node {
             ExprKind::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 // Ex) Optional[...], Union[...]
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::MissingFutureAnnotationsImport)
-                    && (self.settings.target_version < PythonVersion::Py310
-                        && (self.settings.target_version >= PythonVersion::Py37
-                            && !self.ctx.future_annotations()
-                            && self.ctx.in_annotation()))
-                    && analyze::typing::is_pep604_builtin(value, &self.ctx)
-                {
-                    flake8_future_annotations::rules::missing_future_annotations(self, value);
-                }
-                if self.settings.rules.enabled(Rule::NonPEP604Annotation)
-                    && (self.settings.target_version >= PythonVersion::Py310
-                        || (self.settings.target_version >= PythonVersion::Py37
-                            && self.ctx.future_annotations()
-                            && self.ctx.in_annotation()))
-                    && analyze::typing::is_pep604_builtin(value, &self.ctx)
-                {
-                    pyupgrade::rules::use_pep604_annotation(self, expr, value, slice);
+                if self.settings.rules.any_enabled(&[
+                    Rule::MissingFutureAnnotationsImport,
+                    Rule::NonPEP604Annotation,
+                ]) {
+                    if let Some(operator) =
+                        analyze::typing::to_pep604_operator(value, slice, &self.ctx)
+                    {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(Rule::MissingFutureAnnotationsImport)
+                        {
+                            if self.settings.target_version < PythonVersion::Py310
+                                && self.settings.target_version >= PythonVersion::Py37
+                                && !self.ctx.future_annotations()
+                                && self.ctx.in_annotation()
+                            {
+                                flake8_future_annotations::rules::missing_future_annotations(
+                                    self, value,
+                                );
+                            }
+                        }
+                        if self.settings.rules.enabled(Rule::NonPEP604Annotation) {
+                            if self.settings.target_version >= PythonVersion::Py310
+                                || (self.settings.target_version >= PythonVersion::Py37
+                                    && self.ctx.future_annotations()
+                                    && self.ctx.in_annotation())
+                            {
+                                pyupgrade::rules::use_pep604_annotation(
+                                    self, expr, slice, operator,
+                                );
+                            }
+                        }
+                    }
                 }
 
                 if self.ctx.match_typing_expr(value, "Literal") {
@@ -2332,27 +2346,42 @@ where
                         }
 
                         // Ex) List[...]
-                        if self
-                            .settings
-                            .rules
-                            .enabled(Rule::MissingFutureAnnotationsImport)
-                            && (self.settings.target_version < PythonVersion::Py39
-                                && (self.settings.target_version >= PythonVersion::Py37
-                                    && !self.ctx.future_annotations()
-                                    && self.ctx.in_annotation()))
-                            && analyze::typing::is_pep585_builtin(expr, &self.ctx)
-                        {
-                            flake8_future_annotations::rules::missing_future_annotations(
-                                self, expr,
-                            );
-                        }
-                        if self.settings.rules.enabled(Rule::NonPEP585Annotation)
-                            && (self.settings.target_version >= PythonVersion::Py39
-                                || (self.settings.target_version >= PythonVersion::Py37
-                                    && self.ctx.future_annotations()
-                                    && self.ctx.in_annotation()))
-                        {
-                            pyupgrade::rules::use_pep585_annotation(self, expr);
+                        if self.settings.rules.any_enabled(&[
+                            Rule::MissingFutureAnnotationsImport,
+                            Rule::NonPEP585Annotation,
+                        ]) {
+                            if let Some(replacement) =
+                                analyze::typing::to_pep585_generic(expr, &self.ctx)
+                            {
+                                if self
+                                    .settings
+                                    .rules
+                                    .enabled(Rule::MissingFutureAnnotationsImport)
+                                {
+                                    if self.settings.target_version < PythonVersion::Py39
+                                        && self.settings.target_version >= PythonVersion::Py37
+                                        && !self.ctx.future_annotations()
+                                        && self.ctx.in_annotation()
+                                    {
+                                        flake8_future_annotations::rules::missing_future_annotations(
+                                            self, expr,
+                                        );
+                                    }
+                                }
+                                if self.settings.rules.enabled(Rule::NonPEP585Annotation) {
+                                    if self.settings.target_version >= PythonVersion::Py39
+                                        || (self.settings.target_version >= PythonVersion::Py37
+                                            && self.ctx.future_annotations()
+                                            && self.ctx.in_annotation())
+                                    {
+                                        pyupgrade::rules::use_pep585_annotation(
+                                            self,
+                                            expr,
+                                            &replacement,
+                                        );
+                                    }
+                                }
+                            }
                         }
 
                         self.handle_node_load(expr);
@@ -2395,25 +2424,36 @@ where
             }
             ExprKind::Attribute(ast::ExprAttribute { attr, value, .. }) => {
                 // Ex) typing.List[...]
-                if self
-                    .settings
-                    .rules
-                    .enabled(Rule::MissingFutureAnnotationsImport)
-                    && (self.settings.target_version < PythonVersion::Py39
-                        && (self.settings.target_version >= PythonVersion::Py37
-                            && !self.ctx.future_annotations()
-                            && self.ctx.in_annotation()))
-                    && analyze::typing::is_pep585_builtin(expr, &self.ctx)
-                {
-                    flake8_future_annotations::rules::missing_future_annotations(self, expr);
-                }
-                if self.settings.rules.enabled(Rule::NonPEP585Annotation)
-                    && (self.settings.target_version >= PythonVersion::Py39
-                        || (self.settings.target_version >= PythonVersion::Py37
-                            && self.ctx.future_annotations()
-                            && self.ctx.in_annotation()))
-                {
-                    pyupgrade::rules::use_pep585_annotation(self, expr);
+                if self.settings.rules.any_enabled(&[
+                    Rule::MissingFutureAnnotationsImport,
+                    Rule::NonPEP585Annotation,
+                ]) {
+                    if let Some(replacement) = analyze::typing::to_pep585_generic(expr, &self.ctx) {
+                        if self
+                            .settings
+                            .rules
+                            .enabled(Rule::MissingFutureAnnotationsImport)
+                        {
+                            if self.settings.target_version < PythonVersion::Py39
+                                && self.settings.target_version >= PythonVersion::Py37
+                                && !self.ctx.future_annotations()
+                                && self.ctx.in_annotation()
+                            {
+                                flake8_future_annotations::rules::missing_future_annotations(
+                                    self, expr,
+                                );
+                            }
+                        }
+                        if self.settings.rules.enabled(Rule::NonPEP585Annotation) {
+                            if self.settings.target_version >= PythonVersion::Py39
+                                || (self.settings.target_version >= PythonVersion::Py37
+                                    && self.ctx.future_annotations()
+                                    && self.ctx.in_annotation())
+                            {
+                                pyupgrade::rules::use_pep585_annotation(self, expr, &replacement);
+                            }
+                        }
+                    }
                 }
                 if self.settings.rules.enabled(Rule::DatetimeTimezoneUTC)
                     && self.settings.target_version >= PythonVersion::Py311

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -2,7 +2,8 @@ use rustpython_parser::ast::Expr;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::analyze::typing::{to_pep585_generic, ModuleMember, SymbolReplacement};
+use ruff_python_ast::call_path::compose_call_path;
+use ruff_python_semantic::analyze::typing::ModuleMember;
 
 use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
@@ -10,8 +11,8 @@ use crate::registry::AsRule;
 
 #[violation]
 pub struct NonPEP585Annotation {
-    from: ModuleMember<'static>,
-    to: ModuleMember<'static>,
+    from: String,
+    to: String,
 }
 
 impl Violation for NonPEP585Annotation {
@@ -30,42 +31,48 @@ impl Violation for NonPEP585Annotation {
 }
 
 /// UP006
-pub(crate) fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
-    let Some(SymbolReplacement { from, to }) = to_pep585_generic(expr, &checker.ctx) else {
+pub(crate) fn use_pep585_annotation(
+    checker: &mut Checker,
+    expr: &Expr,
+    replacement: &ModuleMember,
+) {
+    let Some(from) = compose_call_path(expr) else {
         return;
     };
-
-    let fixable = !checker.ctx.in_complex_string_type_definition();
     let mut diagnostic = Diagnostic::new(
         NonPEP585Annotation {
-            from: from.clone(),
-            to: to.clone(),
+            from,
+            to: replacement.to_string(),
         },
         expr.range(),
     );
+    let fixable = !checker.ctx.in_complex_string_type_definition();
     if fixable && checker.patch(diagnostic.kind.rule()) {
-        if to.is_builtin() {
-            // Built-in type, like `list`.
-            if checker.ctx.is_builtin(to.member()) {
-                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
-                    to.member().to_string(),
-                    expr.range(),
-                )));
+        match replacement {
+            ModuleMember::BuiltIn(name) => {
+                // Built-in type, like `list`.
+                if checker.ctx.is_builtin(name) {
+                    diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                        (*name).to_string(),
+                        expr.range(),
+                    )));
+                }
             }
-        } else {
-            // Imported type, like `collections.deque`.
-            diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = get_or_import_symbol(
-                    to.module(),
-                    to.member(),
-                    expr.start(),
-                    &checker.ctx,
-                    &checker.importer,
-                    checker.locator,
-                )?;
-                let reference_edit = Edit::range_replacement(binding, expr.range());
-                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
-            });
+            ModuleMember::Member(module, member) => {
+                // Imported type, like `collections.deque`.
+                diagnostic.try_set_fix(|| {
+                    let (import_edit, binding) = get_or_import_symbol(
+                        module,
+                        member,
+                        expr.start(),
+                        &checker.ctx,
+                        &checker.importer,
+                        checker.locator,
+                    )?;
+                    let reference_edit = Edit::range_replacement(binding, expr.range());
+                    Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+                });
+            }
         }
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -2,13 +2,16 @@ use rustpython_parser::ast::Expr;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_semantic::analyze::typing::{to_pep585_generic, ModuleMember, SymbolReplacement};
 
+use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
 #[violation]
 pub struct NonPEP585Annotation {
-    name: String,
+    from: ModuleMember<'static>,
+    to: ModuleMember<'static>,
 }
 
 impl Violation for NonPEP585Annotation {
@@ -16,44 +19,54 @@ impl Violation for NonPEP585Annotation {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        let NonPEP585Annotation { name } = self;
-        format!(
-            "Use `{}` instead of `{}` for type annotations",
-            name.to_lowercase(),
-            name,
-        )
+        let NonPEP585Annotation { from, to } = self;
+        format!("Use `{to}` instead of `{from}` for type annotation")
     }
 
     fn autofix_title(&self) -> Option<String> {
-        let NonPEP585Annotation { name } = self;
-        Some(format!("Replace `{name}` with `{}`", name.to_lowercase()))
+        let NonPEP585Annotation { to, .. } = self;
+        Some(format!("Replace with `{to}`"))
     }
 }
 
 /// UP006
 pub(crate) fn use_pep585_annotation(checker: &mut Checker, expr: &Expr) {
-    if let Some(binding) = checker
-        .ctx
-        .resolve_call_path(expr)
-        .and_then(|call_path| call_path.last().copied())
-    {
-        let fixable = !checker.ctx.in_complex_string_type_definition();
-        let mut diagnostic = Diagnostic::new(
-            NonPEP585Annotation {
-                name: binding.to_string(),
-            },
-            expr.range(),
-        );
-        if fixable && checker.patch(diagnostic.kind.rule()) {
-            let binding = binding.to_lowercase();
-            if checker.ctx.is_builtin(&binding) {
-                #[allow(deprecated)]
-                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    binding,
+    let Some(SymbolReplacement { from, to }) = to_pep585_generic(expr, &checker.ctx) else {
+        return;
+    };
+
+    let fixable = !checker.ctx.in_complex_string_type_definition();
+    let mut diagnostic = Diagnostic::new(
+        NonPEP585Annotation {
+            from: from.clone(),
+            to: to.clone(),
+        },
+        expr.range(),
+    );
+    if fixable && checker.patch(diagnostic.kind.rule()) {
+        if to.is_builtin() {
+            // Built-in type, like `list`.
+            if checker.ctx.is_builtin(to.member()) {
+                diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
+                    to.member().to_string(),
                     expr.range(),
                 )));
             }
+        } else {
+            // Imported type, like `collections.deque`.
+            diagnostic.try_set_fix(|| {
+                let (import_edit, binding) = get_or_import_symbol(
+                    to.module(),
+                    to.member(),
+                    expr.start(),
+                    &checker.ctx,
+                    &checker.importer,
+                    checker.locator,
+                )?;
+                let reference_edit = Edit::range_replacement(binding, expr.range());
+                Ok(Fix::suggested_edits(import_edit, [reference_edit]))
+            });
         }
-        checker.diagnostics.push(diagnostic);
     }
+    checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
@@ -1,13 +1,13 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-UP006.py:4:10: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:4:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
   |
 4 | def f(x: typing.List[str]) -> None:
   |          ^^^^^^^^^^^ UP006
 5 |     ...
   |
-  = help: Replace `List` with `list`
+  = help: Replace with `list`
 
 ℹ Suggested fix
 1 1 | import typing
@@ -19,13 +19,13 @@ UP006.py:4:10: UP006 [*] Use `list` instead of `List` for type annotations
 6 6 | 
 7 7 | 
 
-UP006.py:11:10: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:11:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 11 | def f(x: List[str]) -> None:
    |          ^^^^ UP006
 12 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 8  8  | from typing import List
@@ -37,13 +37,13 @@ UP006.py:11:10: UP006 [*] Use `list` instead of `List` for type annotations
 13 13 | 
 14 14 | 
 
-UP006.py:18:10: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:18:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 18 | def f(x: t.List[str]) -> None:
    |          ^^^^^^ UP006
 19 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 15 15 | import typing as t
@@ -55,13 +55,13 @@ UP006.py:18:10: UP006 [*] Use `list` instead of `List` for type annotations
 20 20 | 
 21 21 | 
 
-UP006.py:25:10: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:25:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 25 | def f(x: IList[str]) -> None:
    |          ^^^^^ UP006
 26 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 22 22 | from typing import List as IList
@@ -73,13 +73,13 @@ UP006.py:25:10: UP006 [*] Use `list` instead of `List` for type annotations
 27 27 | 
 28 28 | 
 
-UP006.py:29:11: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:29:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 29 | def f(x: "List[str]") -> None:
    |           ^^^^ UP006
 30 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 26 26 |     ...
@@ -91,13 +91,13 @@ UP006.py:29:11: UP006 [*] Use `list` instead of `List` for type annotations
 31 31 | 
 32 32 | 
 
-UP006.py:33:12: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:33:12: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 33 | def f(x: r"List[str]") -> None:
    |            ^^^^ UP006
 34 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 30 30 |     ...
@@ -109,13 +109,13 @@ UP006.py:33:12: UP006 [*] Use `list` instead of `List` for type annotations
 35 35 | 
 36 36 | 
 
-UP006.py:37:11: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:37:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 37 | def f(x: "List[str]") -> None:
    |           ^^^^ UP006
 38 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 34 34 |     ...
@@ -127,13 +127,13 @@ UP006.py:37:11: UP006 [*] Use `list` instead of `List` for type annotations
 39 39 | 
 40 40 | 
 
-UP006.py:41:13: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:41:13: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 41 | def f(x: """List[str]""") -> None:
    |             ^^^^ UP006
 42 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 38 38 |     ...
@@ -145,21 +145,21 @@ UP006.py:41:13: UP006 [*] Use `list` instead of `List` for type annotations
 43 43 | 
 44 44 | 
 
-UP006.py:45:10: UP006 Use `list` instead of `List` for type annotations
+UP006.py:45:10: UP006 Use `list` instead of `typing.List` for type annotation
    |
 45 | def f(x: "Li" "st[str]") -> None:
    |          ^^^^^^^^^^^^^^ UP006
 46 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
-UP006.py:49:11: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:49:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 49 | def f(x: "List['List[str]']") -> None:
    |           ^^^^ UP006
 50 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 46 46 |     ...
@@ -171,13 +171,13 @@ UP006.py:49:11: UP006 [*] Use `list` instead of `List` for type annotations
 51 51 | 
 52 52 | 
 
-UP006.py:49:17: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:49:17: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 49 | def f(x: "List['List[str]']") -> None:
    |                 ^^^^ UP006
 50 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 46 46 |     ...
@@ -189,13 +189,13 @@ UP006.py:49:17: UP006 [*] Use `list` instead of `List` for type annotations
 51 51 | 
 52 52 | 
 
-UP006.py:53:11: UP006 [*] Use `list` instead of `List` for type annotations
+UP006.py:53:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 53 | def f(x: "List['Li' 'st[str]']") -> None:
    |           ^^^^ UP006
 54 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 50 50 |     ...
@@ -207,28 +207,78 @@ UP006.py:53:11: UP006 [*] Use `list` instead of `List` for type annotations
 55 55 | 
 56 56 | 
 
-UP006.py:53:16: UP006 Use `list` instead of `List` for type annotations
+UP006.py:53:16: UP006 Use `list` instead of `typing.List` for type annotation
    |
 53 | def f(x: "List['Li' 'st[str]']") -> None:
    |                ^^^^^^^^^^^^^^ UP006
 54 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
-UP006.py:57:10: UP006 Use `list` instead of `List` for type annotations
+UP006.py:57:10: UP006 Use `list` instead of `typing.List` for type annotation
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
    |          ^^^^^^^^^^^^^^^^^^^^^^ UP006
 58 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
-UP006.py:57:10: UP006 Use `list` instead of `List` for type annotations
+UP006.py:57:10: UP006 Use `list` instead of `typing.List` for type annotation
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
    |          ^^^^^^^^^^^^^^^^^^^^^^ UP006
 58 |     ...
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
+
+UP006.py:61:10: UP006 [*] Use `collections.deque` instead of `typing.Deque` for type annotation
+   |
+61 | def f(x: typing.Deque[str]) -> None:
+   |          ^^^^^^^^^^^^ UP006
+62 |     ...
+   |
+   = help: Replace with `collections.deque`
+
+ℹ Suggested fix
+20 20 | 
+21 21 | 
+22 22 | from typing import List as IList
+   23 |+import collections
+23 24 | 
+24 25 | 
+25 26 | def f(x: IList[str]) -> None:
+--------------------------------------------------------------------------------
+58 59 |     ...
+59 60 | 
+60 61 | 
+61    |-def f(x: typing.Deque[str]) -> None:
+   62 |+def f(x: collections.deque[str]) -> None:
+62 63 |     ...
+63 64 | 
+64 65 | 
+
+UP006.py:65:10: UP006 [*] Use `collections.defaultdict` instead of `typing.DefaultDict` for type annotation
+   |
+65 | def f(x: typing.DefaultDict[str, str]) -> None:
+   |          ^^^^^^^^^^^^^^^^^^ UP006
+66 |     ...
+   |
+   = help: Replace with `collections.defaultdict`
+
+ℹ Suggested fix
+20 20 | 
+21 21 | 
+22 22 | from typing import List as IList
+   23 |+import collections
+23 24 | 
+24 25 | 
+25 26 | def f(x: IList[str]) -> None:
+--------------------------------------------------------------------------------
+62 63 |     ...
+63 64 | 
+64 65 | 
+65    |-def f(x: typing.DefaultDict[str, str]) -> None:
+   66 |+def f(x: collections.defaultdict[str, str]) -> None:
+66 67 |     ...
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006.py.snap
@@ -9,7 +9,7 @@ UP006.py:4:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
   |
   = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | import typing
 2 2 | 
 3 3 | 
@@ -19,7 +19,7 @@ UP006.py:4:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
 6 6 | 
 7 7 | 
 
-UP006.py:11:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:11:10: UP006 [*] Use `list` instead of `List` for type annotation
    |
 11 | def f(x: List[str]) -> None:
    |          ^^^^ UP006
@@ -27,7 +27,7 @@ UP006.py:11:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 8  8  | from typing import List
 9  9  | 
 10 10 | 
@@ -37,7 +37,7 @@ UP006.py:11:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 13 13 | 
 14 14 | 
 
-UP006.py:18:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:18:10: UP006 [*] Use `list` instead of `t.List` for type annotation
    |
 18 | def f(x: t.List[str]) -> None:
    |          ^^^^^^ UP006
@@ -45,7 +45,7 @@ UP006.py:18:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 15 15 | import typing as t
 16 16 | 
 17 17 | 
@@ -55,7 +55,7 @@ UP006.py:18:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 20 20 | 
 21 21 | 
 
-UP006.py:25:10: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:25:10: UP006 [*] Use `list` instead of `IList` for type annotation
    |
 25 | def f(x: IList[str]) -> None:
    |          ^^^^^ UP006
@@ -63,7 +63,7 @@ UP006.py:25:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 22 22 | from typing import List as IList
 23 23 | 
 24 24 | 
@@ -73,7 +73,7 @@ UP006.py:25:10: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 27 27 | 
 28 28 | 
 
-UP006.py:29:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:29:11: UP006 [*] Use `list` instead of `List` for type annotation
    |
 29 | def f(x: "List[str]") -> None:
    |           ^^^^ UP006
@@ -81,7 +81,7 @@ UP006.py:29:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 26 26 |     ...
 27 27 | 
 28 28 | 
@@ -91,7 +91,7 @@ UP006.py:29:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 31 31 | 
 32 32 | 
 
-UP006.py:33:12: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:33:12: UP006 [*] Use `list` instead of `List` for type annotation
    |
 33 | def f(x: r"List[str]") -> None:
    |            ^^^^ UP006
@@ -99,7 +99,7 @@ UP006.py:33:12: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 30 30 |     ...
 31 31 | 
 32 32 | 
@@ -109,7 +109,7 @@ UP006.py:33:12: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 35 35 | 
 36 36 | 
 
-UP006.py:37:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:37:11: UP006 [*] Use `list` instead of `List` for type annotation
    |
 37 | def f(x: "List[str]") -> None:
    |           ^^^^ UP006
@@ -117,7 +117,7 @@ UP006.py:37:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 34 34 |     ...
 35 35 | 
 36 36 | 
@@ -127,7 +127,7 @@ UP006.py:37:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 39 39 | 
 40 40 | 
 
-UP006.py:41:13: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:41:13: UP006 [*] Use `list` instead of `List` for type annotation
    |
 41 | def f(x: """List[str]""") -> None:
    |             ^^^^ UP006
@@ -135,7 +135,7 @@ UP006.py:41:13: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 38 38 |     ...
 39 39 | 
 40 40 | 
@@ -145,7 +145,7 @@ UP006.py:41:13: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 43 43 | 
 44 44 | 
 
-UP006.py:45:10: UP006 Use `list` instead of `typing.List` for type annotation
+UP006.py:45:10: UP006 Use `list` instead of `List` for type annotation
    |
 45 | def f(x: "Li" "st[str]") -> None:
    |          ^^^^^^^^^^^^^^ UP006
@@ -153,7 +153,7 @@ UP006.py:45:10: UP006 Use `list` instead of `typing.List` for type annotation
    |
    = help: Replace with `list`
 
-UP006.py:49:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:49:11: UP006 [*] Use `list` instead of `List` for type annotation
    |
 49 | def f(x: "List['List[str]']") -> None:
    |           ^^^^ UP006
@@ -161,7 +161,7 @@ UP006.py:49:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 46 46 |     ...
 47 47 | 
 48 48 | 
@@ -171,7 +171,7 @@ UP006.py:49:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 51 51 | 
 52 52 | 
 
-UP006.py:49:17: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:49:17: UP006 [*] Use `list` instead of `List` for type annotation
    |
 49 | def f(x: "List['List[str]']") -> None:
    |                 ^^^^ UP006
@@ -179,7 +179,7 @@ UP006.py:49:17: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 46 46 |     ...
 47 47 | 
 48 48 | 
@@ -189,7 +189,7 @@ UP006.py:49:17: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 51 51 | 
 52 52 | 
 
-UP006.py:53:11: UP006 [*] Use `list` instead of `typing.List` for type annotation
+UP006.py:53:11: UP006 [*] Use `list` instead of `List` for type annotation
    |
 53 | def f(x: "List['Li' 'st[str]']") -> None:
    |           ^^^^ UP006
@@ -197,7 +197,7 @@ UP006.py:53:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 50 50 |     ...
 51 51 | 
 52 52 | 
@@ -207,7 +207,7 @@ UP006.py:53:11: UP006 [*] Use `list` instead of `typing.List` for type annotatio
 55 55 | 
 56 56 | 
 
-UP006.py:53:16: UP006 Use `list` instead of `typing.List` for type annotation
+UP006.py:53:16: UP006 Use `list` instead of `List` for type annotation
    |
 53 | def f(x: "List['Li' 'st[str]']") -> None:
    |                ^^^^^^^^^^^^^^ UP006
@@ -215,7 +215,7 @@ UP006.py:53:16: UP006 Use `list` instead of `typing.List` for type annotation
    |
    = help: Replace with `list`
 
-UP006.py:57:10: UP006 Use `list` instead of `typing.List` for type annotation
+UP006.py:57:10: UP006 Use `list` instead of `List` for type annotation
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
    |          ^^^^^^^^^^^^^^^^^^^^^^ UP006
@@ -223,7 +223,7 @@ UP006.py:57:10: UP006 Use `list` instead of `typing.List` for type annotation
    |
    = help: Replace with `list`
 
-UP006.py:57:10: UP006 Use `list` instead of `typing.List` for type annotation
+UP006.py:57:10: UP006 Use `list` instead of `List` for type annotation
    |
 57 | def f(x: "Li" "st['List[str]']") -> None:
    |          ^^^^^^^^^^^^^^^^^^^^^^ UP006

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-future_annotations.py:34:18: UP006 [*] Use `list` instead of `List` for type annotations
+future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 34 | def f(x: int) -> List[int]:
    |                  ^^^^ UP006
 35 |     y = List[int]()
 36 |     y.append(x)
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 31 31 |         return cls(x=0, y=0)

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_p37.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for type annotation
+future_annotations.py:34:18: UP006 [*] Use `list` instead of `List` for type annotation
    |
 34 | def f(x: int) -> List[int]:
    |                  ^^^^ UP006
@@ -10,7 +10,7 @@ future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for t
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 31 31 |         return cls(x=0, y=0)
 32 32 | 
 33 33 | 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-future_annotations.py:34:18: UP006 [*] Use `list` instead of `List` for type annotations
+future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 34 | def f(x: int) -> List[int]:
    |                  ^^^^ UP006
 35 |     y = List[int]()
 36 |     y.append(x)
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 31 31 |         return cls(x=0, y=0)
@@ -20,7 +20,7 @@ future_annotations.py:34:18: UP006 [*] Use `list` instead of `List` for type ann
 36 36 |     y.append(x)
 37 37 |     return y
 
-future_annotations.py:35:9: UP006 [*] Use `list` instead of `List` for type annotations
+future_annotations.py:35:9: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 35 | def f(x: int) -> List[int]:
 36 |     y = List[int]()
@@ -28,7 +28,7 @@ future_annotations.py:35:9: UP006 [*] Use `list` instead of `List` for type anno
 37 |     y.append(x)
 38 |     return y
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 32 32 | 
@@ -40,14 +40,14 @@ future_annotations.py:35:9: UP006 [*] Use `list` instead of `List` for type anno
 37 37 |     return y
 38 38 | 
 
-future_annotations.py:42:27: UP006 [*] Use `list` instead of `List` for type annotations
+future_annotations.py:42:27: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 42 | x: Optional[int] = None
 43 | 
 44 | MyList: TypeAlias = Union[List[int], List[str]]
    |                           ^^^^ UP006
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 39 39 | 
@@ -56,14 +56,14 @@ future_annotations.py:42:27: UP006 [*] Use `list` instead of `List` for type ann
 42    |-MyList: TypeAlias = Union[List[int], List[str]]
    42 |+MyList: TypeAlias = Union[list[int], List[str]]
 
-future_annotations.py:42:38: UP006 [*] Use `list` instead of `List` for type annotations
+future_annotations.py:42:38: UP006 [*] Use `list` instead of `typing.List` for type annotation
    |
 42 | x: Optional[int] = None
 43 | 
 44 | MyList: TypeAlias = Union[List[int], List[str]]
    |                                      ^^^^ UP006
    |
-   = help: Replace `List` with `list`
+   = help: Replace with `list`
 
 ℹ Suggested fix
 39 39 | 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__future_annotations_pep_585_py310.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pyupgrade/mod.rs
 ---
-future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for type annotation
+future_annotations.py:34:18: UP006 [*] Use `list` instead of `List` for type annotation
    |
 34 | def f(x: int) -> List[int]:
    |                  ^^^^ UP006
@@ -10,7 +10,7 @@ future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for t
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 31 31 |         return cls(x=0, y=0)
 32 32 | 
 33 33 | 
@@ -20,7 +20,7 @@ future_annotations.py:34:18: UP006 [*] Use `list` instead of `typing.List` for t
 36 36 |     y.append(x)
 37 37 |     return y
 
-future_annotations.py:35:9: UP006 [*] Use `list` instead of `typing.List` for type annotation
+future_annotations.py:35:9: UP006 [*] Use `list` instead of `List` for type annotation
    |
 35 | def f(x: int) -> List[int]:
 36 |     y = List[int]()
@@ -30,7 +30,7 @@ future_annotations.py:35:9: UP006 [*] Use `list` instead of `typing.List` for ty
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 32 32 | 
 33 33 | 
 34 34 | def f(x: int) -> List[int]:
@@ -40,7 +40,7 @@ future_annotations.py:35:9: UP006 [*] Use `list` instead of `typing.List` for ty
 37 37 |     return y
 38 38 | 
 
-future_annotations.py:42:27: UP006 [*] Use `list` instead of `typing.List` for type annotation
+future_annotations.py:42:27: UP006 [*] Use `list` instead of `List` for type annotation
    |
 42 | x: Optional[int] = None
 43 | 
@@ -49,14 +49,14 @@ future_annotations.py:42:27: UP006 [*] Use `list` instead of `typing.List` for t
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 39 39 | 
 40 40 | x: Optional[int] = None
 41 41 | 
 42    |-MyList: TypeAlias = Union[List[int], List[str]]
    42 |+MyList: TypeAlias = Union[list[int], List[str]]
 
-future_annotations.py:42:38: UP006 [*] Use `list` instead of `typing.List` for type annotation
+future_annotations.py:42:38: UP006 [*] Use `list` instead of `List` for type annotation
    |
 42 | x: Optional[int] = None
 43 | 
@@ -65,7 +65,7 @@ future_annotations.py:42:38: UP006 [*] Use `list` instead of `typing.List` for t
    |
    = help: Replace with `list`
 
-ℹ Suggested fix
+ℹ Fix
 39 39 | 
 40 40 | x: Optional[int] = None
 41 41 | 

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -61,59 +61,26 @@ pub fn match_annotated_subscript<'a>(
     })
 }
 
-/// A module member, like `("typing", "Deque")`.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct ModuleMember<'a> {
-    /// The module name, like `"typing"`.
-    module: &'a str,
-    /// The member name, like `"Deque"`.
-    member: &'a str,
+pub enum ModuleMember {
+    /// A builtin symbol, like `"list"`.
+    BuiltIn(&'static str),
+    /// A module member, like `("collections", "deque")`.
+    Member(&'static str, &'static str),
 }
 
-impl ModuleMember<'_> {
-    /// Returns the module name, like `"typing"`.
-    pub fn module(&self) -> &str {
-        self.module
-    }
-
-    /// Returns the member name, like `"Deque"`.
-    pub fn member(&self) -> &str {
-        self.member
-    }
-
-    /// Returns `true` if this is a builtin symbol, like `int`.
-    pub fn is_builtin(&self) -> bool {
-        self.module.is_empty()
-    }
-}
-
-impl std::fmt::Display for ModuleMember<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_builtin() {
-            std::write!(f, "{}", self.member)
-        } else {
-            std::write!(
-                f,
-                "{module}.{member}",
-                module = self.module,
-                member = self.member
-            )
+impl std::fmt::Display for ModuleMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ModuleMember::BuiltIn(name) => std::write!(f, "{name}"),
+            ModuleMember::Member(module, member) => std::write!(f, "{module}.{member}"),
         }
     }
 }
 
-/// A symbol replacement, like `(("typing", "Deque"), ("collections", "deque"))`.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct SymbolReplacement<'a> {
-    /// The symbol to replace, like `("typing", "Deque")`.
-    pub from: ModuleMember<'a>,
-    /// The symbol to replace with, like `("collections", "deque")`.
-    pub to: ModuleMember<'a>,
-}
-
 /// Returns the PEP 585 standard library generic variant for a `typing` module reference, if such
 /// a variant exists.
-pub fn to_pep585_generic(expr: &Expr, context: &Context) -> Option<SymbolReplacement<'static>> {
+pub fn to_pep585_generic(expr: &Expr, context: &Context) -> Option<ModuleMember> {
     context.resolve_call_path(expr).and_then(|call_path| {
         let [module, name] = call_path.as_slice() else {
             return None;
@@ -122,16 +89,11 @@ pub fn to_pep585_generic(expr: &Expr, context: &Context) -> Option<SymbolReplace
             .iter()
             .find_map(|((from_module, from_member), (to_module, to_member))| {
                 if module == from_module && name == from_member {
-                    Some(SymbolReplacement {
-                        from: ModuleMember {
-                            module: from_module,
-                            member: from_member,
-                        },
-                        to: ModuleMember {
-                            module: to_module,
-                            member: to_member,
-                        },
-                    })
+                    if to_module.is_empty() {
+                        Some(ModuleMember::BuiltIn(to_member))
+                    } else {
+                        Some(ModuleMember::Member(to_module, to_member))
+                    }
                 } else {
                     None
                 }
@@ -139,15 +101,50 @@ pub fn to_pep585_generic(expr: &Expr, context: &Context) -> Option<SymbolReplace
     })
 }
 
-/// Returns `true` if `Expr` represents a reference to a typing object with a
-/// PEP 603 built-in.
-pub fn is_pep604_builtin(expr: &Expr, context: &Context) -> bool {
-    context.resolve_call_path(expr).map_or(false, |call_path| {
-        context.match_typing_call_path(&call_path, "Optional")
-            || context.match_typing_call_path(&call_path, "Union")
-    })
+#[derive(Debug, Copy, Clone)]
+pub enum Pep604Operator {
+    /// The union operator, e.g., `Union[str, int]`, expressible as `str | int` after PEP 604.
+    Union,
+    /// The union operator, e.g., `Optional[str]`, expressible as `str | None` after PEP 604.
+    Optional,
 }
 
+/// Return the PEP 604 operator variant to which the given subscript [`Expr`] corresponds, if any.
+pub fn to_pep604_operator(value: &Expr, slice: &Expr, context: &Context) -> Option<Pep604Operator> {
+    /// Returns `true` if any argument in the slice is a string.
+    fn any_arg_is_str(slice: &Expr) -> bool {
+        match &slice.node {
+            ExprKind::Constant(ast::ExprConstant {
+                value: Constant::Str(_),
+                ..
+            }) => true,
+            ExprKind::Tuple(ast::ExprTuple { elts, .. }) => elts.iter().any(any_arg_is_str),
+            _ => false,
+        }
+    }
+
+    // If any of the _arguments_ are forward references, we can't use PEP 604.
+    // Ex) `Union["str", "int"]` can't be converted to `"str" | "int"`.
+    if any_arg_is_str(slice) {
+        return None;
+    }
+
+    context
+        .resolve_call_path(value)
+        .as_ref()
+        .and_then(|call_path| {
+            if context.match_typing_call_path(call_path, "Optional") {
+                Some(Pep604Operator::Optional)
+            } else if context.match_typing_call_path(call_path, "Union") {
+                Some(Pep604Operator::Union)
+            } else {
+                None
+            }
+        })
+}
+
+/// Return `true` if `Expr` represents a reference to a type annotation that resolves to an
+/// immutable type.
 pub fn is_immutable_annotation(context: &Context, expr: &Expr) -> bool {
     match &expr.node {
         ExprKind::Name(_) | ExprKind::Attribute(_) => {
@@ -213,6 +210,7 @@ const IMMUTABLE_FUNCS: &[&[&str]] = &[
     &["re", "compile"],
 ];
 
+/// Return `true` if `func` is a function that returns an immutable object.
 pub fn is_immutable_func(
     context: &Context,
     func: &Expr,

--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -187,15 +187,26 @@ pub const PEP_593_SUBSCRIPTS: &[&[&str]] = &[
     &["typing_extensions", "Annotated"],
 ];
 
+type ModuleMember = (&'static str, &'static str);
+
+type SymbolReplacement = (ModuleMember, ModuleMember);
+
 // See: https://peps.python.org/pep-0585/
-pub const PEP_585_BUILTINS_ELIGIBLE: &[&[&str]] = &[
-    &["typing", "Dict"],
-    &["typing", "FrozenSet"],
-    &["typing", "List"],
-    &["typing", "Set"],
-    &["typing", "Tuple"],
-    &["typing", "Type"],
-    &["typing_extensions", "Type"],
+pub const PEP_585_GENERICS: &[SymbolReplacement] = &[
+    (("typing", "Dict"), ("", "dict")),
+    (("typing", "FrozenSet"), ("", "frozenset")),
+    (("typing", "List"), ("", "list")),
+    (("typing", "Set"), ("", "set")),
+    (("typing", "Tuple"), ("", "tuple")),
+    (("typing", "Type"), ("", "type")),
+    (("typing_extensions", "Type"), ("", "type")),
+    (("typing", "Deque"), ("collections", "deque")),
+    (("typing_extensions", "Deque"), ("collections", "deque")),
+    (("typing", "DefaultDict"), ("collections", "defaultdict")),
+    (
+        ("typing_extensions", "DefaultDict"),
+        ("collections", "defaultdict"),
+    ),
 ];
 
 // See: https://github.com/JelleZijlstra/autotyping/blob/0adba5ba0eee33c1de4ad9d0c79acfd737321dd9/autotyping/autotyping.py#L69-L91


### PR DESCRIPTION
## Summary

This PR leverages our import-dependent autofix machinery to enable replacing usages of `typing.Deque` with `collections.deque`, which is available as a standard library generic since Python 3.9 (or usable earlier with `from __future__ import annotations`).

There are a few other symbols we can rewrite as well, but `typing.Deque` and `typing.DefaultDict` are the most common, so I want to start with those.

Closes #3510.
