### PR TITLE
Introduce `ruff_index` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,6 +1905,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_index"
+version = "0.0.0"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "ruff_macros"
 version = "0.0.0"
 dependencies = [
@@ -1965,6 +1972,7 @@ dependencies = [
  "bitflags 2.3.1",
  "is-macro",
  "nohash-hasher",
+ "ruff_index",
  "ruff_python_ast",
  "ruff_python_stdlib",
  "ruff_text_size",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
 name = "ruff_index"
 version = "0.0.0"
 dependencies = [
+ "ruff_macros",
  "static_assertions",
 ]
 

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -5529,7 +5529,7 @@ impl<'a> Checker<'a> {
                     self.semantic_model
                         .scopes
                         .ancestor_ids(*scope_id)
-                        .flat_map(|scope_id| runtime_imports[usize::from(scope_id)].iter())
+                        .flat_map(|scope_id| runtime_imports[scope_id.as_usize()].iter())
                         .copied()
                         .collect()
                 };

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ruff_index"
+version = "0.0.0"
+publish = false
+edition = { workspace = true }
+rust-version = { workspace = true }
+
+[lib]
+
+[dependencies]
+static_assertions = "1.1.0"

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -9,3 +9,4 @@ rust-version = { workspace = true }
 
 [dependencies]
 static_assertions = "1.1.0"
+ruff_macros = { path = "../ruff_macros" }

--- a/crates/ruff_index/Cargo.toml
+++ b/crates/ruff_index/Cargo.toml
@@ -8,5 +8,7 @@ rust-version = { workspace = true }
 [lib]
 
 [dependencies]
-static_assertions = "1.1.0"
 ruff_macros = { path = "../ruff_macros" }
+
+[dev-dependencies]
+static_assertions = "1.1.0"

--- a/crates/ruff_index/src/idx.rs
+++ b/crates/ruff_index/src/idx.rs
@@ -1,152 +1,62 @@
-use static_assertions::assert_eq_size;
-use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
-use std::num::NonZeroU32;
-use std::ops::Add;
 
 /// Represents a newtype wrapper used to index into a Vec or a slice.
-pub trait Idx: Copy + PartialEq + Eq + Hash + Debug + 'static {
+///
+/// You can use the [`newtype_index`](crate::newtype_index) macro to define your own index.
+pub trait Idx: Copy + PartialEq + Eq + Hash + std::fmt::Debug + 'static {
     fn new(value: usize) -> Self;
 
     fn index(self) -> usize;
 }
 
-/// New-type wrapper for an index that can represent up to `u32::MAX - 1` entries.
-///
-/// The `u32::MAX - 1` is an optimization so that `Option<U32Index>` has the same size as `U32Index`.
-///
-/// Can store at most `u32::MAX - 1` values
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct U32Index(NonZeroU32);
-
-impl U32Index {
-    const MAX: u32 = u32::MAX - 1;
-
-    pub const fn from_usize(value: usize) -> Self {
-        assert!(value <= Self::MAX as usize);
-
-        // SAFETY:
-        // * The `value < u32::MAX` guarantees that the add doesn't overflow.
-        // * The `+ 1` guarantees that the index is not zero
-        #[allow(unsafe_code)]
-        Self(unsafe { NonZeroU32::new_unchecked((value as u32) + 1) })
-    }
-
-    pub const fn from_u32(value: u32) -> Self {
-        assert!(value <= Self::MAX);
-
-        // SAFETY:
-        // * The `value < u32::MAX` guarantees that the add doesn't overflow.
-        // * The `+ 1` guarantees that the index is larger than zero.
-        #[allow(unsafe_code)]
-        Self(unsafe { NonZeroU32::new_unchecked(value + 1) })
-    }
-
-    /// Returns the index as a `u32` value
-    #[inline]
-    pub const fn as_u32(self) -> u32 {
-        self.0.get() - 1
-    }
-
-    /// Returns the index as a `u32` value
-    #[inline]
-    pub const fn as_usize(self) -> usize {
-        self.as_u32() as usize
-    }
-
-    #[inline]
-    pub const fn index(self) -> usize {
-        self.as_usize()
-    }
-}
-
-impl Add<usize> for U32Index {
-    type Output = U32Index;
-
-    fn add(self, rhs: usize) -> Self::Output {
-        U32Index::from_usize(self.index() + rhs)
-    }
-}
-
-impl Add for U32Index {
-    type Output = U32Index;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        U32Index::from_usize(self.index() + rhs.index())
-    }
-}
-
-impl Debug for U32Index {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.index())
-    }
-}
-
-impl Idx for U32Index {
-    #[inline(always)]
-    fn new(value: usize) -> Self {
-        U32Index::from_usize(value)
-    }
-
-    #[inline(always)]
-    fn index(self) -> usize {
-        self.index()
-    }
-}
-
-impl From<usize> for U32Index {
-    fn from(value: usize) -> Self {
-        U32Index::from_usize(value)
-    }
-}
-
-impl From<u32> for U32Index {
-    fn from(value: u32) -> Self {
-        U32Index::from_u32(value)
-    }
-}
-
-impl From<U32Index> for usize {
-    fn from(value: U32Index) -> Self {
-        value.as_usize()
-    }
-}
-
-impl From<U32Index> for u32 {
-    fn from(value: U32Index) -> Self {
-        value.as_u32()
-    }
-}
-
-assert_eq_size!(U32Index, Option<U32Index>);
-
 #[cfg(test)]
 mod tests {
-    use crate::U32Index;
+
+    use crate::newtype_index;
+    use static_assertions::{assert_eq_size, assert_impl_all};
+
+    // Allows the macro invocation below to work
+    use crate as ruff_index;
+
+    // The two derives are intentional to test that the order doesn't matter
+    #[derive(Ord)]
+    #[newtype_index]
+    #[derive(PartialOrd)]
+    struct MyIndex;
+
+    assert_impl_all!(MyIndex: Ord, PartialOrd);
+    assert_eq_size!(MyIndex, Option<MyIndex>);
 
     #[test]
     #[should_panic(expected = "assertion failed: value <= Self::MAX")]
     fn from_u32_panics_for_u32_max() {
-        U32Index::from_u32(u32::MAX);
+        MyIndex::from_u32(u32::MAX);
     }
 
     #[test]
     #[should_panic(expected = "assertion failed: value <= Self::MAX")]
     fn from_usize_panics_for_u32_max() {
-        U32Index::from_usize(u32::MAX as usize);
+        MyIndex::from_usize(u32::MAX as usize);
     }
 
     #[test]
     fn max_value() {
-        let max_value = U32Index::from_u32(u32::MAX - 1);
+        let max_value = MyIndex::from_u32(u32::MAX - 1);
 
         assert_eq!(max_value.as_u32(), u32::MAX - 1);
     }
 
     #[test]
     fn max_value_usize() {
-        let max_value = U32Index::from_usize((u32::MAX - 1) as usize);
+        let max_value = MyIndex::from_usize((u32::MAX - 1) as usize);
 
         assert_eq!(max_value.as_u32(), u32::MAX - 1);
+    }
+
+    #[test]
+    fn debug() {
+        let output = format!("{:?}", MyIndex::from(10u32));
+
+        assert_eq!(output, "MyIndex(10)")
     }
 }

