### PR TITLE
Invert quote-style when generating code within f-strings

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP018.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP018.py
@@ -25,3 +25,4 @@ bytes()
 bytes(b"foo")
 bytes(b"""
 foo""")
+f"{str()}"

--- a/crates/ruff/resources/test/fixtures/ruff/RUF005.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF005.py
@@ -43,3 +43,6 @@ second = first + [
 
 [] + foo + [  # This will be preserved, but doesn't prevent the fix
 ]
+
+# Uses the non-preferred quote style, which should be retained.
+f"{[*a(), 'b']}"

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -143,30 +143,10 @@ impl<'a> Checker<'a> {
                 return None;
             }
 
-            let Some(expr) = context.expr() else {
-                return None;
-            };
-
-            // Find the f-string containing the current expression.
-            let start = expr.start();
-            let string_ranges = indexer.f_string_ranges();
-            let Ok(string_range_index) = string_ranges.binary_search_by(|range| {
-                if start < range.start() {
-                    std::cmp::Ordering::Greater
-                } else if range.contains(start) {
-                    std::cmp::Ordering::Equal
-                } else {
-                    std::cmp::Ordering::Less
-                }
-            }) else {
-                return None;
-            };
-            let string_range = string_ranges[string_range_index];
-
-            // Find the quote character used to start the f-string.
-            let Some(trailing_quote) = trailing_quote(locator.slice(string_range)) else {
-                return None;
-            };
+            // Find the quote character used to start the containing f-string.
+            let expr = context.expr()?;
+            let string_range = indexer.f_string_range(expr.start())?;
+            let trailing_quote = trailing_quote(locator.slice(string_range))?;
 
             // Invert the quote character, if it's a single quote.
             match *trailing_quote {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -62,14 +62,14 @@ fn unparse_string_format_expression(checker: &mut Checker, expr: &Expr) -> Optio
         }) => {
             let Some(parent) = checker.ctx.expr_parent() else {
                 if any_over_expr(expr, &has_string_literal) {
-                    return Some(unparse_expr(expr, checker.stylist));
+                    return Some(unparse_expr(expr, checker.generator()));
                 }
                 return None;
             };
             // Only evaluate the full BinOp, not the nested components.
             let Expr::BinOp(_ )= parent else {
                 if any_over_expr(expr, &has_string_literal) {
-                    return Some(unparse_expr(expr, checker.stylist));
+                    return Some(unparse_expr(expr, checker.generator()));
                 }
                 return None;
             };
@@ -81,12 +81,12 @@ fn unparse_string_format_expression(checker: &mut Checker, expr: &Expr) -> Optio
             };
             // "select * from table where val = {}".format(...)
             if attr == "format" && string_literal(value).is_some() {
-                return Some(unparse_expr(expr, checker.stylist));
+                return Some(unparse_expr(expr, checker.generator()));
             };
             None
         }
         // f"select * from table where val = {val}"
-        Expr::JoinedStr(_) => Some(unparse_expr(expr, checker.stylist)),
+        Expr::JoinedStr(_) => Some(unparse_expr(expr, checker.generator())),
         _ => None,
     }
 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -48,7 +48,7 @@ pub(crate) fn request_without_timeout(
                 Expr::Constant(ast::ExprConstant {
                     value: value @ Constant::None,
                     ..
-                }) => Some(unparse_constant(value, checker.stylist)),
+                }) => Some(unparse_constant(value, checker.generator())),
                 _ => None,
             } {
                 checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -56,7 +56,7 @@ pub(crate) fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_stmt(&assertion_error(msg), checker.stylist),
+            unparse_stmt(&assertion_error(msg), checker.generator()),
             stmt.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -97,9 +97,9 @@ fn duplicate_handler_exceptions<'a>(
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                     if unique_elts.len() == 1 {
-                        unparse_expr(unique_elts[0], checker.stylist)
+                        unparse_expr(unique_elts[0], checker.generator())
                     } else {
-                        unparse_expr(&type_pattern(unique_elts), checker.stylist)
+                        unparse_expr(&type_pattern(unique_elts), checker.generator())
                     },
                     expr.range(),
                 )));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -69,7 +69,7 @@ pub(crate) fn getattr_with_constant(
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&attribute(obj, value), checker.stylist),
+            unparse_expr(&attribute(obj, value), checker.generator()),
             expr.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -45,14 +45,14 @@ pub(crate) fn redundant_tuple_in_exception_handler(
         };
         let mut diagnostic = Diagnostic::new(
             RedundantTupleInExceptionHandler {
-                name: unparse_expr(elt, checker.stylist),
+                name: unparse_expr(elt, checker.generator()),
             },
             type_.range(),
         );
         if checker.patch(diagnostic.kind.rule()) {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(elt, checker.stylist),
+                unparse_expr(elt, checker.generator()),
                 type_.range(),
             )));
         }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
-use ruff_python_ast::source_code::Stylist;
+use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
 
 use crate::checkers::ast::Checker;
@@ -27,7 +27,7 @@ impl AlwaysAutofixableViolation for SetAttrWithConstant {
     }
 }
 
