### PR TITLE
Fix scoping of comprehensions within classes

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -35,7 +35,7 @@ impl AlwaysAutofixableViolation for InDictKeys {
 fn get_value_content_for_key_in_dict(
     locator: &Locator,
     stylist: &Stylist,
-    expr: &rustpython_parser::ast::Expr,
+    expr: &Expr,
 ) -> Result<String> {
     let content = locator.slice(expr.range());
     let mut expression = match_expression(content)?;

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -1030,6 +1030,23 @@ mod tests {
         "#,
             &[],
         );
+
+        flakes(
+            r#"
+        class A:
+            T = 1
+
+            # In each case, `T` is undefined. Only the first `iter` uses the class scope.
+            X = (T for x in range(10))
+            Y = [x for x in range(10) if T]
+            Z = [x for x in range(10) for y in T]
+        "#,
+            &[
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+                Rule::UndefinedName,
+            ],
+        );
     }
 
     #[test]

--- a/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -99,10 +99,7 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
     }
 
     // Require the function to be the builtin `zip`.
-    if id != "zip" {
-        return;
-    }
-    if !checker.ctx.is_builtin(id) {
+    if !(id == "zip" && checker.ctx.is_builtin(id)) {
         return;
     }
 
@@ -118,9 +115,9 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
     };
 
     // Require second argument to be a `Subscript`.
-    let Expr::Subscript (_) = &args[1] else {
+    if !matches!(&args[1], Expr::Subscript(_)) {
         return;
-    };
+    }
     let Some(second_arg_info) = match_slice_info(&args[1]) else {
         return;
     };


### PR DESCRIPTION
## Summary

See the lengthy inline comment. It turns out that we're missing an edge case in how comprehensions-within-classes are handled. Pyflakes has the same behavior.

For more, see the [PEP 709](https://discuss.python.org/t/pep-709-one-behavior-change-that-was-missed-in-the-pep/26691) follow-up discussion, or the linked issue (#4486).

Closes #4486.