--- a/crates/ruff_index/src/idx.rs
+++ b/crates/ruff_index/src/idx.rs
@@ -1,0 +1,152 @@
+use static_assertions::assert_eq_size;
+use std::fmt::{Debug, Formatter};
+use std::hash::Hash;
+use std::num::NonZeroU32;
+use std::ops::Add;
+
+/// Represents a newtype wrapper used to index into a Vec or a slice.
+pub trait Idx: Copy + PartialEq + Eq + Hash + Debug + 'static {
+    fn new(value: usize) -> Self;
+
+    fn index(self) -> usize;
+}
+
+/// New-type wrapper for an index that can represent up to `u32::MAX - 1` entries.
+///
+/// The `u32::MAX - 1` is an optimization so that `Option<U32Index>` has the same size as `U32Index`.
+///
+/// Can store at most `u32::MAX - 1` values
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct U32Index(NonZeroU32);
+
+impl U32Index {
+    const MAX: u32 = u32::MAX - 1;
+
+    pub const fn from_usize(value: usize) -> Self {
+        assert!(value <= Self::MAX as usize);
+
+        // SAFETY:
+        // * The `value < u32::MAX` guarantees that the add doesn't overflow.
+        // * The `+ 1` guarantees that the index is not zero
+        #[allow(unsafe_code)]
+        Self(unsafe { NonZeroU32::new_unchecked((value as u32) + 1) })
+    }
+
+    pub const fn from_u32(value: u32) -> Self {
+        assert!(value <= Self::MAX);
+
+        // SAFETY:
+        // * The `value < u32::MAX` guarantees that the add doesn't overflow.
+        // * The `+ 1` guarantees that the index is larger than zero.
+        #[allow(unsafe_code)]
+        Self(unsafe { NonZeroU32::new_unchecked(value + 1) })
+    }
+
+    /// Returns the index as a `u32` value
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0.get() - 1
+    }
+
+    /// Returns the index as a `u32` value
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        self.as_u32() as usize
+    }
+
+    #[inline]
+    pub const fn index(self) -> usize {
+        self.as_usize()
+    }
+}
+
+impl Add<usize> for U32Index {
+    type Output = U32Index;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        U32Index::from_usize(self.index() + rhs)
+    }
+}
+
+impl Add for U32Index {
+    type Output = U32Index;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        U32Index::from_usize(self.index() + rhs.index())
+    }
+}
+
+impl Debug for U32Index {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.index())
+    }
+}
+
+impl Idx for U32Index {
+    #[inline(always)]
+    fn new(value: usize) -> Self {
+        U32Index::from_usize(value)
+    }
+
+    #[inline(always)]
+    fn index(self) -> usize {
+        self.index()
+    }
+}
+
+impl From<usize> for U32Index {
+    fn from(value: usize) -> Self {
+        U32Index::from_usize(value)
+    }
+}
+
+impl From<u32> for U32Index {
+    fn from(value: u32) -> Self {
+        U32Index::from_u32(value)
+    }
+}
+
+impl From<U32Index> for usize {
+    fn from(value: U32Index) -> Self {
+        value.as_usize()
+    }
+}
+
+impl From<U32Index> for u32 {
+    fn from(value: U32Index) -> Self {
+        value.as_u32()
+    }
+}
+
+assert_eq_size!(U32Index, Option<U32Index>);
+
+#[cfg(test)]
+mod tests {
+    use crate::U32Index;
+
+    #[test]
+    #[should_panic(expected = "assertion failed: value <= Self::MAX")]
+    fn from_u32_panics_for_u32_max() {
+        U32Index::from_u32(u32::MAX);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed: value <= Self::MAX")]
+    fn from_usize_panics_for_u32_max() {
+        U32Index::from_usize(u32::MAX as usize);
+    }
+
+    #[test]
+    fn max_value() {
+        let max_value = U32Index::from_u32(u32::MAX - 1);
+
+        assert_eq!(max_value.as_u32(), u32::MAX - 1);
+    }
+
+    #[test]
+    fn max_value_usize() {
+        let max_value = U32Index::from_usize((u32::MAX - 1) as usize);
+
+        assert_eq!(max_value.as_u32(), u32::MAX - 1);
+    }
+}

--- a/crates/ruff_index/src/idx.rs
+++ b/crates/ruff_index/src/idx.rs
@@ -18,10 +18,8 @@ mod tests {
     // Allows the macro invocation below to work
     use crate as ruff_index;
 
-    // The two derives are intentional to test that the order doesn't matter
-    #[derive(Ord)]
     #[newtype_index]
-    #[derive(PartialOrd)]
+    #[derive(PartialOrd, Ord)]
     struct MyIndex;
 
     assert_impl_all!(MyIndex: Ord, PartialOrd);
@@ -57,6 +55,6 @@ mod tests {
     fn debug() {
         let output = format!("{:?}", MyIndex::from(10u32));
 
-        assert_eq!(output, "MyIndex(10)")
+        assert_eq!(output, "MyIndex(10)");
     }
 }

--- a/crates/ruff_index/src/lib.rs
+++ b/crates/ruff_index/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provides new-type wrappers for collections that are indexed by a [`Idx`] rather
-//! than `usize.
+//! than `usize`.
 //!
-//! Inspired by https://github.com/rust-lang/rust/blob/master/compiler/rustc_index/src/lib.rs
+//! Inspired by [rustc_index](https://github.com/rust-lang/rust/blob/master/compiler/rustc_index/src/lib.rs).
 
 mod idx;
 mod slice;

--- a/crates/ruff_index/src/lib.rs
+++ b/crates/ruff_index/src/lib.rs
@@ -7,6 +7,7 @@ mod idx;
 mod slice;
 mod vec;
 
-pub use idx::{Idx, U32Index};
+pub use idx::Idx;
+pub use ruff_macros::newtype_index;
 pub use slice::IndexSlice;
 pub use vec::IndexVec;

--- a/crates/ruff_index/src/lib.rs
+++ b/crates/ruff_index/src/lib.rs
@@ -1,0 +1,12 @@
+//! Provides new-type wrappers for collections that are indexed by a [`Idx`] rather
+//! than `usize.
+//!
+//! Inspired by https://github.com/rust-lang/rust/blob/master/compiler/rustc_index/src/lib.rs
+
+mod idx;
+mod slice;
+mod vec;
+
+pub use idx::{Idx, U32Index};
+pub use slice::IndexSlice;
+pub use vec::IndexVec;

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -1,0 +1,174 @@
+use crate::vec::IndexVec;
+use crate::Idx;
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+/// A view into contiguous `T`s, indexed by `I` rather than by `usize`.
+#[derive(PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct IndexSlice<I, T> {
+    index: PhantomData<I>,
+    pub raw: [T],
+}
+
+impl<I: Idx, T> IndexSlice<I, T> {
+    #[inline]
+    pub const fn empty() -> &'static Self {
+        Self::from_raw(&[])
+    }
+
+    #[inline]
+    pub const fn from_raw(raw: &[T]) -> &Self {
+        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute(raw)
+        }
+    }
+
+    #[inline]
+    pub fn from_raw_mut(raw: &mut [T]) -> &mut Self {
+        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute(raw)
+        }
+    }
+
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.raw.len()
+    }
+
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.raw.iter()
+    }
+
+    /// Returns an iterator over the indices
+    #[inline]
+    pub fn indices(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = I> + ExactSizeIterator + Clone + 'static {
+        (0..self.len()).map(|n| I::new(n))
+    }
+
+    #[inline]
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
+        self.raw.iter_mut()
+    }
+
+    #[inline]
+    pub fn last_index(&self) -> Option<I> {
+        self.len().checked_sub(1).map(I::new)
+    }
+
+    #[inline]
+    pub fn swap(&mut self, a: I, b: I) {
+        self.raw.swap(a.index(), b.index())
+    }
+
+    #[inline]
+    pub fn get(&self, index: I) -> Option<&T> {
+        self.raw.get(index.index())
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, index: I) -> Option<&mut T> {
+        self.raw.get_mut(index.index())
+    }
+
+    #[inline]
+    pub fn binary_search(&self, value: &T) -> Result<I, I>
+    where
+        T: Ord,
+    {
+        match self.raw.binary_search(value) {
+            Ok(i) => Ok(Idx::new(i)),
+            Err(i) => Err(Idx::new(i)),
+        }
+    }
+}
+
+impl<I, T> Debug for IndexSlice<I, T>
+where
+    I: Idx,
+    T: Debug,
+{
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.raw, fmt)
+    }
+}
+
+impl<I: Idx, T> Index<I> for IndexSlice<I, T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, index: I) -> &T {
+        &self.raw[index.index()]
+    }
+}
+
+impl<I: Idx, T> IndexMut<I> for IndexSlice<I, T> {
+    #[inline]
+    fn index_mut(&mut self, index: I) -> &mut T {
+        &mut self.raw[index.index()]
+    }
+}
+
+impl<'a, I: Idx, T> IntoIterator for &'a IndexSlice<I, T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> std::slice::Iter<'a, T> {
+        self.raw.iter()
+    }
+}
+
+impl<'a, I: Idx, T> IntoIterator for &'a mut IndexSlice<I, T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> std::slice::IterMut<'a, T> {
+        self.raw.iter_mut()
+    }
+}
+
+impl<I: Idx, T: Clone> ToOwned for IndexSlice<I, T> {
+    type Owned = IndexVec<I, T>;
+
+    fn to_owned(&self) -> IndexVec<I, T> {
+        IndexVec::from_raw(self.raw.to_owned())
+    }
+
+    fn clone_into(&self, target: &mut IndexVec<I, T>) {
+        self.raw.clone_into(&mut target.raw)
+    }
+}
+
+impl<I: Idx, T> Default for &IndexSlice<I, T> {
+    #[inline]
+    fn default() -> Self {
+        IndexSlice::from_raw(Default::default())
+    }
+}
+
+impl<I: Idx, T> Default for &mut IndexSlice<I, T> {
+    #[inline]
+    fn default() -> Self {
+        IndexSlice::from_raw_mut(Default::default())
+    }
+}
+
+// Whether `IndexSlice` is `Send` depends only on the data,
+// not the phantom data.
+#[allow(unsafe_code)]
+unsafe impl<I: Idx, T> Send for IndexSlice<I, T> where T: Send {}

