### PR TITLE
Improve handling of `__qualname__`, `__module__`, and `__class__`

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4841,13 +4841,6 @@ impl<'a> Checker<'a> {
                         return;
                     }
 
-                    // Allow "__module__" and "__qualname__" in class scopes.
-                    if (id == "__module__" || id == "__qualname__")
-                        && matches!(self.ctx.scope().kind, ScopeKind::Class(..))
-                    {
-                        return;
-                    }
-
                     // Avoid flagging if `NameError` is handled.
                     if self
                         .ctx

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -473,6 +473,16 @@ mod tests {
         "#,
             &[Rule::UndefinedName],
         );
+        flakes(
+            r#"
+        def f():
+            __qualname__ = 1
+
+            class Foo:
+                __qualname__
+        "#,
+            &[Rule::UnusedVariable],
+        );
     }
 
     #[test]
@@ -1150,6 +1160,40 @@ mod tests {
         t = Test()
         "#,
             &[],
+        );
+        flakes(
+            r#"
+        class Test(object):
+            print(__class__.__name__)
+
+            def __init__(self):
+                self.x = 1
+
+        t = Test()
+        "#,
+            &[Rule::UndefinedName],
+        );
+        flakes(
+            r#"
+        class Test(object):
+            X = [__class__ for _ in range(10)]
+
+            def __init__(self):
+                self.x = 1
+
+        t = Test()
+        "#,
+            &[Rule::UndefinedName],
+        );
+        flakes(
+            r#"
+        def f(self):
+            print(__class__.__name__)
+            self.x = 1
+
+        f()
+        "#,
+            &[Rule::UndefinedName],
         );
     }
 


### PR DESCRIPTION
## Summary

Removing some special-casing from `Checker`, and improve handling in a few cases (all the updated test cases were "wrong" before as compared to observed runtime behavior).