-fn assignment(obj: &Expr, name: &str, value: &Expr, stylist: &Stylist) -> String {
+fn assignment(obj: &Expr, name: &str, value: &Expr, generator: Generator) -> String {
     let stmt = Stmt::Assign(ast::StmtAssign {
         targets: vec![Expr::Attribute(ast::ExprAttribute {
             value: Box::new(obj.clone()),
@@ -39,7 +39,7 @@ fn assignment(obj: &Expr, name: &str, value: &Expr, stylist: &Stylist) -> String
         type_comment: None,
         range: TextRange::default(),
     });
-    unparse_stmt(&stmt, stylist)
+    unparse_stmt(&stmt, generator)
 }
 
 /// B010
@@ -84,7 +84,7 @@ pub(crate) fn setattr_with_constant(
             if checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    assignment(obj, name, value, checker.stylist),
+                    assignment(obj, name, value, checker.generator()),
                     expr.range(),
                 )));
             }

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -443,7 +443,7 @@ pub(crate) fn non_unique_enums<'a, 'b>(
         if !seen_targets.insert(ComparableExpr::from(value)) {
             let diagnostic = Diagnostic::new(
                 NonUniqueEnums {
-                    value: unparse_expr(value, checker.stylist),
+                    value: unparse_expr(value, checker.generator()),
                 },
                 stmt.range(),
             );
@@ -612,7 +612,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &mut Checker, expr: &Expr) {
                 let bool_op = node;
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    unparse_expr(&bool_op, checker.stylist),
+                    unparse_expr(&bool_op, checker.generator()),
                     expr.range(),
                 )));
             }

--- a/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/duplicate_union_member.rs
@@ -61,7 +61,7 @@ fn traverse_union<'a>(
     if !seen_nodes.insert(expr.into()) {
         let mut diagnostic = Diagnostic::new(
             DuplicateUnionMember {
-                duplicate_name: unparse_expr(expr, checker.stylist),
+                duplicate_name: unparse_expr(expr, checker.generator()),
             },
             expr.range(),
         );
@@ -82,7 +82,7 @@ fn traverse_union<'a>(
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 unparse_expr(
                     if expr == left.as_ref() { right } else { left },
-                    checker.stylist,
+                    checker.generator(),
                 ),
                 parent.range(),
             )));

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -198,7 +198,7 @@ pub(crate) fn unittest_assertion(
                     if let Ok(stmt) = unittest_assert.generate_assert(args, keywords) {
                         #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                            unparse_stmt(&stmt, checker.stylist),
+                            unparse_stmt(&stmt, checker.generator()),
                             expr.range(),
                         )));
                     }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -78,7 +78,7 @@ fn elts_to_csv(elts: &[Expr], checker: &Checker) -> Option<String> {
         kind: None,
         range: TextRange::default(),
     });
-    Some(unparse_expr(&node, checker.stylist))
+    Some(unparse_expr(&node, checker.generator()))
 }
 
 /// Returns the range of the `name` argument of `@pytest.mark.parametrize`.
@@ -164,7 +164,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             });
                             #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                format!("({})", unparse_expr(&node, checker.stylist,)),
+                                format!("({})", unparse_expr(&node, checker.generator())),
                                 name_range,
                             )));
                         }
@@ -195,7 +195,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             });
                             #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                unparse_expr(&node, checker.stylist),
+                                unparse_expr(&node, checker.generator()),
                                 name_range,
                             )));
                         }
@@ -228,7 +228,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             });
                             #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                unparse_expr(&node, checker.stylist),
+                                unparse_expr(&node, checker.generator()),
                                 expr.range(),
                             )));
                         }
@@ -278,7 +278,7 @@ fn check_names(checker: &mut Checker, decorator: &Expr, expr: &Expr) {
                             });
                             #[allow(deprecated)]
                             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                format!("({})", unparse_expr(&node, checker.stylist,)),
+                                format!("({})", unparse_expr(&node, checker.generator())),
                                 expr.range(),
                             )));
                         }
@@ -373,7 +373,7 @@ fn handle_single_name(checker: &mut Checker, expr: &Expr, value: &Expr) {
         let node = value.clone();
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&node, checker.stylist),
+            unparse_expr(&node, checker.generator()),
             expr.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -11,8 +11,6 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, AutofixKind, Diagnostic, Edit
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
 use ruff_python_ast::helpers::{contains_effect, has_comments, unparse_expr, Truthiness};
-use ruff_python_ast::source_code::Stylist;
-use ruff_python_semantic::context::Context;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -370,7 +368,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
                 // multiple duplicates, the fixes will conflict.
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    unparse_expr(&bool_op, checker.stylist),
+                    unparse_expr(&bool_op, checker.generator()),
                     expr.range(),
                 )));
             }
@@ -457,7 +455,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
         let in_expr = node2.into();
         let mut diagnostic = Diagnostic::new(
             CompareWithTuple {
-                replacement: unparse_expr(&in_expr, checker.stylist),
+                replacement: unparse_expr(&in_expr, checker.generator()),
             },
             expr.range(),
         );
@@ -481,7 +479,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(&in_expr, checker.stylist),
+                unparse_expr(&in_expr, checker.generator()),
                 expr.range(),
             )));
         }