--- a/crates/ruff_index/src/slice.rs
+++ b/crates/ruff_index/src/slice.rs
@@ -20,19 +20,23 @@ impl<I: Idx, T> IndexSlice<I, T> {
 
     #[inline]
     pub const fn from_raw(raw: &[T]) -> &Self {
-        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
+        let ptr: *const [T] = raw;
+
         #[allow(unsafe_code)]
+        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
         unsafe {
-            std::mem::transmute(raw)
+            &*(ptr as *const Self)
         }
     }
 
     #[inline]
     pub fn from_raw_mut(raw: &mut [T]) -> &mut Self {
-        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
+        let ptr: *mut [T] = raw;
+
         #[allow(unsafe_code)]
+        // SAFETY: `IndexSlice` is `repr(transparent)` over a normal slice
         unsafe {
-            std::mem::transmute(raw)
+            &mut *(ptr as *mut Self)
         }
     }
 
@@ -71,7 +75,7 @@ impl<I: Idx, T> IndexSlice<I, T> {
 
     #[inline]
     pub fn swap(&mut self, a: I, b: I) {
-        self.raw.swap(a.index(), b.index())
+        self.raw.swap(a.index(), b.index());
     }
 
     #[inline]
@@ -150,7 +154,7 @@ impl<I: Idx, T: Clone> ToOwned for IndexSlice<I, T> {
     }
 
     fn clone_into(&self, target: &mut IndexVec<I, T>) {
-        self.raw.clone_into(&mut target.raw)
+        self.raw.clone_into(&mut target.raw);
     }
 }
 

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -39,18 +39,13 @@ impl<I: Idx, T> IndexVec<I, T> {
     }
 
     #[inline]
-    pub fn into_iter(self) -> std::vec::IntoIter<T> {
-        self.raw.into_iter()
-    }
-
-    #[inline]
     pub fn drain<R: RangeBounds<usize>>(&mut self, range: R) -> impl Iterator<Item = T> + '_ {
         self.raw.drain(range)
     }
 
     #[inline]
     pub fn truncate(&mut self, a: usize) {
-        self.raw.truncate(a)
+        self.raw.truncate(a);
     }
 
     #[inline]
