### PR TITLE
Include precise tokens for extraneous-whitespace diagnostics

### DIFF
--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E201_E20.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E201_E20.py.snap
@@ -10,7 +10,7 @@ E20.py:2:6: E201 Whitespace after '('
 5 | spam(ham[ 1], {eggs: 2})
   |
 
-E20.py:4:10: E201 Whitespace after '('
+E20.py:4:10: E201 Whitespace after '['
   |
 4 | spam( ham[1], {eggs: 2})
 5 | #: E201:1:10
@@ -20,7 +20,7 @@ E20.py:4:10: E201 Whitespace after '('
 8 | spam(ham[1], { eggs: 2})
   |
 
-E20.py:6:15: E201 Whitespace after '('
+E20.py:6:15: E201 Whitespace after '{'
    |
  6 | spam(ham[ 1], {eggs: 2})
  7 | #: E201:1:15
@@ -40,7 +40,7 @@ E20.py:8:6: E201 Whitespace after '('
 12 | spam(ham[   1], {eggs: 2})
    |
 
-E20.py:10:10: E201 Whitespace after '('
+E20.py:10:10: E201 Whitespace after '['
    |
 10 | spam(   ham[1], {eggs: 2})
 11 | #: E201:1:10
@@ -50,7 +50,7 @@ E20.py:10:10: E201 Whitespace after '('
 14 | spam(ham[1], {  eggs: 2})
    |
 
-E20.py:12:15: E201 Whitespace after '('
+E20.py:12:15: E201 Whitespace after '{'
    |
 12 | spam(ham[   1], {eggs: 2})
 13 | #: E201:1:15

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E202_E20.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E202_E20.py.snap
@@ -10,7 +10,7 @@ E20.py:19:23: E202 Whitespace before ')'
 22 | spam(ham[1], {eggs: 2 })
    |
 
-E20.py:21:22: E202 Whitespace before ')'
+E20.py:21:22: E202 Whitespace before '}'
    |
 21 | spam(ham[1], {eggs: 2} )
 22 | #: E202:1:22
@@ -20,7 +20,7 @@ E20.py:21:22: E202 Whitespace before ')'
 25 | spam(ham[1 ], {eggs: 2})
    |
 
-E20.py:23:11: E202 Whitespace before ')'
+E20.py:23:11: E202 Whitespace before ']'
    |
 23 | spam(ham[1], {eggs: 2 })
 24 | #: E202:1:11
@@ -40,7 +40,7 @@ E20.py:25:23: E202 Whitespace before ')'
 29 | spam(ham[1], {eggs: 2   })
    |
 
-E20.py:27:22: E202 Whitespace before ')'
+E20.py:27:22: E202 Whitespace before '}'
    |
 27 | spam(ham[1], {eggs: 2}  )
 28 | #: E202:1:22
@@ -50,7 +50,7 @@ E20.py:27:22: E202 Whitespace before ')'
 31 | spam(ham[1  ], {eggs: 2})
    |
 
-E20.py:29:11: E202 Whitespace before ')'
+E20.py:29:11: E202 Whitespace before ']'
    |
 29 | spam(ham[1], {eggs: 2   })
 30 | #: E202:1:11

--- a/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E203_E20.py.snap
+++ b/crates/ruff/src/rules/pycodestyle/snapshots/ruff__rules__pycodestyle__tests__E203_E20.py.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff/src/rules/pycodestyle/mod.rs
 ---
-E20.py:51:10: E203 Whitespace before ',', ';', or ':'
+E20.py:51:10: E203 Whitespace before ':'
    |
 51 | #: E203:1:10
 52 | if x == 4 :
@@ -10,7 +10,7 @@ E20.py:51:10: E203 Whitespace before ',', ';', or ':'
 54 |     x, y = y, x
    |
 
-E20.py:55:10: E203 Whitespace before ',', ';', or ':'
+E20.py:55:10: E203 Whitespace before ':'
    |
 55 |     x, y = y, x
 56 | #: E203:1:10
@@ -20,7 +20,7 @@ E20.py:55:10: E203 Whitespace before ',', ';', or ':'
 59 |     x, y = y, x
    |
 
-E20.py:60:15: E203 Whitespace before ',', ';', or ':'
+E20.py:60:15: E203 Whitespace before ';'
    |
 60 | #: E203:2:15 E702:2:16
 61 | if x == 4:
@@ -30,7 +30,7 @@ E20.py:60:15: E203 Whitespace before ',', ';', or ':'
 64 | if x == 4:
    |
 
-E20.py:63:15: E203 Whitespace before ',', ';', or ':'
+E20.py:63:15: E203 Whitespace before ';'
    |
 63 | #: E203:2:15 E702:2:16
 64 | if x == 4:
@@ -40,7 +40,7 @@ E20.py:63:15: E203 Whitespace before ',', ';', or ':'
 67 | if x == 4:
    |
 
-E20.py:67:13: E203 Whitespace before ',', ';', or ':'
+E20.py:67:13: E203 Whitespace before ','
    |
 67 | if x == 4:
 68 |     print x, y
@@ -50,7 +50,7 @@ E20.py:67:13: E203 Whitespace before ',', ';', or ':'
 71 | if x == 4:
    |
 
-E20.py:71:13: E203 Whitespace before ',', ';', or ':'
+E20.py:71:13: E203 Whitespace before ','
    |
 71 | if x == 4:
 72 |     print x, y


### PR DESCRIPTION
## Summary

This PR modifies the message such that it shows the actual bracket used (like `[`) instead of always using a parenthesis (like `(`), which is consistent with pycodestyle.