@@ -604,7 +602,7 @@ pub(crate) fn get_short_circuit_edit(
     range: TextRange,
     truthiness: Truthiness,
     in_boolean_test: bool,
-    stylist: &Stylist,
+    checker: &Checker,
 ) -> Edit {
     let content = if in_boolean_test {
         match truthiness {
@@ -615,7 +613,7 @@ pub(crate) fn get_short_circuit_edit(
             }
         }
     } else {
-        unparse_expr(expr, stylist)
+        unparse_expr(expr, checker.generator())
     };
     Edit::range_replacement(content, range)
 }
@@ -623,8 +621,7 @@ pub(crate) fn get_short_circuit_edit(
 fn is_short_circuit(
     expr: &Expr,
     expected_op: Boolop,
-    context: &Context,
-    stylist: &Stylist,
+    checker: &Checker,
 ) -> Option<(Edit, ContentAround)> {
     let Expr::BoolOp(ast::ExprBoolOp { op, values, range: _, }) = expr else {
         return None;
@@ -643,12 +640,14 @@ fn is_short_circuit(
 
     for (index, (value, next_value)) in values.iter().tuple_windows().enumerate() {
         // Keep track of the location of the furthest-right, truthy or falsey expression.
-        let value_truthiness = Truthiness::from_expr(value, |id| context.is_builtin(id));
-        let next_value_truthiness = Truthiness::from_expr(next_value, |id| context.is_builtin(id));
+        let value_truthiness = Truthiness::from_expr(value, |id| checker.ctx.is_builtin(id));
+        let next_value_truthiness =
+            Truthiness::from_expr(next_value, |id| checker.ctx.is_builtin(id));
 
         // Keep track of the location of the furthest-right, non-effectful expression.
         if value_truthiness.is_unknown()
-            && (!context.in_boolean_test() || contains_effect(value, |id| context.is_builtin(id)))
+            && (!checker.ctx.in_boolean_test()
+                || contains_effect(value, |id| checker.ctx.is_builtin(id)))
         {
             location = next_value.start();
             continue;
@@ -668,8 +667,8 @@ fn is_short_circuit(
                 value,
                 TextRange::new(location, expr.end()),
                 short_circuit_truthiness,
-                context.in_boolean_test(),
-                stylist,
+                checker.ctx.in_boolean_test(),
+                checker,
             ));
             break;
         }
@@ -686,8 +685,8 @@ fn is_short_circuit(
                 next_value,
                 TextRange::new(location, expr.end()),
                 short_circuit_truthiness,
-                context.in_boolean_test(),
-                stylist,
+                checker.ctx.in_boolean_test(),
+                checker,
             ));
             break;
         }
@@ -701,8 +700,7 @@ fn is_short_circuit(
 
 /// SIM222
 pub(crate) fn expr_or_true(checker: &mut Checker, expr: &Expr) {
-    if let Some((edit, remove)) = is_short_circuit(expr, Boolop::Or, &checker.ctx, checker.stylist)
-    {
+    if let Some((edit, remove)) = is_short_circuit(expr, Boolop::Or, checker) {
         let mut diagnostic = Diagnostic::new(
             ExprOrTrue {
                 expr: edit.content().unwrap_or_default().to_string(),
@@ -720,8 +718,7 @@ pub(crate) fn expr_or_true(checker: &mut Checker, expr: &Expr) {
 
 /// SIM223
 pub(crate) fn expr_and_false(checker: &mut Checker, expr: &Expr) {
-    if let Some((edit, remove)) = is_short_circuit(expr, Boolop::And, &checker.ctx, checker.stylist)
-    {
+    if let Some((edit, remove)) = is_short_circuit(expr, Boolop::And, checker) {
         let mut diagnostic = Diagnostic::new(
             ExprAndFalse {
                 expr: edit.content().unwrap_or_default().to_string(),

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -149,7 +149,7 @@ fn check_os_environ_subscript(checker: &mut Checker, expr: &Expr) {
         let new_env_var = node.into();
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&new_env_var, checker.stylist),
+            unparse_expr(&new_env_var, checker.generator()),
             slice.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -348,7 +348,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
         return;
     }
 
-    let condition = unparse_expr(test, checker.stylist);
+    let condition = unparse_expr(test, checker.generator());
     let fixable = matches!(if_return, Bool::True)
         && matches!(else_return, Bool::False)
         && !has_comments(stmt, checker.locator)
@@ -364,7 +364,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_stmt(&node.into(), checker.stylist),
+                unparse_stmt(&node.into(), checker.generator()),
                 stmt.range(),
             )));
         } else {
@@ -387,7 +387,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_stmt(&node2.into(), checker.stylist),
+                unparse_stmt(&node2.into(), checker.generator()),
                 stmt.range(),
             )));
         };
@@ -504,7 +504,7 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: O
 
     let target_var = &body_targets[0];
     let ternary = ternary(target_var, body_value, test, orelse_value);
-    let contents = unparse_stmt(&ternary, checker.stylist);
+    let contents = unparse_stmt(&ternary, checker.generator());
 
     // Don't flag if the resulting expression would exceed the maximum line length.
     let line_start = checker.locator.line_start(stmt.start());
@@ -859,7 +859,7 @@ pub(crate) fn use_dict_get_with_default(
         type_comment: None,
         range: TextRange::default(),
     };
-    let contents = unparse_stmt(&node5.into(), checker.stylist);
+    let contents = unparse_stmt(&node5.into(), checker.generator());
 
     // Don't flag if the resulting expression would exceed the maximum line length.
     let line_start = checker.locator.line_start(stmt.start());

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -97,7 +97,7 @@ pub(crate) fn explicit_true_false_in_ifexpr(
 
     let mut diagnostic = Diagnostic::new(
         IfExprWithTrueFalse {
-            expr: unparse_expr(test, checker.stylist),
+            expr: unparse_expr(test, checker.generator()),
         },
         expr.range(),
     );
@@ -105,7 +105,7 @@ pub(crate) fn explicit_true_false_in_ifexpr(
         if matches!(test, Expr::Compare(_)) {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(&test.clone(), checker.stylist),
+                unparse_expr(&test.clone(), checker.generator()),
                 expr.range(),
             )));
         } else if checker.ctx.is_builtin("bool") {
@@ -122,7 +122,7 @@ pub(crate) fn explicit_true_false_in_ifexpr(
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(&node1.into(), checker.stylist),
+                unparse_expr(&node1.into(), checker.generator()),
                 expr.range(),
             )));
         };
@@ -153,7 +153,7 @@ pub(crate) fn explicit_false_true_in_ifexpr(
 
     let mut diagnostic = Diagnostic::new(
         IfExprWithFalseTrue {
-            expr: unparse_expr(test, checker.stylist),
+            expr: unparse_expr(test, checker.generator()),
         },
         expr.range(),
     );
@@ -166,7 +166,7 @@ pub(crate) fn explicit_false_true_in_ifexpr(
         };
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&node1.into(), checker.stylist),
+            unparse_expr(&node1.into(), checker.generator()),
             expr.range(),
         )));
     }