@@ -114,7 +109,7 @@ impl<I: Idx, T> BorrowMut<IndexSlice<I, T>> for IndexVec<I, T> {
 impl<I, T> Extend<T> for IndexVec<I, T> {
     #[inline]
     fn extend<Iter: IntoIterator<Item = T>>(&mut self, iter: Iter) {
-        self.raw.extend(iter)
+        self.raw.extend(iter);
     }
 }
 

--- a/crates/ruff_index/src/vec.rs
+++ b/crates/ruff_index/src/vec.rs
@@ -1,0 +1,175 @@
+use crate::slice::IndexSlice;
+use crate::Idx;
+use std::borrow::{Borrow, BorrowMut};
+use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut, RangeBounds};
+
+/// An owned sequence of `T` indexed by `I`
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct IndexVec<I, T> {
+    pub raw: Vec<T>,
+    index: PhantomData<I>,
+}
+
+impl<I: Idx, T> IndexVec<I, T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            raw: Vec::new(),
+            index: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            raw: Vec::with_capacity(capacity),
+            index: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn from_raw(raw: Vec<T>) -> Self {
+        Self {
+            raw,
+            index: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn into_iter(self) -> std::vec::IntoIter<T> {
+        self.raw.into_iter()
+    }
+
+    #[inline]
+    pub fn drain<R: RangeBounds<usize>>(&mut self, range: R) -> impl Iterator<Item = T> + '_ {
+        self.raw.drain(range)
+    }
+
+    #[inline]
+    pub fn truncate(&mut self, a: usize) {
+        self.raw.truncate(a)
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &IndexSlice<I, T> {
+        IndexSlice::from_raw(&self.raw)
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut IndexSlice<I, T> {
+        IndexSlice::from_raw_mut(&mut self.raw)
+    }
+
+    #[inline]
+    pub fn push(&mut self, data: T) -> I {
+        let index = self.next_index();
+        self.raw.push(data);
+        index
+    }
+
+    #[inline]
+    pub fn next_index(&self) -> I {
+        I::new(self.raw.len())
+    }
+}
+
+impl<I, T> Debug for IndexVec<I, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.raw, f)
+    }
+}
+
+impl<I: Idx, T> Deref for IndexVec<I, T> {
+    type Target = IndexSlice<I, T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<I: Idx, T> DerefMut for IndexVec<I, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<I: Idx, T> Borrow<IndexSlice<I, T>> for IndexVec<I, T> {
+    fn borrow(&self) -> &IndexSlice<I, T> {
+        self
+    }
+}
+
+impl<I: Idx, T> BorrowMut<IndexSlice<I, T>> for IndexVec<I, T> {
+    fn borrow_mut(&mut self) -> &mut IndexSlice<I, T> {
+        self
+    }
+}
+
+impl<I, T> Extend<T> for IndexVec<I, T> {
+    #[inline]
+    fn extend<Iter: IntoIterator<Item = T>>(&mut self, iter: Iter) {
+        self.raw.extend(iter)
+    }
+}
+
+impl<I: Idx, T> FromIterator<T> for IndexVec<I, T> {
+    #[inline]
+    fn from_iter<Iter: IntoIterator<Item = T>>(iter: Iter) -> Self {
+        Self::from_raw(Vec::from_iter(iter))
+    }
+}
+
+impl<I: Idx, T> IntoIterator for IndexVec<I, T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    #[inline]
+    fn into_iter(self) -> std::vec::IntoIter<T> {
+        self.raw.into_iter()
+    }
+}
+
+impl<'a, I: Idx, T> IntoIterator for &'a IndexVec<I, T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> std::slice::Iter<'a, T> {
+        self.iter()
+    }
+}
+
+impl<'a, I: Idx, T> IntoIterator for &'a mut IndexVec<I, T> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> std::slice::IterMut<'a, T> {
+        self.iter_mut()
+    }
+}
+
+impl<I: Idx, T> Default for IndexVec<I, T> {
+    #[inline]
+    fn default() -> Self {
+        IndexVec::new()
+    }
+}
+
+impl<I: Idx, T, const N: usize> From<[T; N]> for IndexVec<I, T> {
+    #[inline]
+    fn from(array: [T; N]) -> Self {
+        IndexVec::from_raw(array.into())
+    }
+}
+
+// Whether `IndexVec` is `Send` depends only on the data,
+// not the phantom data.
+#[allow(unsafe_code)]
+unsafe impl<I: Idx, T> Send for IndexVec<I, T> where T: Send {}

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -12,6 +12,6 @@ doctest = false
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["derive", "parsing", "extra-traits"] }
+syn = { workspace = true, features = ["derive", "parsing", "extra-traits", "full"] }
 textwrap = { workspace = true }
 itertools = { workspace = true }

