### PR TITLE
Gate `schemars` skip under feature flag

### DIFF
--- a/crates/ruff/src/settings/options.rs
+++ b/crates/ruff/src/settings/options.rs
@@ -191,7 +191,7 @@ pub struct Options {
     ///
     /// This option has been **deprecated** in favor of `unfixable` since its usage is now
     /// interchangeable with `unfixable`.
-    #[schemars(skip)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
     pub extend_unfixable: Option<Vec<RuleSelector>>,
     #[option(
         default = "[]",


### PR DESCRIPTION
This snuck in due to merging against a non-updated main.