### PR TITLE
Fix false-positive for TRY302 if exception cause is given

### DIFF
--- a/crates/ruff/resources/test/fixtures/tryceratops/TRY302.py
+++ b/crates/ruff/resources/test/fixtures/tryceratops/TRY302.py
@@ -72,6 +72,12 @@ def fine():
     try:
         process()
     except Exception as e:
+        raise e from None
+
+def fine():
+    try:
+        process()
+    except Exception as e:
         raise ex
 
 def fine():

--- a/crates/ruff/resources/test/fixtures/tryceratops/TRY302.py
+++ b/crates/ruff/resources/test/fixtures/tryceratops/TRY302.py
@@ -78,6 +78,12 @@ def fine():
     try:
         process()
     except Exception as e:
+        raise e from Exception
+
+def fine():
+    try:
+        process()
+    except Exception as e:
         raise ex
 
 def fine():

--- a/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/useless_try_except.rs
@@ -44,7 +44,7 @@ pub(crate) fn useless_try_except(checker: &mut Checker, handlers: &[Excepthandle
         .iter()
         .map(|handler| {
             let ExceptHandler(ExcepthandlerExceptHandler { name, body, .. }) = handler;
-            let Some(Stmt::Raise(ast::StmtRaise {  exc, .. })) = &body.first() else {
+            let Some(Stmt::Raise(ast::StmtRaise {  exc, cause: None, .. })) = &body.first() else {
                 return None;
             };
             if let Some(expr) = exc {


### PR DESCRIPTION
Fix #4548.

Add new test to fixtures with expected success, but it fails with old rule implementation: https://github.com/153957/ruff/actions/runs/5037490516/jobs/9034361352#step:7:1861

And is successful with the change to the rule, as the CI for this PR will show.