### PR TITLE
Include empty success test in JUnit output

### DIFF
--- a/crates/ruff/src/message/junit.rs
+++ b/crates/ruff/src/message/junit.rs
@@ -19,49 +19,60 @@ impl Emitter for JunitEmitter {
     ) -> anyhow::Result<()> {
         let mut report = Report::new("ruff");
 
-        for (filename, messages) in group_messages_by_filename(messages) {
-            let mut test_suite = TestSuite::new(filename);
+        if messages.is_empty() {
+            let mut test_suite = TestSuite::new("ruff");
             test_suite
                 .extra
                 .insert("package".to_string(), "org.ruff".to_string());
-
-            for message in messages {
-                let MessageWithLocation {
-                    message,
-                    start_location,
-                } = message;
-                let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
-                status.set_message(message.kind.body.clone());
-                let location = if context.is_jupyter_notebook(message.filename()) {
-                    // We can't give a reasonable location for the structured formats,
-                    // so we show one that's clearly a fallback
-                    SourceLocation::default()
-                } else {
-                    start_location
-                };
-
-                status.set_description(format!(
-                    "line {row}, col {col}, {body}",
-                    row = location.row,
-                    col = location.column,
-                    body = message.kind.body
-                ));
-                let mut case = TestCase::new(
-                    format!("org.ruff.{}", message.kind.rule().noqa_code()),
-                    status,
-                );
-                let file_path = Path::new(filename);
-                let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
-                let classname = file_path.parent().unwrap().join(file_stem);
-                case.set_classname(classname.to_str().unwrap());
-                case.extra
-                    .insert("line".to_string(), location.row.to_string());
-                case.extra
-                    .insert("column".to_string(), location.column.to_string());
-
-                test_suite.add_test_case(case);
-            }
+            let mut case = TestCase::new("No errors found", TestCaseStatus::success());
+            case.set_classname("ruff");
+            test_suite.add_test_case(case);
             report.add_test_suite(test_suite);
+        } else {
+            for (filename, messages) in group_messages_by_filename(messages) {
+                let mut test_suite = TestSuite::new(filename);
+                test_suite
+                    .extra
+                    .insert("package".to_string(), "org.ruff".to_string());
+
+                for message in messages {
+                    let MessageWithLocation {
+                        message,
+                        start_location,
+                    } = message;
+                    let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
+                    status.set_message(message.kind.body.clone());
+                    let location = if context.is_jupyter_notebook(message.filename()) {
+                        // We can't give a reasonable location for the structured formats,
+                        // so we show one that's clearly a fallback
+                        SourceLocation::default()
+                    } else {
+                        start_location
+                    };
+
+                    status.set_description(format!(
+                        "line {row}, col {col}, {body}",
+                        row = location.row,
+                        col = location.column,
+                        body = message.kind.body
+                    ));
+                    let mut case = TestCase::new(
+                        format!("org.ruff.{}", message.kind.rule().noqa_code()),
+                        status,
+                    );
+                    let file_path = Path::new(filename);
+                    let file_stem = file_path.file_stem().unwrap().to_str().unwrap();
+                    let classname = file_path.parent().unwrap().join(file_stem);
+                    case.set_classname(classname.to_str().unwrap());
+                    case.extra
+                        .insert("line".to_string(), location.row.to_string());
+                    case.extra
+                        .insert("column".to_string(), location.column.to_string());
+
+                    test_suite.add_test_case(case);
+                }
+                report.add_test_suite(test_suite);
+            }
         }
 
         report.serialize(writer)?;


### PR DESCRIPTION
## Summary

When Jenkins encounters a JUnit XML file that doesn't contain _any_ test results, by default, it errors. You can configure Jenkins to treat empty files as "successful", but that opens the door to silently ignoring valid errors in your configuration or test running.

This PR modifies the JUnit reporter to include a single successful test if Ruff doesn't find any valid diagnostics.

Closes #4502.

## Test Plan

Ran `cargo run -p ruff_cli -- check foo.py --format junit --select F` on an empty file:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites name="ruff" tests="1" failures="0" errors="0">
    <testsuite name="ruff" tests="1" disabled="0" errors="0" failures="0" package="org.ruff">
        <testcase name="No errors found" classname="ruff">
        </testcase>
    </testsuite>
</testsuites>
```

I also uploaded this to a JUnit result visualizer online, and it looked reasonable:

<img width="1792" alt="Screen Shot 2023-05-19 at 11 34 15 PM" src="https://github.com/charliermarsh/ruff/assets/1309177/79d6c876-ec0d-473d-9c49-5675133f6801">
