### PR TITLE
Rename ruff_python_semantic's `Context` struct to `SemanticModel`

### DIFF
--- a/crates/ruff/src/autofix/actions.rs
+++ b/crates/ruff/src/autofix/actions.rs
@@ -13,7 +13,7 @@ use ruff_python_ast::helpers;
 use ruff_python_ast::imports::{AnyImport, Import};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::cst::helpers::compose_module_path;
 use crate::cst::matchers::match_module;
@@ -435,11 +435,11 @@ pub(crate) fn get_or_import_symbol(
     module: &str,
     member: &str,
     at: TextSize,
-    context: &Context,
+    model: &SemanticModel,
     importer: &Importer,
     locator: &Locator,
 ) -> Result<(Edit, String)> {
-    if let Some((source, binding)) = context.resolve_qualified_import_name(module, member) {
+    if let Some((source, binding)) = model.resolve_qualified_import_name(module, member) {
         // If the symbol is already available in the current scope, use it.
 
         // The exception: the symbol source (i.e., the import statement) comes after the current
@@ -477,7 +477,7 @@ pub(crate) fn get_or_import_symbol(
             // Case 1: `from functools import lru_cache` is in scope, and we're trying to reference
             // `functools.cache`; thus, we add `cache` to the import, and return `"cache"` as the
             // bound name.
-            if context
+            if model
                 .find_binding(member)
                 .map_or(true, |binding| binding.kind.is_builtin())
             {
@@ -489,7 +489,7 @@ pub(crate) fn get_or_import_symbol(
         } else {
             // Case 2: No `functools` import is in scope; thus, we add `import functools`, and
             // return `"functools.cache"` as the bound name.
-            if context
+            if model
                 .find_binding(module)
                 .map_or(true, |binding| binding.kind.is_builtin())
             {

--- a/crates/ruff/src/checkers/ast/deferred.rs
+++ b/crates/ruff/src/checkers/ast/deferred.rs
@@ -1,7 +1,7 @@
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::context::Snapshot;
+use ruff_python_semantic::model::Snapshot;
 
 /// A collection of AST nodes that are deferred for later analysis.
 /// Used to, e.g., store functions, whose bodies shouldn't be analyzed until all

--- a/crates/ruff/src/docstrings/sections.rs
+++ b/crates/ruff/src/docstrings/sections.rs
@@ -1,12 +1,14 @@
-use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
-use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::fmt::{Debug, Formatter};
 use std::iter::FusedIterator;
+
+use ruff_text_size::{TextLen, TextRange, TextSize};
 use strum_macros::EnumIter;
+
+use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
+use ruff_python_ast::whitespace;
 
 use crate::docstrings::styles::SectionStyle;
 use crate::docstrings::{Docstring, DocstringBody};
-use ruff_python_ast::whitespace;
 
 #[derive(EnumIter, PartialEq, Eq, Debug, Clone, Copy)]
 pub enum SectionKind {

--- a/crates/ruff/src/flake8_to_ruff/converter.rs
+++ b/crates/ruff/src/flake8_to_ruff/converter.rs
@@ -3,9 +3,6 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use itertools::Itertools;
 
-use super::external_config::ExternalConfig;
-use super::plugin::Plugin;
-use super::{parser, plugin};
 use crate::registry::Linter;
 use crate::rule_selector::RuleSelector;
 use crate::rules::flake8_pytest_style::types::{
@@ -22,6 +19,10 @@ use crate::settings::options::Options;
 use crate::settings::pyproject::Pyproject;
 use crate::settings::types::PythonVersion;
 use crate::warn_user;
+
+use super::external_config::ExternalConfig;
+use super::plugin::Plugin;
+use super::{parser, plugin};
 
 const DEFAULT_SELECTORS: &[RuleSelector] = &[
     RuleSelector::Linter(Linter::Pyflakes),
@@ -456,8 +457,6 @@ mod tests {
     use pep440_rs::VersionSpecifiers;
     use pretty_assertions::assert_eq;
 
-    use super::super::plugin::Plugin;
-    use super::convert;
     use crate::flake8_to_ruff::converter::DEFAULT_SELECTORS;
     use crate::flake8_to_ruff::pep621::Project;
     use crate::flake8_to_ruff::ExternalConfig;
@@ -468,6 +467,9 @@ mod tests {
     use crate::settings::options::Options;
     use crate::settings::pyproject::Pyproject;
     use crate::settings::types::PythonVersion;
+
+    use super::super::plugin::Plugin;
+    use super::convert;
 
     fn default_options(plugins: impl IntoIterator<Item = RuleSelector>) -> Options {
         Options {

--- a/crates/ruff/src/flake8_to_ruff/mod.rs
+++ b/crates/ruff/src/flake8_to_ruff/mod.rs
@@ -1,3 +1,8 @@
+pub use converter::convert;
+pub use external_config::ExternalConfig;
+pub use plugin::Plugin;
+pub use pyproject::parse;
+
 mod black;
 mod converter;
 mod external_config;
@@ -6,8 +11,3 @@ mod parser;
 pub mod pep621;
 mod plugin;
 mod pyproject;
-
-pub use converter::convert;
-pub use external_config::ExternalConfig;
-pub use plugin::Plugin;
-pub use pyproject::parse;

--- a/crates/ruff/src/flake8_to_ruff/parser.rs
+++ b/crates/ruff/src/flake8_to_ruff/parser.rs
@@ -195,11 +195,12 @@ pub(crate) fn collect_per_file_ignores(
 mod tests {
     use anyhow::Result;
 
-    use super::{parse_files_to_codes_mapping, parse_prefix_codes, parse_strings};
     use crate::codes;
     use crate::registry::Linter;
     use crate::rule_selector::RuleSelector;
     use crate::settings::types::PatternPrefixPair;
+
+    use super::{parse_files_to_codes_mapping, parse_prefix_codes, parse_strings};
 
     #[test]
     fn it_parses_prefix_codes() {

--- a/crates/ruff/src/importer/insertion.rs
+++ b/crates/ruff/src/importer/insertion.rs
@@ -1,8 +1,8 @@
-use ruff_diagnostics::Edit;
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{Ranged, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers::is_docstring_stmt;
 use ruff_python_ast::source_code::{Locator, Stylist};
 

--- a/crates/ruff/src/jupyter/mod.rs
+++ b/crates/ruff/src/jupyter/mod.rs
@@ -1,7 +1,7 @@
 //! Utils for reading and writing jupyter notebooks
 
-mod notebook;
-mod schema;
-
 pub use notebook::*;
 pub use schema::*;
+
+mod notebook;
+mod schema;

--- a/crates/ruff/src/jupyter/notebook.rs
+++ b/crates/ruff/src/jupyter/notebook.rs
@@ -1,9 +1,9 @@
-use ruff_text_size::TextRange;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::iter;
 use std::path::Path;
 
+use ruff_text_size::TextRange;
 use serde::Serialize;
 use serde_json::error::Category;
 

--- a/crates/ruff/src/logging.rs
+++ b/crates/ruff/src/logging.rs
@@ -2,14 +2,16 @@ use std::fmt::{Display, Formatter, Write};
 use std::path::Path;
 use std::sync::Mutex;
 
-use crate::fs;
 use anyhow::Result;
 use colored::Colorize;
 use fern;
 use log::Level;
 use once_cell::sync::Lazy;
-use ruff_python_ast::source_code::SourceCode;
 use rustpython_parser::{ParseError, ParseErrorType};
+
+use ruff_python_ast::source_code::SourceCode;
+
+use crate::fs;
 
 pub(crate) static WARNINGS: Lazy<Mutex<Vec<&'static str>>> = Lazy::new(Mutex::default);
 

--- a/crates/ruff/src/message/azure.rs
+++ b/crates/ruff/src/message/azure.rs
@@ -1,7 +1,9 @@
+use std::io::Write;
+
+use ruff_python_ast::source_code::SourceLocation;
+
 use crate::message::{Emitter, EmitterContext, Message};
 use crate::registry::AsRule;
-use ruff_python_ast::source_code::SourceLocation;
-use std::io::Write;
 
 /// Generate error logging commands for Azure Pipelines format.
 /// See [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#logissue-log-an-error-or-warning)
@@ -42,9 +44,10 @@ impl Emitter for AzureEmitter {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::AzureEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/diff.rs
+++ b/crates/ruff/src/message/diff.rs
@@ -1,11 +1,14 @@
-use crate::message::Message;
-use colored::{Color, ColoredString, Colorize, Styles};
-use ruff_diagnostics::{Applicability, Fix};
-use ruff_python_ast::source_code::{OneIndexed, SourceFile};
-use ruff_text_size::{TextRange, TextSize};
-use similar::{ChangeTag, TextDiff};
 use std::fmt::{Display, Formatter};
 use std::num::NonZeroUsize;
+
+use colored::{Color, ColoredString, Colorize, Styles};
+use ruff_text_size::{TextRange, TextSize};
+use similar::{ChangeTag, TextDiff};
+
+use ruff_diagnostics::{Applicability, Fix};
+use ruff_python_ast::source_code::{OneIndexed, SourceFile};
+
+use crate::message::Message;
 
 /// Renders a diff that shows the code fixes.
 ///

--- a/crates/ruff/src/message/github.rs
+++ b/crates/ruff/src/message/github.rs
@@ -1,8 +1,10 @@
+use std::io::Write;
+
+use ruff_python_ast::source_code::SourceLocation;
+
 use crate::fs::relativize_path;
 use crate::message::{Emitter, EmitterContext, Message};
 use crate::registry::AsRule;
-use ruff_python_ast::source_code::SourceLocation;
-use std::io::Write;
 
 /// Generate error workflow command in GitHub Actions format.
 /// See: [GitHub documentation](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message)
@@ -57,9 +59,10 @@ impl Emitter for GithubEmitter {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GithubEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/gitlab.rs
+++ b/crates/ruff/src/message/gitlab.rs
@@ -1,13 +1,16 @@
-use crate::fs::{relativize_path, relativize_path_to};
-use crate::message::{Emitter, EmitterContext, Message};
-use crate::registry::AsRule;
-use ruff_python_ast::source_code::SourceLocation;
-use serde::ser::SerializeSeq;
-use serde::{Serialize, Serializer};
-use serde_json::json;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
+
+use serde::ser::SerializeSeq;
+use serde::{Serialize, Serializer};
+use serde_json::json;
+
+use ruff_python_ast::source_code::SourceLocation;
+
+use crate::fs::{relativize_path, relativize_path_to};
+use crate::message::{Emitter, EmitterContext, Message};
+use crate::registry::AsRule;
 
 /// Generate JSON with violations in GitLab CI format
 //  https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
@@ -122,9 +125,10 @@ fn fingerprint(
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GitlabEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -1,3 +1,11 @@
+use std::fmt::{Display, Formatter};
+use std::io::Write;
+use std::num::NonZeroUsize;
+
+use colored::Colorize;
+
+use ruff_python_ast::source_code::OneIndexed;
+
 use crate::fs::relativize_path;
 use crate::jupyter::JupyterIndex;
 use crate::message::diff::calculate_print_width;
@@ -5,11 +13,6 @@ use crate::message::text::{MessageCodeFrame, RuleCodeAndBody};
 use crate::message::{
     group_messages_by_filename, Emitter, EmitterContext, Message, MessageWithLocation,
 };
-use colored::Colorize;
-use ruff_python_ast::source_code::OneIndexed;
-use std::fmt::{Display, Formatter};
-use std::io::Write;
-use std::num::NonZeroUsize;
 
 #[derive(Default)]
 pub struct GroupedEmitter {
@@ -175,9 +178,10 @@ impl std::fmt::Write for PadAdapter<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::GroupedEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn default() {

--- a/crates/ruff/src/message/json.rs
+++ b/crates/ruff/src/message/json.rs
@@ -1,11 +1,14 @@
-use crate::message::{Emitter, EmitterContext, Message};
-use crate::registry::AsRule;
-use ruff_diagnostics::Edit;
-use ruff_python_ast::source_code::SourceCode;
+use std::io::Write;
+
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 use serde_json::json;
-use std::io::Write;
+
+use ruff_diagnostics::Edit;
+use ruff_python_ast::source_code::SourceCode;
+
+use crate::message::{Emitter, EmitterContext, Message};
+use crate::registry::AsRule;
 
 #[derive(Default)]
 pub struct JsonEmitter;
@@ -94,9 +97,10 @@ impl Serialize for ExpandedEdits<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::JsonEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/junit.rs
+++ b/crates/ruff/src/message/junit.rs
@@ -1,11 +1,14 @@
+use std::io::Write;
+use std::path::Path;
+
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
+
+use ruff_python_ast::source_code::SourceLocation;
+
 use crate::message::{
     group_messages_by_filename, Emitter, EmitterContext, Message, MessageWithLocation,
 };
 use crate::registry::AsRule;
-use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
-use ruff_python_ast::source_code::SourceLocation;
-use std::io::Write;
-use std::path::Path;
 
 #[derive(Default)]
 pub struct JunitEmitter;
@@ -83,9 +86,10 @@ impl Emitter for JunitEmitter {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::JunitEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -1,3 +1,25 @@
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::ops::Deref;
+
+use ruff_text_size::{TextRange, TextSize};
+use rustc_hash::FxHashMap;
+
+pub use azure::AzureEmitter;
+pub use github::GithubEmitter;
+pub use gitlab::GitlabEmitter;
+pub use grouped::GroupedEmitter;
+pub use json::JsonEmitter;
+pub use junit::JunitEmitter;
+pub use pylint::PylintEmitter;
+use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
+use ruff_python_ast::source_code::{SourceFile, SourceLocation};
+pub use text::TextEmitter;
+
+use crate::jupyter::JupyterIndex;
+use crate::registry::AsRule;
+
 mod azure;
 mod diff;
 mod github;
@@ -7,27 +29,6 @@ mod json;
 mod junit;
 mod pylint;
 mod text;
-
-use ruff_text_size::{TextRange, TextSize};
-use rustc_hash::FxHashMap;
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::io::Write;
-use std::ops::Deref;
-
-pub use azure::AzureEmitter;
-pub use github::GithubEmitter;
-pub use gitlab::GitlabEmitter;
-pub use grouped::GroupedEmitter;
-pub use json::JsonEmitter;
-pub use junit::JunitEmitter;
-pub use pylint::PylintEmitter;
-pub use text::TextEmitter;
-
-use crate::jupyter::JupyterIndex;
-use crate::registry::AsRule;
-use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
-use ruff_python_ast::source_code::{SourceFile, SourceLocation};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Message {
@@ -152,12 +153,14 @@ impl<'a> EmitterContext<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::message::{Emitter, EmitterContext, Message};
-    use crate::rules::pyflakes::rules::{UndefinedName, UnusedImport, UnusedVariable};
-    use ruff_diagnostics::{Diagnostic, Edit, Fix};
-    use ruff_python_ast::source_code::SourceFileBuilder;
     use ruff_text_size::{TextRange, TextSize};
     use rustc_hash::FxHashMap;
+
+    use ruff_diagnostics::{Diagnostic, Edit, Fix};
+    use ruff_python_ast::source_code::SourceFileBuilder;
+
+    use crate::message::{Emitter, EmitterContext, Message};
+    use crate::rules::pyflakes::rules::{UndefinedName, UnusedImport, UnusedVariable};
 
     pub(super) fn create_messages() -> Vec<Message> {
         let fib = r#"import os

--- a/crates/ruff/src/message/pylint.rs
+++ b/crates/ruff/src/message/pylint.rs
@@ -1,8 +1,10 @@
+use std::io::Write;
+
+use ruff_python_ast::source_code::OneIndexed;
+
 use crate::fs::relativize_path;
 use crate::message::{Emitter, EmitterContext, Message};
 use crate::registry::AsRule;
-use ruff_python_ast::source_code::OneIndexed;
-use std::io::Write;
 
 /// Generate violations in Pylint format.
 /// See: [Flake8 documentation](https://flake8.pycqa.org/en/latest/internal/formatters.html#pylint-formatter)
@@ -40,9 +42,10 @@ impl Emitter for PylintEmitter {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::PylintEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn output() {

--- a/crates/ruff/src/message/text.rs
+++ b/crates/ruff/src/message/text.rs
@@ -1,16 +1,19 @@
-use crate::fs::relativize_path;
-use crate::message::diff::Diff;
-use crate::message::{Emitter, EmitterContext, Message};
-use crate::registry::AsRule;
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
+use std::io::Write;
+
 use annotate_snippets::display_list::{DisplayList, FormatOptions};
 use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use bitflags::bitflags;
 use colored::Colorize;
-use ruff_python_ast::source_code::{OneIndexed, SourceLocation};
 use ruff_text_size::{TextRange, TextSize};
-use std::borrow::Cow;
-use std::fmt::{Display, Formatter};
-use std::io::Write;
+
+use ruff_python_ast::source_code::{OneIndexed, SourceLocation};
+
+use crate::fs::relativize_path;
+use crate::message::diff::Diff;
+use crate::message::{Emitter, EmitterContext, Message};
+use crate::registry::AsRule;
 
 bitflags! {
     #[derive(Default)]
@@ -292,9 +295,10 @@ struct SourceCode<'a> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::message::tests::{capture_emitter_output, create_messages};
     use crate::message::TextEmitter;
-    use insta::assert_snapshot;
 
     #[test]
     fn default() {

--- a/crates/ruff/src/registry.rs
+++ b/crates/ruff/src/registry.rs
@@ -1,15 +1,15 @@
 //! Registry of all [`Rule`] implementations.
 
-mod rule_set;
-
 use strum_macros::{AsRefStr, EnumIter};
 
 use ruff_diagnostics::Violation;
 use ruff_macros::RuleNamespace;
+pub use rule_set::{RuleSet, RuleSetIterator};
 
 use crate::codes::{self, RuleCodePrefix};
 use crate::rules;
-pub use rule_set::{RuleSet, RuleSetIterator};
+
+mod rule_set;
 
 ruff_macros::register_rules!(
     // pycodestyle errors
@@ -1003,6 +1003,7 @@ pub const INCOMPATIBLE_CODES: &[(Rule, Rule, &str); 2] = &[
 #[cfg(test)]
 mod tests {
     use std::mem::size_of;
+
     use strum::IntoEnumIterator;
 
     use super::{Linter, Rule, RuleNamespace};

--- a/crates/ruff/src/rules/eradicate/mod.rs
+++ b/crates/ruff/src/rules/eradicate/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_2020/mod.rs
+++ b/crates/ruff/src/rules/flake8_2020/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -115,7 +115,7 @@ impl Violation for SysVersionSlice1 {
 
 fn is_sys(checker: &Checker, expr: &Expr, target: &str) -> bool {
     checker
-        .ctx
+        .model
         .resolve_call_path(expr)
         .map_or(false, |call_path| call_path.as_slice() == ["sys", target])
 }
@@ -272,7 +272,7 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], compara
 /// YTT202
 pub(crate) fn name_or_attribute(checker: &mut Checker, expr: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(expr)
         .map_or(false, |call_path| call_path.as_slice() == ["six", "PY3"])
     {

--- a/crates/ruff/src/rules/flake8_annotations/helpers.rs
+++ b/crates/ruff/src/rules/flake8_annotations/helpers.rs
@@ -44,7 +44,7 @@ pub(crate) fn overloaded_name(checker: &Checker, definition: &Definition) -> Opt
         ..
     }) = definition
     {
-        if visibility::is_overload(&checker.ctx, cast::decorator_list(stmt)) {
+        if visibility::is_overload(&checker.model, cast::decorator_list(stmt)) {
             let (name, ..) = match_function_def(stmt);
             Some(name.to_string())
         } else {
@@ -68,7 +68,7 @@ pub(crate) fn is_overload_impl(
         ..
     }) = definition
     {
-        if visibility::is_overload(&checker.ctx, cast::decorator_list(stmt)) {
+        if visibility::is_overload(&checker.model, cast::decorator_list(stmt)) {
             false
         } else {
             let (name, ..) = match_function_def(stmt);

--- a/crates/ruff/src/rules/flake8_annotations/mod.rs
+++ b/crates/ruff/src/rules/flake8_annotations/mod.rs
@@ -8,9 +8,9 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_async/rules.rs
+++ b/crates/ruff/src/rules/flake8_async/rules.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 use ruff_python_semantic::scope::{FunctionDef, ScopeKind};
 
 use crate::checkers::ast::Checker;
@@ -66,9 +66,9 @@ const BLOCKING_HTTP_CALLS: &[&[&str]] = &[
 
 /// ASYNC100
 pub(crate) fn blocking_http_call(checker: &mut Checker, expr: &Expr) {
-    if in_async_function(&checker.ctx) {
+    if in_async_function(&checker.model) {
         if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if let Some(call_path) = checker.ctx.resolve_call_path(func) {
+            if let Some(call_path) = checker.model.resolve_call_path(func) {
                 if BLOCKING_HTTP_CALLS.contains(&call_path.as_slice()) {
                     checker.diagnostics.push(Diagnostic::new(
                         BlockingHttpCallInAsyncFunction,
@@ -133,9 +133,9 @@ const OPEN_SLEEP_OR_SUBPROCESS_CALL: &[&[&str]] = &[
 
 /// ASYNC101
 pub(crate) fn open_sleep_or_subprocess_call(checker: &mut Checker, expr: &Expr) {
-    if in_async_function(&checker.ctx) {
+    if in_async_function(&checker.model) {
         if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if let Some(call_path) = checker.ctx.resolve_call_path(func) {
+            if let Some(call_path) = checker.model.resolve_call_path(func) {
                 if OPEN_SLEEP_OR_SUBPROCESS_CALL.contains(&call_path.as_slice()) {
                     checker.diagnostics.push(Diagnostic::new(
                         OpenSleepOrSubprocessInAsyncFunction,
@@ -197,9 +197,9 @@ const UNSAFE_OS_METHODS: &[&[&str]] = &[
 
 /// ASYNC102
 pub(crate) fn blocking_os_call(checker: &mut Checker, expr: &Expr) {
-    if in_async_function(&checker.ctx) {
+    if in_async_function(&checker.model) {
         if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if let Some(call_path) = checker.ctx.resolve_call_path(func) {
+            if let Some(call_path) = checker.model.resolve_call_path(func) {
                 if UNSAFE_OS_METHODS.contains(&call_path.as_slice()) {
                     checker
                         .diagnostics
@@ -210,9 +210,9 @@ pub(crate) fn blocking_os_call(checker: &mut Checker, expr: &Expr) {
     }
 }
 
-/// Return `true` if the [`Context`] is inside an async function definition.
-fn in_async_function(context: &Context) -> bool {
-    context
+/// Return `true` if the [`SemanticModel`] is inside an async function definition.
+fn in_async_function(model: &SemanticModel) -> bool {
+    model
         .scopes()
         .find_map(|scope| {
             if let ScopeKind::Function(FunctionDef { async_, .. }) = &scope.kind {

--- a/crates/ruff/src/rules/flake8_bandit/helpers.rs
+++ b/crates/ruff/src/rules/flake8_bandit/helpers.rs
@@ -27,7 +27,7 @@ pub(crate) fn is_untyped_exception(type_: Option<&Expr>, checker: &Checker) -> b
         if let Expr::Tuple(ast::ExprTuple { elts, .. }) = &type_ {
             elts.iter().any(|type_| {
                 checker
-                    .ctx
+                    .model
                     .resolve_call_path(type_)
                     .map_or(false, |call_path| {
                         call_path.as_slice() == ["", "Exception"]
@@ -36,7 +36,7 @@ pub(crate) fn is_untyped_exception(type_: Option<&Expr>, checker: &Checker) -> b
             })
         } else {
             checker
-                .ctx
+                .model
                 .resolve_call_path(type_)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["", "Exception"]

--- a/crates/ruff/src/rules/flake8_bandit/mod.rs
+++ b/crates/ruff/src/rules/flake8_bandit/mod.rs
@@ -7,11 +7,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/bad_file_permissions.rs
@@ -108,7 +108,7 @@ pub(crate) fn bad_file_permissions(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["os", "chmod"])
     {

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 #[violation]
 pub struct HardcodedBindAllInterfaces;

--- a/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hardcoded_sql_expression.rs
@@ -60,7 +60,7 @@ fn unparse_string_format_expression(checker: &mut Checker, expr: &Expr) -> Optio
             op: Operator::Add | Operator::Mod,
             ..
         }) => {
-            let Some(parent) = checker.ctx.expr_parent() else {
+            let Some(parent) = checker.model.expr_parent() else {
                 if any_over_expr(expr, &has_string_literal) {
                     return Some(checker.generator().expr(expr));
                 }

--- a/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/hashlib_insecure_hash_functions.rs
@@ -48,7 +48,7 @@ pub(crate) fn hashlib_insecure_hash_functions(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if let Some(hashlib_call) = checker.ctx.resolve_call_path(func).and_then(|call_path| {
+    if let Some(hashlib_call) = checker.model.resolve_call_path(func).and_then(|call_path| {
         if call_path.as_slice() == ["hashlib", "new"] {
             Some(HashlibCall::New)
         } else {

--- a/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/jinja2_autoescape_false.rs
@@ -37,7 +37,7 @@ pub(crate) fn jinja2_autoescape_false(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["jinja2", "Environment"]

--- a/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/logging_config_insecure_listen.rs
@@ -24,7 +24,7 @@ pub(crate) fn logging_config_insecure_listen(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["logging", "config", "listen"]

--- a/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/paramiko_calls.rs
@@ -18,7 +18,7 @@ impl Violation for ParamikoCall {
 /// S601
 pub(crate) fn paramiko_call(checker: &mut Checker, func: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["paramiko", "exec_command"]

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_with_no_cert_validation.rs
@@ -43,7 +43,7 @@ pub(crate) fn request_with_no_cert_validation(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if let Some(target) = checker.ctx.resolve_call_path(func).and_then(|call_path| {
+    if let Some(target) = checker.model.resolve_call_path(func).and_then(|call_path| {
         if call_path.len() == 2 {
             if call_path[0] == "requests" && REQUESTS_HTTP_VERBS.contains(&call_path[1]) {
                 return Some("requests");

--- a/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -34,7 +34,7 @@ pub(crate) fn request_without_timeout(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             HTTP_VERBS

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -7,7 +7,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::Truthiness;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::{
     checkers::ast::Checker, registry::Rule, rules::flake8_bandit::helpers::string_literal,
@@ -97,8 +97,8 @@ enum CallKind {
 }
 
 /// Return the [`CallKind`] of the given function call.
-fn get_call_kind(func: &Expr, context: &Context) -> Option<CallKind> {
-    context
+fn get_call_kind(func: &Expr, model: &SemanticModel) -> Option<CallKind> {
+    model
         .resolve_call_path(func)
         .and_then(|call_path| match call_path.as_slice() {
             &[module, submodule] => match module {
@@ -138,12 +138,15 @@ struct ShellKeyword<'a> {
 }
 
 /// Return the `shell` keyword argument to the given function call, if any.
-fn find_shell_keyword<'a>(ctx: &Context, keywords: &'a [Keyword]) -> Option<ShellKeyword<'a>> {
+fn find_shell_keyword<'a>(
+    model: &SemanticModel,
+    keywords: &'a [Keyword],
+) -> Option<ShellKeyword<'a>> {
     keywords
         .iter()
         .find(|keyword| keyword.arg.as_ref().map_or(false, |arg| arg == "shell"))
         .map(|keyword| ShellKeyword {
-            truthiness: Truthiness::from_expr(&keyword.value, |id| ctx.is_builtin(id)),
+            truthiness: Truthiness::from_expr(&keyword.value, |id| model.is_builtin(id)),
             keyword,
         })
 }
@@ -181,11 +184,11 @@ pub(crate) fn shell_injection(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    let call_kind = get_call_kind(func, &checker.ctx);
+    let call_kind = get_call_kind(func, &checker.model);
 
     if matches!(call_kind, Some(CallKind::Subprocess)) {
         if let Some(arg) = args.first() {
-            match find_shell_keyword(&checker.ctx, keywords) {
+            match find_shell_keyword(&checker.model, keywords) {
                 // S602
                 Some(ShellKeyword {
                     truthiness: Truthiness::Truthy,
@@ -238,7 +241,7 @@ pub(crate) fn shell_injection(
     } else if let Some(ShellKeyword {
         truthiness: Truthiness::Truthy,
         keyword,
-    }) = find_shell_keyword(&checker.ctx, keywords)
+    }) = find_shell_keyword(&checker.model, keywords)
     {
         // S604
         if checker

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_insecure_version.rs
@@ -25,7 +25,7 @@ pub(crate) fn snmp_insecure_version(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pysnmp", "hlapi", "CommunityData"]

--- a/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/snmp_weak_cryptography.rs
@@ -27,7 +27,7 @@ pub(crate) fn snmp_weak_cryptography(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pysnmp", "hlapi", "UsmUserData"]

--- a/crates/ruff/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -470,7 +470,7 @@ pub(crate) fn suspicious_function_call(checker: &mut Checker, expr: &Expr) {
         return;
     };
 
-    let Some(reason) = checker.ctx.resolve_call_path(func).and_then(|call_path| {
+    let Some(reason) = checker.model.resolve_call_path(func).and_then(|call_path| {
         for module in SUSPICIOUS_MEMBERS {
             for member in module.members {
                 if call_path.as_slice() == *member {

--- a/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/unsafe_yaml_load.rs
@@ -38,14 +38,14 @@ pub(crate) fn unsafe_yaml_load(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["yaml", "load"])
     {
         let call_args = SimpleCallArgs::new(args, keywords);
         if let Some(loader_arg) = call_args.argument("Loader", 1) {
             if !checker
-                .ctx
+                .model
                 .resolve_call_path(loader_arg)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["yaml", "SafeLoader"]

--- a/crates/ruff/src/rules/flake8_blind_except/mod.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_blind_except/rules.rs
+++ b/crates/ruff/src/rules/flake8_blind_except/rules.rs
@@ -34,7 +34,7 @@ pub(crate) fn blind_except(
         return;
     };
     for exception in ["BaseException", "Exception"] {
-        if id == exception && checker.ctx.is_builtin(exception) {
+        if id == exception && checker.model.is_builtin(exception) {
             // If the exception is re-raised, don't flag an error.
             if body.iter().any(|stmt| {
                 if let Stmt::Raise(ast::StmtRaise { exc, .. }) = stmt {
@@ -58,7 +58,7 @@ pub(crate) fn blind_except(
             if body.iter().any(|stmt| {
                 if let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt {
                     if let Expr::Call(ast::ExprCall { func, keywords, .. }) = value.as_ref() {
-                        if logging::is_logger_candidate(&checker.ctx, func) {
+                        if logging::is_logger_candidate(&checker.model, func) {
                             if let Some(attribute) = func.as_attribute_expr() {
                                 let attr = attribute.attr.as_str();
                                 if attr == "exception" {

--- a/crates/ruff/src/rules/flake8_boolean_trap/mod.rs
+++ b/crates/ruff/src/rules/flake8_boolean_trap/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/mod.rs
@@ -6,11 +6,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -3,7 +3,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged, Stmt};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::analyze::visibility::{is_abstract, is_overload};
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;
@@ -35,16 +35,16 @@ impl Violation for EmptyMethodWithoutAbstractDecorator {
     }
 }
 
-fn is_abc_class(context: &Context, bases: &[Expr], keywords: &[Keyword]) -> bool {
+fn is_abc_class(model: &SemanticModel, bases: &[Expr], keywords: &[Keyword]) -> bool {
     keywords.iter().any(|keyword| {
         keyword.arg.as_ref().map_or(false, |arg| arg == "metaclass")
-            && context
+            && model
                 .resolve_call_path(&keyword.value)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["abc", "ABCMeta"]
                 })
     }) || bases.iter().any(|base| {
-        context
+        model
             .resolve_call_path(base)
             .map_or(false, |call_path| call_path.as_slice() == ["abc", "ABC"])
     })
@@ -79,7 +79,7 @@ pub(crate) fn abstract_base_class(
     if bases.len() + keywords.len() != 1 {
         return;
     }
-    if !is_abc_class(&checker.ctx, bases, keywords) {
+    if !is_abc_class(&checker.model, bases, keywords) {
         return;
     }
 
@@ -108,7 +108,7 @@ pub(crate) fn abstract_base_class(
             continue;
         };
 
-        let has_abstract_decorator = is_abstract(&checker.ctx, decorator_list);
+        let has_abstract_decorator = is_abstract(&checker.model, decorator_list);
         has_abstract_method |= has_abstract_decorator;
 
         if !checker
@@ -121,7 +121,7 @@ pub(crate) fn abstract_base_class(
 
         if !has_abstract_decorator
             && is_empty_body(body)
-            && !is_overload(&checker.ctx, decorator_list)
+            && !is_overload(&checker.model, decorator_list)
         {
             checker.diagnostics.push(Diagnostic::new(
                 EmptyMethodWithoutAbstractDecorator {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -66,7 +66,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items:
     }
 
     if !checker
-        .ctx
+        .model
         .resolve_call_path(args.first().unwrap())
         .map_or(false, |call_path| call_path.as_slice() == ["", "Exception"])
     {
@@ -78,7 +78,7 @@ pub(crate) fn assert_raises_exception(checker: &mut Checker, stmt: &Stmt, items:
         {
             AssertionKind::AssertRaises
         } else if checker
-            .ctx
+            .model
             .resolve_call_path(func)
             .map_or(false, |call_path| {
                 call_path.as_slice() == ["pytest", "raises"]

--- a/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/cached_instance_method.rs
@@ -20,7 +20,7 @@ impl Violation for CachedInstanceMethod {
 
 fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
     checker
-        .ctx
+        .model
         .resolve_call_path(expr)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["functools", "lru_cache"]
@@ -30,7 +30,7 @@ fn is_cache_func(checker: &Checker, expr: &Expr) -> bool {
 
 /// B019
 pub(crate) fn cached_instance_method(checker: &mut Checker, decorator_list: &[Expr]) {
-    if !matches!(checker.ctx.scope().kind, ScopeKind::Class(_)) {
+    if !matches!(checker.model.scope().kind, ScopeKind::Class(_)) {
         return;
     }
     for decorator in decorator_list {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/function_call_argument_default.rs
@@ -86,7 +86,7 @@ where
         match expr {
             Expr::Call(ast::ExprCall { func, args, .. }) => {
                 if !is_mutable_func(self.checker, func)
-                    && !is_immutable_func(&self.checker.ctx, func, &self.extend_immutable_calls)
+                    && !is_immutable_func(&self.checker.model, func, &self.extend_immutable_calls)
                     && !is_nan_or_infinity(func, args)
                 {
                     self.diagnostics.push((

--- a/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/getattr_with_constant.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -27,7 +27,7 @@ const MUTABLE_FUNCS: &[&[&str]] = &[
 
 pub(crate) fn is_mutable_func(checker: &Checker, func: &Expr) -> bool {
     checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             MUTABLE_FUNCS
@@ -70,7 +70,7 @@ pub(crate) fn mutable_argument_default(checker: &mut Checker, arguments: &Argume
             && !arg
                 .annotation
                 .as_ref()
-                .map_or(false, |expr| is_immutable_annotation(&checker.ctx, expr))
+                .map_or(false, |expr| is_immutable_annotation(&checker.model, expr))
         {
             checker
                 .diagnostics

--- a/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/no_explicit_stacklevel.rs
@@ -45,7 +45,7 @@ pub(crate) fn no_explicit_stacklevel(
     keywords: &[Keyword],
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["warnings", "warn"]

--- a/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/reuse_of_groupby_generator.rs
@@ -342,7 +342,7 @@ pub(crate) fn reuse_of_groupby_generator(
     };
     // Check if the function call is `itertools.groupby`
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["itertools", "groupby"]

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::{is_identifier, is_mangled_private};
 

--- a/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -76,7 +76,7 @@ pub(crate) fn setattr_with_constant(
     if let Stmt::Expr(ast::StmtExpr {
         value: child,
         range: _,
-    }) = &checker.ctx.stmt()
+    }) = &checker.model.stmt()
     {
         if expr == child.as_ref() {
             let mut diagnostic = Diagnostic::new(SetAttrWithConstant, expr.range());

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -26,7 +26,7 @@ pub(crate) fn useless_contextlib_suppress(
 ) {
     if args.is_empty()
         && checker
-            .ctx
+            .model
             .resolve_call_path(func)
             .map_or(false, |call_path| {
                 call_path.as_slice() == ["contextlib", "suppress"]

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_contextlib_suppress.rs
@@ -1,8 +1,9 @@
 use rustpython_parser::ast::{Expr, Ranged};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 #[violation]
 pub struct UselessContextlibSuppress;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/useless_expression.rs
@@ -53,7 +53,7 @@ pub(crate) fn useless_expression(checker: &mut Checker, value: &Expr) {
     }
 
     // Ignore statements that have side effects.
-    if contains_effect(value, |id| checker.ctx.is_builtin(id)) {
+    if contains_effect(value, |id| checker.model.is_builtin(id)) {
         // Flag attributes as useless expressions, even if they're attached to calls or other
         // expressions.
         if matches!(value, Expr::Attribute(_)) {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -1,8 +1,9 @@
 use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 #[violation]
 pub struct ZipWithoutExplicitStrict;

--- a/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/zip_without_explicit_strict.rs
@@ -23,7 +23,7 @@ pub(crate) fn zip_without_explicit_strict(
 ) {
     if let Expr::Name(ast::ExprName { id, .. }) = func {
         if id == "zip"
-            && checker.ctx.is_builtin("zip")
+            && checker.model.is_builtin("zip")
             && !kwargs
                 .iter()
                 .any(|keyword| keyword.arg.as_ref().map_or(false, |name| name == "strict"))

--- a/crates/ruff/src/rules/flake8_builtins/rules.rs
+++ b/crates/ruff/src/rules/flake8_builtins/rules.rs
@@ -1,8 +1,9 @@
+use rustpython_parser::ast::Ranged;
+
 use ruff_diagnostics::Diagnostic;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_stdlib::builtins::BUILTINS;
-use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/flake8_commas/mod.rs
+++ b/crates/ruff/src/rules/flake8_commas/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_comprehensions/mod.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/mod.rs
@@ -7,11 +7,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{self, Expr, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -74,7 +74,7 @@ pub(crate) fn unnecessary_call_around_sorted(
     if inner != "sorted" {
         return;
     }
-    if !checker.ctx.is_builtin(inner) || !checker.ctx.is_builtin(outer) {
+    if !checker.model.is_builtin(inner) || !checker.model.is_builtin(outer) {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_collection_call.rs
@@ -79,7 +79,7 @@ pub(crate) fn unnecessary_collection_call(
         }
         _ => return,
     };
-    if !checker.ctx.is_builtin(id) {
+    if !checker.model.is_builtin(id) {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension.rs
@@ -56,7 +56,7 @@ fn add_diagnostic(checker: &mut Checker, expr: &Expr) {
         Expr::DictComp(_) => "dict",
         _ => return,
     };
-    if !checker.ctx.is_builtin(id) {
+    if !checker.model.is_builtin(id) {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_comprehension_any_all.rs
@@ -76,7 +76,7 @@ pub(crate) fn unnecessary_comprehension_any_all(
         if is_async_generator(elt) {
             return;
         }
-        if !checker.ctx.is_builtin(id) {
+        if !checker.model.is_builtin(id) {
             return;
         }
         let mut diagnostic = Diagnostic::new(UnnecessaryComprehensionAnyAll, args[0].range());

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -90,7 +90,7 @@ pub(crate) fn unnecessary_double_cast_or_process(
     let Some(inner) = helpers::expr_name(func) else {
         return;
     };
-    if !checker.ctx.is_builtin(inner) || !checker.ctx.is_builtin(outer) {
+    if !checker.model.is_builtin(inner) || !checker.model.is_builtin(outer) {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_list.rs
@@ -52,7 +52,7 @@ pub(crate) fn unnecessary_generator_list(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("list", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("list") {
+    if !checker.model.is_builtin("list") {
         return;
     }
     if let Expr::GeneratorExp(_) = argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_generator_set.rs
@@ -53,7 +53,7 @@ pub(crate) fn unnecessary_generator_set(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("set", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("set") {
+    if !checker.model.is_builtin("set") {
         return;
     }
     if let Expr::GeneratorExp(_) = argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{Expr, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -47,7 +47,7 @@ pub(crate) fn unnecessary_list_call(
     let Some(argument) = helpers::first_argument_with_matching_function("list", func, args) else {
         return;
     };
-    if !checker.ctx.is_builtin("list") {
+    if !checker.model.is_builtin("list") {
         return;
     }
     if !argument.is_list_comp_expr() {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -49,7 +49,7 @@ pub(crate) fn unnecessary_list_comprehension_dict(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("dict", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("dict") {
+    if !checker.model.is_builtin("dict") {
         return;
     }
     let Expr::ListComp(ast::ExprListComp { elt, .. }) = argument else {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_dict.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_list_comprehension_set.rs
@@ -50,7 +50,7 @@ pub(crate) fn unnecessary_list_comprehension_set(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("set", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("set") {
+    if !checker.model.is_builtin("set") {
         return;
     }
     if argument.is_list_comp_expr() {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -56,7 +56,7 @@ pub(crate) fn unnecessary_literal_dict(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("dict", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("dict") {
+    if !checker.model.is_builtin("dict") {
         return;
     }
     let (kind, elts) = match argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_dict.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -57,7 +57,7 @@ pub(crate) fn unnecessary_literal_set(
     let Some(argument) = helpers::exactly_one_argument_with_matching_function("set", func, args, keywords) else {
         return;
     };
-    if !checker.ctx.is_builtin("set") {
+    if !checker.model.is_builtin("set") {
         return;
     }
     let kind = match argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_set.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -1,5 +1,6 @@
-use rustpython_parser::ast::{Expr, Keyword, Ranged};
 use std::fmt;
+
+use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_dict_call.rs
@@ -75,7 +75,7 @@ pub(crate) fn unnecessary_literal_within_dict_call(
     let Some(argument) = helpers::first_argument_with_matching_function("dict", func, args) else {
         return;
     };
-    if !checker.ctx.is_builtin("dict") {
+    if !checker.model.is_builtin("dict") {
         return;
     }
     let argument_kind = match argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -78,7 +78,7 @@ pub(crate) fn unnecessary_literal_within_list_call(
     let Some(argument) = helpers::first_argument_with_matching_function("list", func, args) else {
         return;
     };
-    if !checker.ctx.is_builtin("list") {
+    if !checker.model.is_builtin("list") {
         return;
     }
     let argument_kind = match argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_list_call.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -79,7 +79,7 @@ pub(crate) fn unnecessary_literal_within_tuple_call(
     let Some(argument) = helpers::first_argument_with_matching_function("tuple", func, args) else {
         return;
     };
-    if !checker.ctx.is_builtin("tuple") {
+    if !checker.model.is_builtin("tuple") {
         return;
     }
     let argument_kind = match argument {

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_literal_within_tuple_call.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{Expr, Keyword, Ranged};
 
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_macros::{derive_message_formats, violation};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_comprehensions::fixes;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
-use ruff_macros::{derive_message_formats, violation};
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_map.rs
@@ -88,7 +88,7 @@ pub(crate) fn unnecessary_map(
     };
     match id {
         "map" => {
-            if !checker.ctx.is_builtin(id) {
+            if !checker.model.is_builtin(id) {
                 return;
             }
 
@@ -119,7 +119,7 @@ pub(crate) fn unnecessary_map(
             }
         }
         "list" | "set" => {
-            if !checker.ctx.is_builtin(id) {
+            if !checker.model.is_builtin(id) {
                 return;
             }
 
@@ -149,7 +149,7 @@ pub(crate) fn unnecessary_map(
             }
         }
         "dict" => {
-            if !checker.ctx.is_builtin(id) {
+            if !checker.model.is_builtin(id) {
                 return;
             }
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -1,9 +1,10 @@
 use num_bigint::BigInt;
 use rustpython_parser::ast::{self, Constant, Expr, Ranged, Unaryop};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 use super::helpers;
 

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_subscript_reversal.rs
@@ -57,7 +57,7 @@ pub(crate) fn unnecessary_subscript_reversal(
     if !(id == "set" || id == "sorted" || id == "reversed") {
         return;
     }
-    if !checker.ctx.is_builtin(id) {
+    if !checker.model.is_builtin(id) {
         return;
     }
     let Expr::Subscript(ast::ExprSubscript { slice, .. }) = first_arg else {

--- a/crates/ruff/src/rules/flake8_datetimez/mod.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_datetimez/rules.rs
+++ b/crates/ruff/src/rules/flake8_datetimez/rules.rs
@@ -125,7 +125,7 @@ pub(crate) fn call_datetime_without_tzinfo(
     location: TextRange,
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime"]
@@ -158,7 +158,7 @@ pub(crate) fn call_datetime_without_tzinfo(
 /// Use `datetime.datetime.now(tz=)` instead.
 pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: TextRange) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "today"]
@@ -180,7 +180,7 @@ pub(crate) fn call_datetime_today(checker: &mut Checker, func: &Expr, location: 
 /// current time in UTC is by calling `datetime.now(timezone.utc)`.
 pub(crate) fn call_datetime_utcnow(checker: &mut Checker, func: &Expr, location: TextRange) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "utcnow"]
@@ -207,7 +207,7 @@ pub(crate) fn call_datetime_utcfromtimestamp(
     location: TextRange,
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "utcfromtimestamp"]
@@ -228,7 +228,7 @@ pub(crate) fn call_datetime_now_without_tzinfo(
     location: TextRange,
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "now"]
@@ -270,7 +270,7 @@ pub(crate) fn call_datetime_fromtimestamp(
     location: TextRange,
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "fromtimestamp"]
@@ -311,7 +311,7 @@ pub(crate) fn call_datetime_strptime_without_zone(
     location: TextRange,
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "datetime", "strptime"]
@@ -332,7 +332,7 @@ pub(crate) fn call_datetime_strptime_without_zone(
         }
     };
 
-    let (Some(grandparent), Some(parent)) = (checker.ctx.expr_grandparent(), checker.ctx.expr_parent()) else {
+    let (Some(grandparent), Some(parent)) = (checker.model.expr_grandparent(), checker.model.expr_parent()) else {
         checker.diagnostics.push(Diagnostic::new(
             CallDatetimeStrptimeWithoutZone,
             location,
@@ -370,7 +370,7 @@ pub(crate) fn call_datetime_strptime_without_zone(
 /// Use `datetime.datetime.now(tz=).date()` instead.
 pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: TextRange) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "date", "today"]
@@ -390,7 +390,7 @@ pub(crate) fn call_date_today(checker: &mut Checker, func: &Expr, location: Text
 /// Use `datetime.datetime.fromtimestamp(, tz=).date()` instead.
 pub(crate) fn call_date_fromtimestamp(checker: &mut Checker, func: &Expr, location: TextRange) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "date", "fromtimestamp"]

--- a/crates/ruff/src/rules/flake8_debugger/mod.rs
+++ b/crates/ruff/src/rules/flake8_debugger/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -1,10 +1,11 @@
 use rustpython_parser::ast::{Expr, Ranged, Stmt};
 
-use crate::checkers::ast::Checker;
-use crate::rules::flake8_debugger::types::DebuggerUsingType;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::{format_call_path, from_unqualified_name, CallPath};
+
+use crate::checkers::ast::Checker;
+use crate::rules::flake8_debugger::types::DebuggerUsingType;
 
 #[violation]
 pub struct Debugger {

--- a/crates/ruff/src/rules/flake8_debugger/rules.rs
+++ b/crates/ruff/src/rules/flake8_debugger/rules.rs
@@ -42,7 +42,7 @@ const DEBUGGERS: &[&[&str]] = &[
 
 /// Checks for the presence of a debugger call.
 pub(crate) fn debugger_call(checker: &mut Checker, expr: &Expr, func: &Expr) {
-    if let Some(target) = checker.ctx.resolve_call_path(func).and_then(|call_path| {
+    if let Some(target) = checker.model.resolve_call_path(func).and_then(|call_path| {
         DEBUGGERS
             .iter()
             .find(|target| call_path.as_slice() == **target)

--- a/crates/ruff/src/rules/flake8_django/mod.rs
+++ b/crates/ruff/src/rules/flake8_django/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/all_with_model_form.rs
@@ -52,7 +52,7 @@ pub(crate) fn all_with_model_form(
     bases: &[Expr],
     body: &[Stmt],
 ) -> Option<Diagnostic> {
-    if !bases.iter().any(|base| is_model_form(&checker.ctx, base)) {
+    if !bases.iter().any(|base| is_model_form(&checker.model, base)) {
         return None;
     }
     for element in body.iter() {

--- a/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/exclude_with_model_form.rs
@@ -50,7 +50,7 @@ pub(crate) fn exclude_with_model_form(
     bases: &[Expr],
     body: &[Stmt],
 ) -> Option<Diagnostic> {
-    if !bases.iter().any(|base| is_model_form(&checker.ctx, base)) {
+    if !bases.iter().any(|base| is_model_form(&checker.model, base)) {
         return None;
     }
     for element in body.iter() {

--- a/crates/ruff/src/rules/flake8_django/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/helpers.rs
@@ -1,25 +1,25 @@
 use rustpython_parser::ast::Expr;
 
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 /// Return `true` if a Python class appears to be a Django model, based on its base classes.
-pub(crate) fn is_model(context: &Context, base: &Expr) -> bool {
-    context.resolve_call_path(base).map_or(false, |call_path| {
+pub(crate) fn is_model(model: &SemanticModel, base: &Expr) -> bool {
+    model.resolve_call_path(base).map_or(false, |call_path| {
         call_path.as_slice() == ["django", "db", "models", "Model"]
     })
 }
 
 /// Return `true` if a Python class appears to be a Django model form, based on its base classes.
-pub(crate) fn is_model_form(context: &Context, base: &Expr) -> bool {
-    context.resolve_call_path(base).map_or(false, |call_path| {
+pub(crate) fn is_model_form(model: &SemanticModel, base: &Expr) -> bool {
+    model.resolve_call_path(base).map_or(false, |call_path| {
         call_path.as_slice() == ["django", "forms", "ModelForm"]
             || call_path.as_slice() == ["django", "forms", "models", "ModelForm"]
     })
 }
 
 /// Return `true` if the expression is constructor for a Django model field.
-pub(crate) fn is_model_field(context: &Context, expr: &Expr) -> bool {
-    context.resolve_call_path(expr).map_or(false, |call_path| {
+pub(crate) fn is_model_field(model: &SemanticModel, expr: &Expr) -> bool {
+    model.resolve_call_path(expr).map_or(false, |call_path| {
         call_path
             .as_slice()
             .starts_with(&["django", "db", "models"])
@@ -27,8 +27,11 @@ pub(crate) fn is_model_field(context: &Context, expr: &Expr) -> bool {
 }
 
 /// Return the name of the field type, if the expression is constructor for a Django model field.
-pub(crate) fn get_model_field_name<'a>(context: &'a Context, expr: &'a Expr) -> Option<&'a str> {
-    context.resolve_call_path(expr).and_then(|call_path| {
+pub(crate) fn get_model_field_name<'a>(
+    model: &'a SemanticModel,
+    expr: &'a Expr,
+) -> Option<&'a str> {
+    model.resolve_call_path(expr).and_then(|call_path| {
         let call_path = call_path.as_slice();
         if !call_path.starts_with(&["django", "db", "models"]) {
             return None;

--- a/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/locals_in_render_function.rs
@@ -50,7 +50,7 @@ pub(crate) fn locals_in_render_function(
     keywords: &[Keyword],
 ) {
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["django", "shortcuts", "render"]
@@ -87,7 +87,7 @@ fn is_locals_call(checker: &Checker, expr: &Expr) -> bool {
         return false
     };
     checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["", "locals"])
 }

--- a/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/model_without_dunder_str.rs
@@ -84,7 +84,7 @@ fn checker_applies(checker: &Checker, bases: &[Expr], body: &[Stmt]) -> bool {
         if is_model_abstract(body) {
             continue;
         }
-        if helpers::is_model(&checker.ctx, base) {
+        if helpers::is_model(&checker.model, base) {
             return true;
         }
     }

--- a/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/nullable_model_string_field.rs
@@ -84,7 +84,7 @@ fn is_nullable_field<'a>(checker: &'a Checker, value: &'a Expr) -> Option<&'a st
         return None;
     };
 
-    let Some(valid_field_name) = helpers::get_model_field_name(&checker.ctx, func) else {
+    let Some(valid_field_name) = helpers::get_model_field_name(&checker.model, func) else {
         return None;
     };
 

--- a/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
+++ b/crates/ruff/src/rules/flake8_django/rules/unordered_body_content_in_model.rs
@@ -103,7 +103,7 @@ fn get_element_type(checker: &Checker, element: &Stmt) -> Option<ContentType> {
     match element {
         Stmt::Assign(ast::StmtAssign { targets, value, .. }) => {
             if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
-                if helpers::is_model_field(&checker.ctx, func) {
+                if helpers::is_model_field(&checker.model, func) {
                     return Some(ContentType::FieldDeclaration);
                 }
             }
@@ -144,7 +144,7 @@ pub(crate) fn unordered_body_content_in_model(
 ) {
     if !bases
         .iter()
-        .any(|base| helpers::is_model(&checker.ctx, base))
+        .any(|base| helpers::is_model(&checker.model, base))
     {
         return;
     }

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Ranged, Stmt};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::source_code::{Generator, Stylist};
 use ruff_python_ast::whitespace;
 

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -234,7 +234,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                         if string.len() > checker.settings.flake8_errmsg.max_string_length {
                             let indentation = whitespace::indentation(checker.locator, stmt)
                                 .and_then(|indentation| {
-                                    if checker.ctx.find_binding("msg").is_none() {
+                                    if checker.model.find_binding("msg").is_none() {
                                         Some(indentation)
                                     } else {
                                         None
@@ -262,7 +262,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                     if checker.settings.rules.enabled(Rule::FStringInException) {
                         let indentation = whitespace::indentation(checker.locator, stmt).and_then(
                             |indentation| {
-                                if checker.ctx.find_binding("msg").is_none() {
+                                if checker.model.find_binding("msg").is_none() {
                                     Some(indentation)
                                 } else {
                                     None
@@ -293,7 +293,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                             if attr == "format" && value.is_constant_expr() {
                                 let indentation = whitespace::indentation(checker.locator, stmt)
                                     .and_then(|indentation| {
-                                        if checker.ctx.find_binding("msg").is_none() {
+                                        if checker.model.find_binding("msg").is_none() {
                                             Some(indentation)
                                         } else {
                                             None

--- a/crates/ruff/src/rules/flake8_executable/helpers.rs
+++ b/crates/ruff/src/rules/flake8_executable/helpers.rs
@@ -51,11 +51,11 @@ pub(crate) fn is_executable(filepath: &Path) -> Result<bool> {
 
 #[cfg(test)]
 mod tests {
+    use ruff_text_size::TextSize;
+
     use crate::rules::flake8_executable::helpers::{
         extract_shebang, ShebangDirective, SHEBANG_REGEX,
     };
-
-    use ruff_text_size::TextSize;
 
     #[test]
     fn shebang_regex() {

--- a/crates/ruff/src/rules/flake8_executable/mod.rs
+++ b/crates/ruff/src/rules/flake8_executable/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_missing.rs
@@ -1,7 +1,8 @@
 #![allow(unused_imports)]
 
-use ruff_text_size::TextRange;
 use std::path::Path;
+
+use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
+++ b/crates/ruff/src/rules/flake8_executable/rules/shebang_not_executable.rs
@@ -1,7 +1,8 @@
 #![allow(unused_imports)]
 
-use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::path::Path;
+
+use ruff_text_size::{TextLen, TextRange, TextSize};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/flake8_future_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_future_annotations/rules.rs
@@ -67,7 +67,7 @@ impl Violation for MissingFutureAnnotationsImport {
 
 /// FA100
 pub(crate) fn missing_future_annotations(checker: &mut Checker, expr: &Expr) {
-    if let Some(binding) = checker.ctx.resolve_call_path(expr) {
+    if let Some(binding) = checker.model.resolve_call_path(expr) {
         checker.diagnostics.push(Diagnostic::new(
             MissingFutureAnnotationsImport {
                 name: format_call_path(&binding),

--- a/crates/ruff/src/rules/flake8_gettext/mod.rs
+++ b/crates/ruff/src/rules/flake8_gettext/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_implicit_str_concat/mod.rs
+++ b/crates/ruff/src/rules/flake8_implicit_str_concat/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_import_conventions/mod.rs
+++ b/crates/ruff/src/rules/flake8_import_conventions/mod.rs
@@ -6,11 +6,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use rustc_hash::{FxHashMap, FxHashSet};
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -106,7 +106,7 @@ fn check_log_record_attr_clash(checker: &mut Checker, extra: &Keyword) {
         }
         Expr::Call(ast::ExprCall { func, keywords, .. }) => {
             if checker
-                .ctx
+                .model
                 .resolve_call_path(func)
                 .map_or(false, |call_path| call_path.as_slice() == ["", "dict"])
             {
@@ -151,7 +151,7 @@ pub(crate) fn logging_call(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    if !logging::is_logger_candidate(&checker.ctx, func) {
+    if !logging::is_logger_candidate(&checker.model, func) {
         return;
     }
 
@@ -198,7 +198,7 @@ pub(crate) fn logging_call(
                     .rules
                     .enabled(Rule::LoggingRedundantExcInfo)
             {
-                if !checker.ctx.in_exception_handler() {
+                if !checker.model.in_exception_handler() {
                     return;
                 }
                 if let Some(exc_info) = find_keyword(keywords, "exc_info") {
@@ -212,7 +212,7 @@ pub(crate) fn logging_call(
                         })
                     ) || if let Expr::Call(ast::ExprCall { func, .. }) = &exc_info.value {
                         checker
-                            .ctx
+                            .model
                             .resolve_call_path(func)
                             .map_or(false, |call_path| {
                                 call_path.as_slice() == ["sys", "exc_info"]

--- a/crates/ruff/src/rules/flake8_no_pep420/mod.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/mod.rs
@@ -5,11 +5,10 @@ pub(crate) mod rules;
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::{test_path, test_resource_path};

--- a/crates/ruff/src/rules/flake8_no_pep420/rules.rs
+++ b/crates/ruff/src/rules/flake8_no_pep420/rules.rs
@@ -1,5 +1,6 @@
-use ruff_text_size::TextRange;
 use std::path::{Path, PathBuf};
+
+use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/flake8_pie/mod.rs
+++ b/crates/ruff/src/rules/flake8_pie/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_pie/rules.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules.rs
@@ -417,7 +417,7 @@ pub(crate) fn non_unique_enums<'a, 'b>(
 
     if !bases.iter().any(|expr| {
         checker
-            .ctx
+            .model
             .resolve_call_path(expr)
             .map_or(false, |call_path| call_path.as_slice() == ["enum", "Enum"])
     }) {
@@ -432,7 +432,7 @@ pub(crate) fn non_unique_enums<'a, 'b>(
 
         if let Expr::Call(ast::ExprCall { func, .. }) = value.as_ref() {
             if checker
-                .ctx
+                .model
                 .resolve_call_path(func)
                 .map_or(false, |call_path| call_path.as_slice() == ["enum", "auto"])
             {

--- a/crates/ruff/src/rules/flake8_print/mod.rs
+++ b/crates/ruff/src/rules/flake8_print/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -78,7 +78,7 @@ impl Violation for PPrint {
 /// T201, T203
 pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword]) {
     let diagnostic = {
-        let call_path = checker.ctx.resolve_call_path(func);
+        let call_path = checker.model.resolve_call_path(func);
         if call_path
             .as_ref()
             .map_or(false, |call_path| *call_path.as_slice() == ["", "print"])
@@ -91,7 +91,7 @@ pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword
             {
                 if !is_const_none(&keyword.value) {
                     if checker
-                        .ctx
+                        .model
                         .resolve_call_path(&keyword.value)
                         .map_or(true, |call_path| {
                             call_path.as_slice() != ["sys", "stdout"]

--- a/crates/ruff/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff/src/rules/flake8_pyi/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -1,8 +1,9 @@
 use rustpython_parser::ast::{Cmpop, Expr, Ranged};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for usages of comparators other than `<` and `>=` for

--- a/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -68,7 +68,7 @@ pub(crate) fn bad_version_info_comparison(
     };
 
     if !checker
-        .ctx
+        .model
         .resolve_call_path(left)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["sys", "version_info"]

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -1,13 +1,13 @@
-use crate::autofix::actions::delete_stmt;
 use log::error;
+use rustpython_parser::ast::{Ranged, Stmt};
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::types::RefEquality;
 
+use crate::autofix::actions::delete_stmt;
 use crate::checkers::ast::Checker;
-
 use crate::registry::AsRule;
-use rustpython_parser::ast::{Ranged, Stmt};
 
 #[violation]
 pub struct PassInClassBody;

--- a/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/prefix_type_params.rs
@@ -70,12 +70,12 @@ pub(crate) fn prefix_type_params(checker: &mut Checker, value: &Expr, targets: &
     };
 
     if let Expr::Call(ast::ExprCall { func, .. }) = value {
-        let Some(kind) = checker.ctx.resolve_call_path(func).and_then(|call_path| {
-            if checker.ctx.match_typing_call_path(&call_path, "ParamSpec") {
+        let Some(kind) = checker.model.resolve_call_path(func).and_then(|call_path| {
+            if checker.model.match_typing_call_path(&call_path, "ParamSpec") {
                 Some(VarKind::ParamSpec)
-            } else if checker.ctx.match_typing_call_path(&call_path, "TypeVar") {
+            } else if checker.model.match_typing_call_path(&call_path, "TypeVar") {
                 Some(VarKind::TypeVar)
-            } else if checker.ctx.match_typing_call_path(&call_path, "TypeVarTuple") {
+            } else if checker.model.match_typing_call_path(&call_path, "TypeVarTuple") {
                 Some(VarKind::TypeVarTuple)
             } else {
                 None

--- a/crates/ruff/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/quoted_annotation_in_stub.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -103,7 +103,7 @@ pub(crate) fn unrecognized_platform(
     let diagnostic_unrecognized_platform_check =
         Diagnostic::new(UnrecognizedPlatformCheck, expr.range());
     if !checker
-        .ctx
+        .model
         .resolve_call_path(left)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["sys", "platform"]

--- a/crates/ruff/src/rules/flake8_pytest_style/mod.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -184,9 +184,9 @@ pub(crate) fn unittest_assertion(
             if let Ok(unittest_assert) = UnittestAssert::try_from(attr.as_str()) {
                 // We're converting an expression to a statement, so avoid applying the fix if
                 // the assertion is part of a larger expression.
-                let fixable = checker.ctx.stmt().is_expr_stmt()
-                    && checker.ctx.expr_parent().is_none()
-                    && !checker.ctx.scope().kind.is_lambda()
+                let fixable = checker.model.stmt().is_expr_stmt()
+                    && checker.model.expr_parent().is_none()
+                    && !checker.model.scope().kind.is_lambda()
                     && !has_comments_in(expr.range(), checker.locator);
                 let mut diagnostic = Diagnostic::new(
                     PytestUnittestAssertion {
@@ -214,7 +214,7 @@ pub(crate) fn unittest_assertion(
 
 /// PT015
 pub(crate) fn assert_falsy(checker: &mut Checker, stmt: &Stmt, test: &Expr) {
-    if Truthiness::from_expr(test, |id| checker.ctx.is_builtin(id)).is_falsey() {
+    if Truthiness::from_expr(test, |id| checker.model.is_builtin(id)).is_falsey() {
         checker
             .diagnostics
             .push(Diagnostic::new(PytestAssertAlwaysFalse, stmt.range()));

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use anyhow::bail;
 use anyhow::Result;
 use libcst_native::{
@@ -6,7 +8,6 @@ use libcst_native::{
     SmallStatement, Statement, Suite, TrailingWhitespace, UnaryOp, UnaryOperation,
 };
 use rustpython_parser::ast::{self, Boolop, Excepthandler, Expr, Keyword, Ranged, Stmt, Unaryop};
-use std::borrow::Cow;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fail.rs
@@ -19,7 +19,7 @@ impl Violation for PytestFailWithoutMessage {
 }
 
 pub(crate) fn fail_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
-    if is_pytest_fail(&checker.ctx, func) {
+    if is_pytest_fail(&checker.model, func) {
         let call_args = SimpleCallArgs::new(args, keywords);
         let msg = call_args.argument("msg", 0);
 

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -12,7 +12,7 @@ use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{helpers, visitor};
 use ruff_python_semantic::analyze::visibility::is_abstract;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::autofix::actions::remove_argument;
 use crate::checkers::ast::Checker;
@@ -242,9 +242,9 @@ where
     }
 }
 
-fn get_fixture_decorator<'a>(context: &Context, decorators: &'a [Expr]) -> Option<&'a Expr> {
+fn get_fixture_decorator<'a>(model: &SemanticModel, decorators: &'a [Expr]) -> Option<&'a Expr> {
     decorators.iter().find(|decorator| {
-        is_pytest_fixture(context, decorator) || is_pytest_yield_fixture(context, decorator)
+        is_pytest_fixture(model, decorator) || is_pytest_yield_fixture(model, decorator)
     })
 }
 
@@ -456,7 +456,7 @@ fn check_test_function_args(checker: &mut Checker, args: &Arguments) {
 
 /// PT020
 fn check_fixture_decorator_name(checker: &mut Checker, decorator: &Expr) {
-    if is_pytest_yield_fixture(&checker.ctx, decorator) {
+    if is_pytest_yield_fixture(&checker.model, decorator) {
         checker.diagnostics.push(Diagnostic::new(
             PytestDeprecatedYieldFixture,
             decorator.range(),
@@ -532,7 +532,7 @@ pub(crate) fn fixture(
     decorators: &[Expr],
     body: &[Stmt],
 ) {
-    let decorator = get_fixture_decorator(&checker.ctx, decorators);
+    let decorator = get_fixture_decorator(&checker.model, decorators);
     if let Some(decorator) = decorator {
         if checker
             .settings
@@ -571,7 +571,7 @@ pub(crate) fn fixture(
                 .settings
                 .rules
                 .enabled(Rule::PytestUselessYieldFixture))
-            && !is_abstract(&checker.ctx, decorators)
+            && !is_abstract(&checker.model, decorators)
         {
             check_fixture_returns(checker, stmt, name, body);
         }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -1,7 +1,8 @@
+use std::fmt;
+
 use anyhow::Result;
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ast::{self, Arguments, Expr, Keyword, Ranged, Stmt};
-use std::fmt;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/helpers.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword};
 
 use ruff_python_ast::call_path::{collect_call_path, CallPath};
 use ruff_python_ast::helpers::map_callable;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 pub(super) fn get_mark_decorators(decorators: &[Expr]) -> impl Iterator<Item = (&Expr, CallPath)> {
     decorators.iter().filter_map(|decorator| {
@@ -17,30 +17,30 @@ pub(super) fn get_mark_decorators(decorators: &[Expr]) -> impl Iterator<Item = (
     })
 }
 
-pub(super) fn is_pytest_fail(context: &Context, call: &Expr) -> bool {
-    context.resolve_call_path(call).map_or(false, |call_path| {
+pub(super) fn is_pytest_fail(model: &SemanticModel, call: &Expr) -> bool {
+    model.resolve_call_path(call).map_or(false, |call_path| {
         call_path.as_slice() == ["pytest", "fail"]
     })
 }
 
-pub(super) fn is_pytest_fixture(context: &Context, decorator: &Expr) -> bool {
-    context
+pub(super) fn is_pytest_fixture(model: &SemanticModel, decorator: &Expr) -> bool {
+    model
         .resolve_call_path(map_callable(decorator))
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pytest", "fixture"]
         })
 }
 
-pub(super) fn is_pytest_yield_fixture(context: &Context, decorator: &Expr) -> bool {
-    context
+pub(super) fn is_pytest_yield_fixture(model: &SemanticModel, decorator: &Expr) -> bool {
+    model
         .resolve_call_path(map_callable(decorator))
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pytest", "yield_fixture"]
         })
 }
 
-pub(super) fn is_pytest_parametrize(context: &Context, decorator: &Expr) -> bool {
-    context
+pub(super) fn is_pytest_parametrize(model: &SemanticModel, decorator: &Expr) -> bool {
+    model
         .resolve_call_path(map_callable(decorator))
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pytest", "mark", "parametrize"]

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -416,7 +416,7 @@ fn handle_value_rows(
 
 pub(crate) fn parametrize(checker: &mut Checker, decorators: &[Expr]) {
     for decorator in decorators {
-        if is_pytest_parametrize(&checker.ctx, decorator) {
+        if is_pytest_parametrize(&checker.model, decorator) {
             if let Expr::Call(ast::ExprCall { args, .. }) = decorator {
                 if checker
                     .settings

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -48,7 +48,7 @@ impl Violation for PytestRaisesWithoutException {
 
 fn is_pytest_raises(checker: &Checker, func: &Expr) -> bool {
     checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["pytest", "raises"]
@@ -147,7 +147,7 @@ pub(crate) fn complex_raises(
 /// PT011
 fn exception_needs_match(checker: &mut Checker, exception: &Expr) {
     if let Some(call_path) = checker
-        .ctx
+        .model
         .resolve_call_path(exception)
         .and_then(|call_path| {
             let is_broad_exception = checker

--- a/crates/ruff/src/rules/flake8_pytest_style/types.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/types.rs
@@ -1,6 +1,8 @@
-use ruff_macros::CacheKey;
-use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use ruff_macros::CacheKey;
 
 #[derive(Clone, Copy, Debug, CacheKey, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/ruff/src/rules/flake8_quotes/mod.rs
+++ b/crates/ruff/src/rules/flake8_quotes/mod.rs
@@ -6,11 +6,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_raise/mod.rs
+++ b/crates/ruff/src/rules/flake8_raise/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_return/mod.rs
+++ b/crates/ruff/src/rules/flake8_return/mod.rs
@@ -8,11 +8,10 @@ mod visitor;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/flake8_self/mod.rs
+++ b/crates/ruff/src/rules/flake8_self/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
+++ b/crates/ruff/src/rules/flake8_self/rules/private_member_access.rs
@@ -94,7 +94,7 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
 
                     // Ignore accesses on class members from _within_ the class.
                     if checker
-                        .ctx
+                        .model
                         .scopes
                         .iter()
                         .rev()
@@ -104,14 +104,14 @@ pub(crate) fn private_member_access(checker: &mut Checker, expr: &Expr) {
                         })
                         .map_or(false, |class_def| {
                             if call_path.as_slice() == [class_def.name] {
-                                checker
-                                    .ctx
-                                    .find_binding(class_def.name)
-                                    .map_or(false, |binding| {
+                                checker.model.find_binding(class_def.name).map_or(
+                                    false,
+                                    |binding| {
                                         // TODO(charlie): Could the name ever be bound to a
                                         // _different_ class here?
                                         binding.kind.is_class_definition()
-                                    })
+                                    },
+                                )
                             } else {
                                 false
                             }

--- a/crates/ruff/src/rules/flake8_simplify/mod.rs
+++ b/crates/ruff/src/rules/flake8_simplify/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -271,7 +271,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
         if func_name != "isinstance" {
             continue;
         }
-        if !checker.ctx.is_builtin("isinstance") {
+        if !checker.model.is_builtin("isinstance") {
             continue;
         }
 
@@ -293,7 +293,7 @@ pub(crate) fn duplicate_isinstance_call(checker: &mut Checker, expr: &Expr) {
             } else {
                 unreachable!("Indices should only contain `isinstance` calls")
             };
-            let fixable = !contains_effect(target, |id| checker.ctx.is_builtin(id));
+            let fixable = !contains_effect(target, |id| checker.model.is_builtin(id));
             let mut diagnostic = Diagnostic::new(
                 DuplicateIsinstanceCall {
                     name: if let Expr::Name(ast::ExprName { id, .. }) = target {
@@ -425,7 +425,7 @@ pub(crate) fn compare_with_tuple(checker: &mut Checker, expr: &Expr) {
         // Avoid rewriting (e.g.) `a == "foo" or a == f()`.
         if comparators
             .iter()
-            .any(|expr| contains_effect(expr, |id| checker.ctx.is_builtin(id)))
+            .any(|expr| contains_effect(expr, |id| checker.model.is_builtin(id)))
         {
             continue;
         }
@@ -516,7 +516,7 @@ pub(crate) fn expr_and_not_expr(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if contains_effect(expr, |id| checker.ctx.is_builtin(id)) {
+    if contains_effect(expr, |id| checker.model.is_builtin(id)) {
         return;
     }
 
@@ -571,7 +571,7 @@ pub(crate) fn expr_or_not_expr(checker: &mut Checker, expr: &Expr) {
         return;
     }
 
-    if contains_effect(expr, |id| checker.ctx.is_builtin(id)) {
+    if contains_effect(expr, |id| checker.model.is_builtin(id)) {
         return;
     }
 
@@ -640,14 +640,14 @@ fn is_short_circuit(
 
     for (index, (value, next_value)) in values.iter().tuple_windows().enumerate() {
         // Keep track of the location of the furthest-right, truthy or falsey expression.
-        let value_truthiness = Truthiness::from_expr(value, |id| checker.ctx.is_builtin(id));
+        let value_truthiness = Truthiness::from_expr(value, |id| checker.model.is_builtin(id));
         let next_value_truthiness =
-            Truthiness::from_expr(next_value, |id| checker.ctx.is_builtin(id));
+            Truthiness::from_expr(next_value, |id| checker.model.is_builtin(id));
 
         // Keep track of the location of the furthest-right, non-effectful expression.
         if value_truthiness.is_unknown()
-            && (!checker.ctx.in_boolean_test()
-                || contains_effect(value, |id| checker.ctx.is_builtin(id)))
+            && (!checker.model.in_boolean_test()
+                || contains_effect(value, |id| checker.model.is_builtin(id)))
         {
             location = next_value.start();
             continue;
@@ -667,7 +667,7 @@ fn is_short_circuit(
                 value,
                 TextRange::new(location, expr.end()),
                 short_circuit_truthiness,
-                checker.ctx.in_boolean_test(),
+                checker.model.in_boolean_test(),
                 checker,
             ));
             break;
@@ -685,7 +685,7 @@ fn is_short_circuit(
                 next_value,
                 TextRange::new(location, expr.end()),
                 short_circuit_truthiness,
-                checker.ctx.in_boolean_test(),
+                checker.model.in_boolean_test(),
                 checker,
             ));
             break;

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -87,7 +87,7 @@ pub(crate) fn use_capital_environment_variables(checker: &mut Checker, expr: &Ex
         return;
     };
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["os", "environ", "get"]

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_if.rs
@@ -11,7 +11,7 @@ use ruff_python_ast::helpers::{
     any_over_expr, contains_effect, first_colon_range, has_comments, has_comments_in,
 };
 use ruff_python_ast::newlines::StrExt;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -351,7 +351,7 @@ pub(crate) fn needless_bool(checker: &mut Checker, stmt: &Stmt) {
     let fixable = matches!(if_return, Bool::True)
         && matches!(else_return, Bool::False)
         && !has_comments(stmt, checker.locator)
-        && (test.is_compare_expr() || checker.ctx.is_builtin("bool"));
+        && (test.is_compare_expr() || checker.model.is_builtin("bool"));
 
     let mut diagnostic = Diagnostic::new(NeedlessBool { condition }, stmt.range());
     if fixable && checker.patch(diagnostic.kind.rule()) {
@@ -411,9 +411,10 @@ fn ternary(target_var: &Expr, body_value: &Expr, test: &Expr, orelse_value: &Exp
 }
 
 /// Return `true` if the `Expr` contains a reference to `${module}.${target}`.
-fn contains_call_path(ctx: &Context, expr: &Expr, target: &[&str]) -> bool {
+fn contains_call_path(model: &SemanticModel, expr: &Expr, target: &[&str]) -> bool {
     any_over_expr(expr, &|expr| {
-        ctx.resolve_call_path(expr)
+        model
+            .resolve_call_path(expr)
             .map_or(false, |call_path| call_path.as_slice() == target)
     })
 }
@@ -446,13 +447,13 @@ pub(crate) fn use_ternary_operator(checker: &mut Checker, stmt: &Stmt, parent: O
     }
 
     // Avoid suggesting ternary for `if sys.version_info >= ...`-style checks.
-    if contains_call_path(&checker.ctx, test, &["sys", "version_info"]) {
+    if contains_call_path(&checker.model, test, &["sys", "version_info"]) {
         return;
     }
 
     // Avoid suggesting ternary for `if sys.platform.startswith("...")`-style
     // checks.
-    if contains_call_path(&checker.ctx, test, &["sys", "platform"]) {
+    if contains_call_path(&checker.model, test, &["sys", "platform"]) {
         return;
     }
 
@@ -647,7 +648,7 @@ pub(crate) fn manual_dict_lookup(
         return;
     };
     if value.as_ref().map_or(false, |value| {
-        contains_effect(value, |id| checker.ctx.is_builtin(id))
+        contains_effect(value, |id| checker.model.is_builtin(id))
     }) {
         return;
     }
@@ -720,7 +721,7 @@ pub(crate) fn manual_dict_lookup(
             return;
         };
         if value.as_ref().map_or(false, |value| {
-            contains_effect(value, |id| checker.ctx.is_builtin(id))
+            contains_effect(value, |id| checker.model.is_builtin(id))
         }) {
             return;
         };
@@ -803,7 +804,7 @@ pub(crate) fn use_dict_get_with_default(
     }
 
     // Check that the default value is not "complex".
-    if contains_effect(default_value, |id| checker.ctx.is_builtin(id)) {
+    if contains_effect(default_value, |id| checker.model.is_builtin(id)) {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -107,7 +107,7 @@ pub(crate) fn explicit_true_false_in_ifexpr(
                 checker.generator().expr(&test.clone()),
                 expr.range(),
             )));
-        } else if checker.ctx.is_builtin("bool") {
+        } else if checker.model.is_builtin("bool") {
             let node = ast::ExprName {
                 id: "bool".into(),
                 ctx: ExprContext::Load,

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -94,12 +94,12 @@ pub(crate) fn negation_with_equal_op(
     if !matches!(&ops[..], [Cmpop::Eq]) {
         return;
     }
-    if is_exception_check(checker.ctx.stmt()) {
+    if is_exception_check(checker.model.stmt()) {
         return;
     }
 
     // Avoid flagging issues in dunder implementations.
-    if let ScopeKind::Function(def) = &checker.ctx.scope().kind {
+    if let ScopeKind::Function(def) = &checker.model.scope().kind {
         if DUNDER_METHODS.contains(&def.name) {
             return;
         }
@@ -144,12 +144,12 @@ pub(crate) fn negation_with_not_equal_op(
     if !matches!(&ops[..], [Cmpop::NotEq]) {
         return;
     }
-    if is_exception_check(checker.ctx.stmt()) {
+    if is_exception_check(checker.model.stmt()) {
         return;
     }
 
     // Avoid flagging issues in dunder implementations.
-    if let ScopeKind::Function(def) = &checker.ctx.scope().kind {
+    if let ScopeKind::Function(def) = &checker.model.scope().kind {
         if DUNDER_METHODS.contains(&def.name) {
             return;
         }
@@ -197,13 +197,13 @@ pub(crate) fn double_negation(checker: &mut Checker, expr: &Expr, op: Unaryop, o
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        if checker.ctx.in_boolean_test() {
+        if checker.model.in_boolean_test() {
             #[allow(deprecated)]
             diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
                 checker.generator().expr(operand),
                 expr.range(),
             )));
-        } else if checker.ctx.is_builtin("bool") {
+        } else if checker.model.is_builtin("bool") {
             let node = ast::ExprName {
                 id: "bool".into(),
                 ctx: ExprContext::Load,

--- a/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Cmpop, Expr, ExprContext, Ranged, Stmt, Unary
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_semantic::scope::ScopeKind;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use anyhow::{bail, Result};
 use libcst_native::{
     BooleanOp, BooleanOperation, Codegen, CodegenState, CompoundStatement, Expression, If,
@@ -5,7 +7,6 @@ use libcst_native::{
     Statement, Suite,
 };
 use rustpython_parser::ast::Ranged;
-use std::borrow::Cow;
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -238,7 +238,7 @@ pub(crate) fn convert_for_loop_to_any_all(
                     },
                     TextRange::new(stmt.start(), loop_info.terminal),
                 );
-                if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("any") {
+                if checker.patch(diagnostic.kind.rule()) && checker.model.is_builtin("any") {
                     #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,
@@ -328,7 +328,7 @@ pub(crate) fn convert_for_loop_to_any_all(
                     },
                     TextRange::new(stmt.start(), loop_info.terminal),
                 );
-                if checker.patch(diagnostic.kind.rule()) && checker.ctx.is_builtin("all") {
+                if checker.patch(diagnostic.kind.rule()) && checker.model.is_builtin("all") {
                     #[allow(deprecated)]
                     diagnostic.set_fix(Fix::unspecified(Edit::replacement(
                         contents,

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -6,7 +6,6 @@ use unicode_width::UnicodeWidthStr;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::source_code::Generator;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -93,7 +93,7 @@ pub(crate) fn suppressible_exception(
                         "contextlib",
                         "suppress",
                         stmt.start(),
-                        &checker.ctx,
+                        &checker.model,
                         &checker.importer,
                         checker.locator,
                     )?;

--- a/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
+++ b/crates/ruff/src/rules/flake8_tidy_imports/banned_api.rs
@@ -96,7 +96,7 @@ where
 /// TID251
 pub(crate) fn banned_attribute_access(checker: &mut Checker, expr: &Expr) {
     let banned_api = &checker.settings.flake8_tidy_imports.banned_api;
-    if let Some((banned_path, ban)) = checker.ctx.resolve_call_path(expr).and_then(|call_path| {
+    if let Some((banned_path, ban)) = checker.model.resolve_call_path(expr).and_then(|call_path| {
         banned_api
             .iter()
             .find(|(banned_path, ..)| call_path == from_qualified_name(banned_path))

--- a/crates/ruff/src/rules/flake8_type_checking/mod.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -60,7 +60,7 @@ pub(crate) fn empty_type_checking_block<'a, 'b>(
 
         // Delete the entire type-checking block.
         if checker.patch(diagnostic.kind.rule()) {
-            let parent = checker.ctx.stmts.parent(stmt);
+            let parent = checker.model.stmts.parent(stmt);
             let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
             match delete_stmt(
                 stmt,

--- a/crates/ruff/src/rules/flake8_unused_arguments/mod.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
@@ -289,7 +289,7 @@ pub(crate) fn unused_arguments(
             ..
         }) => {
             match function_type::classify(
-                &checker.ctx,
+                &checker.model,
                 parent,
                 name,
                 decorator_list,
@@ -301,7 +301,7 @@ pub(crate) fn unused_arguments(
                         .settings
                         .rules
                         .enabled(Argumentable::Function.rule_code())
-                        && !visibility::is_overload(&checker.ctx, decorator_list)
+                        && !visibility::is_overload(&checker.model, decorator_list)
                     {
                         function(
                             Argumentable::Function,
@@ -328,9 +328,9 @@ pub(crate) fn unused_arguments(
                             || visibility::is_init(name)
                             || visibility::is_new(name)
                             || visibility::is_call(name))
-                        && !visibility::is_abstract(&checker.ctx, decorator_list)
-                        && !visibility::is_override(&checker.ctx, decorator_list)
-                        && !visibility::is_overload(&checker.ctx, decorator_list)
+                        && !visibility::is_abstract(&checker.model, decorator_list)
+                        && !visibility::is_override(&checker.model, decorator_list)
+                        && !visibility::is_overload(&checker.model, decorator_list)
                     {
                         method(
                             Argumentable::Method,
@@ -357,9 +357,9 @@ pub(crate) fn unused_arguments(
                             || visibility::is_init(name)
                             || visibility::is_new(name)
                             || visibility::is_call(name))
-                        && !visibility::is_abstract(&checker.ctx, decorator_list)
-                        && !visibility::is_override(&checker.ctx, decorator_list)
-                        && !visibility::is_overload(&checker.ctx, decorator_list)
+                        && !visibility::is_abstract(&checker.model, decorator_list)
+                        && !visibility::is_override(&checker.model, decorator_list)
+                        && !visibility::is_overload(&checker.model, decorator_list)
                     {
                         method(
                             Argumentable::ClassMethod,
@@ -386,9 +386,9 @@ pub(crate) fn unused_arguments(
                             || visibility::is_init(name)
                             || visibility::is_new(name)
                             || visibility::is_call(name))
-                        && !visibility::is_abstract(&checker.ctx, decorator_list)
-                        && !visibility::is_override(&checker.ctx, decorator_list)
-                        && !visibility::is_overload(&checker.ctx, decorator_list)
+                        && !visibility::is_abstract(&checker.model, decorator_list)
+                        && !visibility::is_override(&checker.model, decorator_list)
+                        && !visibility::is_overload(&checker.model, decorator_list)
                     {
                         function(
                             Argumentable::StaticMethod,

--- a/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
@@ -1,5 +1,7 @@
 use rustpython_parser::ast::{Expr, Ranged};
 
+use ruff_diagnostics::{Diagnostic, DiagnosticKind};
+
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 use crate::rules::flake8_use_pathlib::violations::{
@@ -9,7 +11,6 @@ use crate::rules::flake8_use_pathlib::violations::{
     OsRmdir, OsStat, OsUnlink, PathlibReplace, PyPath,
 };
 use crate::settings::types::PythonVersion;
-use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 
 pub(crate) fn replaceable_by_pathlib(checker: &mut Checker, expr: &Expr) {
     if let Some(diagnostic_kind) =

--- a/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
@@ -14,7 +14,7 @@ use ruff_diagnostics::{Diagnostic, DiagnosticKind};
 pub(crate) fn replaceable_by_pathlib(checker: &mut Checker, expr: &Expr) {
     if let Some(diagnostic_kind) =
         checker
-            .ctx
+            .model
             .resolve_call_path(expr)
             .and_then(|call_path| match call_path.as_slice() {
                 ["os", "path", "abspath"] => Some(OsPathAbspath.into()),

--- a/crates/ruff/src/rules/flynt/rules/mod.rs
+++ b/crates/ruff/src/rules/flynt/rules/mod.rs
@@ -1,3 +1,3 @@
-mod static_join_to_fstring;
-
 pub(crate) use static_join_to_fstring::{static_join_to_fstring, StaticJoinToFString};
+
+mod static_join_to_fstring;

--- a/crates/ruff/src/rules/isort/comments.rs
+++ b/crates/ruff/src/rules/isort/comments.rs
@@ -1,6 +1,6 @@
-use ruff_text_size::{TextRange, TextSize};
 use std::borrow::Cow;
 
+use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::{lexer, Mode, Tok};
 
 use ruff_python_ast::source_code::Locator;

--- a/crates/ruff/src/rules/isort/format.rs
+++ b/crates/ruff/src/rules/isort/format.rs
@@ -1,5 +1,6 @@
-use ruff_python_ast::source_code::Stylist;
 use unicode_width::UnicodeWidthStr;
+
+use ruff_python_ast::source_code::Stylist;
 
 use super::types::{AliasData, CommentSet, ImportFromData, Importable};
 

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -282,12 +282,11 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
-    use crate::message::Message;
     use rustc_hash::FxHashMap;
     use test_case::test_case;
 
     use crate::assert_messages;
+    use crate::message::Message;
     use crate::registry::Rule;
     use crate::rules::isort::categorize::{ImportSection, KnownModules};
     use crate::settings::Settings;

--- a/crates/ruff/src/rules/isort/normalize.rs
+++ b/crates/ruff/src/rules/isort/normalize.rs
@@ -1,5 +1,6 @@
-use crate::rules::isort::types::TrailingComma;
 use std::collections::BTreeSet;
+
+use crate::rules::isort::types::TrailingComma;
 
 use super::types::{AliasData, ImportBlock, ImportFromData};
 use super::AnnotatedImport;

--- a/crates/ruff/src/rules/mccabe/mod.rs
+++ b/crates/ruff/src/rules/mccabe/mod.rs
@@ -6,11 +6,10 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::settings::Settings;
     use crate::test::test_path;

--- a/crates/ruff/src/rules/mccabe/settings.rs
+++ b/crates/ruff/src/rules/mccabe/settings.rs
@@ -1,7 +1,8 @@
 //! Settings for the `mccabe` plugin.
 
-use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 #[derive(
     Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,

--- a/crates/ruff/src/rules/numpy/mod.rs
+++ b/crates/ruff/src/rules/numpy/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
+++ b/crates/ruff/src/rules/numpy/rules/deprecated_type_alias.rs
@@ -48,7 +48,7 @@ impl AlwaysAutofixableViolation for NumpyDeprecatedTypeAlias {
 
 /// NPY001
 pub(crate) fn deprecated_type_alias(checker: &mut Checker, expr: &Expr) {
-    if let Some(type_name) = checker.ctx.resolve_call_path(expr).and_then(|call_path| {
+    if let Some(type_name) = checker.model.resolve_call_path(expr).and_then(|call_path| {
         if call_path.as_slice() == ["numpy", "bool"]
             || call_path.as_slice() == ["numpy", "int"]
             || call_path.as_slice() == ["numpy", "float"]

--- a/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
+++ b/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
@@ -57,7 +57,7 @@ impl Violation for NumpyLegacyRandom {
 
 /// NPY002
 pub(crate) fn numpy_legacy_random(checker: &mut Checker, expr: &Expr) {
-    if let Some(method_name) = checker.ctx.resolve_call_path(expr).and_then(|call_path| {
+    if let Some(method_name) = checker.model.resolve_call_path(expr).and_then(|call_path| {
         // seeding state
         if call_path.as_slice() == ["numpy", "random", "seed"]
             || call_path.as_slice() == ["numpy", "random", "get_state"]

--- a/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
+++ b/crates/ruff/src/rules/numpy/rules/numpy_legacy_random.rs
@@ -1,8 +1,9 @@
 use rustpython_parser::ast::{Expr, Ranged};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for the use of legacy `np.random` function calls.

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,5 +1,5 @@
 use ruff_python_semantic::binding::{BindingKind, Importation};
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 use rustpython_parser::ast;
 use rustpython_parser::ast::Expr;
 
@@ -15,7 +15,7 @@ pub(crate) enum Resolution {
 }
 
 /// Test an [`Expr`] for relevance to Pandas-related operations.
-pub(crate) fn test_expression(expr: &Expr, context: &Context) -> Resolution {
+pub(crate) fn test_expression(expr: &Expr, model: &SemanticModel) -> Resolution {
     match expr {
         Expr::Constant(_)
         | Expr::Tuple(_)
@@ -27,7 +27,7 @@ pub(crate) fn test_expression(expr: &Expr, context: &Context) -> Resolution {
         | Expr::DictComp(_)
         | Expr::GeneratorExp(_) => Resolution::IrrelevantExpression,
         Expr::Name(ast::ExprName { id, .. }) => {
-            context
+            model
                 .find_binding(id)
                 .map_or(Resolution::IrrelevantBinding, |binding| {
                     match binding.kind {

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -1,7 +1,8 @@
-use ruff_python_semantic::binding::{BindingKind, Importation};
-use ruff_python_semantic::model::SemanticModel;
 use rustpython_parser::ast;
 use rustpython_parser::ast::Expr;
+
+use ruff_python_semantic::binding::{BindingKind, Importation};
+use ruff_python_semantic::model::SemanticModel;
 
 pub(crate) enum Resolution {
     /// The expression resolves to an irrelevant expression type (e.g., a constant).

--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use rustpython_parser::lexer::LexResult;
     use test_case::test_case;
     use textwrap::dedent;

--- a/crates/ruff/src/rules/pandas_vet/rules/attr.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/attr.rs
@@ -26,7 +26,7 @@ pub(crate) fn attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &
     };
 
     // Avoid flagging on function calls (e.g., `df.values()`).
-    if let Some(parent) = checker.ctx.expr_parent() {
+    if let Some(parent) = checker.model.expr_parent() {
         if matches!(parent, Expr::Call(_)) {
             return;
         }
@@ -35,7 +35,7 @@ pub(crate) fn attr(checker: &mut Checker, attr: &str, value: &Expr, attr_expr: &
     // Avoid flagging on non-DataFrames (e.g., `{"a": 1}.values`), and on irrelevant bindings
     // (like imports).
     if !matches!(
-        test_expression(value, &checker.ctx),
+        test_expression(value, &checker.model),
         Resolution::RelevantLocal
     ) {
         return;

--- a/crates/ruff/src/rules/pandas_vet/rules/call.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/call.rs
@@ -80,7 +80,7 @@ pub(crate) fn call(checker: &mut Checker, func: &Expr) {
 
     // Ignore irrelevant bindings (like imports).
     if !matches!(
-        test_expression(value, &checker.ctx),
+        test_expression(value, &checker.model),
         Resolution::RelevantLocal | Resolution::PandasModule
     ) {
         return;

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -60,11 +60,11 @@ pub(crate) fn inplace_argument(
     let mut is_checkable = false;
     let mut is_pandas = false;
 
-    if let Some(call_path) = checker.ctx.resolve_call_path(func) {
+    if let Some(call_path) = checker.model.resolve_call_path(func) {
         is_checkable = true;
 
         let module = call_path[0];
-        is_pandas = checker.ctx.find_binding(module).map_or(false, |binding| {
+        is_pandas = checker.model.find_binding(module).map_or(false, |binding| {
             matches!(
                 binding.kind,
                 BindingKind::Importation(Importation {
@@ -99,9 +99,9 @@ pub(crate) fn inplace_argument(
                 //    but we don't currently restore expression stacks when parsing deferred nodes,
                 //    and so the parent is lost.
                 let fixable = !seen_star
-                    && checker.ctx.stmt().is_expr_stmt()
-                    && checker.ctx.expr_parent().is_none()
-                    && !checker.ctx.scope().kind.is_lambda();
+                    && checker.model.stmt().is_expr_stmt()
+                    && checker.model.expr_parent().is_none()
+                    && !checker.model.scope().kind.is_lambda();
                 let mut diagnostic = Diagnostic::new(PandasUseOfInplaceArgument, keyword.range());
                 if fixable && checker.patch(diagnostic.kind.rule()) {
                     if let Some(fix) = convert_inplace_argument_to_assignment(

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -1,8 +1,8 @@
-use ruff_python_semantic::binding::{BindingKind, Importation};
 use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_semantic::binding::{BindingKind, Importation};
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;

--- a/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/subscript.rs
@@ -54,7 +54,7 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, expr: &Expr) {
     // Avoid flagging on non-DataFrames (e.g., `{"a": 1}.at[0]`), and on irrelevant bindings
     // (like imports).
     if !matches!(
-        test_expression(value, &checker.ctx),
+        test_expression(value, &checker.model),
         Resolution::RelevantLocal
     ) {
         return;

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
-use ruff_python_semantic::model::SemanticModel;
 use rustpython_parser::ast::{self, Expr, Stmt};
 
+use ruff_python_semantic::model::SemanticModel;
 use ruff_python_stdlib::str::{is_lower, is_upper};
 
 pub(crate) fn is_camelcase(name: &str) -> bool {

--- a/crates/ruff/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff/src/rules/pep8_naming/helpers.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 use rustpython_parser::ast::{self, Expr, Stmt};
 
 use ruff_python_stdlib::str::{is_lower, is_upper};
@@ -22,14 +22,14 @@ pub(crate) fn is_acronym(name: &str, asname: &str) -> bool {
     name.chars().filter(|c| c.is_uppercase()).join("") == asname
 }
 
-pub(crate) fn is_named_tuple_assignment(context: &Context, stmt: &Stmt) -> bool {
+pub(crate) fn is_named_tuple_assignment(model: &SemanticModel, stmt: &Stmt) -> bool {
     let Stmt::Assign(ast::StmtAssign { value, .. }) = stmt else {
         return false;
     };
     let Expr::Call(ast::ExprCall {func, ..}) = value.as_ref() else {
         return false;
     };
-    context.resolve_call_path(func).map_or(false, |call_path| {
+    model.resolve_call_path(func).map_or(false, |call_path| {
         matches!(
             call_path.as_slice(),
             ["collections", "namedtuple"] | ["typing", "NamedTuple"]
@@ -37,35 +37,35 @@ pub(crate) fn is_named_tuple_assignment(context: &Context, stmt: &Stmt) -> bool 
     })
 }
 
-pub(crate) fn is_typed_dict_assignment(context: &Context, stmt: &Stmt) -> bool {
+pub(crate) fn is_typed_dict_assignment(model: &SemanticModel, stmt: &Stmt) -> bool {
     let Stmt::Assign(ast::StmtAssign { value, .. }) = stmt else {
         return false;
     };
     let Expr::Call(ast::ExprCall {func, ..}) = value.as_ref() else {
         return false;
     };
-    context.resolve_call_path(func).map_or(false, |call_path| {
+    model.resolve_call_path(func).map_or(false, |call_path| {
         call_path.as_slice() == ["typing", "TypedDict"]
     })
 }
 
-pub(crate) fn is_type_var_assignment(context: &Context, stmt: &Stmt) -> bool {
+pub(crate) fn is_type_var_assignment(model: &SemanticModel, stmt: &Stmt) -> bool {
     let Stmt::Assign(ast::StmtAssign { value, .. }) = stmt else {
         return false;
     };
     let Expr::Call(ast::ExprCall {func, ..}) = value.as_ref() else {
         return false;
     };
-    context.resolve_call_path(func).map_or(false, |call_path| {
+    model.resolve_call_path(func).map_or(false, |call_path| {
         call_path.as_slice() == ["typing", "TypeVar"]
             || call_path.as_slice() == ["typing", "NewType"]
     })
 }
 
-pub(crate) fn is_typed_dict_class(context: &Context, bases: &[Expr]) -> bool {
+pub(crate) fn is_typed_dict_class(model: &SemanticModel, bases: &[Expr]) -> bool {
     bases
         .iter()
-        .any(|base| context.match_typing_expr(base, "TypedDict"))
+        .any(|base| model.match_typing_expr(base, "TypedDict"))
 }
 
 #[cfg(test)]

--- a/crates/ruff/src/rules/pep8_naming/mod.rs
+++ b/crates/ruff/src/rules/pep8_naming/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_class_method.rs
@@ -64,7 +64,7 @@ pub(crate) fn invalid_first_argument_name_for_class_method(
 ) -> Option<Diagnostic> {
     if !matches!(
         function_type::classify(
-            &checker.ctx,
+            &checker.model,
             scope,
             name,
             decorator_list,

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_first_argument_name_for_method.rs
@@ -61,7 +61,7 @@ pub(crate) fn invalid_first_argument_name_for_method(
 ) -> Option<Diagnostic> {
     if !matches!(
         function_type::classify(
-            &checker.ctx,
+            &checker.model,
             scope,
             name,
             decorator_list,

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_function_name.rs
@@ -5,7 +5,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::identifier_range;
 use ruff_python_ast::source_code::Locator;
 use ruff_python_semantic::analyze::visibility;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 /// ## What it does
 /// Checks for functions names that do not follow the `snake_case` naming
@@ -53,7 +53,7 @@ pub(crate) fn invalid_function_name(
     name: &str,
     decorator_list: &[Expr],
     ignore_names: &[String],
-    ctx: &Context,
+    model: &SemanticModel,
     locator: &Locator,
 ) -> Option<Diagnostic> {
     // Ignore any explicitly-ignored function names.
@@ -68,7 +68,7 @@ pub(crate) fn invalid_function_name(
 
     // Ignore any functions that are explicitly `@override`. These are defined elsewhere,
     // so if they're first-party, we'll flag them at the definition site.
-    if visibility::is_override(ctx, decorator_list) {
+    if visibility::is_override(model, decorator_list) {
         return None;
     }
 

--- a/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/invalid_module_name.rs
@@ -1,6 +1,7 @@
-use ruff_text_size::TextRange;
 use std::ffi::OsStr;
 use std::path::Path;
+
+use ruff_text_size::TextRange;
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_class_scope.rs
@@ -67,8 +67,8 @@ pub(crate) fn mixed_case_variable_in_class_scope(
         return;
     }
     if helpers::is_mixed_case(name)
-        && !helpers::is_named_tuple_assignment(&checker.ctx, stmt)
-        && !helpers::is_typed_dict_class(&checker.ctx, bases)
+        && !helpers::is_named_tuple_assignment(&checker.model, stmt)
+        && !helpers::is_typed_dict_class(&checker.model, bases)
     {
         checker.diagnostics.push(Diagnostic::new(
             MixedCaseVariableInClassScope {

--- a/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/mixed_case_variable_in_global_scope.rs
@@ -75,7 +75,7 @@ pub(crate) fn mixed_case_variable_in_global_scope(
     {
         return;
     }
-    if helpers::is_mixed_case(name) && !helpers::is_named_tuple_assignment(&checker.ctx, stmt) {
+    if helpers::is_mixed_case(name) && !helpers::is_named_tuple_assignment(&checker.model, stmt) {
         checker.diagnostics.push(Diagnostic::new(
             MixedCaseVariableInGlobalScope {
                 name: name.to_string(),

--- a/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
+++ b/crates/ruff/src/rules/pep8_naming/rules/non_lowercase_variable_in_function.rs
@@ -66,9 +66,9 @@ pub(crate) fn non_lowercase_variable_in_function(
     }
 
     if name.to_lowercase() != name
-        && !helpers::is_named_tuple_assignment(&checker.ctx, stmt)
-        && !helpers::is_typed_dict_assignment(&checker.ctx, stmt)
-        && !helpers::is_type_var_assignment(&checker.ctx, stmt)
+        && !helpers::is_named_tuple_assignment(&checker.model, stmt)
+        && !helpers::is_typed_dict_assignment(&checker.model, stmt)
+        && !helpers::is_type_var_assignment(&checker.model, stmt)
     {
         checker.diagnostics.push(Diagnostic::new(
             NonLowercaseVariableInFunction {

--- a/crates/ruff/src/rules/pep8_naming/settings.rs
+++ b/crates/ruff/src/rules/pep8_naming/settings.rs
@@ -1,7 +1,8 @@
 //! Settings for the `pep8-naming` plugin.
 
-use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 const IGNORE_NAMES: [&str; 12] = [
     "setUp",

--- a/crates/ruff/src/rules/pycodestyle/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_class_name.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_function_name.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/ambiguous_variable_name.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 use crate::rules::pycodestyle::helpers::is_ambiguous_name;
 

--- a/crates/ruff/src/rules/pycodestyle/rules/errors.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/errors.rs
@@ -1,10 +1,11 @@
 use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ParseError;
 
-use crate::logging::DisplayParseErrorType;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
+
+use crate::logging::DisplayParseErrorType;
 
 #[violation]
 pub struct IOError {

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -1,9 +1,10 @@
 use rustpython_parser::ast::{Alias, Ranged, Stmt};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Check for multiple imports on one line.

--- a/crates/ruff/src/rules/pycodestyle/rules/imports.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/imports.rs
@@ -87,7 +87,7 @@ pub(crate) fn module_import_not_at_top_of_file(
     stmt: &Stmt,
     locator: &Locator,
 ) {
-    if checker.ctx.seen_import_boundary() && locator.is_at_start_of_line(stmt.start()) {
+    if checker.model.seen_import_boundary() && locator.is_at_start_of_line(stmt.start()) {
         checker
             .diagnostics
             .push(Diagnostic::new(ModuleImportNotAtTopOfFile, stmt.range()));

--- a/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/lambda_assignment.rs
@@ -7,7 +7,7 @@ use ruff_python_ast::helpers::{has_leading_content, has_trailing_content};
 use ruff_python_ast::newlines::StrExt;
 use ruff_python_ast::source_code::Generator;
 use ruff_python_ast::whitespace::leading_space;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 use ruff_python_semantic::scope::ScopeKind;
 
 use crate::checkers::ast::Checker;
@@ -72,7 +72,7 @@ pub(crate) fn lambda_assignment(
             // package like dataclasses, which wouldn't consider the
             // rewritten function definition to be equivalent.
             // See https://github.com/charliermarsh/ruff/issues/3046
-            let fixable = !matches!(checker.ctx.scope().kind, ScopeKind::Class(_));
+            let fixable = !matches!(checker.model.scope().kind, ScopeKind::Class(_));
 
             let mut diagnostic = Diagnostic::new(
                 LambdaAssignment {
@@ -90,7 +90,7 @@ pub(crate) fn lambda_assignment(
                 let indentation = &leading_space(first_line);
                 let mut indented = String::new();
                 for (idx, line) in function(
-                    &checker.ctx,
+                    &checker.model,
                     id,
                     args,
                     body,
@@ -124,7 +124,7 @@ pub(crate) fn lambda_assignment(
 /// The `Callable` import can be from either `collections.abc` or `typing`.
 /// If an ellipsis is used for the argument types, an empty list is returned.
 /// The returned values are cloned, so they can be used as-is.
-fn extract_types(ctx: &Context, annotation: &Expr) -> Option<(Vec<Expr>, Expr)> {
+fn extract_types(model: &SemanticModel, annotation: &Expr) -> Option<(Vec<Expr>, Expr)> {
     let Expr::Subscript(ast::ExprSubscript { value, slice, .. }) = &annotation else {
         return None;
     };
@@ -135,9 +135,9 @@ fn extract_types(ctx: &Context, annotation: &Expr) -> Option<(Vec<Expr>, Expr)> 
         return None;
     }
 
-    if !ctx.resolve_call_path(value).map_or(false, |call_path| {
+    if !model.resolve_call_path(value).map_or(false, |call_path| {
         call_path.as_slice() == ["collections", "abc", "Callable"]
-            || ctx.match_typing_call_path(&call_path, "Callable")
+            || model.match_typing_call_path(&call_path, "Callable")
     }) {
         return None;
     }
@@ -160,7 +160,7 @@ fn extract_types(ctx: &Context, annotation: &Expr) -> Option<(Vec<Expr>, Expr)> 
 }
 
 fn function(
-    ctx: &Context,
+    model: &SemanticModel,
     name: &str,
     args: &Arguments,
     body: &Expr,
@@ -172,7 +172,7 @@ fn function(
         range: TextRange::default(),
     });
     if let Some(annotation) = annotation {
-        if let Some((arg_types, return_type)) = extract_types(ctx, annotation) {
+        if let Some((arg_types, return_type)) = extract_types(model, annotation) {
             // A `lambda` expression can only have positional and positional-only
             // arguments. The order is always positional-only first, then positional.
             let new_posonlyargs = args

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -1,10 +1,13 @@
-use super::LogicalLine;
-use crate::checkers::logical_lines::LogicalLinesContext;
+use ruff_text_size::TextSize;
+
 use ruff_diagnostics::Edit;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::TextSize;
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+
+use super::LogicalLine;
 
 #[violation]
 pub struct MissingWhitespace {

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace_after_keyword.rs
@@ -1,8 +1,9 @@
-use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 #[violation]
 pub struct MissingWhitespaceAfterKeyword;

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/space_around_operator.rs
@@ -1,10 +1,12 @@
 use ruff_text_size::TextRange;
 
-use super::{LogicalLine, Whitespace};
-use crate::checkers::logical_lines::LogicalLinesContext;
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+
+use super::{LogicalLine, Whitespace};
 
 /// ## What it does
 /// Checks for extraneous tabs before an operator.

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_keywords.rs
@@ -1,8 +1,11 @@
-use super::{LogicalLine, Whitespace};
-use crate::checkers::logical_lines::LogicalLinesContext;
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+
+use super::{LogicalLine, Whitespace};
 
 /// ## What it does
 /// Checks for extraneous whitespace after keywords.

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -1,9 +1,11 @@
-use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::rules::pycodestyle::rules::logical_lines::{LogicalLine, LogicalLineToken};
+use ruff_text_size::{TextRange, TextSize};
+
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::{TextRange, TextSize};
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::{LogicalLine, LogicalLineToken};
 
 #[violation]
 pub struct UnexpectedSpacesAroundKeywordParameterEquals;

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_comment.rs
@@ -1,10 +1,12 @@
-use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
+use ruff_text_size::{TextLen, TextRange, TextSize};
+
 use ruff_diagnostics::Violation;
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::Locator;
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::{TextLen, TextRange, TextSize};
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 /// ## What it does
 /// Checks if inline comments are separated by at least two spaces.

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_before_parameters.rs
@@ -1,9 +1,11 @@
-use crate::checkers::logical_lines::LogicalLinesContext;
-use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
+use ruff_text_size::{TextRange, TextSize};
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::token_kind::TokenKind;
-use ruff_text_size::{TextRange, TextSize};
+
+use crate::checkers::logical_lines::LogicalLinesContext;
+use crate::rules::pycodestyle::rules::logical_lines::LogicalLine;
 
 #[violation]
 pub struct WhitespaceBeforeParameters {

--- a/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/mixed_spaces_and_tabs.rs
@@ -1,8 +1,9 @@
+use ruff_text_size::{TextLen, TextRange};
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::Line;
 use ruff_python_ast::whitespace::leading_space;
-use ruff_text_size::{TextLen, TextRange};
 
 /// ## What it does
 /// Checks for mixed tabs and spaces in indentation.

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -1,9 +1,10 @@
 use itertools::izip;
 use rustpython_parser::ast::{self, Cmpop, Constant, Expr, Ranged};
 
-use crate::checkers::ast::Checker;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+
+use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for object type comparisons without using isinstance().

--- a/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/type_comparison.rs
@@ -51,7 +51,7 @@ pub(crate) fn type_comparison(
             Expr::Call(ast::ExprCall { func, args, .. }) => {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     // Ex) `type(False)`
-                    if id == "type" && checker.ctx.is_builtin("type") {
+                    if id == "type" && checker.model.is_builtin("type") {
                         if let Some(arg) = args.first() {
                             // Allow comparison for types which are not obvious.
                             if !matches!(
@@ -76,7 +76,7 @@ pub(crate) fn type_comparison(
                     // Ex) `types.NoneType`
                     if id == "types"
                         && checker
-                            .ctx
+                            .model
                             .resolve_call_path(value)
                             .map_or(false, |call_path| {
                                 call_path.first().map_or(false, |module| *module == "types")

--- a/crates/ruff/src/rules/pycodestyle/settings.rs
+++ b/crates/ruff/src/rules/pycodestyle/settings.rs
@@ -1,7 +1,8 @@
 //! Settings for the `pycodestyle` plugin.
 
-use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 #[derive(
     Debug, PartialEq, Eq, Serialize, Deserialize, Default, ConfigurationOptions, CombineOptions,

--- a/crates/ruff/src/rules/pydocstyle/helpers.rs
+++ b/crates/ruff/src/rules/pydocstyle/helpers.rs
@@ -52,7 +52,7 @@ pub(crate) fn should_ignore_definition(
     }) = definition
     {
         for decorator in cast::decorator_list(stmt) {
-            if let Some(call_path) = checker.ctx.resolve_call_path(map_callable(decorator)) {
+            if let Some(call_path) = checker.model.resolve_call_path(map_callable(decorator)) {
                 if ignore_decorators
                     .iter()
                     .any(|decorator| from_qualified_name(decorator) == call_path)

--- a/crates/ruff/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff/src/rules/pydocstyle/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -1,9 +1,10 @@
+use ruff_text_size::{TextLen, TextRange};
+use rustpython_parser::ast::Ranged;
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{StrExt, UniversalNewlineIterator};
 use ruff_python_semantic::definition::{Definition, Member, MemberKind};
-use ruff_text_size::{TextLen, TextRange};
-use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/if_needed.rs
@@ -27,7 +27,7 @@ pub(crate) fn if_needed(checker: &mut Checker, docstring: &Docstring) {
     }) = docstring.definition else {
         return;
     };
-    if !is_overload(&checker.ctx, cast::decorator_list(stmt)) {
+    if !is_overload(&checker.model, cast::decorator_list(stmt)) {
         return;
     }
     checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -1,9 +1,10 @@
+use ruff_text_size::{TextLen, TextRange};
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Violation};
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::whitespace;
-use ruff_text_size::{TextLen, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/newline_after_last_paragraph.rs
@@ -1,9 +1,10 @@
+use ruff_text_size::{TextLen, TextSize};
+use rustpython_parser::ast::Ranged;
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::{NewlineWithTrailingNewline, StrExt};
 use ruff_python_ast::whitespace;
-use ruff_text_size::{TextLen, TextSize};
-use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/no_surrounding_whitespace.rs
@@ -1,7 +1,8 @@
+use ruff_text_size::{TextLen, TextRange};
+
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
-use ruff_text_size::{TextLen, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::docstrings::Docstring;

--- a/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/non_imperative_mood.rs
@@ -41,7 +41,7 @@ pub(crate) fn non_imperative_mood(
 
     if is_test(cast::name(stmt))
         || is_property(
-            &checker.ctx,
+            &checker.model,
             cast::decorator_list(stmt),
             &property_decorators,
         )

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -1,3 +1,5 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::cast;
@@ -6,10 +8,8 @@ use ruff_python_semantic::analyze::visibility::{
     is_call, is_init, is_magic, is_new, is_overload, is_override, Visibility,
 };
 use ruff_python_semantic::definition::{Definition, Member, MemberKind, Module, ModuleKind};
-use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
-
 use crate::registry::Rule;
 
 #[violation]

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -174,7 +174,7 @@ pub(crate) fn not_missing(
             stmt,
             ..
         }) => {
-            if is_overload(&checker.ctx, cast::decorator_list(stmt)) {
+            if is_overload(&checker.model, cast::decorator_list(stmt)) {
                 true
             } else {
                 if checker
@@ -195,8 +195,8 @@ pub(crate) fn not_missing(
             stmt,
             ..
         }) => {
-            if is_overload(&checker.ctx, cast::decorator_list(stmt))
-                || is_override(&checker.ctx, cast::decorator_list(stmt))
+            if is_overload(&checker.model, cast::decorator_list(stmt))
+                || is_override(&checker.model, cast::decorator_list(stmt))
             {
                 true
             } else if is_init(cast::name(stmt)) {

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -760,7 +760,7 @@ fn missing_args(checker: &mut Checker, docstring: &Docstring, docstrings_args: &
             // If this is a non-static method, skip `cls` or `self`.
             usize::from(
                 docstring.definition.is_method()
-                    && !is_staticmethod(&checker.ctx, cast::decorator_list(stmt)),
+                    && !is_staticmethod(&checker.model, cast::decorator_list(stmt)),
             ),
         )
     {

--- a/crates/ruff/src/rules/pydocstyle/settings.rs
+++ b/crates/ruff/src/rules/pydocstyle/settings.rs
@@ -1,9 +1,12 @@
 //! Settings for the `pydocstyle` plugin.
 
-use crate::registry::Rule;
-use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
-use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
+
+use crate::registry::Rule;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -1,15 +1,15 @@
 use anyhow::{bail, Ok, Result};
 use libcst_native::{Codegen, CodegenState, DictElement, Expression};
 use ruff_text_size::TextRange;
+use rustpython_format::{
+    FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
+};
 use rustpython_parser::ast::{Excepthandler, Expr, Ranged};
 use rustpython_parser::{lexer, Mode, Tok};
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::str::raw_contents;
-use rustpython_format::{
-    FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
-};
 
 use crate::cst::matchers::{
     match_attribute, match_call, match_dict, match_expression, match_simple_string,

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -9,13 +9,12 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use regex::Regex;
-    use ruff_diagnostics::Diagnostic;
     use rustpython_parser::lexer::LexResult;
     use test_case::test_case;
     use textwrap::dedent;
 
+    use ruff_diagnostics::Diagnostic;
     use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 
     use crate::linter::{check_path, LinterResult};

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -23,7 +23,7 @@ pub(crate) fn invalid_print_syntax(checker: &mut Checker, left: &Expr) {
     if id != "print" {
         return;
     }
-    if !checker.ctx.is_builtin("print") {
+    if !checker.model.is_builtin("print") {
         return;
     };
     checker

--- a/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/return_outside_function.rs
@@ -18,7 +18,7 @@ impl Violation for ReturnOutsideFunction {
 
 pub(crate) fn return_outside_function(checker: &mut Checker, stmt: &Stmt) {
     if matches!(
-        checker.ctx.scope().kind,
+        checker.model.scope().kind,
         ScopeKind::Class(_) | ScopeKind::Module
     ) {
         checker

--- a/crates/ruff/src/rules/pyflakes/rules/strings.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/strings.rs
@@ -1,6 +1,6 @@
-use ruff_text_size::TextRange;
 use std::string::ToString;
 
+use ruff_text_size::TextRange;
 use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{self, Constant, Expr, Identifier, Keyword};
 

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -1,7 +1,8 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::scope::Scope;
-use ruff_text_size::TextRange;
 
 #[violation]
 pub struct UndefinedExport {

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -21,7 +21,7 @@ impl Violation for UndefinedLocal {
 /// F823
 pub(crate) fn undefined_local(checker: &mut Checker, name: &str) {
     // If the name hasn't already been defined in the current scope...
-    let current = checker.ctx.scope();
+    let current = checker.model.scope();
     if !current.kind.is_function() || current.defines(name) {
         return;
     }
@@ -31,16 +31,16 @@ pub(crate) fn undefined_local(checker: &mut Checker, name: &str) {
     };
 
     // For every function and module scope above us...
-    for scope in checker.ctx.scopes.ancestors(parent) {
+    for scope in checker.model.scopes.ancestors(parent) {
         if !(scope.kind.is_function() || scope.kind.is_module()) {
             continue;
         }
 
         // If the name was defined in that scope...
-        if let Some(binding) = scope.get(name).map(|index| &checker.ctx.bindings[*index]) {
+        if let Some(binding) = scope.get(name).map(|index| &checker.model.bindings[*index]) {
             // And has already been accessed in the current scope...
             if let Some((scope_id, location)) = binding.runtime_usage {
-                if scope_id == checker.ctx.scope_id {
+                if scope_id == checker.model.scope_id {
                     // Then it's probably an error.
                     checker.diagnostics.push(Diagnostic::new(
                         UndefinedLocal {

--- a/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_annotation.rs
@@ -19,10 +19,10 @@ impl Violation for UnusedAnnotation {
 
 /// F842
 pub(crate) fn unused_annotation(checker: &mut Checker, scope: ScopeId) {
-    let scope = &checker.ctx.scopes[scope];
+    let scope = &checker.model.scopes[scope];
     for (name, binding) in scope
         .bindings()
-        .map(|(name, index)| (name, &checker.ctx.bindings[*index]))
+        .map(|(name, index)| (name, &checker.model.bindings[*index]))
     {
         if !binding.used()
             && binding.kind.is_annotation()

--- a/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/yield_outside_function.rs
@@ -40,7 +40,7 @@ impl Violation for YieldOutsideFunction {
 
 pub(crate) fn yield_outside_function(checker: &mut Checker, expr: &Expr) {
     if matches!(
-        checker.ctx.scope().kind,
+        checker.model.scope().kind,
         ScopeKind::Class(_) | ScopeKind::Module
     ) {
         let keyword = match expr {

--- a/crates/ruff/src/rules/pygrep_hooks/mod.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/mod.rs
@@ -6,7 +6,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/deprecated_log_warn.rs
@@ -44,7 +44,7 @@ impl Violation for DeprecatedLogWarn {
 /// PGH002
 pub(crate) fn deprecated_log_warn(checker: &mut Checker, func: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["logging", "warn"]

--- a/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
+++ b/crates/ruff/src/rules/pygrep_hooks/rules/no_eval.rs
@@ -46,7 +46,7 @@ pub(crate) fn no_eval(checker: &mut Checker, func: &Expr) {
     if id != "eval" {
         return;
     }
-    if !checker.ctx.is_builtin("eval") {
+    if !checker.model.is_builtin("eval") {
         return;
     }
     checker

--- a/crates/ruff/src/rules/pylint/helpers.rs
+++ b/crates/ruff/src/rules/pylint/helpers.rs
@@ -5,7 +5,7 @@ use ruff_python_semantic::scope::{FunctionDef, ScopeKind};
 use crate::checkers::ast::Checker;
 
 pub(crate) fn in_dunder_init(checker: &Checker) -> bool {
-    let scope = checker.ctx.scope();
+    let scope = checker.model.scope();
     let ScopeKind::Function(FunctionDef {
         name,
         decorator_list,
@@ -16,13 +16,13 @@ pub(crate) fn in_dunder_init(checker: &Checker) -> bool {
     if name != "__init__" {
         return false;
     }
-    let Some(parent) = scope.parent.map(|scope_id| &checker.ctx.scopes[scope_id]) else {
+    let Some(parent) = scope.parent.map(|scope_id| &checker.model.scopes[scope_id]) else {
         return false;
     };
 
     if !matches!(
         function_type::classify(
-            &checker.ctx,
+            &checker.model,
             parent,
             name,
             decorator_list,

--- a/crates/ruff/src/rules/pylint/mod.rs
+++ b/crates/ruff/src/rules/pylint/mod.rs
@@ -7,12 +7,11 @@ pub mod settings;
 mod tests {
     use std::path::Path;
 
-    use crate::assert_messages;
     use anyhow::Result;
-
     use regex::Regex;
     use test_case::test_case;
 
+    use crate::assert_messages;
     use crate::registry::Rule;
     use crate::rules::pylint;
     use crate::settings::types::PythonVersion;

--- a/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
+++ b/crates/ruff/src/rules/pylint/rules/await_outside_async.rs
@@ -46,7 +46,7 @@ impl Violation for AwaitOutsideAsync {
 /// PLE1142
 pub(crate) fn await_outside_async(checker: &mut Checker, expr: &Expr) {
     if !checker
-        .ctx
+        .model
         .scopes()
         .find_map(|scope| {
             if let ScopeKind::Function(FunctionDef { async_, .. }) = &scope.kind {

--- a/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
+++ b/crates/ruff/src/rules/pylint/rules/bad_string_format_type.rs
@@ -1,6 +1,6 @@
-use ruff_text_size::TextRange;
 use std::str::FromStr;
 
+use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use rustpython_format::cformat::{CFormatPart, CFormatSpec, CFormatStrOrBytes, CFormatString};
 use rustpython_parser::ast::{self, Constant, Expr, Operator, Ranged};

--- a/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -98,7 +98,7 @@ pub(crate) fn compare_to_empty_string(
 ) {
     // Omit string comparison rules within subscripts. This is mostly commonly used within
     // DataFrame and np.ndarray indexing.
-    for parent in checker.ctx.expr_ancestors() {
+    for parent in checker.model.expr_ancestors() {
         if matches!(parent, Expr::Subscript(_)) {
             return;
         }

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -1,6 +1,7 @@
+use rustpython_parser::ast::Ranged;
+
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
-use rustpython_parser::ast::Ranged;
 
 use crate::checkers::ast::Checker;
 

--- a/crates/ruff/src/rules/pylint/rules/global_statement.rs
+++ b/crates/ruff/src/rules/pylint/rules/global_statement.rs
@@ -54,11 +54,11 @@ impl Violation for GlobalStatement {
 
 /// PLW0603
 pub(crate) fn global_statement(checker: &mut Checker, name: &str) {
-    let scope = checker.ctx.scope();
+    let scope = checker.model.scope();
     if let Some(index) = scope.get(name) {
-        let binding = &checker.ctx.bindings[*index];
+        let binding = &checker.model.bindings[*index];
         if binding.kind.is_global() {
-            let source = checker.ctx.stmts[binding
+            let source = checker.model.stmts[binding
                 .source
                 .expect("`global` bindings should always have a `source`")];
             let diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_default.rs
@@ -84,7 +84,7 @@ pub(crate) fn invalid_envvar_default(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["os", "getenv"])
     {

--- a/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
+++ b/crates/ruff/src/rules/pylint/rules/invalid_envvar_value.rs
@@ -81,7 +81,7 @@ pub(crate) fn invalid_envvar_value(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["os", "getenv"])
     {

--- a/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
@@ -55,7 +55,7 @@ impl Violation for LoadBeforeGlobalDeclaration {
 }
 /// PLE0118
 pub(crate) fn load_before_global_declaration(checker: &mut Checker, name: &str, expr: &Expr) {
-    let globals = match &checker.ctx.scope().kind {
+    let globals = match &checker.model.scope().kind {
         ScopeKind::Class(class_def) => &class_def.globals,
         ScopeKind::Function(function_def) => &function_def.globals,
         _ => return,

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -102,7 +102,7 @@ pub(crate) fn logging_call(
         return;
     }
 
-    if !logging::is_logger_candidate(&checker.ctx, func) {
+    if !logging::is_logger_candidate(&checker.model, func) {
         return;
     }
 

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -4,7 +4,7 @@ use rustpython_parser::ast::{self, Expr, Keyword, Ranged};
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::has_comments;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::{checkers::ast::Checker, registry::AsRule};
 
@@ -59,16 +59,16 @@ impl Violation for NestedMinMax {
 
 impl MinMax {
     /// Converts a function call [`Expr`] into a [`MinMax`] if it is a call to `min` or `max`.
-    fn try_from_call(func: &Expr, keywords: &[Keyword], context: &Context) -> Option<MinMax> {
+    fn try_from_call(func: &Expr, keywords: &[Keyword], model: &SemanticModel) -> Option<MinMax> {
         if !keywords.is_empty() {
             return None;
         }
         let Expr::Name(ast::ExprName { id, .. }) = func else {
             return None;
         };
-        if id.as_str() == "min" && context.is_builtin("min") {
+        if id.as_str() == "min" && model.is_builtin("min") {
             Some(MinMax::Min)
-        } else if id.as_str() == "max" && context.is_builtin("max") {
+        } else if id.as_str() == "max" && model.is_builtin("max") {
             Some(MinMax::Max)
         } else {
             None
@@ -87,8 +87,8 @@ impl std::fmt::Display for MinMax {
 
 /// Collect a new set of arguments to by either accepting existing args as-is or
 /// collecting child arguments, if it's a call to the same function.
-fn collect_nested_args(context: &Context, min_max: MinMax, args: &[Expr]) -> Vec<Expr> {
-    fn inner(context: &Context, min_max: MinMax, args: &[Expr], new_args: &mut Vec<Expr>) {
+fn collect_nested_args(model: &SemanticModel, min_max: MinMax, args: &[Expr]) -> Vec<Expr> {
+    fn inner(model: &SemanticModel, min_max: MinMax, args: &[Expr], new_args: &mut Vec<Expr>) {
         for arg in args {
             if let Expr::Call(ast::ExprCall {
                 func,
@@ -106,8 +106,8 @@ fn collect_nested_args(context: &Context, min_max: MinMax, args: &[Expr]) -> Vec
                     new_args.push(new_arg);
                     continue;
                 }
-                if MinMax::try_from_call(func, keywords, context) == Some(min_max) {
-                    inner(context, min_max, args, new_args);
+                if MinMax::try_from_call(func, keywords, model) == Some(min_max) {
+                    inner(model, min_max, args, new_args);
                     continue;
                 }
             }
@@ -116,7 +116,7 @@ fn collect_nested_args(context: &Context, min_max: MinMax, args: &[Expr]) -> Vec
     }
 
     let mut new_args = Vec::with_capacity(args.len());
-    inner(context, min_max, args, &mut new_args);
+    inner(model, min_max, args, &mut new_args);
     new_args
 }
 
@@ -128,7 +128,7 @@ pub(crate) fn nested_min_max(
     args: &[Expr],
     keywords: &[Keyword],
 ) {
-    let Some(min_max) = MinMax::try_from_call(func, keywords, &checker.ctx) else {
+    let Some(min_max) = MinMax::try_from_call(func, keywords, &checker.model) else {
         return;
     };
 
@@ -136,14 +136,14 @@ pub(crate) fn nested_min_max(
         let Expr::Call(ast::ExprCall { func, keywords, ..} )= arg else {
             return false;
         };
-        MinMax::try_from_call(func.as_ref(), keywords.as_ref(), &checker.ctx) == Some(min_max)
+        MinMax::try_from_call(func.as_ref(), keywords.as_ref(), &checker.model) == Some(min_max)
     }) {
         let fixable = !has_comments(expr, checker.locator);
         let mut diagnostic = Diagnostic::new(NestedMinMax { func: min_max }, expr.range());
         if fixable && checker.patch(diagnostic.kind.rule()) {
             let flattened_expr = Expr::Call(ast::ExprCall {
                 func: Box::new(func.clone()),
-                args: collect_nested_args(&checker.ctx, min_max, args),
+                args: collect_nested_args(&checker.model, min_max, args),
                 keywords: keywords.to_owned(),
                 range: TextRange::default(),
             });

--- a/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
+++ b/crates/ruff/src/rules/pylint/rules/property_with_parameters.rs
@@ -59,7 +59,7 @@ pub(crate) fn property_with_parameters(
     {
         return;
     }
-    if checker.ctx.is_builtin("property")
+    if checker.model.is_builtin("property")
         && args
             .args
             .iter()

--- a/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff/src/rules/pylint/rules/redefined_loop_name.rs
@@ -6,7 +6,6 @@ use rustpython_parser::ast::{self, Expr, ExprContext, Ranged, Stmt, Withitem};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::comparable::ComparableExpr;
-
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
 use ruff_python_ast::types::Node;
 use ruff_python_semantic::model::SemanticModel;

--- a/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
+++ b/crates/ruff/src/rules/pylint/rules/repeated_isinstance_calls.rs
@@ -58,7 +58,7 @@ pub(crate) fn repeated_isinstance_calls(
     op: Boolop,
     values: &[Expr],
 ) {
-    if !matches!(op, Boolop::Or) || !checker.ctx.is_builtin("isinstance") {
+    if !matches!(op, Boolop::Or) || !checker.model.is_builtin("isinstance") {
         return;
     }
 

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -65,7 +65,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
         if id != name {
             continue;
         }
-        if !checker.ctx.is_builtin(name) {
+        if !checker.model.is_builtin(name) {
             continue;
         }
         let mut diagnostic = Diagnostic::new(
@@ -80,7 +80,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
                     "sys",
                     "exit",
                     func.start(),
-                    &checker.ctx,
+                    &checker.model,
                     &checker.importer,
                     checker.locator,
                 )?;

--- a/crates/ruff/src/rules/pylint/rules/unexpected_special_method_signature.rs
+++ b/crates/ruff/src/rules/pylint/rules/unexpected_special_method_signature.rs
@@ -145,7 +145,7 @@ pub(crate) fn unexpected_special_method_signature(
     args: &Arguments,
     locator: &Locator,
 ) {
-    if !checker.ctx.scope().kind.is_class() {
+    if !checker.model.scope().kind.is_class() {
         return;
     }
 
@@ -163,7 +163,7 @@ pub(crate) fn unexpected_special_method_signature(
     let optional_params = args.defaults.len();
     let mandatory_params = actual_params - optional_params;
 
-    let Some(expected_params) = ExpectedParams::from_method(name, is_staticmethod(&checker.ctx, decorator_list)) else {
+    let Some(expected_params) = ExpectedParams::from_method(name, is_staticmethod(&checker.model, decorator_list)) else {
         return;
     };
 

--- a/crates/ruff/src/rules/pylint/settings.rs
+++ b/crates/ruff/src/rules/pylint/settings.rs
@@ -1,9 +1,10 @@
 //! Settings for the `pylint` plugin.
 
 use anyhow::anyhow;
-use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 use rustpython_parser::ast::Constant;
 use serde::{Deserialize, Serialize};
+
+use ruff_macros::{CacheKey, CombineOptions, ConfigurationOptions};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, CacheKey)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]

--- a/crates/ruff/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff/src/rules/pyupgrade/mod.rs
@@ -9,7 +9,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -52,7 +52,7 @@ fn match_named_tuple_assign<'a>(
         return None;
     };
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["typing", "NamedTuple"]

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -5,7 +5,6 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Keyword, Ranged,
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::is_identifier;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -53,7 +53,7 @@ fn match_typed_dict_assign<'a>(
         return None;
     };
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["typing", "TypedDict"]

--- a/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -5,7 +5,6 @@ use rustpython_parser::ast::{self, Constant, Expr, ExprContext, Keyword, Ranged,
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::source_code::Generator;
 use ruff_python_stdlib::identifiers::is_identifier;
 

--- a/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/datetime_utc_alias.rs
@@ -28,7 +28,7 @@ impl Violation for DatetimeTimezoneUTC {
 /// UP017
 pub(crate) fn datetime_utc_alias(checker: &mut Checker, expr: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(expr)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["datetime", "timezone", "utc"]

--- a/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/f_strings.rs
@@ -1,10 +1,11 @@
+use std::borrow::Cow;
+
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
 use rustpython_format::{
     FieldName, FieldNamePart, FieldType, FormatPart, FormatString, FromTemplate,
 };
 use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
-use std::borrow::Cow;
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -38,7 +38,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
         if args.is_empty()
             && keywords.len() == 1
             && checker
-                .ctx
+                .model
                 .resolve_call_path(func)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["functools", "lru_cache"]
@@ -69,7 +69,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                             "functools",
                             "cache",
                             expr.start(),
-                            &checker.ctx,
+                            &checker.model,
                             &checker.importer,
                             checker.locator,
                         )?;

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -37,7 +37,7 @@ pub(crate) fn lru_cache_without_parameters(checker: &mut Checker, decorator_list
         if args.is_empty()
             && keywords.is_empty()
             && checker
-                .ctx
+                .model
                 .resolve_call_path(func)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["functools", "lru_cache"]

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -4,7 +4,6 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_ast::str::is_implicit_concatenation;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/native_literals.rs
@@ -57,7 +57,7 @@ pub(crate) fn native_literals(
         return;
     }
 
-    if (id == "str" || id == "bytes") && checker.ctx.is_builtin(id) {
+    if (id == "str" || id == "bytes") && checker.model.is_builtin(id) {
         let Some(arg) = args.get(0) else {
             let mut diagnostic = Diagnostic::new(NativeLiterals{literal_type:if id == "str" {
                 LiteralType::Str

--- a/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/open_alias.rs
@@ -25,12 +25,12 @@ impl Violation for OpenAlias {
 /// UP020
 pub(crate) fn open_alias(checker: &mut Checker, expr: &Expr, func: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["io", "open"])
     {
         let fixable = checker
-            .ctx
+            .model
             .find_binding("open")
             .map_or(true, |binding| binding.kind.is_builtin());
         let mut diagnostic = Diagnostic::new(OpenAlias, expr.range());

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -4,7 +4,6 @@ use rustpython_parser::ast::{self, Excepthandler, Expr, ExprContext, Ranged};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::compose_call_path;
-
 use ruff_python_semantic::model::SemanticModel;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -5,7 +5,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::compose_call_path;
 
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
@@ -40,8 +40,8 @@ const ALIASES: &[(&str, &str)] = &[
 ];
 
 /// Return `true` if an [`Expr`] is an alias of `OSError`.
-fn is_alias(context: &Context, expr: &Expr) -> bool {
-    context.resolve_call_path(expr).map_or(false, |call_path| {
+fn is_alias(model: &SemanticModel, expr: &Expr) -> bool {
+    model.resolve_call_path(expr).map_or(false, |call_path| {
         ALIASES
             .iter()
             .any(|(module, member)| call_path.as_slice() == [*module, *member])
@@ -49,8 +49,8 @@ fn is_alias(context: &Context, expr: &Expr) -> bool {
 }
 
 /// Return `true` if an [`Expr`] is `OSError`.
-fn is_os_error(context: &Context, expr: &Expr) -> bool {
-    context
+fn is_os_error(model: &SemanticModel, expr: &Expr) -> bool {
+    model
         .resolve_call_path(expr)
         .map_or(false, |call_path| call_path.as_slice() == ["", "OSError"])
 }
@@ -94,7 +94,7 @@ fn tuple_diagnostic(checker: &mut Checker, target: &Expr, aliases: &[&Expr]) {
             .collect();
 
         // If `OSError` itself isn't already in the tuple, add it.
-        if elts.iter().all(|elt| !is_os_error(&checker.ctx, elt)) {
+        if elts.iter().all(|elt| !is_os_error(&checker.model, elt)) {
             let node = ast::ExprName {
                 id: "OSError".into(),
                 ctx: ExprContext::Load,
@@ -134,7 +134,7 @@ pub(crate) fn os_error_alias_handlers(checker: &mut Checker, handlers: &[Excepth
         };
         match expr.as_ref() {
             Expr::Name(_) | Expr::Attribute(_) => {
-                if is_alias(&checker.ctx, expr) {
+                if is_alias(&checker.model, expr) {
                     atom_diagnostic(checker, expr);
                 }
             }
@@ -142,7 +142,7 @@ pub(crate) fn os_error_alias_handlers(checker: &mut Checker, handlers: &[Excepth
                 // List of aliases to replace with `OSError`.
                 let mut aliases: Vec<&Expr> = vec![];
                 for elt in elts {
-                    if is_alias(&checker.ctx, elt) {
+                    if is_alias(&checker.model, elt) {
                         aliases.push(elt);
                     }
                 }
@@ -157,7 +157,7 @@ pub(crate) fn os_error_alias_handlers(checker: &mut Checker, handlers: &[Excepth
 
 /// UP024
 pub(crate) fn os_error_alias_call(checker: &mut Checker, func: &Expr) {
-    if is_alias(&checker.ctx, func) {
+    if is_alias(&checker.model, func) {
         atom_diagnostic(checker, func);
     }
 }
@@ -165,7 +165,7 @@ pub(crate) fn os_error_alias_call(checker: &mut Checker, func: &Expr) {
 /// UP024
 pub(crate) fn os_error_alias_raise(checker: &mut Checker, expr: &Expr) {
     if matches!(expr, Expr::Name(_) | Expr::Attribute(_)) {
-        if is_alias(&checker.ctx, expr) {
+        if is_alias(&checker.model, expr) {
             atom_diagnostic(checker, expr);
         }
     }

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -164,8 +164,8 @@ fn fix_py2_block(
         // of its parent, so avoid passing in the parent at all. Otherwise,
         // `delete_stmt` will erroneously include a `pass`.
         let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
-        let defined_by = checker.ctx.stmt();
-        let defined_in = checker.ctx.stmt_parent();
+        let defined_by = checker.model.stmt();
+        let defined_in = checker.model.stmt_parent();
         return match delete_stmt(
             defined_by,
             if block.starter == Tok::If {
@@ -323,7 +323,7 @@ pub(crate) fn outdated_version_block(
     };
 
     if !checker
-        .ctx
+        .model
         .resolve_call_path(left)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["sys", "version_info"]

--- a/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/printf_string_formatting.rs
@@ -1,6 +1,6 @@
-use ruff_text_size::TextRange;
 use std::str::FromStr;
 
+use ruff_text_size::TextRange;
 use rustpython_format::cformat::{
     CConversionFlags, CFormatPart, CFormatPrecision, CFormatQuantity, CFormatString,
 };

--- a/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/quoted_annotation.rs
@@ -1,6 +1,7 @@
+use ruff_text_size::TextRange;
+
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
-use ruff_text_size::TextRange;
 
 use crate::checkers::ast::Checker;
 use crate::registry::Rule;

--- a/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/redundant_open_modes.rs
@@ -173,7 +173,7 @@ fn create_remove_param_fix(locator: &Locator, expr: &Expr, mode_param: &Expr) ->
 /// UP015
 pub(crate) fn redundant_open_modes(checker: &mut Checker, expr: &Expr) {
     // If `open` has been rebound, skip this check entirely.
-    if !checker.ctx.is_builtin(OPEN_FUNC_NAME) {
+    if !checker.model.is_builtin(OPEN_FUNC_NAME) {
         return;
     }
     let (mode_param, keywords): (Option<&Expr>, Vec<Keyword>) = match_open(expr);

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_stdout_stderr.rs
@@ -61,7 +61,7 @@ pub(crate) fn replace_stdout_stderr(
     keywords: &[Keyword],
 ) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["subprocess", "run"]
@@ -77,13 +77,13 @@ pub(crate) fn replace_stdout_stderr(
 
         // Verify that they're both set to `subprocess.PIPE`.
         if !checker
-            .ctx
+            .model
             .resolve_call_path(&stdout.value)
             .map_or(false, |call_path| {
                 call_path.as_slice() == ["subprocess", "PIPE"]
             })
             || !checker
-                .ctx
+                .model
                 .resolve_call_path(&stderr.value)
                 .map_or(false, |call_path| {
                     call_path.as_slice() == ["subprocess", "PIPE"]

--- a/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/replace_universal_newlines.rs
@@ -25,7 +25,7 @@ impl AlwaysAutofixableViolation for ReplaceUniversalNewlines {
 /// UP021
 pub(crate) fn replace_universal_newlines(checker: &mut Checker, func: &Expr, kwargs: &[Keyword]) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["subprocess", "run"]

--- a/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -43,14 +43,14 @@ pub(crate) fn super_call_with_parameters(
     if !is_super_call_with_arguments(func, args) {
         return;
     }
-    let scope = checker.ctx.scope();
+    let scope = checker.model.scope();
 
     // Check: are we in a Function scope?
     if !matches!(scope.kind, ScopeKind::Function(_)) {
         return;
     }
 
-    let mut parents = checker.ctx.parents();
+    let mut parents = checker.model.parents();
 
     // For a `super` invocation to be unnecessary, the first argument needs to match
     // the enclosing class, and the second argument needs to match the first

--- a/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/type_of_primitive.rs
@@ -32,7 +32,7 @@ pub(crate) fn type_of_primitive(checker: &mut Checker, expr: &Expr, func: &Expr,
         return;
     }
     if !checker
-        .ctx
+        .model
         .resolve_call_path(func)
         .map_or(false, |call_path| call_path.as_slice() == ["", "type"])
     {

--- a/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/typing_text_str_alias.rs
@@ -23,7 +23,7 @@ impl AlwaysAutofixableViolation for TypingTextStrAlias {
 /// UP019
 pub(crate) fn typing_text_str_alias(checker: &mut Checker, expr: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(expr)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["typing", "Text"]

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -106,8 +106,8 @@ pub(crate) fn unnecessary_builtin_import(
 
     if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
-        let defined_by = checker.ctx.stmt();
-        let defined_in = checker.ctx.stmt_parent();
+        let defined_by = checker.model.stmt();
+        let defined_in = checker.model.stmt_parent();
         let unused_imports: Vec<String> = unused_imports
             .iter()
             .map(|alias| format!("{module}.{}", alias.name))

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -86,8 +86,8 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
 
     if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
-        let defined_by = checker.ctx.stmt();
-        let defined_in = checker.ctx.stmt_parent();
+        let defined_by = checker.model.stmt();
+        let defined_in = checker.model.stmt_parent();
         let unused_imports: Vec<String> = unused_imports
             .iter()
             .map(|alias| format!("__future__.{}", alias.name))

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -46,12 +46,12 @@ pub(crate) fn use_pep585_annotation(
         },
         expr.range(),
     );
-    let fixable = !checker.ctx.in_complex_string_type_definition();
+    let fixable = !checker.model.in_complex_string_type_definition();
     if fixable && checker.patch(diagnostic.kind.rule()) {
         match replacement {
             ModuleMember::BuiltIn(name) => {
                 // Built-in type, like `list`.
-                if checker.ctx.is_builtin(name) {
+                if checker.model.is_builtin(name) {
                     diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
                         (*name).to_string(),
                         expr.range(),
@@ -65,7 +65,7 @@ pub(crate) fn use_pep585_annotation(
                         module,
                         member,
                         expr.start(),
-                        &checker.ctx,
+                        &checker.model,
                         &checker.importer,
                         checker.locator,
                     )?;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Constant, Expr, Operator, Ranged};
 
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
-
 use ruff_python_semantic::analyze::typing::Pep604Operator;
 
 use crate::checkers::ast::Checker;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_annotation.rs
@@ -60,7 +60,7 @@ pub(crate) fn use_pep604_annotation(
 ) {
     // Avoid fixing forward references, or types not in an annotation.
     let fixable =
-        checker.ctx.in_type_definition() && !checker.ctx.in_complex_string_type_definition();
+        checker.model.in_type_definition() && !checker.model.in_complex_string_type_definition();
     match operator {
         Pep604Operator::Optional => {
             let mut diagnostic = Diagnostic::new(NonPEP604Annotation, expr.range());

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep604_isinstance.rs
@@ -74,7 +74,7 @@ pub(crate) fn use_pep604_isinstance(
         let Some(kind) = CallKind::from_name(id) else {
             return;
         };
-        if !checker.ctx.is_builtin(id) {
+        if !checker.model.is_builtin(id) {
             return;
         };
         if let Some(types) = args.get(1) {

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -56,8 +56,8 @@ pub(crate) fn useless_metaclass_type(
         };
     if checker.patch(diagnostic.kind.rule()) {
         let deleted: Vec<&Stmt> = checker.deletions.iter().map(Into::into).collect();
-        let defined_by = checker.ctx.stmt();
-        let defined_in = checker.ctx.stmt_parent();
+        let defined_by = checker.model.stmt();
+        let defined_in = checker.model.stmt_parent();
         match actions::delete_stmt(
             defined_by,
             defined_in,

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_object_inheritance.rs
@@ -62,7 +62,8 @@ pub(crate) fn useless_object_inheritance(
     bases: &[Expr],
     keywords: &[Keyword],
 ) {
-    if let Some(mut diagnostic) = rule(name, bases, checker.ctx.scope(), &checker.ctx.bindings) {
+    if let Some(mut diagnostic) = rule(name, bases, checker.model.scope(), &checker.model.bindings)
+    {
         if checker.patch(diagnostic.kind.rule()) {
             let expr_range = diagnostic.range();
             #[allow(deprecated)]

--- a/crates/ruff/src/rules/ruff/mod.rs
+++ b/crates/ruff/src/rules/ruff/mod.rs
@@ -7,7 +7,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use rustc_hash::FxHashSet;
     use test_case::test_case;
 

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -131,7 +131,7 @@ pub(crate) fn explicit_f_string_type_conversion(
             return;
         };
 
-        if !checker.ctx.is_builtin(id) {
+        if !checker.model.is_builtin(id) {
             return;
         }
 

--- a/crates/ruff/src/rules/ruff/rules/mod.rs
+++ b/crates/ruff/src/rules/ruff/rules/mod.rs
@@ -1,12 +1,3 @@
-mod ambiguous_unicode_character;
-mod asyncio_dangling_task;
-mod collection_literal_concatenation;
-mod confusables;
-mod explicit_f_string_type_conversion;
-mod mutable_defaults_in_dataclass_fields;
-mod pairwise_over_zipped;
-mod unused_noqa;
-
 pub(crate) use ambiguous_unicode_character::{
     ambiguous_unicode_character, AmbiguousUnicodeCharacterComment,
     AmbiguousUnicodeCharacterDocstring, AmbiguousUnicodeCharacterString,
@@ -15,6 +6,9 @@ pub(crate) use asyncio_dangling_task::{asyncio_dangling_task, AsyncioDanglingTas
 pub(crate) use collection_literal_concatenation::{
     collection_literal_concatenation, CollectionLiteralConcatenation,
 };
+pub(crate) use explicit_f_string_type_conversion::{
+    explicit_f_string_type_conversion, ExplicitFStringTypeConversion,
+};
 pub(crate) use mutable_defaults_in_dataclass_fields::{
     function_call_in_dataclass_defaults, is_dataclass, mutable_dataclass_default,
     FunctionCallInDataclassDefaultArgument, MutableDataclassDefault,
@@ -22,9 +16,14 @@ pub(crate) use mutable_defaults_in_dataclass_fields::{
 pub(crate) use pairwise_over_zipped::{pairwise_over_zipped, PairwiseOverZipped};
 pub(crate) use unused_noqa::{UnusedCodes, UnusedNOQA};
 
-pub(crate) use explicit_f_string_type_conversion::{
-    explicit_f_string_type_conversion, ExplicitFStringTypeConversion,
-};
+mod ambiguous_unicode_character;
+mod asyncio_dangling_task;
+mod collection_literal_concatenation;
+mod confusables;
+mod explicit_f_string_type_conversion;
+mod mutable_defaults_in_dataclass_fields;
+mod pairwise_over_zipped;
+mod unused_noqa;
 
 #[derive(Clone, Copy)]
 pub(crate) enum Context {

--- a/crates/ruff/src/rules/ruff/rules/mutable_defaults_in_dataclass_fields.rs
+++ b/crates/ruff/src/rules/ruff/rules/mutable_defaults_in_dataclass_fields.rs
@@ -1,8 +1,8 @@
-use ruff_python_ast::call_path::{from_qualified_name, CallPath};
 use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::call_path::{from_qualified_name, CallPath};
 use ruff_python_ast::{call_path::compose_call_path, helpers::map_callable};
 use ruff_python_semantic::{
     analyze::typing::{is_immutable_annotation, is_immutable_func},

--- a/crates/ruff/src/rules/ruff/rules/mutable_defaults_in_dataclass_fields.rs
+++ b/crates/ruff/src/rules/ruff/rules/mutable_defaults_in_dataclass_fields.rs
@@ -6,7 +6,7 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::{call_path::compose_call_path, helpers::map_callable};
 use ruff_python_semantic::{
     analyze::typing::{is_immutable_annotation, is_immutable_func},
-    context::Context,
+    model::SemanticModel,
 };
 
 use crate::checkers::ast::Checker;
@@ -162,8 +162,8 @@ fn is_mutable_expr(expr: &Expr) -> bool {
 
 const ALLOWED_DATACLASS_SPECIFIC_FUNCTIONS: &[&[&str]] = &[&["dataclasses", "field"]];
 
-fn is_allowed_dataclass_function(context: &Context, func: &Expr) -> bool {
-    context.resolve_call_path(func).map_or(false, |call_path| {
+fn is_allowed_dataclass_function(model: &SemanticModel, func: &Expr) -> bool {
+    model.resolve_call_path(func).map_or(false, |call_path| {
         ALLOWED_DATACLASS_SPECIFIC_FUNCTIONS
             .iter()
             .any(|target| call_path.as_slice() == *target)
@@ -171,11 +171,11 @@ fn is_allowed_dataclass_function(context: &Context, func: &Expr) -> bool {
 }
 
 /// Returns `true` if the given [`Expr`] is a `typing.ClassVar` annotation.
-fn is_class_var_annotation(context: &Context, annotation: &Expr) -> bool {
+fn is_class_var_annotation(model: &SemanticModel, annotation: &Expr) -> bool {
     let Expr::Subscript(ast::ExprSubscript { value, .. }) = &annotation else {
         return false;
     };
-    context.match_typing_expr(value, "ClassVar")
+    model.match_typing_expr(value, "ClassVar")
 }
 
 /// RUF009
@@ -195,12 +195,12 @@ pub(crate) fn function_call_in_dataclass_defaults(checker: &mut Checker, body: &
             ..
         }) = statement
         {
-            if is_class_var_annotation(&checker.ctx, annotation) {
+            if is_class_var_annotation(&checker.model, annotation) {
                 continue;
             }
             if let Expr::Call(ast::ExprCall { func, .. }) = expr.as_ref() {
-                if !is_immutable_func(&checker.ctx, func, &extend_immutable_calls)
-                    && !is_allowed_dataclass_function(&checker.ctx, func)
+                if !is_immutable_func(&checker.model, func, &extend_immutable_calls)
+                    && !is_allowed_dataclass_function(&checker.model, func)
                 {
                     checker.diagnostics.push(Diagnostic::new(
                         FunctionCallInDataclassDefaultArgument {
@@ -223,8 +223,8 @@ pub(crate) fn mutable_dataclass_default(checker: &mut Checker, body: &[Stmt]) {
                 value: Some(value),
                 ..
             }) => {
-                if !is_class_var_annotation(&checker.ctx, annotation)
-                    && !is_immutable_annotation(&checker.ctx, annotation)
+                if !is_class_var_annotation(&checker.model, annotation)
+                    && !is_immutable_annotation(&checker.model, annotation)
                     && is_mutable_expr(value)
                 {
                     checker
@@ -247,7 +247,7 @@ pub(crate) fn mutable_dataclass_default(checker: &mut Checker, body: &[Stmt]) {
 pub(crate) fn is_dataclass(checker: &Checker, decorator_list: &[Expr]) -> bool {
     decorator_list.iter().any(|decorator| {
         checker
-            .ctx
+            .model
             .resolve_call_path(map_callable(decorator))
             .map_or(false, |call_path| {
                 call_path.as_slice() == ["dataclasses", "dataclass"]

--- a/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
+++ b/crates/ruff/src/rules/ruff/rules/pairwise_over_zipped.rs
@@ -99,7 +99,7 @@ pub(crate) fn pairwise_over_zipped(checker: &mut Checker, func: &Expr, args: &[E
     }
 
     // Require the function to be the builtin `zip`.
-    if !(id == "zip" && checker.ctx.is_builtin(id)) {
+    if !(id == "zip" && checker.model.is_builtin(id)) {
         return;
     }
 

--- a/crates/ruff/src/rules/tryceratops/helpers.rs
+++ b/crates/ruff/src/rules/tryceratops/helpers.rs
@@ -3,16 +3,16 @@ use rustpython_parser::ast::{self, Expr};
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::analyze::logging;
-use ruff_python_semantic::context::Context;
+use ruff_python_semantic::model::SemanticModel;
 
 /// Collect `logging`-like calls from an AST.
 pub(crate) struct LoggerCandidateVisitor<'a> {
-    context: &'a Context<'a>,
+    context: &'a SemanticModel<'a>,
     pub(crate) calls: Vec<(&'a Expr, &'a Expr)>,
 }
 
 impl<'a> LoggerCandidateVisitor<'a> {
-    pub(crate) fn new(context: &'a Context<'a>) -> Self {
+    pub(crate) fn new(context: &'a SemanticModel<'a>) -> Self {
         LoggerCandidateVisitor {
             context,
             calls: Vec::new(),

--- a/crates/ruff/src/rules/tryceratops/mod.rs
+++ b/crates/ruff/src/rules/tryceratops/mod.rs
@@ -8,7 +8,6 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-
     use test_case::test_case;
 
     use crate::registry::Rule;

--- a/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -57,7 +57,7 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
     for handler in handlers {
         let Excepthandler::ExceptHandler(ast::ExcepthandlerExceptHandler { body, .. }) = handler;
         let calls = {
-            let mut visitor = LoggerCandidateVisitor::new(&checker.ctx);
+            let mut visitor = LoggerCandidateVisitor::new(&checker.model);
             visitor.visit_body(body);
             visitor.calls
         };

--- a/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/raise_vanilla_class.rs
@@ -63,7 +63,7 @@ impl Violation for RaiseVanillaClass {
 /// TRY002
 pub(crate) fn raise_vanilla_class(checker: &mut Checker, expr: &Expr) {
     if checker
-        .ctx
+        .model
         .resolve_call_path(if let Expr::Call(ast::ExprCall { func, .. }) = expr {
             func
         } else {

--- a/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/try_consider_else.rs
@@ -66,7 +66,7 @@ pub(crate) fn try_consider_else(
         if let Some(stmt) = body.last() {
             if let Stmt::Return(ast::StmtReturn { value, range: _ }) = stmt {
                 if let Some(value) = value {
-                    if contains_effect(value, |id| checker.ctx.is_builtin(id)) {
+                    if contains_effect(value, |id| checker.model.is_builtin(id)) {
                         return;
                     }
                 }

--- a/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/type_check_without_type_error.rs
@@ -77,7 +77,7 @@ fn has_control_flow(stmt: &Stmt) -> bool {
 /// Returns `true` if an [`Expr`] is a call to check types.
 fn check_type_check_call(checker: &mut Checker, call: &Expr) -> bool {
     checker
-        .ctx
+        .model
         .resolve_call_path(call)
         .map_or(false, |call_path| {
             call_path.as_slice() == ["", "isinstance"]
@@ -101,7 +101,7 @@ fn check_type_check_test(checker: &mut Checker, test: &Expr) -> bool {
 /// Returns `true` if `exc` is a reference to a builtin exception.
 fn is_builtin_exception(checker: &mut Checker, exc: &Expr) -> bool {
     return checker
-        .ctx
+        .model
         .resolve_call_path(exc)
         .map_or(false, |call_path| {
             [

--- a/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/verbose_log_message.rs
@@ -74,7 +74,7 @@ pub(crate) fn verbose_log_message(checker: &mut Checker, handlers: &[Excepthandl
 
         // Find all calls to `logging.exception`.
         let calls = {
-            let mut visitor = LoggerCandidateVisitor::new(&checker.ctx);
+            let mut visitor = LoggerCandidateVisitor::new(&checker.model);
             visitor.visit_body(body);
             visitor.calls
         };

--- a/crates/ruff/src/settings/types.rs
+++ b/crates/ruff/src/settings/types.rs
@@ -1,12 +1,13 @@
-use anyhow::{bail, Result};
-use globset::{Glob, GlobSet, GlobSetBuilder};
-use pep440_rs::{Version as Pep440Version, VersionSpecifiers};
-use serde::{de, Deserialize, Deserializer, Serialize};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::ToString;
+
+use anyhow::{bail, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use pep440_rs::{Version as Pep440Version, VersionSpecifiers};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -5,10 +5,10 @@ use std::path::Path;
 
 use anyhow::Result;
 use itertools::Itertools;
-use ruff_diagnostics::{AutofixKind, Diagnostic};
 use rustc_hash::FxHashMap;
 use rustpython_parser::lexer::LexResult;
 
+use ruff_diagnostics::{AutofixKind, Diagnostic};
 use ruff_python_ast::source_code::{Indexer, Locator, SourceFileBuilder, Stylist};
 
 use crate::autofix::fix_file;

--- a/crates/ruff_benchmark/benches/linter.rs
+++ b/crates/ruff_benchmark/benches/linter.rs
@@ -1,12 +1,14 @@
+use std::time::Duration;
+
 use criterion::measurement::WallTime;
 use criterion::{
     criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
+
 use ruff::linter::lint_only;
 use ruff::settings::{flags, Settings};
 use ruff::RuleSelector;
 use ruff_benchmark::{TestCase, TestCaseSpeed, TestFile, TestFileDownloadError};
-use std::time::Duration;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/crates/ruff_benchmark/benches/parser.rs
+++ b/crates/ruff_benchmark/benches/parser.rs
@@ -1,9 +1,11 @@
+use std::time::Duration;
+
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use rustpython_parser::ast::Stmt;
+
 use ruff_benchmark::{TestCase, TestCaseSpeed, TestFile, TestFileDownloadError};
 use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
-use rustpython_parser::ast::Stmt;
-use std::time::Duration;
 
 #[cfg(target_os = "windows")]
 #[global_allocator]

--- a/crates/ruff_benchmark/src/lib.rs
+++ b/crates/ruff_benchmark/src/lib.rs
@@ -1,6 +1,7 @@
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::process::Command;
+
 use url::Url;
 
 /// Relative size of a test case. Benchmarks can use it to configure the time for how long a benchmark should run to get stable results.

--- a/crates/ruff_cache/src/cache_key.rs
+++ b/crates/ruff_cache/src/cache_key.rs
@@ -1,11 +1,12 @@
-use itertools::Itertools;
-use regex::Regex;
 use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
+
+use itertools::Itertools;
+use regex::Regex;
 
 #[derive(Clone, Debug, Default)]
 pub struct CacheKeyHasher {

--- a/crates/ruff_cache/src/filetime.rs
+++ b/crates/ruff_cache/src/filetime.rs
@@ -1,6 +1,8 @@
-use crate::{CacheKey, CacheKeyHasher};
-use filetime::FileTime;
 use std::hash::Hash;
+
+use filetime::FileTime;
+
+use crate::{CacheKey, CacheKeyHasher};
 
 impl CacheKey for FileTime {
     fn cache_key(&self, state: &mut CacheKeyHasher) {

--- a/crates/ruff_cache/src/globset.rs
+++ b/crates/ruff_cache/src/globset.rs
@@ -1,5 +1,6 @@
-use crate::{CacheKey, CacheKeyHasher};
 use globset::{Glob, GlobMatcher};
+
+use crate::{CacheKey, CacheKeyHasher};
 
 impl CacheKey for GlobMatcher {
     fn cache_key(&self, state: &mut CacheKeyHasher) {

--- a/crates/ruff_cache/src/lib.rs
+++ b/crates/ruff_cache/src/lib.rs
@@ -1,10 +1,10 @@
-mod cache_key;
-pub mod filetime;
-pub mod globset;
+use std::path::{Path, PathBuf};
 
 pub use cache_key::{CacheKey, CacheKeyHasher};
 
-use std::path::{Path, PathBuf};
+mod cache_key;
+pub mod filetime;
+pub mod globset;
 
 pub const CACHE_DIR_NAME: &str = ".ruff_cache";
 

--- a/crates/ruff_cache/tests/cache_key.rs
+++ b/crates/ruff_cache/tests/cache_key.rs
@@ -1,7 +1,8 @@
-use ruff_cache::{CacheKey, CacheKeyHasher};
-use ruff_macros::CacheKey;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+
+use ruff_cache::{CacheKey, CacheKeyHasher};
+use ruff_macros::CacheKey;
 
 #[derive(CacheKey, Hash)]
 struct UnitStruct;

--- a/crates/ruff_cli/src/args.rs
+++ b/crates/ruff_cli/src/args.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 
 use clap::{command, Parser};
 use regex::Regex;
+use rustc_hash::FxHashMap;
+
 use ruff::logging::LogLevel;
 use ruff::registry::Rule;
 use ruff::resolver::ConfigProcessor;
@@ -11,7 +13,6 @@ use ruff::settings::types::{
     FilePattern, PatternPrefixPair, PerFileIgnore, PythonVersion, SerializationFormat,
 };
 use ruff::RuleSelector;
-use rustc_hash::FxHashMap;
 
 #[derive(Debug, Parser)]
 #[command(

--- a/crates/ruff_cli/src/cache.rs
+++ b/crates/ruff_cli/src/cache.rs
@@ -2,23 +2,24 @@ use std::cell::RefCell;
 use std::fs;
 use std::hash::Hasher;
 use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use anyhow::Result;
 use filetime::FileTime;
 use log::error;
 use path_absolutize::Absolutize;
+use ruff_text_size::{TextRange, TextSize};
+use serde::ser::{SerializeSeq, SerializeStruct};
+use serde::{Deserialize, Serialize, Serializer};
+
 use ruff::message::Message;
 use ruff::settings::{AllSettings, Settings};
 use ruff_cache::{CacheKey, CacheKeyHasher};
 use ruff_diagnostics::{DiagnosticKind, Fix};
 use ruff_python_ast::imports::ImportMap;
 use ruff_python_ast::source_code::SourceFileBuilder;
-use ruff_text_size::{TextRange, TextSize};
-use serde::ser::{SerializeSeq, SerializeStruct};
-use serde::{Deserialize, Serialize, Serializer};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 
 const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 

--- a/crates/ruff_cli/src/commands/config.rs
+++ b/crates/ruff_cli/src/commands/config.rs
@@ -1,5 +1,6 @@
-use crate::ExitStatus;
 use ruff::settings::options::Options;
+
+use crate::ExitStatus;
 
 #[allow(clippy::print_stdout)]
 pub(crate) fn config(key: Option<&str>) -> ExitStatus {

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -388,8 +388,9 @@ fn check(args: CheckArgs, log_level: LogLevel) -> Result<ExitStatus> {
 
 #[cfg(test)]
 mod test_file_change_detector {
-    use crate::{change_detected, ChangeKind};
     use std::path::PathBuf;
+
+    use crate::{change_detected, ChangeKind};
 
     #[test]
     fn detect_correct_file_change() {

--- a/crates/ruff_cli/tests/black_compatibility_test.rs
+++ b/crates/ruff_cli/tests/black_compatibility_test.rs
@@ -11,8 +11,9 @@ use std::{fs, process, str};
 use anyhow::{anyhow, Context, Result};
 use assert_cmd::Command;
 use log::info;
-use ruff::logging::{set_up_logging, LogLevel};
 use walkdir::WalkDir;
+
+use ruff::logging::{set_up_logging, LogLevel};
 
 /// Handles `blackd` process and allows submitting code to it for formatting.
 struct Blackd {

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -7,6 +7,7 @@ use std::{fs, str};
 use anyhow::{bail, Context, Result};
 use clap::CommandFactory;
 use pretty_assertions::StrComparison;
+
 use ruff_cli::args;
 
 use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
@@ -119,9 +120,11 @@ fn check_help_text() -> String {
 
 #[cfg(test)]
 mod test {
-    use super::{main, Args};
-    use crate::generate_all::Mode;
     use anyhow::Result;
+
+    use crate::generate_all::Mode;
+
+    use super::{main, Args};
 
     #[test]
     fn test_generate_json_schema() -> Result<()> {

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -3,12 +3,13 @@
 use std::fs;
 use std::path::PathBuf;
 
-use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 use anyhow::{bail, Result};
 use pretty_assertions::StrComparison;
-use ruff::settings::options::Options;
 use schemars::schema_for;
 
+use ruff::settings::options::Options;
+
+use crate::generate_all::{Mode, REGENERATE_ALL_COMMAND};
 use crate::ROOT_DIR;
 
 #[derive(clap::Args)]
@@ -48,9 +49,11 @@ pub(crate) fn main(args: &Args) -> Result<()> {
 
 #[cfg(test)]
 mod test {
-    use super::{main, Args};
-    use crate::generate_all::Mode;
     use anyhow::Result;
+
+    use crate::generate_all::Mode;
+
+    use super::{main, Args};
 
     #[test]
     fn test_generate_json_schema() -> Result<()> {

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -1,5 +1,6 @@
 //! Generate a Markdown-compatible listing of configuration options.
 use itertools::Itertools;
+
 use ruff::settings::options::Options;
 use ruff::settings::options_base::{OptionEntry, OptionField};
 

--- a/crates/ruff_diagnostics/src/diagnostic.rs
+++ b/crates/ruff_diagnostics/src/diagnostic.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use log::error;
 use ruff_text_size::{TextRange, TextSize};
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruff_diagnostics/src/edit.rs
+++ b/crates/ruff_diagnostics/src/edit.rs
@@ -1,8 +1,8 @@
-use ruff_text_size::{TextRange, TextSize};
+use std::cmp::Ordering;
 
+use ruff_text_size::{TextRange, TextSize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
 
 /// A text edit to be applied to a source file. Inserts, deletes, or replaces
 /// content at a given location.

--- a/crates/ruff_python_ast/src/imports.rs
+++ b/crates/ruff_python_ast/src/imports.rs
@@ -1,6 +1,5 @@
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashMap;
-
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruff_python_ast/src/newlines.rs
+++ b/crates/ruff_python_ast/src/newlines.rs
@@ -1,7 +1,8 @@
-use memchr::{memchr2, memrchr2};
-use ruff_text_size::{TextLen, TextRange, TextSize};
 use std::iter::FusedIterator;
 use std::ops::Deref;
+
+use memchr::{memchr2, memrchr2};
+use ruff_text_size::{TextLen, TextRange, TextSize};
 
 /// Extension trait for [`str`] that provides a [`UniversalNewlineIterator`].
 pub trait StrExt {
@@ -337,9 +338,11 @@ impl Deref for LineEnding {
 
 #[cfg(test)]
 mod tests {
-    use super::UniversalNewlineIterator;
-    use crate::newlines::Line;
     use ruff_text_size::TextSize;
+
+    use crate::newlines::Line;
+
+    use super::UniversalNewlineIterator;
 
     #[test]
     fn universal_newlines_empty_str() {

--- a/crates/ruff_python_ast/src/source_code/generator.rs
+++ b/crates/ruff_python_ast/src/source_code/generator.rs
@@ -9,7 +9,6 @@ use rustpython_parser::ast::{
 };
 
 use crate::newlines::LineEnding;
-
 use crate::source_code::stylist::{Indentation, Quote, Stylist};
 
 mod precedence {
@@ -1457,9 +1456,9 @@ impl<'a> Generator<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::newlines::LineEnding;
     use rustpython_parser as parser;
 
+    use crate::newlines::LineEnding;
     use crate::source_code::stylist::{Indentation, Quote};
     use crate::source_code::Generator;
 

--- a/crates/ruff_python_ast/src/source_code/line_index.rs
+++ b/crates/ruff_python_ast/src/source_code/line_index.rs
@@ -1,12 +1,14 @@
-use crate::source_code::SourceLocation;
-use ruff_text_size::{TextLen, TextRange, TextSize};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::sync::Arc;
+
+use ruff_text_size::{TextLen, TextRange, TextSize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::source_code::SourceLocation;
 
 /// Index for fast [byte offset](TextSize) to [`SourceLocation`] conversions.
 ///
@@ -312,9 +314,10 @@ const fn unwrap<T: Copy>(option: Option<T>) -> T {
 
 #[cfg(test)]
 mod tests {
+    use ruff_text_size::TextSize;
+
     use crate::source_code::line_index::LineIndex;
     use crate::source_code::{OneIndexed, SourceLocation};
-    use ruff_text_size::TextSize;
 
     #[test]
     fn ascii_index() {

--- a/crates/ruff_python_ast/src/source_code/locator.rs
+++ b/crates/ruff_python_ast/src/source_code/locator.rs
@@ -1,11 +1,13 @@
 //! Struct used to efficiently slice source code at (row, column) Locations.
 
-use crate::newlines::find_newline;
-use crate::source_code::{LineIndex, OneIndexed, SourceCode, SourceLocation};
+use std::ops::Add;
+
 use memchr::{memchr2, memrchr2};
 use once_cell::unsync::OnceCell;
 use ruff_text_size::{TextLen, TextRange, TextSize};
-use std::ops::Add;
+
+use crate::newlines::find_newline;
+use crate::source_code::{LineIndex, OneIndexed, SourceCode, SourceLocation};
 
 pub struct Locator<'a> {
     contents: &'a str,

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -1,21 +1,24 @@
-mod generator;
-mod indexer;
-mod line_index;
-mod locator;
-mod stylist;
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 
-pub use crate::source_code::line_index::{LineIndex, OneIndexed};
-pub use generator::Generator;
-pub use indexer::Indexer;
-pub use locator::Locator;
 use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser as parser;
 use rustpython_parser::{lexer, Mode, ParseError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
+
+pub use generator::Generator;
+pub use indexer::Indexer;
+pub use locator::Locator;
 pub use stylist::{Quote, Stylist};
+
+pub use crate::source_code::line_index::{LineIndex, OneIndexed};
+
+mod generator;
+mod indexer;
+mod line_index;
+mod locator;
+mod stylist;
 
 /// Run round-trip source code generation on a given Python code.
 pub fn round_trip(code: &str, source_path: &str) -> Result<String, ParseError> {

--- a/crates/ruff_python_ast/src/source_code/stylist.rs
+++ b/crates/ruff_python_ast/src/source_code/stylist.rs
@@ -9,7 +9,6 @@ use rustpython_parser::lexer::LexResult;
 use rustpython_parser::Tok;
 
 use crate::newlines::{find_newline, LineEnding};
-
 use crate::source_code::Locator;
 use crate::str::leading_quote;
 
@@ -164,10 +163,10 @@ impl Deref for Indentation {
 
 #[cfg(test)]
 mod tests {
-    use crate::newlines::{find_newline, LineEnding};
     use rustpython_parser::lexer::lex;
     use rustpython_parser::Mode;
 
+    use crate::newlines::{find_newline, LineEnding};
     use crate::source_code::stylist::{Indentation, Quote};
     use crate::source_code::{Locator, Stylist};
 

--- a/crates/ruff_python_semantic/src/analyze/logging.rs
+++ b/crates/ruff_python_semantic/src/analyze/logging.rs
@@ -2,7 +2,7 @@ use rustpython_parser::ast::{self, Expr};
 
 use ruff_python_ast::call_path::collect_call_path;
 
-use crate::context::Context;
+use crate::model::SemanticModel;
 
 /// Return `true` if the given `Expr` is a potential logging call. Matches
 /// `logging.error`, `logger.error`, `self.logger.error`, etc., but not
@@ -16,9 +16,9 @@ use crate::context::Context;
 /// # This is detected to be a logger candidate
 /// bar.error()
 /// ```
-pub fn is_logger_candidate(context: &Context, func: &Expr) -> bool {
+pub fn is_logger_candidate(model: &SemanticModel, func: &Expr) -> bool {
     if let Expr::Attribute(ast::ExprAttribute { value, .. }) = func {
-        let Some(call_path) = (if let Some(call_path) = context.resolve_call_path(value) {
+        let Some(call_path) = (if let Some(call_path) = model.resolve_call_path(value) {
             if call_path.first().map_or(false, |module| *module == "logging") || call_path.as_slice() == ["flask", "current_app", "logger"] {
                 Some(call_path)
             } else {

--- a/crates/ruff_python_semantic/src/lib.rs
+++ b/crates/ruff_python_semantic/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod analyze;
 pub mod binding;
-pub mod context;
 pub mod definition;
+pub mod model;
 pub mod node;
 pub mod scope;

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -20,8 +20,8 @@ use crate::definition::{Definition, DefinitionId, Definitions, Member, Module};
 use crate::node::{NodeId, Nodes};
 use crate::scope::{Scope, ScopeId, ScopeKind, Scopes};
 
-#[allow(clippy::struct_excessive_bools)]
-pub struct Context<'a> {
+/// A semantic model for a Python module, to enable querying the module's semantic information.
+pub struct SemanticModel<'a> {
     pub typing_modules: &'a [String],
     pub module_path: Option<&'a [String]>,
     // Stack of all visited statements, along with the identifier of the current statement.
@@ -49,7 +49,7 @@ pub struct Context<'a> {
     pub handled_exceptions: Vec<Exceptions>,
 }
 
-impl<'a> Context<'a> {
+impl<'a> SemanticModel<'a> {
     pub fn new(typing_modules: &'a [String], path: &'a Path, module: Module<'a>) -> Self {
         Self {
             typing_modules,
@@ -836,7 +836,7 @@ impl ContextFlags {
     }
 }
 
-/// A snapshot of the [`Context`] at a given point in the AST traversal.
+/// A snapshot of the [`SemanticModel`] at a given point in the AST traversal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Snapshot {
     scope_id: ScopeId,

--- a/crates/ruff_testing_macros/src/lib.rs
+++ b/crates/ruff_testing_macros/src/lib.rs
@@ -1,11 +1,12 @@
-use glob::{glob, Pattern};
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use quote::{format_ident, quote};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::env;
 use std::path::{Component, PathBuf};
+
+use glob::{glob, Pattern};
+use proc_macro2::Span;
+use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;


### PR DESCRIPTION
## Summary

I'm finding that the term "context" is overloaded in our codebase, and it feels more generic than what this `Context` struct is doing, which is: enabling us to query for semantic information across bindings, scopes, etc.