### PR TITLE
Move `get_or_import_symbol` onto `Importer`

### DIFF
--- a/crates/ruff/src/autofix/actions.rs
+++ b/crates/ruff/src/autofix/actions.rs
@@ -10,14 +10,11 @@ use rustpython_parser::{lexer, Mode, Tok};
 
 use ruff_diagnostics::Edit;
 use ruff_python_ast::helpers;
-use ruff_python_ast::imports::{AnyImport, Import};
 use ruff_python_ast::newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-use ruff_python_semantic::model::SemanticModel;
 
 use crate::cst::helpers::compose_module_path;
 use crate::cst::matchers::match_module;
-use crate::importer::Importer;
 
 /// Determine if a body contains only a single statement, taking into account
 /// deleted.
@@ -419,86 +416,6 @@ pub(crate) fn remove_argument(
         (Some(start), Some(end)) => Ok(Edit::deletion(start, end)),
         _ => {
             bail!("No fix could be constructed")
-        }
-    }
-}
-
-/// Generate an [`Edit`] to reference the given symbol. Returns the [`Edit`] necessary to make the
-/// symbol available in the current scope along with the bound name of the symbol.
-///
-/// For example, assuming `module` is `"functools"` and `member` is `"lru_cache"`, this function
-/// could return an [`Edit`] to add `import functools` to the top of the file, alongside with the
-/// name on which the `lru_cache` symbol would be made available (`"functools.lru_cache"`).
-///
-/// Attempts to reuse existing imports when possible.
-pub(crate) fn get_or_import_symbol(
-    module: &str,
-    member: &str,
-    at: TextSize,
-    model: &SemanticModel,
-    importer: &Importer,
-    locator: &Locator,
-) -> Result<(Edit, String)> {
-    if let Some((source, binding)) = model.resolve_qualified_import_name(module, member) {
-        // If the symbol is already available in the current scope, use it.
-
-        // The exception: the symbol source (i.e., the import statement) comes after the current
-        // location. For example, we could be generating an edit within a function, and the import
-        // could be defined in the module scope, but after the function definition. In this case,
-        // it's unclear whether we can use the symbol (the function could be called between the
-        // import and the current location, and thus the symbol would not be available). It's also
-        // unclear whether should add an import statement at the top of the file, since it could
-        // be shadowed between the import and the current location.
-        if source.start() > at {
-            bail!("Unable to use existing symbol `{binding}` due to late-import");
-        }
-
-        // We also add a no-op edit to force conflicts with any other fixes that might try to
-        // remove the import. Consider:
-        //
-        // ```py
-        // import sys
-        //
-        // quit()
-        // ```
-        //
-        // Assume you omit this no-op edit. If you run Ruff with `unused-imports` and
-        // `sys-exit-alias` over this snippet, it will generate two fixes: (1) remove the unused
-        // `sys` import; and (2) replace `quit()` with `sys.exit()`, under the assumption that `sys`
-        // is already imported and available.
-        //
-        // By adding this no-op edit, we force the `unused-imports` fix to conflict with the
-        // `sys-exit-alias` fix, and thus will avoid applying both fixes in the same pass.
-        let import_edit =
-            Edit::range_replacement(locator.slice(source.range()).to_string(), source.range());
-        Ok((import_edit, binding))
-    } else {
-        if let Some(stmt) = importer.find_import_from(module, at) {
-            // Case 1: `from functools import lru_cache` is in scope, and we're trying to reference
-            // `functools.cache`; thus, we add `cache` to the import, and return `"cache"` as the
-            // bound name.
-            if model
-                .find_binding(member)
-                .map_or(true, |binding| binding.kind.is_builtin())
-            {
-                let import_edit = importer.add_member(stmt, member)?;
-                Ok((import_edit, member.to_string()))
-            } else {
-                bail!("Unable to insert `{member}` into scope due to name conflict")
-            }
-        } else {
-            // Case 2: No `functools` import is in scope; thus, we add `import functools`, and
-            // return `"functools.cache"` as the bound name.
-            if model
-                .find_binding(module)
-                .map_or(true, |binding| binding.kind.is_builtin())
-            {
-                let import_edit =
-                    importer.add_import(&AnyImport::Import(Import::module(module)), at);
-                Ok((import_edit, format!("{module}.{member}")))
-            } else {
-                bail!("Unable to insert `{module}` into scope due to name conflict")
-            }
         }
     }
 }

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -1,13 +1,14 @@
 //! Add and modify import statements to make module members available during fix execution.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use libcst_native::{Codegen, CodegenState, ImportAlias, Name, NameOrAttribute};
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{self, Ranged, Stmt, Suite};
 
 use ruff_diagnostics::Edit;
