### PR TITLE
Merge subsettings when extending configurations

### DIFF
--- a/crates/ruff/src/rules/flake8_annotations/settings.rs
+++ b/crates/ruff/src/rules/flake8_annotations/settings.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use ruff_macros::CacheKey;
 use ruff_macros::ConfigurationOptions;
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -90,6 +92,20 @@ impl From<Settings> for Options {
             suppress_none_returning: Some(settings.suppress_none_returning),
             allow_star_arg_any: Some(settings.allow_star_arg_any),
             ignore_fully_untyped: Some(settings.ignore_fully_untyped),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            mypy_init_return: self.mypy_init_return.or(other.mypy_init_return),
+            suppress_dummy_args: self.suppress_dummy_args.or(other.suppress_dummy_args),
+            suppress_none_returning: self
+                .suppress_none_returning
+                .or(other.suppress_none_returning),
+            allow_star_arg_any: self.allow_star_arg_any.or(other.allow_star_arg_any),
+            ignore_fully_untyped: self.ignore_fully_untyped.or(other.ignore_fully_untyped),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_annotations/settings.rs
+++ b/crates/ruff/src/rules/flake8_annotations/settings.rs
@@ -2,12 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::CacheKey;
-use ruff_macros::ConfigurationOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -92,20 +91,6 @@ impl From<Settings> for Options {
             suppress_none_returning: Some(settings.suppress_none_returning),
             allow_star_arg_any: Some(settings.allow_star_arg_any),
             ignore_fully_untyped: Some(settings.ignore_fully_untyped),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            mypy_init_return: self.mypy_init_return.or(other.mypy_init_return),
-            suppress_dummy_args: self.suppress_dummy_args.or(other.suppress_dummy_args),
-            suppress_none_returning: self
-                .suppress_none_returning
-                .or(other.suppress_none_returning),
-            allow_star_arg_any: self.allow_star_arg_any.or(other.allow_star_arg_any),
-            ignore_fully_untyped: self.ignore_fully_untyped.or(other.ignore_fully_untyped),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/settings.rs
+++ b/crates/ruff/src/rules/flake8_bandit/settings.rs
@@ -2,9 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 fn default_tmp_dirs() -> Vec<String> {
     ["/tmp", "/var/tmp", "/dev/shm"]
@@ -12,7 +10,9 @@ fn default_tmp_dirs() -> Vec<String> {
         .to_vec()
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -86,20 +86,6 @@ impl Default for Settings {
         Self {
             hardcoded_tmp_directory: default_tmp_dirs(),
             check_typed_exception: false,
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            hardcoded_tmp_directory: self
-                .hardcoded_tmp_directory
-                .or(other.hardcoded_tmp_directory),
-            hardcoded_tmp_directory_extend: self
-                .hardcoded_tmp_directory_extend
-                .or(other.hardcoded_tmp_directory_extend),
-            check_typed_exception: self.check_typed_exception.or(other.check_typed_exception),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/settings.rs
+++ b/crates/ruff/src/rules/flake8_bandit/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 fn default_tmp_dirs() -> Vec<String> {
     ["/tmp", "/var/tmp", "/dev/shm"]
         .map(std::string::ToString::to_string)
@@ -84,6 +86,20 @@ impl Default for Settings {
         Self {
             hardcoded_tmp_directory: default_tmp_dirs(),
             check_typed_exception: false,
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            hardcoded_tmp_directory: self
+                .hardcoded_tmp_directory
+                .or(other.hardcoded_tmp_directory),
+            hardcoded_tmp_directory_extend: self
+                .hardcoded_tmp_directory_extend
+                .or(other.hardcoded_tmp_directory_extend),
+            check_typed_exception: self.check_typed_exception.or(other.check_typed_exception),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/settings.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -43,6 +45,14 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             extend_immutable_calls: Some(settings.extend_immutable_calls),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            extend_immutable_calls: self.extend_immutable_calls.or(other.extend_immutable_calls),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/settings.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -45,14 +45,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             extend_immutable_calls: Some(settings.extend_immutable_calls),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            extend_immutable_calls: self.extend_immutable_calls.or(other.extend_immutable_calls),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/settings.rs
+++ b/crates/ruff/src/rules/flake8_builtins/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -40,14 +40,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             builtins_ignorelist: Some(settings.builtins_ignorelist),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            builtins_ignorelist: self.builtins_ignorelist.or(other.builtins_ignorelist),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_builtins/settings.rs
+++ b/crates/ruff/src/rules/flake8_builtins/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -38,6 +40,14 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             builtins_ignorelist: Some(settings.builtins_ignorelist),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            builtins_ignorelist: self.builtins_ignorelist.or(other.builtins_ignorelist),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_comprehensions/settings.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -44,16 +44,6 @@ impl From<Settings> for Options {
             allow_dict_calls_with_keyword_arguments: Some(
                 settings.allow_dict_calls_with_keyword_arguments,
             ),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            allow_dict_calls_with_keyword_arguments: self
-                .allow_dict_calls_with_keyword_arguments
-                .or(other.allow_dict_calls_with_keyword_arguments),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_comprehensions/settings.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Default, Serialize, Deserialize, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -42,6 +44,16 @@ impl From<Settings> for Options {
             allow_dict_calls_with_keyword_arguments: Some(
                 settings.allow_dict_calls_with_keyword_arguments,
             ),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            allow_dict_calls_with_keyword_arguments: self
+                .allow_dict_calls_with_keyword_arguments
+                .or(other.allow_dict_calls_with_keyword_arguments),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_errmsg/settings.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -34,6 +36,14 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             max_string_length: Some(settings.max_string_length),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            max_string_length: self.max_string_length.or(other.max_string_length),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_errmsg/settings.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -36,14 +36,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             max_string_length: Some(settings.max_string_length),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            max_string_length: self.max_string_length.or(other.max_string_length),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_gettext/settings.rs
+++ b/crates/ruff/src/rules/flake8_gettext/settings.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -66,6 +68,19 @@ impl From<Settings> for Options {
         Self {
             function_names: Some(settings.functions_names),
             extend_function_names: vec![],
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            function_names: self.function_names.or(other.function_names),
+            extend_function_names: other
+                .extend_function_names
+                .into_iter()
+                .chain(self.extend_function_names.into_iter())
+                .collect(),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_gettext/settings.rs
+++ b/crates/ruff/src/rules/flake8_gettext/settings.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -68,19 +68,6 @@ impl From<Settings> for Options {
         Self {
             function_names: Some(settings.functions_names),
             extend_function_names: vec![],
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            function_names: self.function_names.or(other.function_names),
-            extend_function_names: other
-                .extend_function_names
-                .into_iter()
-                .chain(self.extend_function_names.into_iter())
-                .collect(),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/settings.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -58,14 +58,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             allow_multiline: Some(settings.allow_multiline),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            allow_multiline: self.allow_multiline.or(other.allow_multiline),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/settings.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -56,6 +58,14 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             allow_multiline: Some(settings.allow_multiline),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            allow_multiline: self.allow_multiline.or(other.allow_multiline),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_import_conventions/settings.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/settings.rs
@@ -3,9 +3,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("altair", "alt"),
@@ -22,7 +20,9 @@ const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("pyarrow", "pa"),
 ];
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -131,17 +131,6 @@ impl From<Settings> for Options {
             extend_aliases: None,
             banned_aliases: None,
             banned_from: None,
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            aliases: self.aliases.or(other.aliases),
-            extend_aliases: self.extend_aliases.or(other.extend_aliases),
-            banned_aliases: self.banned_aliases.or(other.banned_aliases),
-            banned_from: self.banned_from.or(other.banned_from),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_import_conventions/settings.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/settings.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 const CONVENTIONAL_ALIASES: &[(&str, &str)] = &[
     ("altair", "alt"),
     ("matplotlib", "mpl"),
@@ -129,6 +131,17 @@ impl From<Settings> for Options {
             extend_aliases: None,
             banned_aliases: None,
             banned_from: None,
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            aliases: self.aliases.or(other.aliases),
+            extend_aliases: self.extend_aliases.or(other.extend_aliases),
+            banned_aliases: self.banned_aliases.or(other.banned_aliases),
+            banned_from: self.banned_from.or(other.banned_from),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_pytest_style/settings.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/settings.rs
@@ -2,9 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 use super::types;
 
@@ -22,7 +20,9 @@ fn default_broad_exceptions() -> Vec<String> {
     .to_vec()
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -166,28 +166,6 @@ impl Default for Settings {
             raises_require_match_for: default_broad_exceptions(),
             raises_extend_require_match_for: vec![],
             mark_parentheses: true,
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            fixture_parentheses: self.fixture_parentheses.or(other.fixture_parentheses),
-            parametrize_names_type: self.parametrize_names_type.or(other.parametrize_names_type),
-            parametrize_values_type: self
-                .parametrize_values_type
-                .or(other.parametrize_values_type),
-            parametrize_values_row_type: self
-                .parametrize_values_row_type
-                .or(other.parametrize_values_row_type),
-            raises_require_match_for: self
-                .raises_require_match_for
-                .or(other.raises_require_match_for),
-            raises_extend_require_match_for: self
-                .raises_extend_require_match_for
-                .or(other.raises_extend_require_match_for),
-            mark_parentheses: self.mark_parentheses.or(other.mark_parentheses),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_pytest_style/settings.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 use super::types;
 
 fn default_broad_exceptions() -> Vec<String> {
@@ -164,6 +166,28 @@ impl Default for Settings {
             raises_require_match_for: default_broad_exceptions(),
             raises_extend_require_match_for: vec![],
             mark_parentheses: true,
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            fixture_parentheses: self.fixture_parentheses.or(other.fixture_parentheses),
+            parametrize_names_type: self.parametrize_names_type.or(other.parametrize_names_type),
+            parametrize_values_type: self
+                .parametrize_values_type
+                .or(other.parametrize_values_type),
+            parametrize_values_row_type: self
+                .parametrize_values_row_type
+                .or(other.parametrize_values_row_type),
+            raises_require_match_for: self
+                .raises_require_match_for
+                .or(other.raises_require_match_for),
+            raises_extend_require_match_for: self
+                .raises_extend_require_match_for
+                .or(other.raises_extend_require_match_for),
+            mark_parentheses: self.mark_parentheses.or(other.mark_parentheses),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_quotes/settings.rs
+++ b/crates/ruff/src/rules/flake8_quotes/settings.rs
@@ -2,9 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -22,7 +20,9 @@ impl Default for Quote {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -110,17 +110,6 @@ impl From<Settings> for Options {
             multiline_quotes: Some(settings.multiline_quotes),
             docstring_quotes: Some(settings.docstring_quotes),
             avoid_escape: Some(settings.avoid_escape),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            inline_quotes: self.inline_quotes.or(other.inline_quotes),
-            multiline_quotes: self.multiline_quotes.or(other.multiline_quotes),
-            docstring_quotes: self.docstring_quotes.or(other.docstring_quotes),
-            avoid_escape: self.avoid_escape.or(other.avoid_escape),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_quotes/settings.rs
+++ b/crates/ruff/src/rules/flake8_quotes/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -108,6 +110,17 @@ impl From<Settings> for Options {
             multiline_quotes: Some(settings.multiline_quotes),
             docstring_quotes: Some(settings.docstring_quotes),
             avoid_escape: Some(settings.avoid_escape),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            inline_quotes: self.inline_quotes.or(other.inline_quotes),
+            multiline_quotes: self.multiline_quotes.or(other.multiline_quotes),
+            docstring_quotes: self.docstring_quotes.or(other.docstring_quotes),
+            avoid_escape: self.avoid_escape.or(other.avoid_escape),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_self/settings.rs
+++ b/crates/ruff/src/rules/flake8_self/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 // By default, ignore the `namedtuple` methods and attributes, which are underscore-prefixed to
 // prevent conflicts with field names.
 const IGNORE_NAMES: [&str; 5] = ["_make", "_asdict", "_replace", "_fields", "_field_defaults"];
@@ -54,6 +56,13 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             ignore_names: Some(settings.ignore_names),
+        }
+    }
+}
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            ignore_names: self.ignore_names.or(other.ignore_names),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_self/settings.rs
+++ b/crates/ruff/src/rules/flake8_self/settings.rs
@@ -2,15 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 // By default, ignore the `namedtuple` methods and attributes, which are underscore-prefixed to
 // prevent conflicts with field names.
 const IGNORE_NAMES: [&str; 5] = ["_make", "_asdict", "_replace", "_fields", "_field_defaults"];
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -56,13 +56,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             ignore_names: Some(settings.ignore_names),
-        }
-    }
-}
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            ignore_names: self.ignore_names.or(other.ignore_names),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_tidy_imports/options.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/options.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::ConfigurationOptions;
 
+use crate::settings::configuration::CombinePluginOptions;
+
 use super::banned_api::ApiBan;
 use super::relative_imports::Strictness;
 use super::Settings;
@@ -57,6 +59,15 @@ impl From<Settings> for Options {
         Self {
             ban_relative_imports: Some(settings.ban_relative_imports),
             banned_api: Some(settings.banned_api),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            ban_relative_imports: self.ban_relative_imports.or(other.ban_relative_imports),
+            banned_api: self.banned_api.or(other.banned_api),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_tidy_imports/options.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/options.rs
@@ -3,15 +3,15 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::ConfigurationOptions;
-
-use crate::settings::configuration::CombinePluginOptions;
+use ruff_macros::{CombineOptions, ConfigurationOptions};
 
 use super::banned_api::ApiBan;
 use super::relative_imports::Strictness;
 use super::Settings;
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -59,15 +59,6 @@ impl From<Settings> for Options {
         Self {
             ban_relative_imports: Some(settings.ban_relative_imports),
             banned_api: Some(settings.banned_api),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            ban_relative_imports: self.ban_relative_imports.or(other.ban_relative_imports),
-            banned_api: self.banned_api.or(other.banned_api),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_type_checking/settings.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -96,6 +98,21 @@ impl From<Settings> for Options {
             exempt_modules: Some(settings.exempt_modules),
             runtime_evaluated_base_classes: Some(settings.runtime_evaluated_base_classes),
             runtime_evaluated_decorators: Some(settings.runtime_evaluated_decorators),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            strict: self.strict.or(other.strict),
+            exempt_modules: self.exempt_modules.or(other.exempt_modules),
+            runtime_evaluated_base_classes: self
+                .runtime_evaluated_base_classes
+                .or(other.runtime_evaluated_base_classes),
+            runtime_evaluated_decorators: self
+                .runtime_evaluated_decorators
+                .or(other.runtime_evaluated_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_type_checking/settings.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -98,21 +98,6 @@ impl From<Settings> for Options {
             exempt_modules: Some(settings.exempt_modules),
             runtime_evaluated_base_classes: Some(settings.runtime_evaluated_base_classes),
             runtime_evaluated_decorators: Some(settings.runtime_evaluated_decorators),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            strict: self.strict.or(other.strict),
-            exempt_modules: self.exempt_modules.or(other.exempt_modules),
-            runtime_evaluated_base_classes: self
-                .runtime_evaluated_base_classes
-                .or(other.runtime_evaluated_base_classes),
-            runtime_evaluated_decorators: self
-                .runtime_evaluated_decorators
-                .or(other.runtime_evaluated_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_unused_arguments/settings.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/settings.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use ruff_macros::{CacheKey, ConfigurationOptions};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -38,6 +40,13 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             ignore_variadic_names: Some(settings.ignore_variadic_names),
+        }
+    }
+}
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            ignore_variadic_names: self.ignore_variadic_names.or(other.ignore_variadic_names),
         }
     }
 }

--- a/crates/ruff/src/rules/flake8_unused_arguments/settings.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/settings.rs
@@ -2,11 +2,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -40,13 +40,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             ignore_variadic_names: Some(settings.ignore_variadic_names),
-        }
-    }
-}
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            ignore_variadic_names: self.ignore_variadic_names.or(other.ignore_variadic_names),
         }
     }
 }

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -7,11 +7,10 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 use crate::rules::isort::categorize::KnownModules;
 use crate::rules::isort::ImportType;
-use crate::settings::configuration::CombinePluginOptions;
 use crate::warn_user_once;
 
 use super::categorize::ImportSection;
@@ -34,7 +33,9 @@ impl Default for RelativeImportsOrder {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -504,40 +505,6 @@ impl From<Settings> for Options {
                     .map(|(section, modules)| (ImportSection::UserDefined(section), modules))
                     .collect(),
             ),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            force_wrap_aliases: self.force_wrap_aliases.or(other.force_wrap_aliases),
-            force_single_line: self.force_single_line.or(other.force_single_line),
-            single_line_exclusions: self.single_line_exclusions.or(other.single_line_exclusions),
-            combine_as_imports: self.combine_as_imports.or(other.combine_as_imports),
-            split_on_trailing_comma: self
-                .split_on_trailing_comma
-                .or(other.split_on_trailing_comma),
-            order_by_type: self.order_by_type.or(other.order_by_type),
-            force_sort_within_sections: self
-                .force_sort_within_sections
-                .or(other.force_sort_within_sections),
-            force_to_top: self.force_to_top.or(other.force_to_top),
-            known_first_party: self.known_first_party.or(other.known_first_party),
-            known_third_party: self.known_third_party.or(other.known_third_party),
-            known_local_folder: self.known_local_folder.or(other.known_local_folder),
-            extra_standard_library: self.extra_standard_library.or(other.extra_standard_library),
-            relative_imports_order: self.relative_imports_order.or(other.relative_imports_order),
-            required_imports: self.required_imports.or(other.required_imports),
-            classes: self.classes.or(other.classes),
-            constants: self.constants.or(other.constants),
-            variables: self.variables.or(other.variables),
-            no_lines_before: self.no_lines_before.or(other.no_lines_before),
-            lines_after_imports: self.lines_after_imports.or(other.lines_after_imports),
-            lines_between_types: self.lines_between_types.or(other.lines_between_types),
-            forced_separate: self.forced_separate.or(other.forced_separate),
-            section_order: self.section_order.or(other.section_order),
-            sections: self.sections.or(other.sections),
         }
     }
 }

--- a/crates/ruff/src/rules/isort/settings.rs
+++ b/crates/ruff/src/rules/isort/settings.rs
@@ -11,6 +11,7 @@ use ruff_macros::{CacheKey, ConfigurationOptions};
 
 use crate::rules::isort::categorize::KnownModules;
 use crate::rules::isort::ImportType;
+use crate::settings::configuration::CombinePluginOptions;
 use crate::warn_user_once;
 
 use super::categorize::ImportSection;
@@ -503,6 +504,40 @@ impl From<Settings> for Options {
                     .map(|(section, modules)| (ImportSection::UserDefined(section), modules))
                     .collect(),
             ),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            force_wrap_aliases: self.force_wrap_aliases.or(other.force_wrap_aliases),
+            force_single_line: self.force_single_line.or(other.force_single_line),
+            single_line_exclusions: self.single_line_exclusions.or(other.single_line_exclusions),
+            combine_as_imports: self.combine_as_imports.or(other.combine_as_imports),
+            split_on_trailing_comma: self
+                .split_on_trailing_comma
+                .or(other.split_on_trailing_comma),
+            order_by_type: self.order_by_type.or(other.order_by_type),
+            force_sort_within_sections: self
+                .force_sort_within_sections
+                .or(other.force_sort_within_sections),
+            force_to_top: self.force_to_top.or(other.force_to_top),
+            known_first_party: self.known_first_party.or(other.known_first_party),
+            known_third_party: self.known_third_party.or(other.known_third_party),
+            known_local_folder: self.known_local_folder.or(other.known_local_folder),
+            extra_standard_library: self.extra_standard_library.or(other.extra_standard_library),
+            relative_imports_order: self.relative_imports_order.or(other.relative_imports_order),
+            required_imports: self.required_imports.or(other.required_imports),
+            classes: self.classes.or(other.classes),
+            constants: self.constants.or(other.constants),
+            variables: self.variables.or(other.variables),
+            no_lines_before: self.no_lines_before.or(other.no_lines_before),
+            lines_after_imports: self.lines_after_imports.or(other.lines_after_imports),
+            lines_between_types: self.lines_between_types.or(other.lines_between_types),
+            forced_separate: self.forced_separate.or(other.forced_separate),
+            section_order: self.section_order.or(other.section_order),
+            sections: self.sections.or(other.sections),
         }
     }
 }

--- a/crates/ruff/src/rules/mccabe/settings.rs
+++ b/crates/ruff/src/rules/mccabe/settings.rs
@@ -1,11 +1,11 @@
 //! Settings for the `mccabe` plugin.
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -48,14 +48,6 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             max_complexity: Some(settings.max_complexity),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            max_complexity: self.max_complexity.or(other.max_complexity),
         }
     }
 }

--- a/crates/ruff/src/rules/mccabe/settings.rs
+++ b/crates/ruff/src/rules/mccabe/settings.rs
@@ -3,6 +3,8 @@
 use ruff_macros::{CacheKey, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(
     deny_unknown_fields,
@@ -46,6 +48,14 @@ impl From<Settings> for Options {
     fn from(settings: Settings) -> Self {
         Self {
             max_complexity: Some(settings.max_complexity),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            max_complexity: self.max_complexity.or(other.max_complexity),
         }
     }
 }

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -3,6 +3,8 @@
 use ruff_macros::{CacheKey, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 const IGNORE_NAMES: [&str; 12] = [
     "setUp",
     "tearDown",
@@ -102,6 +104,18 @@ impl From<Settings> for Options {
             ignore_names: Some(settings.ignore_names),
             classmethod_decorators: Some(settings.classmethod_decorators),
             staticmethod_decorators: Some(settings.staticmethod_decorators),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            ignore_names: self.ignore_names.or(other.ignore_names),
+            classmethod_decorators: self.classmethod_decorators.or(other.classmethod_decorators),
+            staticmethod_decorators: self
+                .staticmethod_decorators
+                .or(other.staticmethod_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -1,9 +1,7 @@
 //! Settings for the `pep8-naming` plugin.
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
-
-use crate::settings::configuration::CombinePluginOptions;
 
 const IGNORE_NAMES: [&str; 12] = [
     "setUp",
@@ -20,7 +18,9 @@ const IGNORE_NAMES: [&str; 12] = [
     "maxDiff",
 ];
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -104,18 +104,6 @@ impl From<Settings> for Options {
             ignore_names: Some(settings.ignore_names),
             classmethod_decorators: Some(settings.classmethod_decorators),
             staticmethod_decorators: Some(settings.staticmethod_decorators),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            ignore_names: self.ignore_names.or(other.ignore_names),
-            classmethod_decorators: self.classmethod_decorators.or(other.classmethod_decorators),
-            staticmethod_decorators: self
-                .staticmethod_decorators
-                .or(other.staticmethod_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/settings.rs
+++ b/crates/ruff/src/rules/pycodestyle/settings.rs
@@ -3,6 +3,8 @@
 use ruff_macros::{CacheKey, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case", rename = "Pycodestyle")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -52,6 +54,17 @@ impl From<Settings> for Options {
         Self {
             max_doc_length: settings.max_doc_length,
             ignore_overlong_task_comments: Some(settings.ignore_overlong_task_comments),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            max_doc_length: self.max_doc_length.or(other.max_doc_length),
+            ignore_overlong_task_comments: self
+                .ignore_overlong_task_comments
+                .or(other.ignore_overlong_task_comments),
         }
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/settings.rs
+++ b/crates/ruff/src/rules/pycodestyle/settings.rs
@@ -1,11 +1,11 @@
 //! Settings for the `pycodestyle` plugin.
 
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 
-use crate::settings::configuration::CombinePluginOptions;
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case", rename = "Pycodestyle")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
@@ -54,17 +54,6 @@ impl From<Settings> for Options {
         Self {
             max_doc_length: settings.max_doc_length,
             ignore_overlong_task_comments: Some(settings.ignore_overlong_task_comments),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            max_doc_length: self.max_doc_length.or(other.max_doc_length),
-            ignore_overlong_task_comments: self
-                .ignore_overlong_task_comments
-                .or(other.ignore_overlong_task_comments),
         }
     }
 }

--- a/crates/ruff/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff/src/rules/pydocstyle/settings.rs
@@ -1,6 +1,6 @@
 //! Settings for the `pydocstyle` plugin.
 
-use crate::registry::Rule;
+use crate::{registry::Rule, settings::configuration::CombinePluginOptions};
 use ruff_macros::{CacheKey, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -134,6 +134,16 @@ impl From<Settings> for Options {
             convention: settings.convention,
             ignore_decorators: Some(settings.ignore_decorators.into_iter().collect()),
             property_decorators: Some(settings.property_decorators.into_iter().collect()),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            convention: self.convention.or(other.convention),
+            ignore_decorators: self.ignore_decorators.or(other.ignore_decorators),
+            property_decorators: self.property_decorators.or(other.property_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff/src/rules/pydocstyle/settings.rs
@@ -1,7 +1,7 @@
 //! Settings for the `pydocstyle` plugin.
 
-use crate::{registry::Rule, settings::configuration::CombinePluginOptions};
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use crate::registry::Rule;
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
@@ -68,7 +68,9 @@ impl Convention {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case", rename = "Pydocstyle")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Options {
@@ -134,16 +136,6 @@ impl From<Settings> for Options {
             convention: settings.convention,
             ignore_decorators: Some(settings.ignore_decorators.into_iter().collect()),
             property_decorators: Some(settings.property_decorators.into_iter().collect()),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            convention: self.convention.or(other.convention),
-            ignore_decorators: self.ignore_decorators.or(other.ignore_decorators),
-            property_decorators: self.property_decorators.or(other.property_decorators),
         }
     }
 }

--- a/crates/ruff/src/rules/pylint/settings.rs
+++ b/crates/ruff/src/rules/pylint/settings.rs
@@ -5,6 +5,8 @@ use ruff_macros::{CacheKey, ConfigurationOptions};
 use rustpython_parser::ast::Constant;
 use serde::{Deserialize, Serialize};
 
+use crate::settings::configuration::CombinePluginOptions;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -114,6 +116,20 @@ impl From<Settings> for Options {
             max_returns: Some(settings.max_returns),
             max_branches: Some(settings.max_branches),
             max_statements: Some(settings.max_statements),
+        }
+    }
+}
+
+impl CombinePluginOptions for Options {
+    fn combine(self, other: Self) -> Self {
+        Self {
+            allow_magic_value_types: self
+                .allow_magic_value_types
+                .or(other.allow_magic_value_types),
+            max_branches: self.max_branches.or(other.max_branches),
+            max_returns: self.max_returns.or(other.max_returns),
+            max_args: self.max_args.or(other.max_args),
+            max_statements: self.max_statements.or(other.max_statements),
         }
     }
 }

--- a/crates/ruff/src/rules/pylint/settings.rs
+++ b/crates/ruff/src/rules/pylint/settings.rs
@@ -1,11 +1,9 @@
 //! Settings for the `pylint` plugin.
 
 use anyhow::anyhow;
-use ruff_macros::{CacheKey, ConfigurationOptions};
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use rustpython_parser::ast::Constant;
 use serde::{Deserialize, Serialize};
-
-use crate::settings::configuration::CombinePluginOptions;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
@@ -37,7 +35,9 @@ impl TryFrom<&Constant> for ConstantType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions)]
+#[derive(
+    Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,
+)]
 #[serde(
     deny_unknown_fields,
     rename_all = "kebab-case",
@@ -116,20 +116,6 @@ impl From<Settings> for Options {
             max_returns: Some(settings.max_returns),
             max_branches: Some(settings.max_branches),
             max_statements: Some(settings.max_statements),
-        }
-    }
-}
-
-impl CombinePluginOptions for Options {
-    fn combine(self, other: Self) -> Self {
-        Self {
-            allow_magic_value_types: self
-                .allow_magic_value_types
-                .or(other.allow_magic_value_types),
-            max_branches: self.max_branches.or(other.max_branches),
-            max_returns: self.max_returns.or(other.max_returns),
-            max_args: self.max_args.or(other.max_args),
-            max_statements: self.max_statements.or(other.max_statements),
         }
     }
 }

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -299,6 +299,22 @@ impl Configuration {
     }
 }
 
+pub trait CombinePluginOptions {
+    #[must_use]
+    fn combine(self, other: Self) -> Self;
+}
+
+impl<T: CombinePluginOptions> CombinePluginOptions for Option<T> {
+    fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Some(base), Some(other)) => Some(base.combine(other)),
+            (Some(base), None) => Some(base),
+            (None, Some(other)) => Some(other),
+            (None, None) => None,
+        }
+    }
+}
+
 /// Given a list of source paths, which could include glob patterns, resolve the
 /// matching paths.
 pub fn resolve_src(src: &[String], project_root: &Path) -> Result<Vec<PathBuf>> {

--- a/crates/ruff/src/settings/configuration.rs
+++ b/crates/ruff/src/settings/configuration.rs
@@ -268,33 +268,37 @@ impl Configuration {
             task_tags: self.task_tags.or(config.task_tags),
             typing_modules: self.typing_modules.or(config.typing_modules),
             // Plugins
-            flake8_annotations: self.flake8_annotations.or(config.flake8_annotations),
-            flake8_bandit: self.flake8_bandit.or(config.flake8_bandit),
-            flake8_bugbear: self.flake8_bugbear.or(config.flake8_bugbear),
-            flake8_builtins: self.flake8_builtins.or(config.flake8_builtins),
-            flake8_comprehensions: self.flake8_comprehensions.or(config.flake8_comprehensions),
-            flake8_errmsg: self.flake8_errmsg.or(config.flake8_errmsg),
-            flake8_gettext: self.flake8_gettext.or(config.flake8_gettext),
+            flake8_annotations: self.flake8_annotations.combine(config.flake8_annotations),
+            flake8_bandit: self.flake8_bandit.combine(config.flake8_bandit),
+            flake8_bugbear: self.flake8_bugbear.combine(config.flake8_bugbear),
+            flake8_builtins: self.flake8_builtins.combine(config.flake8_builtins),
+            flake8_comprehensions: self
+                .flake8_comprehensions
+                .combine(config.flake8_comprehensions),
+            flake8_errmsg: self.flake8_errmsg.combine(config.flake8_errmsg),
+            flake8_gettext: self.flake8_gettext.combine(config.flake8_gettext),
             flake8_implicit_str_concat: self
                 .flake8_implicit_str_concat
-                .or(config.flake8_implicit_str_concat),
+                .combine(config.flake8_implicit_str_concat),
             flake8_import_conventions: self
                 .flake8_import_conventions
-                .or(config.flake8_import_conventions),
-            flake8_pytest_style: self.flake8_pytest_style.or(config.flake8_pytest_style),
-            flake8_quotes: self.flake8_quotes.or(config.flake8_quotes),
-            flake8_self: self.flake8_self.or(config.flake8_self),
-            flake8_tidy_imports: self.flake8_tidy_imports.or(config.flake8_tidy_imports),
-            flake8_type_checking: self.flake8_type_checking.or(config.flake8_type_checking),
+                .combine(config.flake8_import_conventions),
+            flake8_pytest_style: self.flake8_pytest_style.combine(config.flake8_pytest_style),
+            flake8_quotes: self.flake8_quotes.combine(config.flake8_quotes),
+            flake8_self: self.flake8_self.combine(config.flake8_self),
+            flake8_tidy_imports: self.flake8_tidy_imports.combine(config.flake8_tidy_imports),
+            flake8_type_checking: self
+                .flake8_type_checking
+                .combine(config.flake8_type_checking),
             flake8_unused_arguments: self
                 .flake8_unused_arguments
-                .or(config.flake8_unused_arguments),
-            isort: self.isort.or(config.isort),
-            mccabe: self.mccabe.or(config.mccabe),
-            pep8_naming: self.pep8_naming.or(config.pep8_naming),
-            pycodestyle: self.pycodestyle.or(config.pycodestyle),
-            pydocstyle: self.pydocstyle.or(config.pydocstyle),
-            pylint: self.pylint.or(config.pylint),
+                .combine(config.flake8_unused_arguments),
+            isort: self.isort.combine(config.isort),
+            mccabe: self.mccabe.combine(config.mccabe),
+            pep8_naming: self.pep8_naming.combine(config.pep8_naming),
+            pycodestyle: self.pycodestyle.combine(config.pycodestyle),
+            pydocstyle: self.pydocstyle.combine(config.pydocstyle),
+            pylint: self.pylint.combine(config.pylint),
         }
     }
 }

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -1,0 +1,67 @@
+use quote::{quote, quote_spanned};
+use syn::{Data, DataStruct, DeriveInput, Field, Fields, Path, PathSegment, Type, TypePath};
+
+pub(crate) fn derive_impl(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let DeriveInput { ident, data, .. } = input;
+
+    match data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(fields),
+            ..
+        }) => {
+            let output = fields
+                .named
+                .iter()
+                .map(handle_field)
+                .collect::<Result<Vec<_>, _>>()?;
+
+            Ok(quote! {
+                use crate::settings::configuration::CombinePluginOptions;
+
+                impl CombinePluginOptions for #ident {
+                    fn combine(self, other: Self) -> Self {
+                        Self {
+                        #(
+                            #output
+                        ),*
+                        }
+                    }
+                }
+            })
+        }
+        _ => Err(syn::Error::new(
+            ident.span(),
+            "Can only derive CombineOptions from structs with named fields.",
+        )),
+    }
+}
+
+fn handle_field(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
+    let ident = field
+        .ident
+        .as_ref()
+        .expect("Expected to handle named fields");
+
+    match &field.ty {
+        Type::Path(TypePath {
+            path: Path { segments, .. },
+            ..
+        }) => match segments.first() {
+            Some(PathSegment {
+                ident: type_ident, ..
+            }) if type_ident == "Option" => Ok(quote_spanned!(
+                ident.span() => #ident: self.#ident.or(other.#ident)
+            )),
+            Some(PathSegment {
+                ident: type_ident, ..
+            }) if type_ident == "Vec" => Ok(quote_spanned!(
+                ident.span() => #ident: other.#ident.into_iter().chain(self.#ident.into_iter()).collect()
+            )),
+            _ => Err(syn::Error::new(
+                ident.span(),
+                "Expected `Option<_>` or `Vec<_>` as type.",
+            )),
+        },
+        _ => Err(syn::Error::new(ident.span(), "Expected type.")),
+    }
+}

