### PR TITLE
Remove `regex` dependency from `ruff_python_ast`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,18 +183,8 @@ jobs:
       - name: "Install cargo-udeps"
         uses: taiki-e/install-action@cargo-udeps
       - name: "Run cargo-udeps"
-        run: |
-          unused_dependencies=$(cargo +nightly-2023-03-30 udeps > unused.txt && cat unused.txt | cut -d $'\n' -f 2-)
-          if [ -z "$unused_dependencies" ]; then
-            echo "No unused dependencies found" > $GITHUB_STEP_SUMMARY
-            exit 0
-          else
-            echo "Found unused dependencies" > $GITHUB_STEP_SUMMARY
-            echo '```console' >> $GITHUB_STEP_SUMMARY
-            echo "$unused_dependencies" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit 1
-          fi
+        run: cargo +nightly-2023-03-30 udeps
+
 
   python-package:
     name: "python package"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "once_cell",
- "regex",
  "ruff_text_size",
  "rustc-hash",
  "rustpython-literal",

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -19,7 +19,6 @@ memchr = "2.5.0"
 num-bigint = { version = "0.4.3" }
 num-traits = { version = "0.2.15" }
 once_cell = { workspace = true }
-regex = { workspace = true }
 rustc-hash = { workspace = true }
 rustpython-literal = { workspace = true }
 rustpython-parser = { workspace = true }


### PR DESCRIPTION
I removed the summary from the `udeps` step because it didn't work when `cargo udeps` failed and it truncated the error message from the job output. 

The problem is now again, visible in the job output https://github.com/charliermarsh/ruff/actions/runs/5021522492/jobs/9003987711?pr=4518