### PR TITLE
Avoid infinite loop for required imports with isort: off

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/required_imports/off.py
+++ b/crates/ruff/resources/test/fixtures/isort/required_imports/off.py
@@ -1,0 +1,4 @@
+# isort: off
+
+x = 1
+# isort: on

--- a/crates/ruff/src/checkers/imports.rs
+++ b/crates/ruff/src/checkers/imports.rs
@@ -14,7 +14,7 @@ use ruff_python_stdlib::path::is_python_stub_file;
 use crate::directives::IsortDirectives;
 use crate::registry::Rule;
 use crate::rules::isort;
-use crate::rules::isort::track::{Block, ImportTracker};
+use crate::rules::isort::block::{Block, BlockBuilder};
 use crate::settings::Settings;
 
 fn extract_import_map(path: &Path, package: Option<&Path>, blocks: &[&Block]) -> Option<ImportMap> {
@@ -86,9 +86,9 @@ pub(crate) fn check_imports(
 ) -> (Vec<Diagnostic>, Option<ImportMap>) {
     let is_stub = is_python_stub_file(path);
 
-    // Extract all imports from the AST.
+    // Extract all import blocks from the AST.
     let tracker = {
-        let mut tracker = ImportTracker::new(locator, directives, is_stub);
+        let mut tracker = BlockBuilder::new(locator, directives, is_stub);
         tracker.visit_body(python_ast);
         tracker
     };
@@ -109,7 +109,7 @@ pub(crate) fn check_imports(
     }
     if settings.rules.enabled(Rule::MissingRequiredImport) {
         diagnostics.extend(isort::rules::add_required_imports(
-            &blocks, python_ast, locator, stylist, settings, is_stub,
+            python_ast, locator, stylist, settings, is_stub,
         ));
     }
 

--- a/crates/ruff/src/rules/isort/block.rs
+++ b/crates/ruff/src/rules/isort/block.rs
@@ -7,13 +7,7 @@ use ruff_python_ast::statement_visitor::StatementVisitor;
 use crate::directives::IsortDirectives;
 use crate::rules::isort::helpers;
 
-#[derive(Debug, Copy, Clone)]
-pub(crate) enum Trailer {
-    Sibling,
-    ClassDef,
-    FunctionDef,
-}
-
+/// A block of imports within a Python module.
 #[derive(Debug, Default)]
 pub(crate) struct Block<'a> {
     pub(crate) nested: bool,
@@ -21,7 +15,16 @@ pub(crate) struct Block<'a> {
     pub(crate) trailer: Option<Trailer>,
 }
 
-pub(crate) struct ImportTracker<'a> {
+/// The type of trailer that should follow an import block.
+#[derive(Debug, Copy, Clone)]
+pub(crate) enum Trailer {
+    Sibling,
+    ClassDef,
+    FunctionDef,
+}
+
+/// A builder for identifying and constructing import blocks within a Python module.
+pub(crate) struct BlockBuilder<'a> {
     locator: &'a Locator<'a>,
     is_stub: bool,
     blocks: Vec<Block<'a>>,
@@ -30,7 +33,7 @@ pub(crate) struct ImportTracker<'a> {
     nested: bool,
 }
 