--- a/crates/ruff_macros/src/newtype_index.rs
+++ b/crates/ruff_macros/src/newtype_index.rs
@@ -1,0 +1,139 @@
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Error, ItemStruct};
+
+pub(super) fn generate_newtype_index(item: ItemStruct) -> syn::Result<proc_macro2::TokenStream> {
+    if !item.fields.is_empty() {
+        return Err(Error::new(
+            item.span(),
+            "A new type index cannot have any fields.",
+        ));
+    }
+
+    if !item.generics.params.is_empty() {
+        return Err(Error::new(
+            item.span(),
+            "A new type index cannot be generic.",
+        ));
+    }
+
+    let ItemStruct {
+        attrs,
+        vis,
+        struct_token,
+        ident,
+        generics: _,
+        fields: _,
+        semi_token,
+    } = item;
+
+    let debug_name = ident.to_string();
+
+    let semi_token = semi_token.unwrap_or_default();
+    let output = quote! {
+        #(#attrs)*
+        #[derive(Copy, Clone, Eq, PartialEq, Hash)]
+        #vis #struct_token #ident(std::num::NonZeroU32)#semi_token
+
+        impl #ident {
+            const MAX: u32 = u32::MAX - 1;
+
+            #vis const fn from_usize(value: usize) -> Self {
+                assert!(value <= Self::MAX as usize);
+
+                // SAFETY:
+                // * The `value < u32::MAX` guarantees that the add doesn't overflow.
+                // * The `+ 1` guarantees that the index is not zero
+                #[allow(unsafe_code)]
+                Self(unsafe { std::num::NonZeroU32::new_unchecked((value as u32) + 1) })
+            }
+
+            #vis const fn from_u32(value: u32) -> Self {
+                assert!(value <= Self::MAX);
+
+                // SAFETY:
+                // * The `value < u32::MAX` guarantees that the add doesn't overflow.
+                // * The `+ 1` guarantees that the index is larger than zero.
+                #[allow(unsafe_code)]
+                Self(unsafe { std::num::NonZeroU32::new_unchecked(value + 1) })
+            }
+
+            /// Returns the index as a `u32` value
+            #[inline]
+            #vis const fn as_u32(self) -> u32 {
+                self.0.get() - 1
+            }
+
+            /// Returns the index as a `u32` value
+            #[inline]
+            #vis const fn as_usize(self) -> usize {
+                self.as_u32() as usize
+            }
+
+            #[inline]
+            #vis const fn index(self) -> usize {
+                self.as_usize()
+            }
+        }
+
+        impl std::ops::Add<usize> for #ident {
+            type Output = #ident;
+
+            fn add(self, rhs: usize) -> Self::Output {
+                #ident::from_usize(self.index() + rhs)
+            }
+        }
+
+        impl std::ops::Add for #ident {
+            type Output = #ident;
+
+            fn add(self, rhs: Self) -> Self::Output {
+                #ident::from_usize(self.index() + rhs.index())
+            }
+        }
+
+        impl std::fmt::Debug for #ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(#debug_name).field(&self.index()).finish()
+            }
+        }
+
+        impl ruff_index::Idx for #ident {
+            #[inline]
+            fn new(value: usize) -> Self {
+                #ident::from_usize(value)
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                self.index()
+            }
+        }
+
+        impl From<usize> for #ident {
+            fn from(value: usize) -> Self {
+                #ident::from_usize(value)
+            }
+        }
+
+        impl From<u32> for #ident {
+            fn from(value: u32) -> Self {
+                #ident::from_u32(value)
+            }
+        }
+
+        impl From<#ident> for usize {
+            fn from(value: #ident) -> Self {
+                value.as_usize()
+            }
+        }
+
+        impl From<#ident> for u32 {
+            fn from(value: #ident) -> Self {
+                value.as_u32()
+            }
+        }
+    };
+
+    Ok(output)
+}

