### PR TITLE
Parenthesize more sub-expressions in f-string conversion

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP032_2.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP032_2.py
@@ -14,3 +14,15 @@
 "{.real}".format(0b01)
 "{0.real}".format(0b01)
 "{a.real}".format(a=0b01)
+
+"{}".format(1 + 2)
+"{}".format([1, 2])
+"{}".format({1, 2})
+"{}".format({1: 2, 3: 4})
+"{}".format((i for i in range(2)))
+
+"{.real}".format(1 + 2)
+"{.real}".format([1, 2])
+"{.real}".format({1, 2})
+"{.real}".format({1: 2, 3: 4})
+"{}".format((i for i in range(2)))

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -4,9 +4,11 @@ use rustpython_format::{
     FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
 };
 use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
+use std::borrow::Cow;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::str::{is_implicit_concatenation, leading_quote, trailing_quote};
 
 use crate::checkers::ast::Checker;
@@ -34,21 +36,20 @@ impl AlwaysAutofixableViolation for FString {
 /// respectively.
 #[derive(Debug)]
 struct FormatSummaryValues<'a> {
-    args: Vec<String>,
-    kwargs: FxHashMap<&'a str, String>,
+    args: Vec<&'a Expr>,
+    kwargs: FxHashMap<&'a str, &'a Expr>,
 }
 
 impl<'a> FormatSummaryValues<'a> {
-    fn try_from_expr(checker: &'a Checker, expr: &'a Expr) -> Option<Self> {
-        let mut extracted_args: Vec<String> = Vec::new();
-        let mut extracted_kwargs: FxHashMap<&str, String> = FxHashMap::default();
+    fn try_from_expr(expr: &'a Expr, locator: &'a Locator) -> Option<Self> {
+        let mut extracted_args: Vec<&Expr> = Vec::new();
+        let mut extracted_kwargs: FxHashMap<&str, &Expr> = FxHashMap::default();
         if let Expr::Call(ast::ExprCall { args, keywords, .. }) = expr {
             for arg in args {
-                let arg = checker.locator.slice(arg.range());
-                if contains_invalids(arg) {
+                if contains_invalids(locator.slice(arg.range())) {
                     return None;
                 }
-                extracted_args.push(arg.to_string());
+                extracted_args.push(arg);
             }
             for keyword in keywords {
                 let Keyword {
@@ -57,11 +58,10 @@ impl<'a> FormatSummaryValues<'a> {
                     range: _,
                 } = keyword;
                 if let Some(key) = arg {
-                    let kwarg = checker.locator.slice(value.range());
-                    if contains_invalids(kwarg) {
+                    if contains_invalids(locator.slice(value.range())) {
                         return None;
                     }
-                    extracted_kwargs.insert(key, kwarg.to_string());
+                    extracted_kwargs.insert(key, value);
                 }
             }
         }
@@ -76,7 +76,7 @@ impl<'a> FormatSummaryValues<'a> {
         })
     }
 
-    fn consume_next(&mut self) -> Option<String> {
+    fn consume_next(&mut self) -> Option<&Expr> {
         if self.args.is_empty() {
             None
         } else {
@@ -84,7 +84,7 @@ impl<'a> FormatSummaryValues<'a> {
         }
     }
 
-    fn consume_arg(&mut self, index: usize) -> Option<String> {
+    fn consume_arg(&mut self, index: usize) -> Option<&Expr> {
         if self.args.len() > index {
             Some(self.args.remove(index))
         } else {
@@ -92,13 +92,13 @@ impl<'a> FormatSummaryValues<'a> {
         }
     }
 
-    fn consume_kwarg(&mut self, key: &str) -> Option<String> {
+    fn consume_kwarg(&mut self, key: &str) -> Option<&Expr> {
         self.kwargs.remove(key)
     }
 }
 
-/// Return `true` if the string contains characters that are forbidden in
-/// argument identifier.
+/// Return `true` if the string contains characters that are forbidden by
+/// argument identifiers.
 fn contains_invalids(string: &str) -> bool {
     string.contains('*')
         || string.contains('\'')
@@ -106,8 +106,61 @@ fn contains_invalids(string: &str) -> bool {
         || string.contains("await")
 }
 
+enum FormatContext {
+    /// The expression is used as a bare format spec (e.g., `{x}`).
+    Bare,
+    /// The expression is used with conversion flags, or attribute or subscript access
+    /// (e.g., `{x!r}`, `{x.y}`, `{x[y]}`).
+    Accessed,
+}
+
+/// Given an [`Expr`], format it for use in a formatted expression within an f-string.
+fn formatted_expr<'a>(expr: &Expr, context: FormatContext, locator: &Locator<'a>) -> Cow<'a, str> {
+    let text = locator.slice(expr.range());
+    let parenthesize = match (context, expr) {
+        // E.g., `x + y` should be parenthesized in `f"{(x + y)[0]}"`.
+        (
+            FormatContext::Accessed,
+            Expr::BinOp(_)
+            | Expr::UnaryOp(_)
+            | Expr::BoolOp(_)
+            | Expr::NamedExpr(_)
+            | Expr::Compare(_)
+            | Expr::IfExp(_)
+            | Expr::Lambda(_)
+            | Expr::Await(_)
+            | Expr::Yield(_)
+            | Expr::YieldFrom(_)
+            | Expr::Starred(_),
+        ) => true,
+        // E.g., `12` should be parenthesized in `f"{(12).real}"`.
+        (
+            FormatContext::Accessed,
+            Expr::Constant(ast::ExprConstant {
+                value: Constant::Int(..),
+                ..
+            }),
+        ) => text.chars().all(|c| c.is_ascii_digit()),
+        // E.g., `{x, y}` should be parenthesized in `f"{(x, y)}"`.
+        (
+            _,
+            Expr::GeneratorExp(_)
+            | Expr::Dict(_)
+            | Expr::Set(_)
+            | Expr::SetComp(_)
+            | Expr::DictComp(_),
+        ) => true,
+        _ => false,
+    };
+    if parenthesize && !text.starts_with('(') && !text.ends_with(')') {
+        Cow::Owned(format!("({text})"))
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
 /// Generate an f-string from an [`Expr`].
-fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
+fn try_convert_to_f_string(expr: &Expr, locator: &Locator) -> Option<String> {
     let Expr::Call(ast::ExprCall { func, .. }) = expr else {
         return None;
     };
@@ -124,11 +177,11 @@ fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
         return None;
     };
 
-    let Some(mut summary) = FormatSummaryValues::try_from_expr(checker, expr) else {
+    let Some(mut summary) = FormatSummaryValues::try_from_expr( expr, locator) else {
         return None;
     };
 
-    let contents = checker.locator.slice(value.range());
+    let contents = locator.slice(value.range());
 
     // Skip implicit string concatenations.
     if is_implicit_concatenation(contents) {
@@ -171,39 +224,20 @@ fn try_convert_to_f_string(checker: &Checker, expr: &Expr) -> Option<String> {
                 converted.push('{');
 
                 let field = FieldName::parse(&field_name).ok()?;
-                let has_field_parts = !field.parts.is_empty();
-                match field.field_type {
-                    FieldType::Auto => {
-                        let Some(arg) = summary.consume_next() else {
-                            return None;
-                        };
-                        if has_field_parts && arg.chars().all(|c| c.is_ascii_digit()) {
-                            converted.push_str(&format!("({arg})"));
-                        } else {
-                            converted.push_str(&arg);
-                        }
-                    }
-                    FieldType::Index(index) => {
-                        let Some(arg) = summary.consume_arg(index) else {
-                            return None;
-                        };
-                        if has_field_parts && arg.chars().all(|c| c.is_ascii_digit()) {
-                            converted.push_str(&format!("({arg})"));
-                        } else {
-                            converted.push_str(&arg);
-                        }
-                    }
-                    FieldType::Keyword(name) => {
-                        let Some(arg) = summary.consume_kwarg(&name) else {
-                            return None;
-                        };
-                        if has_field_parts && arg.chars().all(|c| c.is_ascii_digit()) {
-                            converted.push_str(&format!("({arg})"));
-                        } else {
-                            converted.push_str(&arg);
-                        }
-                    }
-                }
+                let arg = match field.field_type {
+                    FieldType::Auto => summary.consume_next(),
+                    FieldType::Index(index) => summary.consume_arg(index),
+                    FieldType::Keyword(name) => summary.consume_kwarg(&name),
+                }?;
+                converted.push_str(&formatted_expr(
+                    arg,
+                    if field.parts.is_empty() {
+                        FormatContext::Bare
+                    } else {
+                        FormatContext::Accessed
+                    },
+                    locator,
+                ));
 
                 for part in field.parts {
                     match part {
@@ -271,7 +305,7 @@ pub(crate) fn f_strings(checker: &mut Checker, summary: &FormatSummary, expr: &E
 
     // Currently, the only issue we know of is in LibCST:
     // https://github.com/Instagram/LibCST/issues/846
-    let Some(mut contents) = try_convert_to_f_string(checker, expr) else {
+    let Some(mut contents) = try_convert_to_f_string( expr, checker.locator) else {
         return;
     };
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_2.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP032_2.py.snap
@@ -200,6 +200,7 @@ UP032_2.py:14:1: UP032 [*] Use f-string instead of `format` call
    14 |+f"{0b01.real}"
 15 15 | "{0.real}".format(0b01)
 16 16 | "{a.real}".format(a=0b01)
+17 17 | 
 
 UP032_2.py:15:1: UP032 [*] Use f-string instead of `format` call
    |
@@ -217,6 +218,8 @@ UP032_2.py:15:1: UP032 [*] Use f-string instead of `format` call
 15    |-"{0.real}".format(0b01)
    15 |+f"{0b01.real}"
 16 16 | "{a.real}".format(a=0b01)
+17 17 | 
+18 18 | "{}".format(1 + 2)
 
 UP032_2.py:16:1: UP032 [*] Use f-string instead of `format` call
    |
@@ -224,6 +227,8 @@ UP032_2.py:16:1: UP032 [*] Use f-string instead of `format` call
 17 | "{0.real}".format(0b01)
 18 | "{a.real}".format(a=0b01)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+19 | 
+20 | "{}".format(1 + 2)
    |
    = help: Convert to f-string
 
@@ -233,5 +238,206 @@ UP032_2.py:16:1: UP032 [*] Use f-string instead of `format` call
 15 15 | "{0.real}".format(0b01)
 16    |-"{a.real}".format(a=0b01)
    16 |+f"{0b01.real}"
+17 17 | 
+18 18 | "{}".format(1 + 2)
+19 19 | "{}".format([1, 2])
+
+UP032_2.py:18:1: UP032 [*] Use f-string instead of `format` call
+   |
+18 | "{a.real}".format(a=0b01)
+19 | 
+20 | "{}".format(1 + 2)
+   | ^^^^^^^^^^^^^^^^^^ UP032
+21 | "{}".format([1, 2])
+22 | "{}".format({1, 2})
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+15 15 | "{0.real}".format(0b01)
+16 16 | "{a.real}".format(a=0b01)
+17 17 | 
+18    |-"{}".format(1 + 2)
+   18 |+f"{1 + 2}"
+19 19 | "{}".format([1, 2])
+20 20 | "{}".format({1, 2})
+21 21 | "{}".format({1: 2, 3: 4})
+
+UP032_2.py:19:1: UP032 [*] Use f-string instead of `format` call
+   |
+19 | "{}".format(1 + 2)
+20 | "{}".format([1, 2])
+   | ^^^^^^^^^^^^^^^^^^^ UP032
+21 | "{}".format({1, 2})
+22 | "{}".format({1: 2, 3: 4})
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+16 16 | "{a.real}".format(a=0b01)
+17 17 | 
+18 18 | "{}".format(1 + 2)
+19    |-"{}".format([1, 2])
+   19 |+f"{[1, 2]}"
+20 20 | "{}".format({1, 2})
+21 21 | "{}".format({1: 2, 3: 4})
+22 22 | "{}".format((i for i in range(2)))
+
+UP032_2.py:20:1: UP032 [*] Use f-string instead of `format` call
+   |
+20 | "{}".format(1 + 2)
+21 | "{}".format([1, 2])
+22 | "{}".format({1, 2})
+   | ^^^^^^^^^^^^^^^^^^^ UP032
+23 | "{}".format({1: 2, 3: 4})
+24 | "{}".format((i for i in range(2)))
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+17 17 | 
+18 18 | "{}".format(1 + 2)
+19 19 | "{}".format([1, 2])
+20    |-"{}".format({1, 2})
+   20 |+f"{({1, 2})}"
+21 21 | "{}".format({1: 2, 3: 4})
+22 22 | "{}".format((i for i in range(2)))
+23 23 | 
+
+UP032_2.py:21:1: UP032 [*] Use f-string instead of `format` call
+   |
+21 | "{}".format([1, 2])
+22 | "{}".format({1, 2})
+23 | "{}".format({1: 2, 3: 4})
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+24 | "{}".format((i for i in range(2)))
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+18 18 | "{}".format(1 + 2)
+19 19 | "{}".format([1, 2])
+20 20 | "{}".format({1, 2})
+21    |-"{}".format({1: 2, 3: 4})
+   21 |+f"{({1: 2, 3: 4})}"
+22 22 | "{}".format((i for i in range(2)))
+23 23 | 
+24 24 | "{.real}".format(1 + 2)
+
+UP032_2.py:22:1: UP032 [*] Use f-string instead of `format` call
+   |
+22 | "{}".format({1, 2})
+23 | "{}".format({1: 2, 3: 4})
+24 | "{}".format((i for i in range(2)))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+25 | 
+26 | "{.real}".format(1 + 2)
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+19 19 | "{}".format([1, 2])
+20 20 | "{}".format({1, 2})
+21 21 | "{}".format({1: 2, 3: 4})
+22    |-"{}".format((i for i in range(2)))
+   22 |+f"{(i for i in range(2))}"
+23 23 | 
+24 24 | "{.real}".format(1 + 2)
+25 25 | "{.real}".format([1, 2])
+
+UP032_2.py:24:1: UP032 [*] Use f-string instead of `format` call
+   |
+24 | "{}".format((i for i in range(2)))
+25 | 
+26 | "{.real}".format(1 + 2)
+   | ^^^^^^^^^^^^^^^^^^^^^^^ UP032
+27 | "{.real}".format([1, 2])
+28 | "{.real}".format({1, 2})
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+21 21 | "{}".format({1: 2, 3: 4})
+22 22 | "{}".format((i for i in range(2)))
+23 23 | 
+24    |-"{.real}".format(1 + 2)
+   24 |+f"{(1 + 2).real}"
+25 25 | "{.real}".format([1, 2])
+26 26 | "{.real}".format({1, 2})
+27 27 | "{.real}".format({1: 2, 3: 4})
+
+UP032_2.py:25:1: UP032 [*] Use f-string instead of `format` call
+   |
+25 | "{.real}".format(1 + 2)
+26 | "{.real}".format([1, 2])
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+27 | "{.real}".format({1, 2})
+28 | "{.real}".format({1: 2, 3: 4})
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+22 22 | "{}".format((i for i in range(2)))
+23 23 | 
+24 24 | "{.real}".format(1 + 2)
+25    |-"{.real}".format([1, 2])
+   25 |+f"{[1, 2].real}"
+26 26 | "{.real}".format({1, 2})
+27 27 | "{.real}".format({1: 2, 3: 4})
+28 28 | "{}".format((i for i in range(2)))
+
+UP032_2.py:26:1: UP032 [*] Use f-string instead of `format` call
+   |
+26 | "{.real}".format(1 + 2)
+27 | "{.real}".format([1, 2])
+28 | "{.real}".format({1, 2})
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+29 | "{.real}".format({1: 2, 3: 4})
+30 | "{}".format((i for i in range(2)))
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+23 23 | 
+24 24 | "{.real}".format(1 + 2)
+25 25 | "{.real}".format([1, 2])
+26    |-"{.real}".format({1, 2})
+   26 |+f"{({1, 2}).real}"
+27 27 | "{.real}".format({1: 2, 3: 4})
+28 28 | "{}".format((i for i in range(2)))
+
+UP032_2.py:27:1: UP032 [*] Use f-string instead of `format` call
+   |
+27 | "{.real}".format([1, 2])
+28 | "{.real}".format({1, 2})
+29 | "{.real}".format({1: 2, 3: 4})
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+30 | "{}".format((i for i in range(2)))
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+24 24 | "{.real}".format(1 + 2)
+25 25 | "{.real}".format([1, 2])
+26 26 | "{.real}".format({1, 2})
+27    |-"{.real}".format({1: 2, 3: 4})
+   27 |+f"{({1: 2, 3: 4}).real}"
+28 28 | "{}".format((i for i in range(2)))
+
+UP032_2.py:28:1: UP032 [*] Use f-string instead of `format` call
+   |
+28 | "{.real}".format({1, 2})
+29 | "{.real}".format({1: 2, 3: 4})
+30 | "{}".format((i for i in range(2)))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ UP032
+   |
+   = help: Convert to f-string
+
+ℹ Suggested fix
+25 25 | "{.real}".format([1, 2])
+26 26 | "{.real}".format({1, 2})
+27 27 | "{.real}".format({1: 2, 3: 4})
+28    |-"{}".format((i for i in range(2)))
+   28 |+f"{(i for i in range(2))}"
 
 


### PR DESCRIPTION
## Summary

E.g., we need to parenthesize dictionary and set literals, and we need to parenthesize a few more expression types when we have access flags (like `f"{1 + 2}.real"`).