### PR TITLE
Remove autofix for ambiguous-unicode rules

### DIFF
--- a/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
+++ b/crates/ruff/src/rules/ruff/rules/ambiguous_unicode_character.rs
@@ -1,6 +1,6 @@
 use ruff_text_size::{TextLen, TextRange, TextSize};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, DiagnosticKind, Edit, Fix};
+use ruff_diagnostics::{Diagnostic, DiagnosticKind, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 
@@ -15,7 +15,8 @@ pub struct AmbiguousUnicodeCharacterString {
     representant: char,
 }
 
-impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterString {
+/// RUF001
+impl Violation for AmbiguousUnicodeCharacterString {
     #[derive_message_formats]
     fn message(&self) -> String {
         let AmbiguousUnicodeCharacterString {
@@ -27,14 +28,6 @@ impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterString {
              `{representant}`?)"
         )
     }
-
-    fn autofix_title(&self) -> String {
-        let AmbiguousUnicodeCharacterString {
-            confusable,
-            representant,
-        } = self;
-        format!("Replace `{confusable}` with `{representant}`")
-    }
 }
 
 #[violation]
@@ -43,7 +36,8 @@ pub struct AmbiguousUnicodeCharacterDocstring {
     representant: char,
 }
 
-impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterDocstring {
+/// RUF002
+impl Violation for AmbiguousUnicodeCharacterDocstring {
     #[derive_message_formats]
     fn message(&self) -> String {
         let AmbiguousUnicodeCharacterDocstring {
@@ -55,14 +49,6 @@ impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterDocstring {
              `{representant}`?)"
         )
     }
-
-    fn autofix_title(&self) -> String {
-        let AmbiguousUnicodeCharacterDocstring {
-            confusable,
-            representant,
-        } = self;
-        format!("Replace `{confusable}` with `{representant}`")
-    }
 }
 
 #[violation]
@@ -71,7 +57,8 @@ pub struct AmbiguousUnicodeCharacterComment {
     representant: char,
 }
 
-impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterComment {
+/// RUF003
+impl Violation for AmbiguousUnicodeCharacterComment {
     #[derive_message_formats]
     fn message(&self) -> String {
         let AmbiguousUnicodeCharacterComment {
@@ -82,14 +69,6 @@ impl AlwaysAutofixableViolation for AmbiguousUnicodeCharacterComment {
             "Comment contains ambiguous unicode character `{confusable}` (did you mean \
              `{representant}`?)"
         )
-    }
-
-    fn autofix_title(&self) -> String {
-        let AmbiguousUnicodeCharacterComment {
-            confusable,
-            representant,
-        } = self;
-        format!("Replace `{confusable}` with `{representant}`")
     }
 }
 
@@ -113,7 +92,7 @@ pub(crate) fn ambiguous_unicode_character(
                         current_char.text_len(),
                     );
 
-                    let mut diagnostic = Diagnostic::new::<DiagnosticKind>(
+                    let diagnostic = Diagnostic::new::<DiagnosticKind>(
                         match context {
                             Context::String => AmbiguousUnicodeCharacterString {
                                 confusable: current_char,
@@ -134,13 +113,6 @@ pub(crate) fn ambiguous_unicode_character(
                         char_range,
                     );
                     if settings.rules.enabled(diagnostic.kind.rule()) {
-                        if settings.rules.should_fix(diagnostic.kind.rule()) {
-                            #[allow(deprecated)]
-                            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
-                                (representant as char).to_string(),
-                                char_range,
-                            )));
-                        }
                         diagnostics.push(diagnostic);
                     }
                 }

--- a/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
+++ b/crates/ruff/src/rules/ruff/rules/collection_literal_concatenation.rs
@@ -55,8 +55,6 @@ enum Kind {
 }
 
 /// RUF005
-/// This suggestion could be unsafe if the non-literal expression in the
-/// expression has overridden the `__add__` (or `__radd__`) magic methods.
 pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Expr) {
     let Expr::BinOp(ast::ExprBinOp { left, op: Operator::Add, right, range: _ }) = expr else {
         return;
@@ -143,8 +141,9 @@ pub(crate) fn collection_literal_concatenation(checker: &mut Checker, expr: &Exp
     );
     if checker.patch(diagnostic.kind.rule()) {
         if fixable {
-            #[allow(deprecated)]
-            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            // This suggestion could be unsafe if the non-literal expression in the
+            // expression has overridden the `__add__` (or `__radd__`) magic methods.
+            diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                 contents,
                 expr.range(),
             )));

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__confusables.snap
@@ -1,22 +1,14 @@
 ---
 source: crates/ruff/src/rules/ruff/mod.rs
 ---
-confusables.py:1:6: RUF001 [*] String contains ambiguous unicode character `𝐁` (did you mean `B`?)
+confusables.py:1:6: RUF001 String contains ambiguous unicode character `𝐁` (did you mean `B`?)
   |
 1 | x = "𝐁ad string"
   |      ^ RUF001
 2 | y = "−"
   |
-  = help: Replace `𝐁` with `B`
 
-ℹ Suggested fix
-1   |-x = "𝐁ad string"
-  1 |+x = "Bad string"
-2 2 | y = "−"
-3 3 | 
-4 4 | 
-
-confusables.py:6:56: RUF002 [*] Docstring contains ambiguous unicode character `）` (did you mean `)`?)
+confusables.py:6:56: RUF002 Docstring contains ambiguous unicode character `）` (did you mean `)`?)
   |
 6 | def f():
 7 |     """Here's a docstring with an unusual parenthesis: ）"""
@@ -24,19 +16,8 @@ confusables.py:6:56: RUF002 [*] Docstring contains ambiguous unicode character `
 8 |     # And here's a comment with an unusual punctuation mark: ᜵
 9 |     ...
   |
-  = help: Replace `）` with `)`
 
-ℹ Suggested fix
-3 3 | 
-4 4 | 
-5 5 | def f():
-6   |-    """Here's a docstring with an unusual parenthesis: ）"""
-  6 |+    """Here's a docstring with an unusual parenthesis: )"""
-7 7 |     # And here's a comment with an unusual punctuation mark: ᜵
-8 8 |     ...
-9 9 | 
-
-confusables.py:7:62: RUF003 [*] Comment contains ambiguous unicode character `᜵` (did you mean `/`?)
+confusables.py:7:62: RUF003 Comment contains ambiguous unicode character `᜵` (did you mean `/`?)
    |
  7 | def f():
  8 |     """Here's a docstring with an unusual parenthesis: ）"""
@@ -44,16 +25,5 @@ confusables.py:7:62: RUF003 [*] Comment contains ambiguous unicode character `�
    |                                                              ^ RUF003
 10 |     ...
    |
-   = help: Replace `᜵` with `/`
-
-ℹ Suggested fix
-4 4 | 
-5 5 | def f():
-6 6 |     """Here's a docstring with an unusual parenthesis: ）"""
-7   |-    # And here's a comment with an unusual punctuation mark: ᜵
-  7 |+    # And here's a comment with an unusual punctuation mark: /
-8 8 |     ...
-9 9 | 
-10 10 | 
 
 


### PR DESCRIPTION
## Summary

We could arguably change this to `Applicability::Manual` when it's supported in the CLI, but for now, I think it's too dangerous to apply as a fix. (We do include the fix suggestion in the diagnostic message anyway, so it's not a total loss to remove the suggestion test) Just look at all the linked issues!

Closes #3977.

Closes #3947.

Closes #3626.

Closes #4519.