@@ -201,8 +201,8 @@ pub(crate) fn twisted_arms_in_ifexpr(
 
     let mut diagnostic = Diagnostic::new(
         IfExprWithTwistedArms {
-            expr_body: unparse_expr(body, checker.stylist),
-            expr_else: unparse_expr(orelse, checker.stylist),
+            expr_body: unparse_expr(body, checker.generator()),
+            expr_else: unparse_expr(orelse, checker.generator()),
         },
         expr.range(),
     );
@@ -218,7 +218,7 @@ pub(crate) fn twisted_arms_in_ifexpr(
         };
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&node3.into(), checker.stylist),
+            unparse_expr(&node3.into(), checker.generator()),
             expr.range(),
         )));
     }

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -107,8 +107,8 @@ pub(crate) fn negation_with_equal_op(
 
     let mut diagnostic = Diagnostic::new(
         NegateEqualOp {
-            left: unparse_expr(left, checker.stylist),
-            right: unparse_expr(&comparators[0], checker.stylist),
+            left: unparse_expr(left, checker.generator()),
+            right: unparse_expr(&comparators[0], checker.generator()),
         },
         expr.range(),
     );
@@ -121,7 +121,7 @@ pub(crate) fn negation_with_equal_op(
         };
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&node.into(), checker.stylist),
+            unparse_expr(&node.into(), checker.generator()),
             expr.range(),
         )));
     }
@@ -157,8 +157,8 @@ pub(crate) fn negation_with_not_equal_op(
 
     let mut diagnostic = Diagnostic::new(
         NegateNotEqualOp {
-            left: unparse_expr(left, checker.stylist),
-            right: unparse_expr(&comparators[0], checker.stylist),
+            left: unparse_expr(left, checker.generator()),
+            right: unparse_expr(&comparators[0], checker.generator()),
         },
         expr.range(),
     );
@@ -171,7 +171,7 @@ pub(crate) fn negation_with_not_equal_op(
         };
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_expr(&node.into(), checker.stylist),
+            unparse_expr(&node.into(), checker.generator()),
             expr.range(),
         )));
     }
@@ -192,7 +192,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: Unaryop, o
 
     let mut diagnostic = Diagnostic::new(
         DoubleNegation {
-            expr: unparse_expr(operand, checker.stylist),
+            expr: unparse_expr(operand, checker.generator()),
         },
         expr.range(),
     );
@@ -200,7 +200,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: Unaryop, o
         if checker.ctx.in_boolean_test() {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(operand, checker.stylist),
+                unparse_expr(operand, checker.generator()),
                 expr.range(),
             )));
         } else if checker.ctx.is_builtin("bool") {
@@ -217,7 +217,7 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: Unaryop, o
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(&node1.into(), checker.stylist),
+                unparse_expr(&node1.into(), checker.generator()),
                 expr.range(),
             )));
         };

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -7,7 +7,7 @@ use unicode_width::UnicodeWidthStr;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
-use ruff_python_ast::source_code::Stylist;
+use ruff_python_ast::source_code::Generator;
 
 use crate::checkers::ast::Checker;
 use crate::registry::{AsRule, Rule};