--- a/crates/ruff_python_semantic/Cargo.toml
+++ b/crates/ruff_python_semantic/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = { workspace = true }
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_python_stdlib = { path = "../ruff_python_stdlib" }
 ruff_text_size = { workspace = true }
+ruff_index = { path = "../ruff_index" }
 
 bitflags = { workspace = true }
 is-macro = { workspace = true }

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::model::SemanticModel;
 use bitflags::bitflags;
-use ruff_index::{Idx, IndexSlice, IndexVec, U32Index};
+use ruff_index::{newtype_index, IndexSlice, IndexVec};
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::Locator;
 use ruff_text_size::TextRange;
@@ -130,20 +130,8 @@ impl<'a> Binding<'a> {
 /// Using a `u32` to identify [Binding]s should is sufficient because Ruff only supports documents with a
 /// size smaller than or equal to `u32::max`. A document with the size of `u32::max` must have fewer than `u32::max`
 /// bindings because bindings must be separated by whitespace (and have an assignment).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct BindingId(U32Index);
-
-impl Idx for BindingId {
-    #[inline(always)]
-    fn new(value: usize) -> Self {
-        BindingId(U32Index::new(value))
-    }
-
-    #[inline(always)]
-    fn index(self) -> usize {
-        self.0.index()
-    }
-}
+#[newtype_index]
+pub struct BindingId;
 
 impl nohash_hasher::IsEnabled for BindingId {}
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -1,8 +1,8 @@
-use std::num::TryFromIntError;
-use std::ops::{Deref, Index, IndexMut};
+use std::ops::{Deref, DerefMut};
 
 use crate::model::SemanticModel;
 use bitflags::bitflags;
+use ruff_index::{Idx, IndexSlice, IndexVec, U32Index};
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::Locator;
 use ruff_text_size::TextRange;
@@ -130,14 +130,18 @@ impl<'a> Binding<'a> {
 /// Using a `u32` to identify [Binding]s should is sufficient because Ruff only supports documents with a
 /// size smaller than or equal to `u32::max`. A document with the size of `u32::max` must have fewer than `u32::max`
 /// bindings because bindings must be separated by whitespace (and have an assignment).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct BindingId(u32);
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct BindingId(U32Index);
 
-impl TryFrom<usize> for BindingId {
-    type Error = TryFromIntError;
+impl Idx for BindingId {
+    #[inline(always)]
+    fn new(value: usize) -> Self {
+        BindingId(U32Index::new(value))
+    }
 
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(Self(u32::try_from(value)?))
+    #[inline(always)]
+    fn index(self) -> usize {
+        self.0.index()
     }
 }
 
@@ -147,53 +151,37 @@ impl nohash_hasher::IsEnabled for BindingId {}
 ///
 /// Bindings are indexed by [`BindingId`]
 #[derive(Debug, Clone, Default)]
-pub struct Bindings<'a>(Vec<Binding<'a>>);
+pub struct Bindings<'a>(IndexVec<BindingId, Binding<'a>>);
 
 impl<'a> Bindings<'a> {
     /// Pushes a new binding and returns its id
     pub fn push(&mut self, binding: Binding<'a>) -> BindingId {
-        let id = self.next_id();
-        self.0.push(binding);
-        id
+        self.0.push(binding)
     }
 
     /// Returns the id that will be assigned when pushing the next binding
     pub fn next_id(&self) -> BindingId {
-        BindingId::try_from(self.0.len()).unwrap()
-    }
-}
-
-impl<'a> Index<BindingId> for Bindings<'a> {
-    type Output = Binding<'a>;
-
-    fn index(&self, index: BindingId) -> &Self::Output {
-        &self.0[usize::from(index)]
-    }
-}
-
-impl<'a> IndexMut<BindingId> for Bindings<'a> {
-    fn index_mut(&mut self, index: BindingId) -> &mut Self::Output {
-        &mut self.0[usize::from(index)]
+        self.0.next_index()
     }
 }
 
 impl<'a> Deref for Bindings<'a> {
-    type Target = [Binding<'a>];
+    type Target = IndexSlice<BindingId, Binding<'a>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> FromIterator<Binding<'a>> for Bindings<'a> {
-    fn from_iter<T: IntoIterator<Item = Binding<'a>>>(iter: T) -> Self {
-        Self(Vec::from_iter(iter))
+impl<'a> DerefMut for Bindings<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
-impl From<BindingId> for usize {
-    fn from(value: BindingId) -> Self {
-        value.0 as usize
+impl<'a> FromIterator<Binding<'a>> for Bindings<'a> {
+    fn from_iter<T: IntoIterator<Item = Binding<'a>>>(iter: T) -> Self {
+        Self(IndexVec::from_iter(iter))
     }
 }
 

--- a/crates/ruff_python_semantic/src/definition.rs
+++ b/crates/ruff_python_semantic/src/definition.rs
@@ -4,7 +4,7 @@
 use std::fmt::Debug;
 use std::ops::Deref;
 
-use ruff_index::{Idx, IndexSlice, IndexVec, U32Index};
+use ruff_index::{newtype_index, IndexSlice, IndexVec};
 use rustpython_parser::ast::{self, Stmt};
 
 use crate::analyze::visibility::{
@@ -12,26 +12,14 @@ use crate::analyze::visibility::{
 };
 
 /// Id uniquely identifying a definition in a program.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct DefinitionId(U32Index);
+#[newtype_index]
+pub struct DefinitionId;
 
 impl DefinitionId {
     /// Returns the ID for the module definition.
     #[inline]
     pub const fn module() -> Self {
-        DefinitionId(U32Index::from_u32(0))
-    }
-}
-
-impl Idx for DefinitionId {
-    #[inline]
-    fn new(value: usize) -> Self {
-        Self(U32Index::from_usize(value))
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        self.0.index()
+        DefinitionId::from_u32(0)
     }
 }
 

--- a/crates/ruff_python_semantic/src/node.rs
+++ b/crates/ruff_python_semantic/src/node.rs
@@ -1,6 +1,6 @@
-use std::num::{NonZeroU32, TryFromIntError};
 use std::ops::{Index, IndexMut};
 
+use ruff_index::{Idx, IndexVec, U32Index};
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Stmt;
 
@@ -12,21 +12,17 @@ use ruff_python_ast::types::RefEquality;
 /// and it is impossible to have more statements than characters in the file. We use a `NonZeroU32` to
 /// take advantage of memory layout optimizations.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct NodeId(NonZeroU32);
+pub struct NodeId(U32Index);
 
-/// Convert a `usize` to a `NodeId` (by adding 1 to the value, and casting to `NonZeroU32`).
-impl TryFrom<usize> for NodeId {
-    type Error = TryFromIntError;
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(Self(NonZeroU32::try_from(u32::try_from(value)? + 1)?))
+impl Idx for NodeId {
+    #[inline]
+    fn new(value: usize) -> Self {
+        Self(U32Index::from_usize(value))
     }
-}
 
-/// Convert a `NodeId` to a `usize` (by subtracting 1 from the value, and casting to `usize`).
-impl From<NodeId> for usize {
-    fn from(value: NodeId) -> Self {
-        value.0.get() as usize - 1
+    #[inline]
+    fn index(self) -> usize {
+        self.0.index()
     }
 }
 
@@ -44,7 +40,7 @@ struct Node<'a> {
 /// The nodes of a program indexed by [`NodeId`]
 #[derive(Debug, Default)]
 pub struct Nodes<'a> {
-    nodes: Vec<Node<'a>>,
+    nodes: IndexVec<NodeId, Node<'a>>,
     node_to_id: FxHashMap<RefEquality<'a, Stmt>, NodeId>,
 }
 
@@ -53,16 +49,15 @@ impl<'a> Nodes<'a> {
     ///
     /// Panics if a node with the same pointer already exists.
     pub fn insert(&mut self, stmt: &'a Stmt, parent: Option<NodeId>) -> NodeId {
-        let next_id = NodeId::try_from(self.nodes.len()).unwrap();
+        let next_id = self.nodes.next_index();
         if let Some(existing_id) = self.node_to_id.insert(RefEquality(stmt), next_id) {
             panic!("Node already exists with id {existing_id:?}");
         }
         self.nodes.push(Node {
             stmt,
             parent,
-            depth: parent.map_or(0, |parent| self.nodes[usize::from(parent)].depth + 1),
-        });
-        next_id
+            depth: parent.map_or(0, |parent| self.nodes[parent].depth + 1),
+        })
     }
 
     /// Returns the [`NodeId`] of the given node.
@@ -74,26 +69,24 @@ impl<'a> Nodes<'a> {
     /// Return the [`NodeId`] of the parent node.
     #[inline]
     pub fn parent_id(&self, node_id: NodeId) -> Option<NodeId> {
-        self.nodes[usize::from(node_id)].parent
+        self.nodes[node_id].parent
     }
 
     /// Return the depth of the node.
     #[inline]
     pub fn depth(&self, node_id: NodeId) -> u32 {
-        self.nodes[usize::from(node_id)].depth
+        self.nodes[node_id].depth
     }
 
     /// Returns an iterator over all [`NodeId`] ancestors, starting from the given [`NodeId`].
     pub fn ancestor_ids(&self, node_id: NodeId) -> impl Iterator<Item = NodeId> + '_ {
-        std::iter::successors(Some(node_id), |&node_id| {
-            self.nodes[usize::from(node_id)].parent
-        })
+        std::iter::successors(Some(node_id), |&node_id| self.nodes[node_id].parent)
     }
 
     /// Return the parent of the given node.
     pub fn parent(&self, node: &'a Stmt) -> Option<&'a Stmt> {
         let node_id = self.node_to_id.get(&RefEquality(node))?;
-        let parent_id = self.nodes[usize::from(*node_id)].parent?;
+        let parent_id = self.nodes[*node_id].parent?;
         Some(self[parent_id])
     }
 }
@@ -101,13 +94,15 @@ impl<'a> Nodes<'a> {
 impl<'a> Index<NodeId> for Nodes<'a> {
     type Output = &'a Stmt;
 
+    #[inline]
     fn index(&self, index: NodeId) -> &Self::Output {
-        &self.nodes[usize::from(index)].stmt
+        &self.nodes[index].stmt
     }
 }
 
 impl<'a> IndexMut<NodeId> for Nodes<'a> {
+    #[inline]
     fn index_mut(&mut self, index: NodeId) -> &mut Self::Output {
-        &mut self.nodes[usize::from(index)].stmt
+        &mut self.nodes[index].stmt
     }
 }

--- a/crates/ruff_python_semantic/src/node.rs
+++ b/crates/ruff_python_semantic/src/node.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use ruff_index::{Idx, IndexVec, U32Index};
+use ruff_index::{newtype_index, IndexVec};
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::Stmt;
 
@@ -11,20 +11,9 @@ use ruff_python_ast::types::RefEquality;
 /// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`
 /// and it is impossible to have more statements than characters in the file. We use a `NonZeroU32` to
 /// take advantage of memory layout optimizations.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct NodeId(U32Index);
-
-impl Idx for NodeId {
-    #[inline]
-    fn new(value: usize) -> Self {
-        Self(U32Index::from_usize(value))
-    }
-
-    #[inline]
-    fn index(self) -> usize {
-        self.0.index()
-    }
-}
+#[newtype_index]
+#[derive(Ord, PartialOrd)]
+pub struct NodeId;
 
 /// A [`Node`] represents a statement in a program, along with a pointer to its parent (if any).
 #[derive(Debug)]

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use ruff_index::{Idx, IndexSlice, IndexVec, U32Index};
+use ruff_index::{newtype_index, Idx, IndexSlice, IndexVec};
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Arguments, Expr, Keyword, Stmt};
 
@@ -151,35 +151,19 @@ pub struct Lambda<'a> {
 /// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`
 /// and it is impossible to have more scopes than characters in the file (because defining a function or class
 /// requires more than one character).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub struct ScopeId(U32Index);
+#[newtype_index]
+pub struct ScopeId;
 
 impl ScopeId {
     /// Returns the ID for the global scope
     #[inline]
     pub const fn global() -> Self {
-        ScopeId(U32Index::from_u32(0))
+        ScopeId::from_u32(0)
     }
 
     /// Returns `true` if this is the id of the global scope
-    pub const fn is_global(self) -> bool {
-        self.0.index() == 0
-    }
-
-    pub const fn as_usize(self) -> usize {
-        self.0.as_usize()
-    }
-}
-
-impl Idx for ScopeId {
-    #[inline(always)]
-    fn new(value: usize) -> Self {
-        Self(U32Index::from_usize(value))
-    }
-
-    #[inline(always)]
-    fn index(self) -> usize {
-        self.0.index()
+    pub const fn is_global(&self) -> bool {
+        self.index() == 0
     }
 }
 

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -1,6 +1,6 @@
-use std::num::TryFromIntError;
-use std::ops::{Deref, Index, IndexMut};
+use std::ops::{Deref, DerefMut};
 
+use ruff_index::{Idx, IndexSlice, IndexVec, U32Index};
 use rustc_hash::FxHashMap;
 use rustpython_parser::ast::{Arguments, Expr, Keyword, Stmt};
 
@@ -151,39 +151,41 @@ pub struct Lambda<'a> {
 /// Using a `u32` is sufficient because Ruff only supports parsing documents with a size of max `u32::max`
 /// and it is impossible to have more scopes than characters in the file (because defining a function or class
 /// requires more than one character).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ScopeId(u32);
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct ScopeId(U32Index);
 
 impl ScopeId {
     /// Returns the ID for the global scope
     #[inline]
     pub const fn global() -> Self {
-        ScopeId(0)
+        ScopeId(U32Index::from_u32(0))
     }
 
     /// Returns `true` if this is the id of the global scope
-    pub const fn is_global(&self) -> bool {
-        self.0 == 0
+    pub const fn is_global(self) -> bool {
+        self.0.index() == 0
+    }
+
+    pub const fn as_usize(self) -> usize {
+        self.0.as_usize()
     }
 }
 
-impl TryFrom<usize> for ScopeId {
-    type Error = TryFromIntError;
-
-    fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(Self(u32::try_from(value)?))
+impl Idx for ScopeId {
+    #[inline(always)]
+    fn new(value: usize) -> Self {
+        Self(U32Index::from_usize(value))
     }
-}
 
-impl From<ScopeId> for usize {
-    fn from(value: ScopeId) -> Self {
-        value.0 as usize
+    #[inline(always)]
+    fn index(self) -> usize {
+        self.0.index()
     }
 }
 
 /// The scopes of a program indexed by [`ScopeId`]
 #[derive(Debug)]
-pub struct Scopes<'a>(Vec<Scope<'a>>);
+pub struct Scopes<'a>(IndexVec<ScopeId, Scope<'a>>);
 
 impl<'a> Scopes<'a> {
     /// Returns a reference to the global scope
@@ -198,7 +200,7 @@ impl<'a> Scopes<'a> {
 
     /// Pushes a new scope and returns its unique id
     pub fn push_scope(&mut self, kind: ScopeKind<'a>, parent: ScopeId) -> ScopeId {
-        let next_id = ScopeId::try_from(self.0.len()).unwrap();
+        let next_id = ScopeId::new(self.0.len());
         self.0.push(Scope::local(kind, parent));
         next_id
     }
@@ -218,27 +220,19 @@ impl<'a> Scopes<'a> {
 
 impl Default for Scopes<'_> {
     fn default() -> Self {
-        Self(vec![Scope::global()])
-    }
-}
-
-impl<'a> Index<ScopeId> for Scopes<'a> {
-    type Output = Scope<'a>;
-
-    fn index(&self, index: ScopeId) -> &Self::Output {
-        &self.0[usize::from(index)]
-    }
-}
-
-impl<'a> IndexMut<ScopeId> for Scopes<'a> {
-    fn index_mut(&mut self, index: ScopeId) -> &mut Self::Output {
-        &mut self.0[usize::from(index)]
+        Self(IndexVec::from_raw(vec![Scope::global()]))
     }
 }
 
 impl<'a> Deref for Scopes<'a> {
-    type Target = [Scope<'a>];
+    type Target = IndexSlice<ScopeId, Scope<'a>>;
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl<'a> DerefMut for Scopes<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }


### PR DESCRIPTION
We have multiple places where we use a custom `Id` to index into a Vector. I now plan to add one new index and thought it might be good to reduce the necessary boilerplate. 

This PR formalizes this approach by introducing new `IndexVec` and `IndexSlice` new type wrappers and thew `newtype_index` macro that allows you to define your own index. 

This work is heavily inspired by [rustc `index` crate](https://github.com/rust-lang/rust/blob/master/compiler/rustc_index/src/lib.rs) and thanks to @boshen for making me aware of it :)