-use ruff_python_ast::imports::AnyImport;
+use ruff_python_ast::imports::{AnyImport, Import};
 use ruff_python_ast::source_code::{Locator, Stylist};
+use ruff_python_semantic::model::SemanticModel;
 
 use crate::cst::matchers::{match_aliases, match_import_from, match_module};
 use crate::importer::insertion::Insertion;
@@ -40,14 +41,6 @@ impl<'a> Importer<'a> {
         self.ordered_imports.push(import);
     }
 
-    /// Return the import statement that precedes the given position, if any.
-    fn preceding_import(&self, at: TextSize) -> Option<&Stmt> {
-        self.ordered_imports
-            .partition_point(|stmt| stmt.start() < at)
-            .checked_sub(1)
-            .map(|idx| self.ordered_imports[idx])
-    }
-
     /// Add an import statement to import the given module.
     ///
     /// If there are no existing imports, the new import will be added at the top
@@ -66,9 +59,123 @@ impl<'a> Importer<'a> {
         }
     }
 
+    /// Generate an [`Edit`] to reference the given symbol. Returns the [`Edit`] necessary to make
+    /// the symbol available in the current scope along with the bound name of the symbol.
+    ///
+    /// Attempts to reuse existing imports when possible.
+    pub(crate) fn get_or_import_symbol(
+        &self,
+        module: &str,
+        member: &str,
+        at: TextSize,
+        semantic_model: &SemanticModel,
+    ) -> Result<(Edit, String)> {
+        self.get_symbol(module, member, at, semantic_model)?
+            .map_or_else(
+                || self.import_symbol(module, member, at, semantic_model),
+                Ok,
+            )
+    }
+
+    /// Return an [`Edit`] to reference an existing symbol, if it's present in the given [`SemanticModel`].
+    fn get_symbol(
+        &self,
+        module: &str,
+        member: &str,
+        at: TextSize,
+        semantic_model: &SemanticModel,
+    ) -> Result<Option<(Edit, String)>> {
+        // If the symbol is already available in the current scope, use it.
+        let Some((source, binding)) = semantic_model.resolve_qualified_import_name(module, member) else {
+            return Ok(None);
+        };
+
+        // The exception: the symbol source (i.e., the import statement) comes after the current
+        // location. For example, we could be generating an edit within a function, and the import
+        // could be defined in the module scope, but after the function definition. In this case,
+        // it's unclear whether we can use the symbol (the function could be called between the
+        // import and the current location, and thus the symbol would not be available). It's also
+        // unclear whether should add an import statement at the top of the file, since it could
+        // be shadowed between the import and the current location.
+        if source.start() > at {
+            bail!("Unable to use existing symbol `{binding}` due to late-import");
+        }
+
+        // We also add a no-op edit to force conflicts with any other fixes that might try to
+        // remove the import. Consider:
+        //
+        // ```py
+        // import sys
+        //
+        // quit()
+        // ```
+        //
+        // Assume you omit this no-op edit. If you run Ruff with `unused-imports` and
+        // `sys-exit-alias` over this snippet, it will generate two fixes: (1) remove the unused
+        // `sys` import; and (2) replace `quit()` with `sys.exit()`, under the assumption that `sys`
+        // is already imported and available.
+        //
+        // By adding this no-op edit, we force the `unused-imports` fix to conflict with the
+        // `sys-exit-alias` fix, and thus will avoid applying both fixes in the same pass.
+        let import_edit = Edit::range_replacement(
+            self.locator.slice(source.range()).to_string(),
+            source.range(),
+        );
+        Ok(Some((import_edit, binding)))
+    }
+
+    /// Generate an [`Edit`] to reference the given symbol. Returns the [`Edit`] necessary to make
+    /// the symbol available in the current scope along with the bound name of the symbol.
+    ///
+    /// For example, assuming `module` is `"functools"` and `member` is `"lru_cache"`, this function
+    /// could return an [`Edit`] to add `import functools` to the top of the file, alongside with
+    /// the name on which the `lru_cache` symbol would be made available (`"functools.lru_cache"`).
+    fn import_symbol(
+        &self,
+        module: &str,
+        member: &str,
+        at: TextSize,
+        semantic_model: &SemanticModel,
+    ) -> Result<(Edit, String)> {
+        if let Some(stmt) = self.find_import_from(module, at) {
+            // Case 1: `from functools import lru_cache` is in scope, and we're trying to reference
+            // `functools.cache`; thus, we add `cache` to the import, and return `"cache"` as the
+            // bound name.
+            if semantic_model
+                .find_binding(member)
+                .map_or(true, |binding| binding.kind.is_builtin())
+            {
+                let import_edit = self.add_member(stmt, member)?;
+                Ok((import_edit, member.to_string()))
+            } else {
+                bail!("Unable to insert `{member}` into scope due to name conflict")
+            }
+        } else {
+            // Case 2: No `functools` import is in scope; thus, we add `import functools`, and
+            // return `"functools.cache"` as the bound name.
+            if semantic_model
+                .find_binding(module)
+                .map_or(true, |binding| binding.kind.is_builtin())
+            {
+                let import_edit = self.add_import(&AnyImport::Import(Import::module(module)), at);
+                Ok((import_edit, format!("{module}.{member}")))
+            } else {
+                bail!("Unable to insert `{module}` into scope due to name conflict")
+            }
+        }
+    }
+
+    /// Return the import statement that precedes the given position, if any.
+    fn preceding_import(&self, at: TextSize) -> Option<&Stmt> {
+        self.ordered_imports
+            .partition_point(|stmt| stmt.start() < at)
+            .checked_sub(1)
+            .map(|idx| self.ordered_imports[idx])
+    }
+
     /// Return the top-level [`Stmt`] that imports the given module using `Stmt::ImportFrom`
     /// preceding the given position, if any.
