### PR TITLE
Prototype Black's string joining/splitting

### DIFF
--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -61,9 +61,16 @@ pub fn fmt(contents: &str) -> Result<Formatted<ASTFormatContext>> {
 mod tests {
     use std::fmt::{Formatter, Write};
     use std::fs;
+    use std::hash::Hasher;
     use std::path::Path;
 
     use anyhow::Result;
+    use insta::assert_snapshot;
+    use ruff_formatter::prelude::{
+        format_once, format_with, group, if_group_breaks, soft_block_indent,
+    };
+    use ruff_formatter::{Format, FormatResult, SimpleFormatContext};
+    use ruff_text_size::TextSize;
     use similar::TextDiff;
 
     use ruff_testing_macros::fixture;
@@ -174,6 +181,80 @@ mod tests {
     for k, v in a_very_long_variable_name_that_exceeds_the_line_length_by_far_keep_going
 }"#
         );
+    }
+
+    #[test]
+    fn string_processing() {
+        use ruff_formatter::prelude::*;
+        use ruff_formatter::{format, format_args, write};
+
+        // 77 after g group (leading quote)
+        let fits =
+            r#"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg h"#;
+        let breaks =
+            r#"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg hh"#;
+
+        struct FormatString<'a>(&'a str);
+
+        impl Format<SimpleFormatContext> for FormatString<'_> {
+            fn fmt(
+                &self,
+                f: &mut ruff_formatter::formatter::Formatter<SimpleFormatContext>,
+            ) -> FormatResult<()> {
+                let format_str = format_with(|f| {
+                    write!(f, [text("\"")])?;
+
+                    let mut words = self.0.split_whitespace().peekable();
+                    let mut fill = f.fill();
+
+                    let separator = format_with(|f| {
+                        group(&format_args![
+                            if_group_breaks(&text("\"")),
+                            soft_line_break_or_space(),
+                            if_group_breaks(&text("\""))
+                        ])
+                        .fmt(f)
+                    });
+
+                    while let Some(word) = words.next() {
+                        let format_word = format_once(|f| {
+                            write!(f, [dynamic_text(word, TextSize::default())])?;
+
+                            if words.peek().is_none() {
+                                write!(f, [text("\"")])?;
+                            }
+
+                            Ok(())
+                        });
+
+                        fill.entry(&separator, &format_word);
+                    }
+
+                    fill.finish()
+                });
+
+                write!(
+                    f,
+                    [group(&format_args![
+                        if_group_breaks(&text("(")),
+                        soft_block_indent(&format_str),
+                        if_group_breaks(&text(")"))
+                    ])]
+                )
+            }
+        }
+
+        let output = format!(
+            SimpleFormatContext::default(),
+            [
+                FormatString(&fits),
+                hard_line_break(),
+                FormatString(&breaks)
+            ]
+        )
+        .expect("Formatting to succeed");
+
+        assert_snapshot!(output.print().expect("Printing to succeed").as_code())
     }
 
     struct Header<'a> {

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
                         group(&format_args![
                             if_group_breaks(&text("\"")),
                             soft_line_break_or_space(),
-                            if_group_breaks(&text("\""))
+                            if_group_breaks(&text("\" "))
                         ])
                         .fmt(f)
                     });

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__string_processing.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__string_processing.snap
@@ -5,5 +5,5 @@ expression: "output.print().expect(\"Printing to succeed\").as_code()"
 "aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg h"
 (
 	"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg"
-	"hh"
+	" hh"
 )

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__string_processing.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__string_processing.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_python_formatter/src/lib.rs
+expression: "output.print().expect(\"Printing to succeed\").as_code()"
+---
+"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg h"
+(
+	"aaaaaaaaaa bbbbbbbbbb cccccccccc dddddddddd eeeeeeeeee ffffffffff gggggggggg"
+	"hh"
+)

--- a/crates/ruff_testing_macros/src/lib.rs
+++ b/crates/ruff_testing_macros/src/lib.rs
@@ -304,6 +304,7 @@ fn find_highest_common_ancestor_module(module: &Module) -> &Module {
     }
 }
 
+#[derive(Debug)]
 struct Test {
     path: PathBuf,
     test_fn: ItemFn,
@@ -316,7 +317,7 @@ impl Test {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct Module {
     children: BTreeMap<String, Child>,
 }
@@ -341,6 +342,7 @@ impl Module {
     }
 }
 
+#[derive(Debug)]
 enum Child {
     Module(Module),
     Test(Test),
@@ -355,7 +357,7 @@ impl Child {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct Modules {
     root: Module,
 }

--- a/crates/ruff_testing_macros/src/lib.rs
+++ b/crates/ruff_testing_macros/src/lib.rs
@@ -304,7 +304,6 @@ fn find_highest_common_ancestor_module(module: &Module) -> &Module {
     }
 }
 
-#[derive(Debug)]
 struct Test {
     path: PathBuf,
     test_fn: ItemFn,
@@ -317,7 +316,7 @@ impl Test {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct Module {
     children: BTreeMap<String, Child>,
 }
@@ -342,7 +341,6 @@ impl Module {
     }
 }
 
-#[derive(Debug)]
 enum Child {
     Module(Module),
     Test(Test),
@@ -357,7 +355,7 @@ impl Child {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 struct Modules {
     root: Module,
 }


### PR DESCRIPTION
This PR adds a test to verify that the `fill` element can be used to implement Black's [string-processing](https://github.com/psf/black/issues/3292)

The "full" implementation needs to split all strings by words and create a single `fill` element for it. But that seems straightforward so that it isn't covered by this test.