-impl<'a> ImportTracker<'a> {
+impl<'a> BlockBuilder<'a> {
     pub(crate) fn new(
         locator: &'a Locator<'a>,
         directives: &'a IsortDirectives,
@@ -111,7 +114,7 @@ impl<'a> ImportTracker<'a> {
     }
 }
 
-impl<'a, 'b> StatementVisitor<'b> for ImportTracker<'a>
+impl<'a, 'b> StatementVisitor<'b> for BlockBuilder<'a>
 where
     'b: 'a,
 {

--- a/crates/ruff/src/rules/isort/mod.rs
+++ b/crates/ruff/src/rules/isort/mod.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use annotate::annotate_imports;
+use block::{Block, Trailer};
 pub(crate) use categorize::categorize;
 use categorize::categorize_imports;
 pub use categorize::{ImportSection, ImportType};
@@ -13,7 +14,6 @@ use order::order_imports;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use settings::RelativeImportsOrder;
 use sorting::cmp_either_import;
-use track::{Block, Trailer};
 use types::EitherImport::{Import, ImportFrom};
 use types::{AliasData, EitherImport, TrailingComma};
 
@@ -22,6 +22,7 @@ use crate::rules::isort::types::ImportBlock;
 use crate::settings::types::PythonVersion;
 
 mod annotate;
+pub(crate) mod block;
 mod categorize;
 mod comments;
 mod format;
@@ -32,7 +33,6 @@ pub(crate) mod rules;
 pub mod settings;
 mod sorting;
 mod split;
-pub(crate) mod track;
 mod types;
 
 #[derive(Debug)]
@@ -687,11 +687,16 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(Path::new("comment.py"))]
     #[test_case(Path::new("docstring.py"))]
     #[test_case(Path::new("docstring.pyi"))]
     #[test_case(Path::new("docstring_only.py"))]
-    #[test_case(Path::new("multiline_docstring.py"))]
+    #[test_case(Path::new("docstring_with_continuation.py"))]
+    #[test_case(Path::new("docstring_with_semicolon.py"))]
     #[test_case(Path::new("empty.py"))]
+    #[test_case(Path::new("existing_import.py"))]
+    #[test_case(Path::new("multiline_docstring.py"))]
+    #[test_case(Path::new("off.py"))]
     fn required_import(path: &Path) -> Result<()> {
         let snapshot = format!("required_import_{}", path.to_string_lossy());
         let diagnostics = test_path(

--- a/crates/ruff/src/rules/isort/rules/organize_imports.rs
+++ b/crates/ruff/src/rules/isort/rules/organize_imports.rs
@@ -16,7 +16,7 @@ use ruff_python_ast::whitespace::leading_space;
 use crate::registry::AsRule;
 use crate::settings::Settings;
 
-use super::super::track::Block;
+use super::super::block::Block;
 use super::super::{comments, format_imports};
 
 /// ## What it does

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_comment.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_comment.py.snap
@@ -1,0 +1,19 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+comment.py:1:1: I002 [*] Missing required import: `from __future__ import annotations`
+  |
+1 | #!/usr/bin/env python3
+  |  I002
+2 | 
+3 | x = 1
+  |
+  = help: Insert required import: `from future import annotations`
+
+ℹ Suggested fix
+1 1 | #!/usr/bin/env python3
+  2 |+from __future__ import annotations
+2 3 | 
+3 4 | x = 1
+
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring_with_continuation.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring_with_continuation.py.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+docstring_with_continuation.py:1:1: I002 [*] Missing required import: `from __future__ import annotations`
+  |
+1 | """Hello, world!"""; x = \
+  |  I002
+2 |     1; y = 2
+  |
+  = help: Insert required import: `from future import annotations`
+
+ℹ Suggested fix
+1   |-"""Hello, world!"""; x = \
+  1 |+"""Hello, world!"""; from __future__ import annotations; x = \
+2 2 |     1; y = 2
+
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring_with_semicolon.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_docstring_with_semicolon.py.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+docstring_with_semicolon.py:1:1: I002 [*] Missing required import: `from __future__ import annotations`
+  |
+1 | """Hello, world!"""; x = 1
+  |  I002
+  |
+  = help: Insert required import: `from future import annotations`
+
+ℹ Suggested fix
+1   |-"""Hello, world!"""; x = 1
+  1 |+"""Hello, world!"""; from __future__ import annotations; x = 1
+
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_existing_import.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_existing_import.py.snap
@@ -1,0 +1,17 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+existing_import.py:1:1: I002 [*] Missing required import: `from __future__ import annotations`
+  |
+1 | from __future__ import generator_stop
+  |  I002
+2 | import os
+  |
+  = help: Insert required import: `from future import annotations`
+
+ℹ Suggested fix
+  1 |+from __future__ import annotations
+1 2 | from __future__ import generator_stop
+2 3 | import os
+
+

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_off.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__required_import_off.py.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff/src/rules/isort/mod.rs
+---
+off.py:1:1: I002 [*] Missing required import: `from __future__ import annotations`
+  |
+1 | # isort: off
+  |  I002
+2 | 
+3 | x = 1
+  |
+  = help: Insert required import: `from future import annotations`
+
+ℹ Suggested fix
+1 1 | # isort: off
+  2 |+from __future__ import annotations
+2 3 | 
+3 4 | x = 1
+4 5 | # isort: on
+
+


### PR DESCRIPTION
## Summary

When determining whether the required import exists in the file, we're ignoring any exclusion blocks. This PR decouples the required import rule from the import block-tracking logic, since we only care about top-level imports anyway.

Closes #4575.