-    pub(crate) fn find_import_from(&self, module: &str, at: TextSize) -> Option<&Stmt> {
+    fn find_import_from(&self, module: &str, at: TextSize) -> Option<&Stmt> {
         let mut import_from = None;
         for stmt in &self.ordered_imports {
             if stmt.start() >= at {
@@ -91,7 +198,7 @@ impl<'a> Importer<'a> {
     }
 
     /// Add the given member to an existing `Stmt::ImportFrom` statement.
-    pub(crate) fn add_member(&self, stmt: &Stmt, member: &str) -> Result<Edit> {
+    fn add_member(&self, stmt: &Stmt, member: &str) -> Result<Edit> {
         let mut tree = match_module(self.locator.slice(stmt.range()))?;
         let import_from = match_import_from(&mut tree)?;
         let aliases = match_aliases(import_from)?;

--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -7,7 +7,6 @@ use ruff_python_ast::call_path::compose_call_path;
 use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::has_comments;
 
-use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
@@ -89,13 +88,11 @@ pub(crate) fn suppressible_exception(
 
             if fixable && checker.patch(diagnostic.kind.rule()) {
                 diagnostic.try_set_fix(|| {
-                    let (import_edit, binding) = get_or_import_symbol(
+                    let (import_edit, binding) = checker.importer.get_or_import_symbol(
                         "contextlib",
                         "suppress",
                         stmt.start(),
                         checker.semantic_model(),
-                        &checker.importer,
-                        checker.locator,
                     )?;
                     let replace_try = Edit::range_replacement(
                         format!("with {binding}({exception})"),

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -3,7 +3,6 @@ use rustpython_parser::ast::{self, Expr, Ranged};
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
@@ -76,13 +75,11 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
         );
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
-                let (import_edit, binding) = get_or_import_symbol(
+                let (import_edit, binding) = checker.importer.get_or_import_symbol(
                     "sys",
                     "exit",
                     func.start(),
                     checker.semantic_model(),
-                    &checker.importer,
-                    checker.locator,
                 )?;
                 let reference_edit = Edit::range_replacement(binding, func.range());
                 #[allow(deprecated)]

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -4,7 +4,6 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged};
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
-use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
@@ -65,13 +64,11 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                 );
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.try_set_fix(|| {
-                        let (import_edit, binding) = get_or_import_symbol(
+                        let (import_edit, binding) = checker.importer.get_or_import_symbol(
                             "functools",
                             "cache",
                             expr.start(),
                             checker.semantic_model(),
-                            &checker.importer,
-                            checker.locator,
                         )?;
                         let reference_edit = Edit::range_replacement(binding, expr.range());
                         #[allow(deprecated)]

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -5,7 +5,6 @@ use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::compose_call_path;
 use ruff_python_semantic::analyze::typing::ModuleMember;
 
-use crate::autofix::actions::get_or_import_symbol;
 use crate::checkers::ast::Checker;
 use crate::registry::AsRule;
 
@@ -61,13 +60,11 @@ pub(crate) fn use_pep585_annotation(
             ModuleMember::Member(module, member) => {
                 // Imported type, like `collections.deque`.
                 diagnostic.try_set_fix(|| {
-                    let (import_edit, binding) = get_or_import_symbol(
+                    let (import_edit, binding) = checker.importer.get_or_import_symbol(
                         module,
                         member,
                         expr.start(),
                         checker.semantic_model(),
-                        &checker.importer,
-                        checker.locator,
                     )?;
                     let reference_edit = Edit::range_replacement(binding, expr.range());
                     Ok(Fix::suggested_edits(import_edit, [reference_edit]))


### PR DESCRIPTION
No behavioral change, just improving discoverability and colocating relevant logic.