### PR TITLE
Include hidden ecosystem_ci option to show fixes without feature

### DIFF
--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -82,4 +82,3 @@ colored = { workspace = true, features = ["no-color"] }
 default = []
 schemars = ["dep:schemars"]
 jupyter_notebook = []
-ecosystem_ci = []

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -66,7 +66,6 @@ ureq = { version = "2.6.2", features = [] }
 
 [features]
 jupyter_notebook = ["ruff/jupyter_notebook"]
-ecosystem_ci = ["ruff/ecosystem_ci"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 mimalloc = "0.1.34"

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -313,7 +313,6 @@ pub struct CheckArgs {
     )]
     pub show_settings: bool,
     /// Dev-only argument to show fixes
-    #[cfg(feature = "ecosystem_ci")]
     #[arg(long, hide = true)]
     pub ecosystem_ci: bool,
 }

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -254,7 +254,6 @@ mod test {
             LogLevel::Default,
             FixMode::None,
             Flags::SHOW_VIOLATIONS,
-            #[cfg(feature = "ecosystem_ci")]
             false,
         );
         let mut writer: Vec<u8> = Vec::new();

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -123,8 +123,13 @@ quoting the executed command, along with the relevant file contents and `pyproje
 }
 
 fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
-    #[cfg(feature = "ecosystem_ci")]
     let ecosystem_ci = args.ecosystem_ci;
+    if ecosystem_ci {
+        warn_user_once!(
+            "The formatting of fixes emitted by this option is a work-in-progress, subject to \
+            change at any time, and intended for use with the ecosystem ci scripts only."
+        );
+    }
     let (cli, overrides) = args.partition();
 
     // Construct the "default" settings. These are used when no `pyproject.toml`
@@ -211,14 +216,7 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
         return Ok(ExitStatus::Success);
     }
 
-    let printer = Printer::new(
-        format,
-        log_level,
-        autofix,
-        printer_flags,
-        #[cfg(feature = "ecosystem_ci")]
-        ecosystem_ci,
-    );
+    let printer = Printer::new(format, log_level, autofix, printer_flags, ecosystem_ci);
 
     if cli.watch {
         if format != SerializationFormat::Text {

--- a/crates/ruff_cli/src/printer.rs
+++ b/crates/ruff_cli/src/printer.rs
@@ -71,7 +71,6 @@ pub(crate) struct Printer {
     autofix_level: flags::FixMode,
     flags: Flags,
     /// Dev-only argument to show fixes
-    #[cfg(feature = "ecosystem_ci")]
     ecosystem_ci: bool,
 }
 
@@ -81,14 +80,13 @@ impl Printer {
         log_level: LogLevel,
         autofix_level: flags::FixMode,
         flags: Flags,
-        #[cfg(feature = "ecosystem_ci")] ecosystem_ci: bool,
+        ecosystem_ci: bool,
     ) -> Self {
         Self {
             format,
             log_level,
             autofix_level,
             flags,
-            #[cfg(feature = "ecosystem_ci")]
             ecosystem_ci,
         }
     }
@@ -189,10 +187,7 @@ impl Printer {
                 JunitEmitter::default().emit(writer, &diagnostics.messages, &context)?;
             }
             SerializationFormat::Text => {
-                #[cfg(feature = "ecosystem_ci")]
                 let show_fixes = self.ecosystem_ci && self.flags.contains(Flags::SHOW_FIXES);
-                #[cfg(not(feature = "ecosystem_ci"))]
-                let show_fixes = false;
 
                 TextEmitter::default()
                     .with_show_fix_status(show_fix_status(self.autofix_level))


### PR DESCRIPTION
This removes the feature flag but adds a warning akin to #4453, so we can use the ecosystem ci option to diff fixes with pypi and other normal builds. This reduces the possible build matrix .

Example output:
```
$ target/debug/ruff --no-cache --select F841 crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi --show-fixes
crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi:16:5: F841 [*] Local variable `T` is assigned to but never used
Found 1 error.
[*] 1 potentially fixable with the --fix option.
$  target/debug/ruff --no-cache --select F841 crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi --ecosystem-ci --show-fixes
warning: The formatting of fixes emitted by this option is a work-in-progress, subject to change at any time, and intended for use with the ecosystem ci scripts only.
crates/ruff/resources/test/fixtures/flake8_pyi/PYI001.pyi:16:5: F841 [*] Local variable `T` is assigned to but never used
ℹ Suggested fix
13 13 | _P = ParamSpec("_P")  # OK
14 14 |
15 15 | def f():
16    |-    T = TypeVar("T")  # OK
   16 |+    TypeVar("T")  # OK

Found 1 error.
[*] 1 potentially fixable with the --fix option.
```