--- a/crates/ruff_macros/src/combine_options.rs
+++ b/crates/ruff_macros/src/combine_options.rs
@@ -52,11 +52,6 @@ fn handle_field(field: &Field) -> syn::Result<proc_macro2::TokenStream> {
             }) if type_ident == "Option" => Ok(quote_spanned!(
                 ident.span() => #ident: self.#ident.or(other.#ident)
             )),
-            Some(PathSegment {
-                ident: type_ident, ..
-            }) if type_ident == "Vec" => Ok(quote_spanned!(
-                ident.span() => #ident: other.#ident.into_iter().chain(self.#ident.into_iter()).collect()
-            )),
             _ => Err(syn::Error::new(
                 ident.span(),
                 "Expected `Option<_>` or `Vec<_>` as type.",

--- a/crates/ruff_macros/src/lib.rs
+++ b/crates/ruff_macros/src/lib.rs
@@ -5,6 +5,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput, ItemFn, ItemStruct};
 
 mod cache_key;
+mod combine_options;
 mod config;
 mod derive_message_formats;
 mod map_codes;
@@ -18,6 +19,15 @@ pub fn derive_config(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
     let input = parse_macro_input!(input as DeriveInput);
 
     config::derive_impl(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+#[proc_macro_derive(CombineOptions)]
+pub fn derive_combine_options(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    combine_options::derive_impl(input)
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }


### PR DESCRIPTION
Currently we override entire config sections when extending configurations.
This change allows us to preserve sections and only override specific config options.

I've verified this works with the tree specified in the linked issue, and with the codebase that spurred me to look into this issue.

(This is my first OSS contribution so please lmk if I've got the process wrong somehow :) )

Closes  #4348