### PR TITLE
Move triple-quoted string detection into Indexer method

### DIFF
--- a/crates/ruff/src/checkers/physical_lines.rs
+++ b/crates/ruff/src/checkers/physical_lines.rs
@@ -55,7 +55,6 @@ pub(crate) fn check_physical_lines(
 
     let mut commented_lines_iter = indexer.comment_ranges().iter().peekable();
     let mut doc_lines_iter = doc_lines.iter().peekable();
-    let string_lines = indexer.triple_quoted_string_ranges();
 
     for (index, line) in locator.contents().universal_newlines().enumerate() {
         while commented_lines_iter
@@ -151,7 +150,7 @@ pub(crate) fn check_physical_lines(
         }
 
         if enforce_tab_indentation {
-            if let Some(diagnostic) = tab_indentation(&line, string_lines) {
+            if let Some(diagnostic) = tab_indentation(&line, indexer) {
                 diagnostics.push(diagnostic);
             }
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/tab_indentation.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/tab_indentation.rs
@@ -3,6 +3,7 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::Line;
+use ruff_python_ast::source_code::Indexer;
 use ruff_python_ast::whitespace::leading_space;
 
 #[violation]
@@ -16,31 +17,17 @@ impl Violation for TabIndentation {
 }
 
 /// W191
-pub(crate) fn tab_indentation(line: &Line, string_ranges: &[TextRange]) -> Option<Diagnostic> {
+pub(crate) fn tab_indentation(line: &Line, indexer: &Indexer) -> Option<Diagnostic> {
     let indent = leading_space(line);
     if let Some(tab_index) = indent.find('\t') {
-        let tab_offset = line.start() + TextSize::try_from(tab_index).unwrap();
-
-        let string_range_index = string_ranges.binary_search_by(|range| {
-            if tab_offset < range.start() {
-                std::cmp::Ordering::Greater
-            } else if range.contains(tab_offset) {
-                std::cmp::Ordering::Equal
-            } else {
-                std::cmp::Ordering::Less
-            }
-        });
-
         // If the tab character is within a multi-line string, abort.
-        if string_range_index.is_ok() {
-            None
-        } else {
-            Some(Diagnostic::new(
+        let tab_offset = line.start() + TextSize::try_from(tab_index).unwrap();
+        if indexer.triple_quoted_string_range(tab_offset).is_none() {
+            return Some(Diagnostic::new(
                 TabIndentation,
                 TextRange::at(line.start(), indent.text_len()),
-            ))
+            ));
         }
-    } else {
-        None
     }
+    None
 }


### PR DESCRIPTION
## Summary

An analogous change to the advice that was given in #4487.