### PR TITLE
Replace token iteration with Indexer/Locator lookups for relevant rules

### DIFF
--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -41,7 +41,6 @@ pub(crate) fn check_tokens(
         Rule::BadQuotesDocstring,
         Rule::AvoidableEscapedQuote,
     ]);
-    // indexer
     let enforce_commented_out_code = settings.rules.enabled(Rule::CommentedOutCode);
     let enforce_compound_statements = settings.rules.any_enabled(&[
         Rule::MultipleStatementsOnOneLineColon,
@@ -60,9 +59,7 @@ pub(crate) fn check_tokens(
         Rule::ProhibitedTrailingComma,
     ]);
     let enforce_extraneous_parenthesis = settings.rules.enabled(Rule::ExtraneousParentheses);
-    // indexer
     let enforce_type_comment_in_stub = settings.rules.enabled(Rule::TypeCommentInStub);
-    // indexer
     let enforce_todos = settings.rules.any_enabled(&[
         Rule::InvalidTodoTag,
         Rule::MissingTodoAuthor,

--- a/crates/ruff/src/checkers/tokens.rs
+++ b/crates/ruff/src/checkers/tokens.rs
@@ -12,10 +12,11 @@ use crate::rules::{
 };
 use crate::settings::Settings;
 use ruff_diagnostics::Diagnostic;
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::source_code::{Indexer, Locator};
 
 pub(crate) fn check_tokens(
     locator: &Locator,
+    indexer: &Indexer,
     tokens: &[LexResult],
     settings: &Settings,
     is_stub: bool,
@@ -40,6 +41,7 @@ pub(crate) fn check_tokens(
         Rule::BadQuotesDocstring,
         Rule::AvoidableEscapedQuote,
     ]);
+    // indexer
     let enforce_commented_out_code = settings.rules.enabled(Rule::CommentedOutCode);
     let enforce_compound_statements = settings.rules.any_enabled(&[
         Rule::MultipleStatementsOnOneLineColon,
@@ -58,7 +60,9 @@ pub(crate) fn check_tokens(
         Rule::ProhibitedTrailingComma,
     ]);
     let enforce_extraneous_parenthesis = settings.rules.enabled(Rule::ExtraneousParentheses);
+    // indexer
     let enforce_type_comment_in_stub = settings.rules.enabled(Rule::TypeCommentInStub);
+    // indexer
     let enforce_todos = settings.rules.any_enabled(&[
         Rule::InvalidTodoTag,
         Rule::MissingTodoAuthor,
@@ -100,15 +104,9 @@ pub(crate) fn check_tokens(
 
     // ERA001
     if enforce_commented_out_code {
-        for (tok, range) in tokens.iter().flatten() {
-            if matches!(tok, Tok::Comment(_)) {
-                if let Some(diagnostic) =
-                    eradicate::rules::commented_out_code(locator, *range, settings)
-                {
-                    diagnostics.push(diagnostic);
-                }
-            }
-        }
+        diagnostics.extend(eradicate::rules::commented_out_code(
+            indexer, locator, settings,
+        ));
     }
 
     // W605
@@ -185,13 +183,13 @@ pub(crate) fn check_tokens(
 
     // PYI033
     if enforce_type_comment_in_stub && is_stub {
-        diagnostics.extend(flake8_pyi::rules::type_comment_in_stub(tokens));
+        diagnostics.extend(flake8_pyi::rules::type_comment_in_stub(indexer, locator));
     }
 
     // TD001, TD002, TD003, TD004, TD005, TD006, TD007
     if enforce_todos {
         diagnostics.extend(
-            flake8_todos::rules::todos(tokens, settings)
+            flake8_todos::rules::todos(indexer, locator, settings)
                 .into_iter()
                 .filter(|diagnostic| settings.rules.enabled(diagnostic.kind.rule())),
         );

--- a/crates/ruff/src/linter.rs
+++ b/crates/ruff/src/linter.rs
@@ -98,7 +98,7 @@ pub fn check_path(
         .any(|rule_code| rule_code.lint_source().is_tokens())
     {
         let is_stub = is_python_stub_file(path);
-        diagnostics.extend(check_tokens(locator, &tokens, settings, is_stub));
+        diagnostics.extend(check_tokens(locator, indexer, &tokens, settings, is_stub));
     }
 
     // Run the filesystem-based rules.

--- a/crates/ruff/src/rules/flake8_todos/rules.rs
+++ b/crates/ruff/src/rules/flake8_todos/rules.rs
@@ -1,9 +1,8 @@
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::RegexSet;
+use ruff_python_ast::source_code::{Indexer, Locator};
 use ruff_text_size::{TextLen, TextRange, TextSize};
-use rustpython_parser::lexer::LexResult;
-use rustpython_parser::Tok;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -289,44 +288,34 @@ static ISSUE_LINK_REGEX_SET: Lazy<RegexSet> = Lazy::new(|| {
     .unwrap()
 });
 
-pub(crate) fn todos(tokens: &[LexResult], settings: &Settings) -> Vec<Diagnostic> {
+pub(crate) fn todos(indexer: &Indexer, locator: &Locator, settings: &Settings) -> Vec<Diagnostic> {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
-    let mut iter = tokens.iter().flatten().multipeek();
-    while let Some((token, token_range)) = iter.next() {
-        let Tok::Comment(comment) = token else {
-            continue;
-        };
+    let mut iter = indexer.comment_ranges().iter().multipeek();
+    while let Some(comment_range) = iter.next() {
+        let comment = locator.slice(*comment_range);
 
         // Check that the comment is a TODO (properly formed or not).
-        let Some(tag) = detect_tag(comment, token_range.start()) else {
+        let Some(tag) = detect_tag(comment, comment_range.start()) else {
             continue;
         };
 
         tag_errors(&tag, &mut diagnostics, settings);
-        static_errors(&mut diagnostics, comment, *token_range, &tag);
+        static_errors(&mut diagnostics, comment, *comment_range, &tag);
 
         // TD003
         let mut has_issue_link = false;
-        while let Some((token, token_range)) = iter.peek() {
-            match token {
-                Tok::Comment(comment) => {
-                    if detect_tag(comment, token_range.start()).is_some() {
-                        break;
-                    }
-                    if ISSUE_LINK_REGEX_SET.is_match(comment) {
-                        has_issue_link = true;
-                        break;
-                    }
-                }
-                Tok::Newline | Tok::NonLogicalNewline => {
-                    continue;
-                }
-                _ => {
-                    break;
-                }
+        while let Some(next_comment_range) = iter.peek() {
+            let next_comment = locator.slice(*next_comment_range.to_owned());
+            if detect_tag(next_comment, next_comment_range.start()).is_some() {
+                break;
+            }
+            if ISSUE_LINK_REGEX_SET.is_match(next_comment) {
+                has_issue_link = true;
+                break;
             }
         }
+
         if !has_issue_link {
             diagnostics.push(Diagnostic::new(MissingTodoLink, tag.range));
         }
@@ -400,6 +389,7 @@ fn static_errors(
                 trimmed.text_len()
             }
         } else {
+            // TD-002
             diagnostics.push(Diagnostic::new(MissingTodoAuthor, tag.range));
 
             TextSize::new(0)
@@ -411,15 +401,18 @@ fn static_errors(
         if let Some(stripped) = after_colon.strip_prefix(' ') {
             stripped
         } else {
+            // TD-007
             diagnostics.push(Diagnostic::new(MissingSpaceAfterTodoColon, tag.range));
             after_colon
         }
     } else {
+        // TD-004
         diagnostics.push(Diagnostic::new(MissingTodoColon, tag.range));
         ""
     };
 
     if post_colon.is_empty() {
+        // TD-005
         diagnostics.push(Diagnostic::new(MissingTodoDescription, tag.range));
     }
 }


### PR DESCRIPTION
[This comment](https://github.com/charliermarsh/ruff/pull/3921#discussion_r1181461746) raised the idea of using `Indexer`/`Locator` for comment-related rules based on token checks. I went through the rules examined in `checkers/tokens.rs` and changed it out for the ones I identified.