### PR TITLE
Create dummy format CLI

### DIFF
--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -67,6 +67,7 @@ ureq = { version = "2.6.2", features = [] }
 [features]
 jupyter_notebook = ["ruff/jupyter_notebook"]
 ecosystem_ci = ["ruff/ecosystem_ci"]
+format = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.34"

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -67,7 +67,6 @@ ureq = { version = "2.6.2", features = [] }
 [features]
 jupyter_notebook = ["ruff/jupyter_notebook"]
 ecosystem_ci = ["ruff/ecosystem_ci"]
-format = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.34"

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -57,6 +57,12 @@ pub enum Command {
     /// Generate shell completion.
     #[clap(alias = "--generate-shell-completion", hide = true)]
     GenerateShellCompletion { shell: clap_complete_command::Shell },
+    /// Format the given files, or stdin when using `-`.
+    #[doc(hidden)]
+    Format {
+        /// List of files or directories to format or `-` for stdin
+        files: Vec<PathBuf>,
+    },
 }
 
 #[derive(Debug, clap::Args)]

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -59,6 +59,7 @@ pub enum Command {
     GenerateShellCompletion { shell: clap_complete_command::Shell },
     /// Format the given files, or stdin when using `-`.
     #[doc(hidden)]
+    #[clap(hide = true)]
     Format {
         /// List of files or directories to format or `-` for stdin
         files: Vec<PathBuf>,

--- a/crates/ruff_cli/src/commands/run_stdin.rs
+++ b/crates/ruff_cli/src/commands/run_stdin.rs
@@ -11,7 +11,7 @@ use crate::args::Overrides;
 use crate::diagnostics::{lint_stdin, Diagnostics};
 
 /// Read a `String` from `stdin`.
-fn read_from_stdin() -> Result<String> {
+pub(crate) fn read_from_stdin() -> Result<String> {
     let mut buffer = String::new();
     io::stdin().lock().read_to_string(&mut buffer)?;
     Ok(buffer)

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -126,7 +126,10 @@ quoting the executed command, along with the relevant file contents and `pyproje
 }
 
 fn format(files: &[PathBuf]) -> Result<ExitStatus> {
-    warn_user_once!("This function is unfinished, broken and for internal use only!");
+    warn_user_once!(
+        "`ruff format` is a work-in-progress, subject to change at any time, and intended for \
+        internal use only."
+    );
 
     // dummy
     let format_code = |code: &str| code.replace("# DEL", "");

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -1,9 +1,9 @@
-use std::io::{self, BufWriter};
+use std::io::{self, stdout, BufWriter, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::mpsc::channel;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::CommandFactory;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 
@@ -13,6 +13,7 @@ use ruff::settings::{flags, CliSettings};
 use ruff::{fs, warn_user_once};
 
 use crate::args::{Args, CheckArgs, Command};
+use crate::commands::run_stdin::read_from_stdin;
 use crate::printer::{Flags as PrinterFlags, Printer};
 
 pub mod args;
@@ -117,8 +118,31 @@ quoting the executed command, along with the relevant file contents and `pyproje
             shell.generate(&mut Args::command(), &mut io::stdout());
         }
         Command::Check(args) => return check(args, log_level),
+        Command::Format { files } => return format(&files),
     }
 
+    Ok(ExitStatus::Success)
+}
+
+#[cfg_attr(not(feature = "format"), allow(unused))]
+fn format(files: &[PathBuf]) -> Result<ExitStatus> {
+    // dummy
+    let format_code = |code: &str| code.replace("# DEL", "");
+
+    let is_stdin = files == vec![PathBuf::from("-")];
+    if is_stdin {
+        let unformatted = read_from_stdin()?;
+        let formatted = format_code(&unformatted);
+        stdout().lock().write_all(formatted.as_bytes())?;
+    } else {
+        for file in files {
+            let unformatted = std::fs::read_to_string(file)
+                .with_context(|| format!("Could not read {}: ", file.display()))?;
+            let formatted = format_code(&unformatted);
+            std::fs::write(file, formatted)
+                .with_context(|| format!("Could not write to {}, exiting", file.display()))?;
+        }
+    }
     Ok(ExitStatus::Success)
 }
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::mpsc::channel;
 
 use anyhow::{Context, Result};
 use clap::CommandFactory;
+use log::warn;
 use notify::{recommended_watcher, RecursiveMode, Watcher};
 
 use ruff::logging::{set_up_logging, LogLevel};
@@ -124,8 +125,9 @@ quoting the executed command, along with the relevant file contents and `pyproje
     Ok(ExitStatus::Success)
 }
 
-#[cfg_attr(not(feature = "format"), allow(unused))]
 fn format(files: &[PathBuf]) -> Result<ExitStatus> {
+    warn!("This function is unfinished, broken and for internal use only!");
+
     // dummy
     let format_code = |code: &str| code.replace("# DEL", "");
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -126,7 +126,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
 }
 
 fn format(files: &[PathBuf]) -> Result<ExitStatus> {
-    warn!("This function is unfinished, broken and for internal use only!");
+    warn_user_once!("This function is unfinished, broken and for internal use only!");
 
     // dummy
     let format_code = |code: &str| code.replace("# DEL", "");


### PR DESCRIPTION
This currently only does a dummy replacement and is hidden behind a feature flag. See also the corresponding ruff-lsp PR.