@@ -171,7 +171,7 @@ fn return_values_for_siblings<'a>(stmt: &'a Stmt, sibling: &'a Stmt) -> Option<L
 }
 
 /// Generate a return statement for an `any` or `all` builtin comprehension.
-fn return_stmt(id: &str, test: &Expr, target: &Expr, iter: &Expr, stylist: &Stylist) -> String {
+fn return_stmt(id: &str, test: &Expr, target: &Expr, iter: &Expr, generator: Generator) -> String {
     let node = ast::ExprGeneratorExp {
         elt: Box::new(test.clone()),
         generators: vec![Comprehension {
@@ -198,7 +198,7 @@ fn return_stmt(id: &str, test: &Expr, target: &Expr, iter: &Expr, stylist: &Styl
         value: Some(Box::new(node2.into())),
         range: TextRange::default(),
     };
-    unparse_stmt(&node3.into(), stylist)
+    unparse_stmt(&node3.into(), generator)
 }
 
 /// SIM110, SIM111
@@ -220,7 +220,7 @@ pub(crate) fn convert_for_loop_to_any_all(
                     loop_info.test,
                     loop_info.target,
                     loop_info.iter,
-                    checker.stylist,
+                    checker.generator(),
                 );
 
                 // Don't flag if the resulting expression would exceed the maximum line length.
@@ -310,7 +310,7 @@ pub(crate) fn convert_for_loop_to_any_all(
                     &test,
                     loop_info.target,
                     loop_info.iter,
-                    checker.stylist,
+                    checker.generator(),
                 );
 
                 // Don't flag if the resulting expression would exceed the maximum line length.

--- a/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/relative_imports.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation, CacheKey};
 use ruff_python_ast::helpers::{resolve_imported_module_path, unparse_stmt};
-use ruff_python_ast::source_code::Stylist;
+use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::checkers::ast::Checker;
@@ -90,7 +90,7 @@ fn fix_banned_relative_import(
     level: Option<u32>,
     module: Option<&str>,
     module_path: Option<&[String]>,
-    stylist: &Stylist,
+    generator: Generator,
 ) -> Option<Fix> {
     // Only fix is the module path is known.
     let Some(module_path) = resolve_imported_module_path(level, module, module_path) else {
@@ -112,7 +112,7 @@ fn fix_banned_relative_import(
         level: Some(Int::new(0)),
         range: TextRange::default(),
     };
-    let content = unparse_stmt(&node.into(), stylist);
+    let content = unparse_stmt(&node.into(), generator);
     #[allow(deprecated)]
     Some(Fix::unspecified(Edit::range_replacement(
         content,
@@ -142,7 +142,7 @@ pub fn banned_relative_import(
         );
         if checker.patch(diagnostic.kind.rule()) {
             if let Some(fix) =
-                fix_banned_relative_import(stmt, level, module, module_path, checker.stylist)
+                fix_banned_relative_import(stmt, level, module, module_path, checker.generator())
             {
                 diagnostic.set_fix(fix);
             };

--- a/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -80,7 +80,7 @@ pub(crate) fn static_join_to_fstring(checker: &mut Checker, expr: &Expr, joiner:
     // convertible to f-string parts).
     let Some(new_expr) = build_fstring(joiner, joinees) else { return };
 
-    let contents = unparse_expr(&new_expr, checker.stylist);
+    let contents = unparse_expr(&new_expr, checker.generator());
 
     let mut diagnostic = Diagnostic::new(
         StaticJoinToFString {

--- a/crates/ruff/src/rules/pycodestyle/helpers.rs
+++ b/crates/ruff/src/rules/pycodestyle/helpers.rs
@@ -1,9 +1,10 @@
-use ruff_python_ast::helpers::unparse_expr;
-use ruff_python_ast::newlines::Line;
-use ruff_python_ast::source_code::Stylist;
 use ruff_text_size::{TextLen, TextRange};
 use rustpython_parser::ast::{self, Cmpop, Expr};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use ruff_python_ast::helpers::unparse_expr;
+use ruff_python_ast::newlines::Line;
+use ruff_python_ast::source_code::Generator;
 
 pub(crate) fn is_ambiguous_name(name: &str) -> bool {
     name == "l" || name == "I" || name == "O"
@@ -13,7 +14,7 @@ pub(crate) fn compare(
     left: &Expr,
     ops: &[Cmpop],
     comparators: &[Expr],
-    stylist: &Stylist,
+    generator: Generator,
 ) -> String {
     let node = ast::ExprCompare {
         left: Box::new(left.clone()),
@@ -21,7 +22,7 @@ pub(crate) fn compare(
         comparators: comparators.to_vec(),
         range: TextRange::default(),
     };
-    unparse_expr(&node.into(), stylist)
+    unparse_expr(&node.into(), generator)
 }
 
 pub(super) fn is_overlong(

--- a/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -278,7 +278,7 @@ pub(crate) fn literal_comparisons(
             .map(|(idx, op)| bad_ops.get(&idx).unwrap_or(op))
             .copied()
             .collect::<Vec<_>>();
-        let content = compare(left, &ops, comparators, checker.stylist);
+        let content = compare(left, &ops, comparators, checker.generator());
         for diagnostic in &mut diagnostics {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(

--- a/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/not_tests.rs
@@ -101,7 +101,12 @@ pub(crate) fn not_tests(
                             if checker.patch(diagnostic.kind.rule()) {
                                 #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                    compare(left, &[Cmpop::NotIn], comparators, checker.stylist),
+                                    compare(
+                                        left,
+                                        &[Cmpop::NotIn],
+                                        comparators,
+                                        checker.generator(),
+                                    ),
                                     expr.range(),
                                 )));
                             }
@@ -114,7 +119,12 @@ pub(crate) fn not_tests(
                             if checker.patch(diagnostic.kind.rule()) {
                                 #[allow(deprecated)]
                                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                    compare(left, &[Cmpop::IsNot], comparators, checker.stylist),
+                                    compare(
+                                        left,
+                                        &[Cmpop::IsNot],
+                                        comparators,
+                                        checker.generator(),
+                                    ),
                                     expr.range(),
                                 )));
                             }

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -106,7 +106,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                             let is_duplicate_value = seen_values.contains(&comparable_value);
                             let mut diagnostic = Diagnostic::new(
                                 MultiValueRepeatedKeyLiteral {
-                                    name: unparse_expr(key, checker.stylist),
+                                    name: unparse_expr(key, checker.generator()),
                                     repeated_value: is_duplicate_value,
                                 },
                                 key.range(),

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -117,8 +117,8 @@ pub(crate) fn compare_to_empty_string(
                 if let Expr::Constant(ast::ExprConstant { value, .. }) = &lhs {
                     if let Constant::Str(s) = value {
                         if s.is_empty() {
-                            let constant = unparse_constant(value, checker.stylist);
-                            let expr = unparse_expr(rhs, checker.stylist);
+                            let constant = unparse_constant(value, checker.generator());
+                            let expr = unparse_expr(rhs, checker.generator());
                             let existing = format!("{constant} {op} {expr}");
                             let replacement = format!("{}{expr}", op.into_unary());
                             checker.diagnostics.push(Diagnostic::new(
@@ -137,8 +137,8 @@ pub(crate) fn compare_to_empty_string(
             if let Expr::Constant(ast::ExprConstant { value, .. }) = &rhs {
                 if let Constant::Str(s) = value {
                     if s.is_empty() {
-                        let expr = unparse_expr(lhs, checker.stylist);
-                        let constant = unparse_constant(value, checker.stylist);
+                        let expr = unparse_expr(lhs, checker.generator());
+                        let constant = unparse_constant(value, checker.generator());
                         let existing = format!("{expr} {op} {constant}");
                         let replacement = format!("{}{expr}", op.into_unary());
                         checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff/src/rules/pylint/rules/comparison_of_constant.rs
@@ -106,9 +106,9 @@ pub(crate) fn comparison_of_constant(
         {
             let diagnostic = Diagnostic::new(
                 ComparisonOfConstant {
-                    left_constant: unparse_constant(left_constant, checker.stylist),
+                    left_constant: unparse_constant(left_constant, checker.generator()),
                     op: op.into(),
-                    right_constant: unparse_constant(right_constant, checker.stylist),
+                    right_constant: unparse_constant(right_constant, checker.generator()),
                 },
                 left.range(),
             );

--- a/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff/src/rules/pylint/rules/magic_value_comparison.rs
@@ -79,7 +79,7 @@ pub(crate) fn magic_value_comparison(checker: &mut Checker, left: &Expr, compara
             if is_magic_value(value, &checker.settings.pylint.allow_magic_value_types) {
                 checker.diagnostics.push(Diagnostic::new(
                     MagicValueComparison {
-                        value: unparse_expr(comparison_expr, checker.stylist),
+                        value: unparse_expr(comparison_expr, checker.generator()),
                     },
                     comparison_expr.range(),
                 ));

--- a/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
+++ b/crates/ruff/src/rules/pylint/rules/manual_import_from.rs
@@ -67,7 +67,7 @@ pub(crate) fn manual_from_import(
         };
         #[allow(deprecated)]
         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-            unparse_stmt(&node.into(), checker.stylist),
+            unparse_stmt(&node.into(), checker.generator()),
             stmt.range(),
         )));
     }

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -149,7 +149,7 @@ pub(crate) fn nested_min_max(
             });
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                unparse_expr(&flattened_expr, checker.stylist),
+                unparse_expr(&flattened_expr, checker.generator()),
                 expr.range(),
             )));
         }

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -393,7 +393,7 @@ pub(crate) fn redefined_loop_name<'a, 'b>(checker: &'a mut Checker<'b>, node: &N
             {
                 checker.diagnostics.push(Diagnostic::new(
                     RedefinedLoopName {
-                        name: unparse_expr(outer_assignment_target.expr, checker.stylist),
+                        name: unparse_expr(outer_assignment_target.expr, checker.generator()),
                         outer_kind: outer_assignment_target.binding_kind,
                         inner_kind: inner_assignment_target.binding_kind,
                     },

--- a/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -12,7 +12,7 @@ use crate::checkers::ast::Checker;
 #[violation]
 pub struct RepeatedIsinstanceCalls {
     obj: String,
-    pub types: Vec<String>,
+    types: Vec<String>,
 }
 
 impl Violation for RepeatedIsinstanceCalls {
@@ -66,11 +66,11 @@ pub(crate) fn repeated_isinstance_calls(
         if num_calls > 1 && types.len() > 1 {
             checker.diagnostics.push(Diagnostic::new(
                 RepeatedIsinstanceCalls {
-                    obj: unparse_expr(obj.as_expr(), checker.stylist),
+                    obj: unparse_expr(obj.as_expr(), checker.generator()),
                     types: types
                         .iter()
                         .map(HashableExpr::as_expr)
-                        .map(|expr| unparse_expr(expr, checker.stylist))
+                        .map(|expr| unparse_expr(expr, checker.generator()))
                         .sorted()
                         .collect(),
                 },

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -6,7 +6,7 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Keyword, Ranged,
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
-use ruff_python_ast::source_code::Stylist;
+use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::checkers::ast::Checker;
@@ -171,11 +171,14 @@ fn convert_to_class(
     typename: &str,
     body: Vec<Stmt>,
     base_class: &Expr,
-    stylist: &Stylist,
+    generator: Generator,
 ) -> Fix {
     #[allow(deprecated)]
     Fix::unspecified(Edit::range_replacement(
-        unparse_stmt(&create_class_def_stmt(typename, body, base_class), stylist),
+        unparse_stmt(
+            &create_class_def_stmt(typename, body, base_class),
+            generator,
+        ),
         stmt.range(),
     ))
 }
@@ -216,7 +219,7 @@ pub(crate) fn convert_named_tuple_functional_to_class(
             typename,
             properties,
             base_class,
-            checker.stylist,
+            checker.generator(),
         ));
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -6,7 +6,7 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Keyword, Ranged,
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::unparse_stmt;
-use ruff_python_ast::source_code::Stylist;
+use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::checkers::ast::Checker;
@@ -222,13 +222,13 @@ fn convert_to_class(
     body: Vec<Stmt>,
     total_keyword: Option<&Keyword>,
     base_class: &Expr,
-    stylist: &Stylist,
+    generator: Generator,
 ) -> Fix {
     #[allow(deprecated)]
     Fix::unspecified(Edit::range_replacement(
         unparse_stmt(
             &create_class_def_stmt(class_name, body, total_keyword, base_class),
-            stylist,
+            generator,
         ),
         stmt.range(),
     ))
@@ -270,7 +270,7 @@ pub(crate) fn convert_typed_dict_functional_to_class(
             body,
             total_keyword,
             base_class,
-            checker.stylist,
+            checker.generator(),
         ));
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -51,7 +51,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
             if checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    unparse_expr(func, checker.stylist),
+                    unparse_expr(func, checker.generator()),
                     expr.range(),
                 )));
             }

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -117,7 +117,7 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
             };
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                format!("({})", unparse_expr(&node.into(), checker.stylist,)),
+                format!("({})", unparse_expr(&node.into(), checker.generator())),
                 target.range(),
             )));
         }

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -67,7 +67,7 @@ pub(crate) fn use_pep604_annotation(
             if fixable && checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
                 diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                    unparse_expr(&optional(slice), checker.stylist),
+                    unparse_expr(&optional(slice), checker.generator()),
                     expr.range(),
                 )));
             }
@@ -83,7 +83,7 @@ pub(crate) fn use_pep604_annotation(
                     Expr::Tuple(ast::ExprTuple { elts, .. }) => {
                         #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                            unparse_expr(&union(elts), checker.stylist),
+                            unparse_expr(&union(elts), checker.generator()),
                             expr.range(),
                         )));
                     }
@@ -91,7 +91,7 @@ pub(crate) fn use_pep604_annotation(
                         // Single argument.
                         #[allow(deprecated)]
                         diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                            unparse_expr(slice, checker.stylist),
+                            unparse_expr(slice, checker.generator()),
                             expr.range(),
                         )));
                     }

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -1,6 +1,6 @@
-use ruff_text_size::TextRange;
 use std::fmt;
 
+use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Expr, Operator, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
@@ -94,7 +94,7 @@ pub(crate) fn use_pep604_isinstance(
                 if checker.patch(diagnostic.kind.rule()) {
                     #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                        unparse_expr(&union(elts), checker.stylist),
+                        unparse_expr(&union(elts), checker.generator()),
                         types.range(),
                     )));
                 }

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP018.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP018.py.snap
@@ -106,6 +106,7 @@ UP018.py:25:1: UP018 [*] Unnecessary call to `bytes`
    25 |+b"foo"
 26 26 | bytes(b"""
 27 27 | foo""")
+28 28 | f"{str()}"
 
 UP018.py:26:1: UP018 [*] Unnecessary call to `bytes`
    |
@@ -114,6 +115,7 @@ UP018.py:26:1: UP018 [*] Unnecessary call to `bytes`
 28 | / bytes(b"""
 29 | | foo""")
    | |_______^ UP018
+30 |   f"{str()}"
    |
    = help: Replace with `bytes`
 
@@ -125,5 +127,22 @@ UP018.py:26:1: UP018 [*] Unnecessary call to `bytes`
 27    |-foo""")
    26 |+b"""
    27 |+foo"""
+28 28 | f"{str()}"
+
+UP018.py:28:4: UP018 [*] Unnecessary call to `str`
+   |
+28 | bytes(b"""
+29 | foo""")
+30 | f"{str()}"
+   |    ^^^^^ UP018
+   |
+   = help: Replace with `str`
+
+ℹ Suggested fix
+25 25 | bytes(b"foo")
+26 26 | bytes(b"""
+27 27 | foo""")
+28    |-f"{str()}"
+   28 |+f"{''}"
 
 

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -130,8 +130,8 @@ pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Exp
 
     let contents = match kind {
         // Wrap the new expression in parentheses if it was a tuple
-        Kind::Tuple => format!("({})", unparse_expr(&new_expr, checker.stylist)),
-        Kind::List => unparse_expr(&new_expr, checker.stylist),
+        Kind::Tuple => format!("({})", unparse_expr(&new_expr, checker.generator())),
+        Kind::List => unparse_expr(&new_expr, checker.generator()),
     };
     let fixable = !has_comments(expr, checker.locator);
 

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF005_RUF005.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF005_RUF005.py.snap
@@ -265,5 +265,7 @@ RUF005.py:44:1: RUF005 [*] Consider `[*foo]` instead of concatenation
 44    |-[] + foo + [  # This will be preserved, but doesn't prevent the fix
    44 |+[*foo] + [  # This will be preserved, but doesn't prevent the fix
 45 45 | ]
+46 46 | 
+47 47 | # Uses the non-preferred quote style, which should be retained.
 
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -17,26 +17,23 @@ use smallvec::SmallVec;
 
 use crate::call_path::CallPath;
 use crate::newlines::UniversalNewlineIterator;
-use crate::source_code::{Generator, Indexer, Locator, Stylist};
+use crate::source_code::{Generator, Indexer, Locator};
 use crate::statement_visitor::{walk_body, walk_stmt, StatementVisitor};
 
 /// Generate source code from an [`Expr`].
-pub fn unparse_expr(expr: &Expr, stylist: &Stylist) -> String {
-    let mut generator: Generator = stylist.into();
+pub fn unparse_expr(expr: &Expr, mut generator: Generator) -> String {
     generator.unparse_expr(expr, 0);
     generator.generate()
 }
 
 /// Generate source code from a [`Stmt`].
-pub fn unparse_stmt(stmt: &Stmt, stylist: &Stylist) -> String {
-    let mut generator: Generator = stylist.into();
+pub fn unparse_stmt(stmt: &Stmt, mut generator: Generator) -> String {
     generator.unparse_stmt(stmt);
     generator.generate()
 }
 
 /// Generate source code from an [`Constant`].
-pub fn unparse_constant(constant: &Constant, stylist: &Stylist) -> String {
-    let mut generator: Generator = stylist.into();
+pub fn unparse_constant(constant: &Constant, mut generator: Generator) -> String {
     generator.unparse_constant(constant);
     generator.generate()
 }

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -15,7 +15,7 @@ use rustpython_parser::{lexer, Mode, ParseError};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-pub use stylist::Stylist;
+pub use stylist::{Quote, Stylist};
 
 /// Run round-trip source code generation on a given Python code.
 pub fn round_trip(code: &str, source_path: &str) -> Result<String, ParseError> {

--- a/crates/ruff_python_semantic/src/context.rs
+++ b/crates/ruff_python_semantic/src/context.rs
@@ -336,6 +336,11 @@ impl<'a> Context<'a> {
         Some(self.stmts[parent_id])
     }
 
+    /// Return the current `Expr`.
+    pub fn expr(&self) -> Option<&'a Expr> {
+        self.exprs.iter().last().copied()
+    }
+
     /// Return the parent `Expr` of the current `Expr`.
     pub fn expr_parent(&self) -> Option<&'a Expr> {
         self.exprs.iter().rev().nth(1).copied()


### PR DESCRIPTION
## Summary

When we generate source code from an AST (via `Generator`), we have a preferred quote style, based on the inferred quote style in the file. Unfortunately, when we try to generate autofixes within f-strings, the `Generator` is unaware of the fact that we're "inside" an f-string, and so continues to use that preferred quote style, which often leads to syntax errors.

This PR modifies our logic to detect when we're inside a single-quoted f-string, and then pass in the "inverted" quote style based on whatever was used to quote that f-string. This in turn requires that we track all f-strings, and are able to map from the current expression to the surrounding f-strings.

Two considerations here:

1. The quote style that we provide to `Generator` is really a "preferred" quote style. The `Generator` will "ignore" that preference if, e.g., it lets us avoid escaping a quote within a string, similar to Black's preferences. This would be problematic within f-strings. However, f-strings can't contain backslashes (it's a syntax error?), so... it might be fine?
2. This doesn't really deal with _nested_ f-strings. I'm not sure what we want to do in those cases. The grammar is so limiting and complicated. We may want to avoid fixing issues within nested f-strings altogether?

Closes #4322.

Closes #4324.

Closes #4323.

Closes #4321.
