### PR TITLE
Migrate some rules from `Fix::unspecified`

### DIFF
--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -54,7 +54,7 @@ pub(crate) fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
-        diagnostic.set_fix(Fix::maybe_correct(Edit::range_replacement(
+        diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
             checker.generator().stmt(&assertion_error(msg)),
             stmt.range(),
         )));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -54,7 +54,7 @@ pub(crate) fn assert_false(checker: &mut Checker, stmt: &Stmt, test: &Expr, msg:
     let mut diagnostic = Diagnostic::new(AssertFalse, test.range());
     if checker.patch(diagnostic.kind.rule()) {
         #[allow(deprecated)]
-        diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+        diagnostic.set_fix(Fix::maybe_correct(Edit::range_replacement(
             checker.generator().stmt(&assertion_error(msg)),
             stmt.range(),
         )));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -94,7 +94,7 @@ fn duplicate_handler_exceptions<'a>(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
-                diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+                diagnostic.set_fix(Fix::maybe_correct(Edit::range_replacement(
                     if unique_elts.len() == 1 {
                         checker.generator().expr(unique_elts[0])
                     } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -94,7 +94,7 @@ fn duplicate_handler_exceptions<'a>(
             );
             if checker.patch(diagnostic.kind.rule()) {
                 #[allow(deprecated)]
-                diagnostic.set_fix(Fix::maybe_correct(Edit::range_replacement(
+                diagnostic.set_fix(Fix::suggested(Edit::range_replacement(
                     if unique_elts.len() == 1 {
                         checker.generator().expr(unique_elts[0])
                     } else {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -50,7 +50,7 @@ pub(crate) fn redundant_tuple_in_exception_handler(
         );
         if checker.patch(diagnostic.kind.rule()) {
             #[allow(deprecated)]
-            diagnostic.set_fix(Fix::safe(Edit::range_replacement(
+            diagnostic.set_fix(Fix::automatic(Edit::range_replacement(
                 checker.generator().expr(elt),
                 type_.range(),
             )));

--- a/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/redundant_tuple_in_exception_handler.rs
@@ -50,7 +50,7 @@ pub(crate) fn redundant_tuple_in_exception_handler(
         );
         if checker.patch(diagnostic.kind.rule()) {
             #[allow(deprecated)]
-            diagnostic.set_fix(Fix::unspecified(Edit::range_replacement(
+            diagnostic.set_fix(Fix::safe(Edit::range_replacement(
                 checker.generator().expr(elt),
                 type_.range(),
             )));

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B013_B013.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B013_B013.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
+assertion_line: 57
 ---
 B013.py:3:8: B013 [*] A length-one tuple literal is redundant. Write `except ValueError` instead of `except (ValueError,)`.
   |
@@ -12,7 +13,7 @@ B013.py:3:8: B013 [*] A length-one tuple literal is redundant. Write `except Val
   |
   = help: Replace with `except ValueError`
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | try:
 2 2 |     pass
 3   |-except (ValueError,):


### PR DESCRIPTION
This PR aims to migrate `unspecified` code to `safe` or `maybe_correct`

Refers: #4184