### PR TITLE
Fix `# isort: split` comment detection in nested blocks

### DIFF
--- a/crates/ruff/resources/test/fixtures/isort/split.py
+++ b/crates/ruff/resources/test/fixtures/isort/split.py
@@ -6,7 +6,16 @@ import f
 import c
 import d
 
-# isort: split  
+# isort: split
 
 import a
 import b
+
+if True:
+    import C
+    import A
+
+    # isort: split
+
+    import D
+    import B

--- a/crates/ruff/src/rules/isort/block.rs
+++ b/crates/ruff/src/rules/isort/block.rs
@@ -121,7 +121,7 @@ where
     fn visit_stmt(&mut self, stmt: &'b Stmt) {
         // Track manual splits.
         for (index, split) in self.splits.iter().enumerate() {
-            if stmt.end() >= *split {
+            if stmt.start() >= *split {
                 self.finalize(self.trailer_for(stmt));
                 self.splits = &self.splits[index + 1..];
             } else {

--- a/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__split.py.snap
+++ b/crates/ruff/src/rules/isort/snapshots/ruff__rules__isort__tests__split.py.snap
@@ -1,4 +1,43 @@
 ---
 source: crates/ruff/src/rules/isort/mod.rs
 ---
+split.py:15:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+15 |   if True:
+16 | /     import C
+17 | |     import A
+18 | | 
+   | |_^ I001
+19 |       # isort: split
+   |
+   = help: Organize imports
+
+ℹ Suggested fix
+12 12 | import b
+13 13 | 
+14 14 | if True:
+   15 |+    import A
+15 16 |     import C
+16    |-    import A
+17 17 | 
+18 18 |     # isort: split
+19 19 | 
+
+split.py:20:1: I001 [*] Import block is un-sorted or un-formatted
+   |
+20 |       # isort: split
+21 |   
+22 | /     import D
+23 | |     import B
+   |
+   = help: Organize imports
+
+ℹ Suggested fix
+17 17 | 
+18 18 |     # isort: split
+19 19 | 
+   20 |+    import B
+20 21 |     import D
+21    |-    import B
+
 


### PR DESCRIPTION
## Summary

Given:

```py
if True:
    import C
    import A

    # isort: split

    import D
    import B
```

Our `stmt.end() >= *split` check meant that we were triggering the split when we visited the outer `if True:`, instead of when visiting the inner `import D`.

Closes #4579.