### PR TITLE
Add LightGBM to user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - Modern Treasury ([Python SDK](https://github.com/Modern-Treasury/modern-treasury-python-sdk))
 - Mozilla ([Firefox](https://github.com/mozilla/gecko-dev))
 - [MegaLinter](https://github.com/oxsecurity/megalinter)
-- Microsoft ([Semantic Kernel](https://github.com/microsoft/semantic-kernel), [ONNX Runtime](https://github.com/microsoft/onnxruntime))
+- Microsoft ([Semantic Kernel](https://github.com/microsoft/semantic-kernel), [ONNX Runtime](https://github.com/microsoft/onnxruntime), [LightGBM](https://github.com/microsoft/LightGBM))
 - Netflix ([Dispatch](https://github.com/Netflix/dispatch))
 - [Neon](https://github.com/neondatabase/neon)
 - [ONNX](https://github.com/onnx/onnx)


### PR DESCRIPTION
We adopted `ruff` into our CI over in LightGBM tonight: https://github.com/microsoft/LightGBM/pull/5871

This PR proposes adding LightGBM to the list of large open-source projects using `ruff` in the README, as a small thank you for the excellent tool you've created here 😊 