### PR TITLE
Avoid emitting empty logical lines

### DIFF
--- a/crates/ruff/resources/test/fixtures/pycodestyle/E11.py
+++ b/crates/ruff/resources/test/fixtures/pycodestyle/E11.py
@@ -49,3 +49,18 @@ if False:
 #:
 if False:  #
     print()
+#:
+if False:
+    print()
+
+    print()
+#:
+if False:
+    print()
+    if False:
+
+        print()
+#:
+if False:
+
+    print()

--- a/crates/ruff/src/checkers/logical_lines.rs
+++ b/crates/ruff/src/checkers/logical_lines.rs
@@ -250,5 +250,20 @@ f()"#
             "f()",
         ];
         assert_eq!(actual, expected);
+
+        let contents = r#"
+if False:
+
+    print()
+"#
+        .trim();
+        let lxr: Vec<LexResult> = lexer::lex(contents, Mode::Module).collect();
+        let locator = Locator::new(contents);
+        let actual: Vec<String> = LogicalLines::from_tokens(&lxr, &locator)
+            .into_iter()
+            .map(|line| line.text_trimmed().to_string())
+            .collect();
+        let expected = vec!["if False:", "print()", ""];
+        assert_eq!(actual, expected);
     }
 }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -500,11 +500,16 @@ impl LogicalLinesBuilder {
     fn finish_line(&mut self) {
         let end = self.tokens.len() as u32;
         if self.current_line.tokens_start < end {
-            self.lines.push(Line {
-                flags: self.current_line.flags,
-                tokens_start: self.current_line.tokens_start,
-                tokens_end: end,
-            });
+            let is_empty = self.tokens[self.current_line.tokens_start as usize..end as usize]
+                .iter()
+                .all(|token| token.kind.is_newline());
+            if !is_empty {
+                self.lines.push(Line {
+                    flags: self.current_line.flags,
+                    tokens_start: self.current_line.tokens_start,
+                    tokens_end: end,
+                });
+            }
 
             self.current_line = CurrentLine {
                 flags: TokenFlags::default(),

--- a/crates/ruff_python_ast/src/token_kind.rs
+++ b/crates/ruff_python_ast/src/token_kind.rs
@@ -168,6 +168,11 @@ pub enum TokenKind {
 
 impl TokenKind {
     #[inline]
+    pub const fn is_newline(&self) -> bool {
+        matches!(self, TokenKind::Newline | TokenKind::NonLogicalNewline)
+    }
+
+    #[inline]
     pub const fn is_unary(&self) -> bool {
         matches!(self, TokenKind::Plus | TokenKind::Minus | TokenKind::Star)
     }


### PR DESCRIPTION
## Summary

The changes to the lexer reflected in #4444 cause us to now encounter empty lines in the token stream, which we're now emitting as logical lines. Pycodestyle skips these entirely, and tracks the "number of blank lines" separately. This PR mimics that behavior, skipping empty lines.

(We may want to make this a flag on `LogicalLine`, but this seems fine for now.)
