### PR TITLE
Use `ThinVec` to shrink AST enum sizes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,7 +8,7 @@ rustflags = [
   # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
   # See: `https://github.com/rust-lang/cargo/issues/5034`
   #      `https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395`
-  "-Dunsafe_code",
+#  "-Dunsafe_code",
   "-Wclippy::pedantic",
   # Allowed pedantic lints
   "-Wclippy::char_lit_as_u8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "strum_macros",
  "test-case",
  "textwrap",
+ "thin-vec",
  "thiserror",
  "toml",
  "typed-arena",
@@ -1934,6 +1935,7 @@ dependencies = [
  "rustpython-parser",
  "serde",
  "smallvec",
+ "thin-vec",
 ]
 
 [[package]]
@@ -1955,6 +1957,7 @@ dependencies = [
  "rustpython-parser",
  "similar",
  "test-case",
+ "thin-vec",
 ]
 
 [[package]]
@@ -1991,7 +1994,6 @@ dependencies = [
 [[package]]
 name = "ruff_source_location"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "memchr",
  "once_cell",
@@ -2011,7 +2013,6 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "schemars",
  "serde",
@@ -2082,18 +2083,17 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "is-macro",
  "num-bigint",
  "rustpython-parser-core",
  "static_assertions",
+ "thin-vec",
 ]
 
 [[package]]
 name = "rustpython-format"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "bitflags 2.2.1",
  "itertools",
@@ -2105,7 +2105,6 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "hexf-parse",
  "lexical-parse-float",
@@ -2116,7 +2115,6 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2129,6 +2127,7 @@ dependencies = [
  "rustc-hash",
  "rustpython-ast",
  "rustpython-parser-core",
+ "thin-vec",
  "tiny-keccak",
  "unic-emoji-char",
  "unic-ucd-ident",
@@ -2138,7 +2137,6 @@ dependencies = [
 [[package]]
 name = "rustpython-parser-core"
 version = "0.2.0"
-source = "git+https://github.com/RustPython/Parser.git?rev=718354673eb2cc9645d63fc0c50b4ad08e5595c2#718354673eb2cc9645d63fc0c50b4ad08e5595c2"
 dependencies = [
  "ruff_source_location",
  "ruff_text_size",
@@ -2461,6 +2459,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81b6fd6beb5884b0cf3321b8117e6e5d47ecb6fc89f414cfdcca8b2fe2dd8"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ proc-macro2 = { version = "1.0.51" }
 quote = { version = "1.0.23" }
 regex = { version = "1.7.1" }
 rustc-hash = { version = "1.1.0" }
-ruff_text_size = { git = "https://github.com/RustPython/Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-format = { git = "https://github.com/RustPython/Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-literal = { git = "https://github.com/RustPython/Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" }
-rustpython-parser = { git = "https://github.com/RustPython/Parser.git", rev = "718354673eb2cc9645d63fc0c50b4ad08e5595c2" , features = ["all-nodes-with-ranges"]}
+ruff_text_size = { path="../RustPython-parser/ruff_text_size" }
+rustpython-format = { path="../RustPython-parser/format" }
+rustpython-literal = { path="../RustPython-parser/literal" }
+rustpython-parser = { path="../RustPython-parser/parser" , features = ["all-nodes-with-ranges"]}
 schemars = { version = "0.8.12" }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.93", features = ["preserve_order"] }

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -70,6 +70,7 @@ thiserror = { version = "1.0.38" }
 toml = { workspace = true }
 typed-arena = { version = "2.0.2" }
 unicode-width = { version = "0.1.10" }
+thin-vec = "0.2.12"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -32,11 +33,11 @@ fn assertion_error(msg: Option<&Expr>) -> Stmt {
                 range: TextRange::default(),
             })),
             args: if let Some(msg) = msg {
-                vec![msg.clone()]
+                thin_vec![msg.clone()]
             } else {
-                vec![]
+                thin_vec![]
             },
-            keywords: vec![],
+            keywords: thin_vec![],
             range: TextRange::default(),
         }))),
         cause: None,

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -29,7 +30,7 @@ impl AlwaysAutofixableViolation for SetAttrWithConstant {
 
 fn assignment(obj: &Expr, name: &str, value: &Expr, stylist: &Stylist) -> String {
     let stmt = Stmt::Assign(ast::StmtAssign {
-        targets: vec![Expr::Attribute(ast::ExprAttribute {
+        targets: thin_vec![Expr::Attribute(ast::ExprAttribute {
             value: Box::new(obj.clone()),
             attr: name.into(),
             ctx: ExprContext::Store,

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -190,7 +191,7 @@ fn generate_fix(stylist: &Stylist, stmt: &Stmt, exc_arg: &Expr, indentation: &st
         range: TextRange::default(),
     });
     let node1 = Stmt::Assign(ast::StmtAssign {
-        targets: vec![node],
+        targets: thin_vec![node],
         value: Box::new(exc_arg.clone()),
         type_comment: None,
         range: TextRange::default(),

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{
     self, Boolop, Constant, Expr, ExprContext, ExprLambda, Keyword, Ranged, Stmt,
 };
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
@@ -586,8 +587,8 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                 });
                 let node3 = Expr::Call(ast::ExprCall {
                     func: Box::new(node2),
-                    args: vec![node],
-                    keywords: vec![],
+                    args: thin_vec![node],
+                    keywords: thin_vec![],
                     range: TextRange::default(),
                 });
                 let call = node3;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, bail, Result};
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{self, Cmpop, Constant, Expr, ExprContext, Keyword, Stmt, Unaryop};
+use thin_vec::thin_vec;
 
 /// An enum to represent the different types of assertions present in the
 /// `unittest` module. Note: any variants that can't be replaced with plain
@@ -152,8 +153,8 @@ fn assert(expr: &Expr, msg: Option<&Expr>) -> Stmt {
 fn compare(left: &Expr, cmpop: Cmpop, right: &Expr) -> Expr {
     Expr::Compare(ast::ExprCompare {
         left: Box::new(left.clone()),
-        ops: vec![cmpop],
-        comparators: vec![right.clone()],
+        ops: thin_vec![cmpop],
+        comparators: thin_vec![right.clone()],
         range: TextRange::default(),
     })
 }
@@ -355,8 +356,8 @@ impl UnittestAssert {
                 };
                 let node1 = ast::ExprCall {
                     func: Box::new(node.into()),
-                    args: vec![(**obj).clone(), (**cls).clone()],
-                    keywords: vec![],
+                    args: thin_vec![(**obj).clone(), (**cls).clone()],
+                    keywords: thin_vec![],
                     range: TextRange::default(),
                 };
                 let isinstance = node1.into();
@@ -396,8 +397,8 @@ impl UnittestAssert {
                 };
                 let node2 = ast::ExprCall {
                     func: Box::new(node1.into()),
-                    args: vec![(**regex).clone(), (**text).clone()],
-                    keywords: vec![],
+                    args: thin_vec![(**regex).clone(), (**text).clone()],
+                    keywords: thin_vec![],
                     range: TextRange::default(),
                 };
                 let re_search = node2.into();

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{self, Boolop, Cmpop, Expr, ExprContext, Ranged, Unaryop};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -344,8 +345,8 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 };
                 let node2 = ast::ExprCall {
                     func: Box::new(node1.into()),
-                    args: vec![target.clone(), node.into()],
-                    keywords: vec![],
+                    args: thin_vec![target.clone(), node.into()],
+                    keywords: thin_vec![],
                     range: TextRange::default(),
                 };
                 let call = node2.into();
@@ -450,8 +451,8 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
         };
         let node2 = ast::ExprCompare {
             left: Box::new(node1.into()),
-            ops: vec![Cmpop::In],
-            comparators: vec![node.into()],
+            ops: thin_vec![Cmpop::In],
+            comparators: thin_vec![node.into()],
             range: TextRange::default(),
         };
         let in_expr = node2.into();

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -2,6 +2,7 @@ use log::error;
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{self, Cmpop, Constant, Expr, ExprContext, Ranged, Stmt};
+use thin_vec::thin_vec;
 use unicode_width::UnicodeWidthStr;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
@@ -377,8 +378,8 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
             };
             let node1 = ast::ExprCall {
                 func: Box::new(node.into()),
-                args: vec![(**test).clone()],
-                keywords: vec![],
+                args: thin_vec![(**test).clone()],
+                keywords: thin_vec![],
                 range: TextRange::default(),
             };
             let node2 = ast::StmtReturn {
@@ -403,7 +404,7 @@ fn ternary(target_var: &Expr, body_value: &Expr, test: &Expr, orelse_value: &Exp
         range: TextRange::default(),
     };
     let node1 = ast::StmtAssign {
-        targets: vec![target_var.clone()],
+        targets: thin_vec![target_var.clone()],
         value: Box::new(node.into()),
         type_comment: None,
         range: TextRange::default(),
@@ -848,13 +849,13 @@ pub(crate) fn use_dict_get_with_default(
     };
     let node3 = ast::ExprCall {
         func: Box::new(node2.into()),
-        args: vec![node1, node],
-        keywords: vec![],
+        args: thin_vec![node1, node],
+        keywords: thin_vec![],
         range: TextRange::default(),
     };
     let node4 = expected_var.clone();
     let node5 = ast::StmtAssign {
-        targets: vec![node4],
+        targets: thin_vec![node4],
         value: Box::new(node3.into()),
         type_comment: None,
         range: TextRange::default(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Unaryop};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -116,8 +117,8 @@ pub(crate) fn explicit_true_false_in_ifexpr(
             };
             let node1 = ast::ExprCall {
                 func: Box::new(node.into()),
-                args: vec![test.clone()],
-                keywords: vec![],
+                args: thin_vec![test.clone()],
+                keywords: thin_vec![],
                 range: TextRange::default(),
             };
             #[allow(deprecated)]

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Cmpop, Expr, ExprContext, Ranged, Stmt, Unaryop};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -115,7 +116,7 @@ pub(crate) fn negation_with_equal_op(
     if checker.patch(diagnostic.kind.rule()) {
         let node = ast::ExprCompare {
             left: left.clone(),
-            ops: vec![Cmpop::NotEq],
+            ops: thin_vec![Cmpop::NotEq],
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
@@ -165,7 +166,7 @@ pub(crate) fn negation_with_not_equal_op(
     if checker.patch(diagnostic.kind.rule()) {
         let node = ast::ExprCompare {
             left: left.clone(),
-            ops: vec![Cmpop::Eq],
+            ops: thin_vec![Cmpop::Eq],
             comparators: comparators.clone(),
             range: TextRange::default(),
         };
@@ -211,8 +212,8 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: Unaryop, o
             };
             let node1 = ast::ExprCall {
                 func: Box::new(node.into()),
-                args: vec![*operand.clone()],
-                keywords: vec![],
+                args: thin_vec![*operand.clone()],
+                keywords: thin_vec![],
                 range: TextRange::default(),
             };
             #[allow(deprecated)]

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -2,6 +2,7 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{
     self, Cmpop, Comprehension, Constant, Expr, ExprContext, Ranged, Stmt, Unaryop,
 };
+use thin_vec::thin_vec;
 use unicode_width::UnicodeWidthStr;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
@@ -174,10 +175,10 @@ fn return_values_for_siblings<'a>(stmt: &'a Stmt, sibling: &'a Stmt) -> Option<L
 fn return_stmt(id: &str, test: &Expr, target: &Expr, iter: &Expr, stylist: &Stylist) -> String {
     let node = ast::ExprGeneratorExp {
         elt: Box::new(test.clone()),
-        generators: vec![Comprehension {
+        generators: thin_vec![Comprehension {
             target: target.clone(),
             iter: iter.clone(),
-            ifs: vec![],
+            ifs: thin_vec![],
             is_async: false,
             range: TextRange::default(),
         }],
@@ -190,8 +191,8 @@ fn return_stmt(id: &str, test: &Expr, target: &Expr, iter: &Expr, stylist: &Styl
     };
     let node2 = ast::ExprCall {
         func: Box::new(node1.into()),
-        args: vec![node.into()],
-        keywords: vec![],
+        args: thin_vec![node.into()],
+        keywords: thin_vec![],
         range: TextRange::default(),
     };
     let node3 = ast::StmtReturn {
@@ -283,8 +284,8 @@ pub(crate) fn convert_for_loop_to_any_all(
                             };
                             let node = ast::ExprCompare {
                                 left: left.clone(),
-                                ops: vec![op],
-                                comparators: vec![comparator.clone()],
+                                ops: thin_vec![op],
+                                comparators: thin_vec![comparator.clone()],
                                 range: TextRange::default(),
                             };
                             node.into()

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Expr, Ranged};
+use thin_vec::ThinVec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -32,7 +33,7 @@ fn is_static_length(elts: &[Expr]) -> bool {
 }
 
 fn build_fstring(joiner: &str, joinees: &[Expr]) -> Option<Expr> {
-    let mut fstring_elems = Vec::with_capacity(joinees.len() * 2);
+    let mut fstring_elems = ThinVec::with_capacity(joinees.len() * 2);
     let mut first = true;
 
     for expr in joinees {

--- a/crates/ruff/src/rules/pycodestyle/helpers.rs
+++ b/crates/ruff/src/rules/pycodestyle/helpers.rs
@@ -3,6 +3,7 @@ use ruff_python_ast::newlines::Line;
 use ruff_python_ast::source_code::Stylist;
 use ruff_text_size::{TextLen, TextRange};
 use rustpython_parser::ast::{self, Cmpop, Expr};
+use thin_vec::ThinVec;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 pub(crate) fn is_ambiguous_name(name: &str) -> bool {
@@ -17,8 +18,8 @@ pub(crate) fn compare(
 ) -> String {
     let node = ast::ExprCompare {
         left: Box::new(left.clone()),
-        ops: ops.to_vec(),
-        comparators: comparators.to_vec(),
+        ops: ThinVec::from(ops),
+        comparators: ThinVec::from(comparators),
         range: TextRange::default(),
     };
     unparse_expr(&node.into(), stylist)

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Alias, Int, Ranged, Stmt};
+use thin_vec::thin_vec;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -57,7 +58,7 @@ pub(crate) fn manual_from_import(
     if fixable && checker.patch(diagnostic.kind.rule()) {
         let node = ast::StmtImportFrom {
             module: Some(module.into()),
-            names: vec![Alias {
+            names: thin_vec![Alias {
                 name: asname.clone(),
                 asname: None,
                 range: TextRange::default(),

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Excepthandler, Expr, ExprContext, Ranged};
+use thin_vec::ThinVec;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -82,7 +83,7 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
         };
 
         // Filter out any `OSErrors` aliases.
-        let mut remaining: Vec<Expr> = elts
+        let mut remaining: ThinVec<Expr> = elts
             .iter()
             .filter_map(|elt| {
                 if aliases.contains(&elt) {

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -96,7 +96,7 @@ fn match_open(expr: &Expr) -> (Option<&Expr>, Vec<Keyword>) {
     {
         if matches!(func.as_ref(), Expr::Name(ast::ExprName {id, ..}) if id == OPEN_FUNC_NAME) {
             // Return the "open mode" parameter and keywords.
-            return (args.get(1), keywords.clone());
+            return (args.get(1), keywords.to_vec());
         }
     }
     (None, vec![])

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -1,5 +1,6 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Expr, ExprContext, Operator, Ranged};
+use thin_vec::ThinVec;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -32,8 +33,8 @@ fn make_splat_elts(
     splat_element: &Expr,
     other_elements: &[Expr],
     splat_at_left: bool,
-) -> Vec<Expr> {
-    let mut new_elts = other_elements.to_owned();
+) -> ThinVec<Expr> {
+    let mut new_elts = ThinVec::from(other_elements);
     let node = ast::ExprStarred {
         value: Box::from(splat_element.clone()),
         ctx: ExprContext::Load,

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -25,6 +25,7 @@ rustpython-literal = { workspace = true }
 rustpython-parser = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true }
+thin-vec = "0.2.12"
 
 [features]
 serde = ["dep:serde", "ruff_text_size/serde"]

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -18,6 +18,7 @@ itertools = { workspace = true }
 once_cell = { workspace = true }
 rustc-hash = { workspace = true }
 rustpython-parser = { workspace = true }
+thin-vec = "0.2.12"
 
 [dev-dependencies]
 ruff_testing_macros = { path = "../ruff_testing_macros" }

--- a/crates/ruff_python_formatter/src/cst/mod.rs
+++ b/crates/ruff_python_formatter/src/cst/mod.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{Constant, Ranged};
 use rustpython_parser::{ast, Mode};
+use thin_vec::ThinVec;
 
 use ruff_python_ast::source_code::Locator;
 
@@ -191,10 +192,10 @@ impl From<&rustpython_parser::ast::Cmpop> for CmpOpKind {
     }
 }
 
-pub(crate) type Body = Attributed<Vec<Stmt>>;
+pub(crate) type Body = Attributed<ThinVec<Stmt>>;
 
-impl From<(Vec<rustpython_parser::ast::Stmt>, &Locator<'_>)> for Body {
-    fn from((body, locator): (Vec<rustpython_parser::ast::Stmt>, &Locator)) -> Self {
+impl From<(ThinVec<rustpython_parser::ast::Stmt>, &Locator<'_>)> for Body {
+    fn from((body, locator): (ThinVec<rustpython_parser::ast::Stmt>, &Locator)) -> Self {
         Body {
             range: body.first().unwrap().range(),
             node: body


### PR DESCRIPTION
See https://github.com/RustPython/Parser/pull/34