### PR TITLE
Overhaul sdist handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: "Build sdist"
         uses: PyO3/maturin-action@v1
         with:
-          args: sdist
+          command: sdist
       - name: "Test sdist"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
           command: sdist
       - name: "Test sdist"
         run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
+          pip install target/wheels/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ruff --help
           python -m ruff --help
       - name: "Upload sdist"
@@ -42,377 +42,378 @@ jobs:
           name: wheels
           path: dist
 
-  macos-x86_64:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels - x86_64"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: x86_64
-          args: --release --out dist
-      - name: "Test wheel - x86_64"
-        run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-          ruff --help
-          python -m ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-x86_64-apple-darwin.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/x86_64-apple-darwin/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  macos-universal:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels - universal2"
-        uses: PyO3/maturin-action@v1
-        with:
-          args: --release --universal2 --out dist
-      - name: "Test wheel - universal2"
-        run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
-          ruff --help
-          python -m ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-aarch64-apple-darwin.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/aarch64-apple-darwin/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        platform:
-          - target: x86_64-pc-windows-msvc
-            arch: x64
-          - target: i686-pc-windows-msvc
-            arch: x86
-          - target: aarch64-pc-windows-msvc
-            arch: x64
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: ${{ matrix.platform.arch }}
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist
-      - name: "Test wheel"
-        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-        shell: bash
-        run: |
-          python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-          ruff --help
-          python -m ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        shell: bash
-        run: |
-          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.zip
-          7z a $ARCHIVE_FILE ./target/${{ matrix.platform.target }}/release/ruff.exe
-          sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.zip
-            *.sha256
-
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          manylinux: auto
-          args: --release --out dist
-      - name: "Test wheel"
-        if: ${{ startsWith(matrix.target, 'x86_64') }}
-        run: |
-          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-          ruff --help
-          python -m ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  linux-cross:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - target: aarch64-unknown-linux-gnu
-            arch: aarch64
-            # see https://github.com/charliermarsh/ruff/issues/3791
-            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-          - target: armv7-unknown-linux-gnueabihf
-            arch: armv7
-          - target: s390x-unknown-linux-gnu
-            arch: s390x
-          - target: powerpc64le-unknown-linux-gnu
-            arch: ppc64le
-          - target: powerpc64-unknown-linux-gnu
-            arch: ppc64
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          manylinux: auto
-          docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --out dist
-      - uses: uraimo/run-on-arch-action@v2
-        if: matrix.platform.arch != 'ppc64'
-        name: Test wheel
-        with:
-          arch: ${{ matrix.platform.arch }}
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-          install: |
-            apt-get update
-            apt-get install -y --no-install-recommends python3 python3-pip
-            pip3 install -U pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-            ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  musllinux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-musl
-          - i686-unknown-linux-musl
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          manylinux: musllinux_1_2
-          args: --release --out dist
-      - name: "Test wheel"
-        if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: addnab/docker-run-action@v3
-        with:
-          image: alpine:latest
-          options: -v ${{ github.workspace }}:/io -w /io
-          run: |
-            apk add py3-pip
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
-            ruff --help
-            python -m ruff --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  musllinux-cross:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - target: aarch64-unknown-linux-musl
-            arch: aarch64
-            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-          - target: armv7-unknown-linux-musleabihf
-            arch: armv7
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: "Prep README.md"
-        run: python scripts/transform_readme.py --target pypi
-      - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          manylinux: musllinux_1_2
-          args: --release --out dist
-          docker-options: ${{ matrix.platform.maturin_docker_options }}
-      - uses: uraimo/run-on-arch-action@v2
-        name: Test wheel
-        with:
-          arch: ${{ matrix.platform.arch }}
-          distro: alpine_latest
-          githubToken: ${{ github.token }}
-          install: |
-            apk add py3-pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-            ruff check --help
-      - name: "Upload wheels"
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: dist
-      - name: "Archive binary"
-        run: |
-          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
-          tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
-          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-      - name: "Upload binary"
-        uses: actions/upload-artifact@v3
-        with:
-          name: binaries
-          path: |
-            *.tar.gz
-            *.sha256
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs:
-      - macos-universal
-      - macos-x86_64
-      - windows
-      - linux
-      - linux-cross
-      - musllinux
-      - musllinux-cross
-    if: "startsWith(github.ref, 'refs/tags/')"
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-      - uses: actions/setup-python@v4
-      - name: "Publish to PyPi"
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.RUFF_TOKEN }}
-        run: |
-          pip install --upgrade twine
-          twine upload --skip-existing *
-      - name: "Update pre-commit mirror"
-        run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.RUFF_PRE_COMMIT_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/charliermarsh/ruff-pre-commit/dispatches --data '{"event_type": "pypi_release"}'
-      - uses: actions/download-artifact@v3
-        with:
-          name: binaries
-          path: binaries
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: binaries/*
+  #macos-x86_64:
+  #  runs-on: macos-latest
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #        architecture: x64
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels - x86_64"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: x86_64
+  #        args: --release --out dist
+  #    - name: "Test wheel - x86_64"
+  #      run: |
+  #        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+  #        ruff --help
+  #        python -m ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-x86_64-apple-darwin.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/x86_64-apple-darwin/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #macos-universal:
+  #  runs-on: macos-latest
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #        architecture: x64
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels - universal2"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        args: --release --universal2 --out dist
+  #    - name: "Test wheel - universal2"
+  #      run: |
+  #        pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
+  #        ruff --help
+  #        python -m ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-aarch64-apple-darwin.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/aarch64-apple-darwin/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #windows:
+  #  runs-on: windows-latest
+  #  strategy:
+  #    matrix:
+  #      platform:
+  #        - target: x86_64-pc-windows-msvc
+  #          arch: x64
+  #        - target: i686-pc-windows-msvc
+  #          arch: x86
+  #        - target: aarch64-pc-windows-msvc
+  #          arch: x64
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #        architecture: ${{ matrix.platform.arch }}
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: ${{ matrix.platform.target }}
+  #        args: --release --out dist
+  #    - name: "Test wheel"
+  #      if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+  #      shell: bash
+  #      run: |
+  #        python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+  #        ruff --help
+  #        python -m ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      shell: bash
+  #      run: |
+  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.zip
+  #        7z a $ARCHIVE_FILE ./target/${{ matrix.platform.target }}/release/ruff.exe
+  #        sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.zip
+  #          *.sha256
+#
+  #linux:
+  #  runs-on: ubuntu-latest
+  #  strategy:
+  #    matrix:
+  #      target:
+  #        - x86_64-unknown-linux-gnu
+  #        - i686-unknown-linux-gnu
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #        architecture: x64
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: ${{ matrix.target }}
+  #        manylinux: auto
+  #        args: --release --out dist
+  #    - name: "Test wheel"
+  #      if: ${{ startsWith(matrix.target, 'x86_64') }}
+  #      run: |
+  #        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+  #        ruff --help
+  #        python -m ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #linux-cross:
+  #  runs-on: ubuntu-latest
+  #  strategy:
+  #    matrix:
+  #      platform:
+  #        - target: aarch64-unknown-linux-gnu
+  #          arch: aarch64
+  #          # see https://github.com/charliermarsh/ruff/issues/3791
+  #          # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
+  #          maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+  #        - target: armv7-unknown-linux-gnueabihf
+  #          arch: armv7
+  #        - target: s390x-unknown-linux-gnu
+  #          arch: s390x
+  #        - target: powerpc64le-unknown-linux-gnu
+  #          arch: ppc64le
+  #        - target: powerpc64-unknown-linux-gnu
+  #          arch: ppc64
+#
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: ${{ matrix.platform.target }}
+  #        manylinux: auto
+  #        docker-options: ${{ matrix.platform.maturin_docker_options }}
+  #        args: --release --out dist
+  #    - uses: uraimo/run-on-arch-action@v2
+  #      if: matrix.platform.arch != 'ppc64'
+  #      name: Test wheel
+  #      with:
+  #        arch: ${{ matrix.platform.arch }}
+  #        distro: ubuntu20.04
+  #        githubToken: ${{ github.token }}
+  #        install: |
+  #          apt-get update
+  #          apt-get install -y --no-install-recommends python3 python3-pip
+  #          pip3 install -U pip
+  #        run: |
+  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+  #          ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #musllinux:
+  #  runs-on: ubuntu-latest
+  #  strategy:
+  #    matrix:
+  #      target:
+  #        - x86_64-unknown-linux-musl
+  #        - i686-unknown-linux-musl
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #        architecture: x64
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: ${{ matrix.target }}
+  #        manylinux: musllinux_1_2
+  #        args: --release --out dist
+  #    - name: "Test wheel"
+  #      if: matrix.target == 'x86_64-unknown-linux-musl'
+  #      uses: addnab/docker-run-action@v3
+  #      with:
+  #        image: alpine:latest
+  #        options: -v ${{ github.workspace }}:/io -w /io
+  #        run: |
+  #          apk add py3-pip
+  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
+  #          ruff --help
+  #          python -m ruff --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #musllinux-cross:
+  #  runs-on: ubuntu-latest
+  #  strategy:
+  #    matrix:
+  #      platform:
+  #        - target: aarch64-unknown-linux-musl
+  #          arch: aarch64
+  #          maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+  #        - target: armv7-unknown-linux-musleabihf
+  #          arch: armv7
+#
+  #  steps:
+  #    - uses: actions/checkout@v3
+  #    - uses: actions/setup-python@v4
+  #      with:
+  #        python-version: ${{ env.PYTHON_VERSION }}
+  #    - name: "Prep README.md"
+  #      run: python scripts/transform_readme.py --target pypi
+  #    - name: "Build wheels"
+  #      uses: PyO3/maturin-action@v1
+  #      with:
+  #        target: ${{ matrix.platform.target }}
+  #        manylinux: musllinux_1_2
+  #        args: --release --out dist
+  #        docker-options: ${{ matrix.platform.maturin_docker_options }}
+  #    - uses: uraimo/run-on-arch-action@v2
+  #      name: Test wheel
+  #      with:
+  #        arch: ${{ matrix.platform.arch }}
+  #        distro: alpine_latest
+  #        githubToken: ${{ github.token }}
+  #        install: |
+  #          apk add py3-pip
+  #        run: |
+  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+  #          ruff check --help
+  #    - name: "Upload wheels"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: wheels
+  #        path: dist
+  #    - name: "Archive binary"
+  #      run: |
+  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
+  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
+  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+  #    - name: "Upload binary"
+  #      uses: actions/upload-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: |
+  #          *.tar.gz
+  #          *.sha256
+#
+  #release:
+  #  name: Release
+  #  runs-on: ubuntu-latest
+  #  needs:
+  #    - macos-universal
+  #    - macos-x86_64
+  #    - windows
+  #    - linux
+  #    - linux-cross
+  #    - musllinux
+  #    - musllinux-cross
+  #  if: "startsWith(github.ref, 'refs/tags/')"
+  #  steps:
+  #    - uses: actions/download-artifact@v3
+  #      with:
+  #        name: wheels
+  #    - uses: actions/setup-python@v4
+  #    - name: "Publish to PyPi"
+  #      env:
+  #        TWINE_USERNAME: __token__
+  #        TWINE_PASSWORD: ${{ secrets.RUFF_TOKEN }}
+  #      run: |
+  #        pip install --upgrade twine
+  #        twine upload --skip-existing *
+  #    - name: "Update pre-commit mirror"
+  #      run: |
+  #        curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.RUFF_PRE_COMMIT_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/charliermarsh/ruff-pre-commit/dispatches --data '{"event_type": "pypi_release"}'
+  #    - uses: actions/download-artifact@v3
+  #      with:
+  #        name: binaries
+  #        path: binaries
+  #    - name: Release
+  #      uses: softprops/action-gh-release@v1
+  #      with:
+  #        files: binaries/*
+#

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,10 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
+          args: --out dist
       - name: "Test sdist"
         run: |
-          pip install target/wheels/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
+          pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
           ruff --help
           python -m ruff --help
       - name: "Upload sdist"
@@ -42,378 +43,377 @@ jobs:
           name: wheels
           path: dist
 
-  #macos-x86_64:
-  #  runs-on: macos-latest
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #        architecture: x64
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels - x86_64"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: x86_64
-  #        args: --release --out dist
-  #    - name: "Test wheel - x86_64"
-  #      run: |
-  #        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-  #        ruff --help
-  #        python -m ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-x86_64-apple-darwin.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/x86_64-apple-darwin/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+  macos-x86_64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels - x86_64"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist
+      - name: "Test wheel - x86_64"
+        run: |
+          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
+          python -m ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-x86_64-apple-darwin.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/x86_64-apple-darwin/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #macos-universal:
-  #  runs-on: macos-latest
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #        architecture: x64
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels - universal2"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        args: --release --universal2 --out dist
-  #    - name: "Test wheel - universal2"
-  #      run: |
-  #        pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
-  #        ruff --help
-  #        python -m ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-aarch64-apple-darwin.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/aarch64-apple-darwin/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+  macos-universal:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels - universal2"
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --universal2 --out dist
+      - name: "Test wheel - universal2"
+        run: |
+          pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall
+          ruff --help
+          python -m ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-aarch64-apple-darwin.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/aarch64-apple-darwin/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #windows:
-  #  runs-on: windows-latest
-  #  strategy:
-  #    matrix:
-  #      platform:
-  #        - target: x86_64-pc-windows-msvc
-  #          arch: x64
-  #        - target: i686-pc-windows-msvc
-  #          arch: x86
-  #        - target: aarch64-pc-windows-msvc
-  #          arch: x64
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #        architecture: ${{ matrix.platform.arch }}
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: ${{ matrix.platform.target }}
-  #        args: --release --out dist
-  #    - name: "Test wheel"
-  #      if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
-  #      shell: bash
-  #      run: |
-  #        python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-  #        ruff --help
-  #        python -m ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      shell: bash
-  #      run: |
-  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.zip
-  #        7z a $ARCHIVE_FILE ./target/${{ matrix.platform.target }}/release/ruff.exe
-  #        sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.zip
-  #          *.sha256
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        platform:
+          - target: x86_64-pc-windows-msvc
+            arch: x64
+          - target: i686-pc-windows-msvc
+            arch: x86
+          - target: aarch64-pc-windows-msvc
+            arch: x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: ${{ matrix.platform.arch }}
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+      - name: "Test wheel"
+        if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
+        shell: bash
+        run: |
+          python -m pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
+          python -m ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        shell: bash
+        run: |
+          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.zip
+          7z a $ARCHIVE_FILE ./target/${{ matrix.platform.target }}/release/ruff.exe
+          sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.zip
+            *.sha256
 #
-  #linux:
-  #  runs-on: ubuntu-latest
-  #  strategy:
-  #    matrix:
-  #      target:
-  #        - x86_64-unknown-linux-gnu
-  #        - i686-unknown-linux-gnu
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #        architecture: x64
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: ${{ matrix.target }}
-  #        manylinux: auto
-  #        args: --release --out dist
-  #    - name: "Test wheel"
-  #      if: ${{ startsWith(matrix.target, 'x86_64') }}
-  #      run: |
-  #        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
-  #        ruff --help
-  #        python -m ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - i686-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --out dist
+      - name: "Test wheel"
+        if: ${{ startsWith(matrix.target, 'x86_64') }}
+        run: |
+          pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+          ruff --help
+          python -m ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #linux-cross:
-  #  runs-on: ubuntu-latest
-  #  strategy:
-  #    matrix:
-  #      platform:
-  #        - target: aarch64-unknown-linux-gnu
-  #          arch: aarch64
-  #          # see https://github.com/charliermarsh/ruff/issues/3791
-  #          # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
-  #          maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-  #        - target: armv7-unknown-linux-gnueabihf
-  #          arch: armv7
-  #        - target: s390x-unknown-linux-gnu
-  #          arch: s390x
-  #        - target: powerpc64le-unknown-linux-gnu
-  #          arch: ppc64le
-  #        - target: powerpc64-unknown-linux-gnu
-  #          arch: ppc64
+  linux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+             see https://github.com/charliermarsh/ruff/issues/3791
+             and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+          - target: armv7-unknown-linux-gnueabihf
+            arch: armv7
+          - target: s390x-unknown-linux-gnu
+            arch: s390x
+          - target: powerpc64le-unknown-linux-gnu
+            arch: ppc64le
+          - target: powerpc64-unknown-linux-gnu
+            arch: ppc64
 #
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: ${{ matrix.platform.target }}
-  #        manylinux: auto
-  #        docker-options: ${{ matrix.platform.maturin_docker_options }}
-  #        args: --release --out dist
-  #    - uses: uraimo/run-on-arch-action@v2
-  #      if: matrix.platform.arch != 'ppc64'
-  #      name: Test wheel
-  #      with:
-  #        arch: ${{ matrix.platform.arch }}
-  #        distro: ubuntu20.04
-  #        githubToken: ${{ github.token }}
-  #        install: |
-  #          apt-get update
-  #          apt-get install -y --no-install-recommends python3 python3-pip
-  #          pip3 install -U pip
-  #        run: |
-  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-  #          ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: auto
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
+          args: --release --out dist
+      - uses: uraimo/run-on-arch-action@v2
+        if: matrix.platform.arch != 'ppc64'
+        name: Test wheel
+        with:
+          arch: ${{ matrix.platform.arch }}
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          install: |
+            apt-get update
+            apt-get install -y --no-install-recommends python3 python3-pip
+            pip3 install -U pip
+          run: |
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #musllinux:
-  #  runs-on: ubuntu-latest
-  #  strategy:
-  #    matrix:
-  #      target:
-  #        - x86_64-unknown-linux-musl
-  #        - i686-unknown-linux-musl
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #        architecture: x64
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: ${{ matrix.target }}
-  #        manylinux: musllinux_1_2
-  #        args: --release --out dist
-  #    - name: "Test wheel"
-  #      if: matrix.target == 'x86_64-unknown-linux-musl'
-  #      uses: addnab/docker-run-action@v3
-  #      with:
-  #        image: alpine:latest
-  #        options: -v ${{ github.workspace }}:/io -w /io
-  #        run: |
-  #          apk add py3-pip
-  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
-  #          ruff --help
-  #          python -m ruff --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+  musllinux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-musl
+          - i686-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          architecture: x64
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist
+      - name: "Test wheel"
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        uses: addnab/docker-run-action@v3
+        with:
+          image: alpine:latest
+          options: -v ${{ github.workspace }}:/io -w /io
+          run: |
+            apk add py3-pip
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/dist/ --force-reinstall
+            ruff --help
+            python -m ruff --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-${{ matrix.target }}.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/${{ matrix.target }}/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #musllinux-cross:
-  #  runs-on: ubuntu-latest
-  #  strategy:
-  #    matrix:
-  #      platform:
-  #        - target: aarch64-unknown-linux-musl
-  #          arch: aarch64
-  #          maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
-  #        - target: armv7-unknown-linux-musleabihf
-  #          arch: armv7
+  musllinux-cross:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - target: aarch64-unknown-linux-musl
+            arch: aarch64
+            maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
+          - target: armv7-unknown-linux-musleabihf
+            arch: armv7
 #
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-python@v4
-  #      with:
-  #        python-version: ${{ env.PYTHON_VERSION }}
-  #    - name: "Prep README.md"
-  #      run: python scripts/transform_readme.py --target pypi
-  #    - name: "Build wheels"
-  #      uses: PyO3/maturin-action@v1
-  #      with:
-  #        target: ${{ matrix.platform.target }}
-  #        manylinux: musllinux_1_2
-  #        args: --release --out dist
-  #        docker-options: ${{ matrix.platform.maturin_docker_options }}
-  #    - uses: uraimo/run-on-arch-action@v2
-  #      name: Test wheel
-  #      with:
-  #        arch: ${{ matrix.platform.arch }}
-  #        distro: alpine_latest
-  #        githubToken: ${{ github.token }}
-  #        install: |
-  #          apk add py3-pip
-  #        run: |
-  #          pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-  #          ruff check --help
-  #    - name: "Upload wheels"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: wheels
-  #        path: dist
-  #    - name: "Archive binary"
-  #      run: |
-  #        ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
-  #        tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
-  #        shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
-  #    - name: "Upload binary"
-  #      uses: actions/upload-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: |
-  #          *.tar.gz
-  #          *.sha256
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build wheels"
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: musllinux_1_2
+          args: --release --out dist
+          docker-options: ${{ matrix.platform.maturin_docker_options }}
+      - uses: uraimo/run-on-arch-action@v2
+        name: Test wheel
+        with:
+          arch: ${{ matrix.platform.arch }}
+          distro: alpine_latest
+          githubToken: ${{ github.token }}
+          install: |
+            apk add py3-pip
+          run: |
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            ruff check --help
+      - name: "Upload wheels"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+      - name: "Archive binary"
+        run: |
+          ARCHIVE_FILE=ruff-${{ matrix.platform.target }}.tar.gz
+          tar czvf $ARCHIVE_FILE -C target/${{ matrix.platform.target }}/release ruff
+          shasum -a 256 $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
+      - name: "Upload binary"
+        uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: |
+            *.tar.gz
+            *.sha256
 #
-  #release:
-  #  name: Release
-  #  runs-on: ubuntu-latest
-  #  needs:
-  #    - macos-universal
-  #    - macos-x86_64
-  #    - windows
-  #    - linux
-  #    - linux-cross
-  #    - musllinux
-  #    - musllinux-cross
-  #  if: "startsWith(github.ref, 'refs/tags/')"
-  #  steps:
-  #    - uses: actions/download-artifact@v3
-  #      with:
-  #        name: wheels
-  #    - uses: actions/setup-python@v4
-  #    - name: "Publish to PyPi"
-  #      env:
-  #        TWINE_USERNAME: __token__
-  #        TWINE_PASSWORD: ${{ secrets.RUFF_TOKEN }}
-  #      run: |
-  #        pip install --upgrade twine
-  #        twine upload --skip-existing *
-  #    - name: "Update pre-commit mirror"
-  #      run: |
-  #        curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.RUFF_PRE_COMMIT_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/charliermarsh/ruff-pre-commit/dispatches --data '{"event_type": "pypi_release"}'
-  #    - uses: actions/download-artifact@v3
-  #      with:
-  #        name: binaries
-  #        path: binaries
-  #    - name: Release
-  #      uses: softprops/action-gh-release@v1
-  #      with:
-  #        files: binaries/*
-#
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - macos-universal
+      - macos-x86_64
+      - windows
+      - linux
+      - linux-cross
+      - musllinux
+      - musllinux-cross
+    if: "startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+      - uses: actions/setup-python@v4
+      - name: "Publish to PyPi"
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.RUFF_TOKEN }}
+        run: |
+          pip install --upgrade twine
+          twine upload --skip-existing *
+      - name: "Update pre-commit mirror"
+        run: |
+          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.RUFF_PRE_COMMIT_PAT }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/charliermarsh/ruff-pre-commit/dispatches --data '{"event_type": "pypi_release"}'
+      - uses: actions/download-artifact@v3
+        with:
+          name: binaries
+          path: binaries
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: binaries/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,30 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: "Prep README.md"
+        run: python scripts/transform_readme.py --target pypi
+      - name: "Build sdist"
+        uses: PyO3/maturin-action@v1
+        with:
+          args: sdist
+      - name: "Test sdist"
+        run: |
+          pip install dist/${{ env.PACKAGE_NAME }}-*.tar.gz --force-reinstall
+          ruff --help
+          python -m ruff --help
+      - name: "Upload sdist"
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
   macos-x86_64:
     runs-on: macos-latest
     steps:
@@ -32,7 +56,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: x86_64
-          args: --release --out dist --sdist
+          args: --release --out dist
       - name: "Test wheel - x86_64"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -220,8 +220,8 @@ jobs:
         platform:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
-             see https://github.com/charliermarsh/ruff/issues/3791
-             and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
+            # see https://github.com/charliermarsh/ruff/issues/3791
+            # and https://github.com/gnzlbg/jemallocator/issues/170#issuecomment-1503228963
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   macos-universal:
     runs-on: macos-latest
     steps:
@@ -117,7 +117,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   windows:
     runs-on: windows-latest
     strategy:
@@ -167,7 +167,7 @@ jobs:
           path: |
             *.zip
             *.sha256
-#
+
   linux:
     runs-on: ubuntu-latest
     strategy:
@@ -212,7 +212,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   linux-cross:
     runs-on: ubuntu-latest
     strategy:
@@ -231,7 +231,7 @@ jobs:
             arch: ppc64le
           - target: powerpc64-unknown-linux-gnu
             arch: ppc64
-#
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -277,7 +277,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   musllinux:
     runs-on: ubuntu-latest
     strategy:
@@ -327,7 +327,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   musllinux-cross:
     runs-on: ubuntu-latest
     strategy:
@@ -338,7 +338,7 @@ jobs:
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-musleabihf
             arch: armv7
-#
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -381,7 +381,7 @@ jobs:
           path: |
             *.tar.gz
             *.sha256
-#
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/crates/flake8_to_ruff/pyproject.toml
+++ b/crates/flake8_to_ruff/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.7"
 repository = "https://github.com/charliermarsh/ruff#subdirectory=crates/flake8_to_ruff"
 
 [build-system]
-requires = ["maturin>=0.15.1,<0.16"]
+requires = ["maturin>=0.15.2,<0.16"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ manifest-path = "crates/ruff_cli/Cargo.toml"
 module-name = "ruff"
 python-source = "python"
 strip = true
+#exclude = [
+#  "crates/ruff/resources/test/fixtures/**/*",
+#  "crates/ruff/src/rules/*/snapshots/**/*"
+#]
 
 [tool.black]
 force-exclude = '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.15.1,<0.16"]
+requires = ["maturin>=0.15.2,<0.16"]
 
 build-backend = "maturin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ manifest-path = "crates/ruff_cli/Cargo.toml"
 module-name = "ruff"
 python-source = "python"
 strip = true
-#exclude = [
-#  "crates/ruff/resources/test/fixtures/**/*",
-#  "crates/ruff/src/rules/*/snapshots/**/*"
-#]
+exclude = [
+  "crates/ruff/resources/test/fixtures/**/*",
+  "crates/ruff/src/rules/*/snapshots/**/*"
+]
 
 [tool.black]
 force-exclude = '''


### PR DESCRIPTION
This does three tings:

 * Fix out sdist by updating maturin (https://github.com/PyO3/maturin/issues/1609)
 * Add a test on release that ensures that the sdist keeps working
 * reduce the size of the sdist by excluding test fixtures:
   `maturin sdist && du -sh target/wheels/ruff-0.0.267.tar.gz`:
   Before: 1,1M
   After: 668K

Closes #4436.