### PR TITLE
Remove source position from `FormatElement::DynamicText`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "rustc-hash",
  "schemars",
  "serde",
+ "static_assertions",
  "tracing",
  "unicode-width",
 ]

--- a/crates/ruff_formatter/Cargo.toml
+++ b/crates/ruff_formatter/Cargo.toml
@@ -14,6 +14,7 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 unicode-width = { version = "0.1.10" }
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/ruff_formatter/src/builders.rs
+++ b/crates/ruff_formatter/src/builders.rs
@@ -297,7 +297,8 @@ impl std::fmt::Debug for StaticText {
 ///     source_position(TextSize::new(8)),
 ///     text("'Ruff'"),
 ///     source_position(TextSize::new(14)),
-///     text("\"")
+///     text("\""),
+///     source_position(TextSize::new(20))
 /// ])?;
 ///
 /// let printed = elements.print()?;
@@ -307,9 +308,10 @@ impl std::fmt::Debug for StaticText {
 ///     SourceMarker { source: TextSize::new(0), dest: TextSize::new(0) },
 ///     SourceMarker { source: TextSize::new(0), dest: TextSize::new(7) },
 ///     SourceMarker { source: TextSize::new(8), dest: TextSize::new(7) },
-///     SourceMarker { source: TextSize::new(8), dest: TextSize::new(14) },
+///     SourceMarker { source: TextSize::new(8), dest: TextSize::new(13) },
 ///     SourceMarker { source: TextSize::new(14), dest: TextSize::new(13) },
 ///     SourceMarker { source: TextSize::new(14), dest: TextSize::new(14) },
+///     SourceMarker { source: TextSize::new(20), dest: TextSize::new(14) },
 /// ]);
 ///
 /// # Ok(())

--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -8,7 +8,6 @@ use crate::{
     BufferExtensions, Format, FormatContext, FormatElement, FormatOptions, FormatResult, Formatter,
     IndentStyle, LineWidth, PrinterOptions,
 };
-use ruff_text_size::TextSize;
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -231,6 +230,16 @@ impl Format<IrFormatContext> for &[FormatElement] {
                     write!(f, [text("expand_parent")])?;
                 }
 
+                FormatElement::SourcePosition(position) => {
+                    write!(
+                        f,
+                        [dynamic_text(
+                            &std::format!("source_position({:?})", position),
+                            None
+                        )]
+                    )?;
+                }
+
                 FormatElement::LineSuffixBoundary => {
                     write!(f, [text("line_suffix_boundary")])?;
                 }
@@ -265,10 +274,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                             write!(
                                 f,
                                 [
-                                    dynamic_text(
-                                        &std::format!("<interned {index}>"),
-                                        TextSize::default()
-                                    ),
+                                    dynamic_text(&std::format!("<interned {index}>"), None),
                                     space(),
                                     &interned.deref(),
                                 ]
@@ -279,7 +285,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 f,
                                 [dynamic_text(
                                     &std::format!("<ref interned *{reference}>"),
-                                    TextSize::default()
+                                    None
                                 )]
                             )?;
                         }
@@ -300,10 +306,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                     f,
                                     [
                                         text("<END_TAG_WITHOUT_START<"),
-                                        dynamic_text(
-                                            &std::format!("{:?}", tag.kind()),
-                                            TextSize::default()
-                                        ),
+                                        dynamic_text(&std::format!("{:?}", tag.kind()), None),
                                         text(">>"),
                                     ]
                                 )?;
@@ -318,15 +321,9 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                         text(")"),
                                         soft_line_break_or_space(),
                                         text("ERROR<START_END_TAG_MISMATCH<start: "),
-                                        dynamic_text(
-                                            &std::format!("{start_kind:?}"),
-                                            TextSize::default()
-                                        ),
+                                        dynamic_text(&std::format!("{start_kind:?}"), None),
                                         text(", end: "),
-                                        dynamic_text(
-                                            &std::format!("{:?}", tag.kind()),
-                                            TextSize::default()
-                                        ),
+                                        dynamic_text(&std::format!("{:?}", tag.kind()), None),
                                         text(">>")
                                     ]
                                 )?;
@@ -358,7 +355,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 f,
                                 [
                                     text("align("),
-                                    dynamic_text(&count.to_string(), TextSize::default()),
+                                    dynamic_text(&count.to_string(), None),
                                     text(","),
                                     space(),
                                 ]
@@ -380,10 +377,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 write!(
                                     f,
                                     [
-                                        dynamic_text(
-                                            &std::format!("\"{group_id:?}\""),
-                                            TextSize::default()
-                                        ),
+                                        dynamic_text(&std::format!("\"{group_id:?}\""), None),
                                         text(","),
                                         space(),
                                     ]
@@ -406,7 +400,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 f,
                                 [
                                     text("indent_if_group_breaks("),
-                                    dynamic_text(&std::format!("\"{id:?}\""), TextSize::default()),
+                                    dynamic_text(&std::format!("\"{id:?}\""), None),
                                     text(","),
                                     space(),
                                 ]
@@ -427,10 +421,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 write!(
                                     f,
                                     [
-                                        dynamic_text(
-                                            &std::format!("\"{group_id:?}\""),
-                                            TextSize::default()
-                                        ),
+                                        dynamic_text(&std::format!("\"{group_id:?}\""), None),
                                         text(","),
                                         space(),
                                     ]
@@ -443,10 +434,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                                 f,
                                 [
                                     text("label("),
-                                    dynamic_text(
-                                        &std::format!("\"{label_id:?}\""),
-                                        TextSize::default()
-                                    ),
+                                    dynamic_text(&std::format!("\"{label_id:?}\""), None),
                                     text(","),
                                     space(),
                                 ]
@@ -490,10 +478,7 @@ impl Format<IrFormatContext> for &[FormatElement] {
                     ContentArrayEnd,
                     text(")"),
                     soft_line_break_or_space(),
-                    dynamic_text(
-                        &std::format!("<START_WITHOUT_END<{top:?}>>"),
-                        TextSize::default()
-                    ),
+                    dynamic_text(&std::format!("<START_WITHOUT_END<{top:?}>>"), None),
                 ]
             )?;
         }

--- a/crates/ruff_formatter/src/format_extensions.rs
+++ b/crates/ruff_formatter/src/format_extensions.rs
@@ -35,7 +35,7 @@ pub trait MemoizeFormat<Context> {
     ///         let value = self.value.get();
     ///         self.value.set(value + 1);
     ///
-    ///         write!(f, [dynamic_text(&std::format!("Formatted {value} times."), TextSize::from(0))])
+    ///         write!(f, [dynamic_text(&std::format!("Formatted {value} times."), None)])
     ///     }
     /// }
     ///
@@ -114,7 +114,7 @@ where
     ///         write!(f, [
     ///             text("Count:"),
     ///             space(),
-    ///             dynamic_text(&std::format!("{current}"), TextSize::default()),
+    ///             dynamic_text(&std::format!("{current}"), None),
     ///             hard_line_break()
     ///         ])?;
     ///

--- a/crates/ruff_formatter/src/lib.rs
+++ b/crates/ruff_formatter/src/lib.rs
@@ -33,7 +33,6 @@ pub mod group_id;
 pub mod macros;
 pub mod prelude;
 pub mod printer;
-mod utility_types;
 
 use crate::formatter::Formatter;
 use crate::group_id::UniqueGroupIdBuilder;
@@ -428,7 +427,7 @@ pub type FormatResult<F> = Result<F, FormatError>;
 ///     fn fmt(&self, f: &mut Formatter<SimpleFormatContext>) -> FormatResult<()> {
 ///         write!(f, [
 ///             hard_line_break(),
-///             dynamic_text(&self.0, TextSize::from(0)),
+///             dynamic_text(&self.0, None),
 ///             hard_line_break(),
 ///         ])
 ///     }

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -128,6 +128,7 @@ impl<'a> Printer<'a> {
 
             FormatElement::SourcePosition(position) => {
                 self.state.source_position = *position;
+                self.push_marker();
             }
 
             FormatElement::LineSuffixBoundary => {
@@ -316,10 +317,7 @@ impl<'a> Printer<'a> {
             self.state.source_position = range.start();
         }
 
-        self.push_marker(SourceMarker {
-            source: self.state.source_position,
-            dest: self.state.buffer.text_len(),
-        });
+        self.push_marker();
 
         self.print_str(text);
 
@@ -327,13 +325,15 @@ impl<'a> Printer<'a> {
             self.state.source_position = range.end();
         }
 
-        self.push_marker(SourceMarker {
-            source: self.state.source_position,
-            dest: self.state.buffer.text_len(),
-        });
+        self.push_marker();
     }
 
-    fn push_marker(&mut self, marker: SourceMarker) {
+    fn push_marker(&mut self) {
+        let marker = SourceMarker {
+            source: self.state.source_position,
+            dest: self.state.buffer.text_len(),
+        };
+
         if let Some(last) = self.state.source_markers.last() {
             if last != &marker {
                 self.state.source_markers.push(marker)

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -95,10 +95,7 @@ impl<'a> Printer<'a> {
             }
 
             FormatElement::StaticText { text } => self.print_text(text, None),
-            FormatElement::DynamicText {
-                text,
-                source_position,
-            } => self.print_text(text, Some(*source_position)),
+            FormatElement::DynamicText { text } => self.print_text(text, None),
             FormatElement::StaticTextSlice { text, range } => self.print_text(&text[*range], None),
             FormatElement::Line(line_mode) => {
                 if args.mode().is_flat()
@@ -127,6 +124,10 @@ impl<'a> Printer<'a> {
 
             FormatElement::ExpandParent => {
                 // Handled in `Document::propagate_expands()
+            }
+
+            FormatElement::SourcePosition(position) => {
+                self.state.source_position = *position;
             }
 
             FormatElement::LineSuffixBoundary => {
@@ -273,7 +274,7 @@ impl<'a> Printer<'a> {
         result
     }
 
-    fn print_text(&mut self, text: &str, source_position: Option<TextSize>) {
+    fn print_text(&mut self, text: &str, source_range: Option<TextRange>) {
         if !self.state.pending_indent.is_empty() {
             let (indent_char, repeat_count) = match self.options.indent_style() {
                 IndentStyle::Tab => ('\t', 1),
@@ -311,8 +312,8 @@ impl<'a> Printer<'a> {
         // If the token has no source position (was created by the formatter)
         // both the start and end marker will use the last known position
         // in the input source (from state.source_position)
-        if let Some(source) = source_position {
-            self.state.source_position = source;
+        if let Some(range) = source_range {
+            self.state.source_position = range.start();
         }
 
         self.push_marker(SourceMarker {
@@ -322,8 +323,8 @@ impl<'a> Printer<'a> {
 
         self.print_str(text);
 
-        if source_position.is_some() {
-            self.state.source_position += text.text_len();
+        if let Some(range) = source_range {
+            self.state.source_position = range.end();
         }
 
         self.push_marker(SourceMarker {
@@ -1007,6 +1008,8 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                     return Ok(Fits::No);
                 }
             }
+
+            FormatElement::SourcePosition(_) => {}
 
             FormatElement::BestFitting(best_fitting) => {
                 let slice = match args.mode() {

--- a/crates/ruff_formatter/src/utility_types.rs
+++ b/crates/ruff_formatter/src/utility_types.rs
@@ -1,7 +1,0 @@
-#[cfg(target_pointer_width = "64")]
-#[macro_export]
-macro_rules! static_assert {
-    ($expr:expr) => {
-        const _: i32 = 0 / $expr as i32;
-    };
-}

--- a/crates/ruff_python_formatter/src/format/alias.rs
+++ b/crates/ruff_python_formatter/src/format/alias.rs
@@ -1,6 +1,5 @@
 use ruff_formatter::prelude::*;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::Alias;
@@ -23,10 +22,10 @@ impl Format<ASTFormatContext> for FormatAlias<'_> {
     fn fmt(&self, f: &mut Formatter<ASTFormatContext>) -> FormatResult<()> {
         let alias = self.item;
 
-        write!(f, [dynamic_text(&alias.name, TextSize::default())])?;
+        write!(f, [dynamic_text(&alias.name, None)])?;
         if let Some(asname) = &alias.asname {
             write!(f, [text(" as ")])?;
-            write!(f, [dynamic_text(asname, TextSize::default())])?;
+            write!(f, [dynamic_text(asname, None)])?;
         }
 
         write!(f, [end_of_line_comments(alias)])?;

--- a/crates/ruff_python_formatter/src/format/arg.rs
+++ b/crates/ruff_python_formatter/src/format/arg.rs
@@ -1,6 +1,5 @@
 use ruff_formatter::prelude::*;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::Arg;
@@ -23,7 +22,7 @@ impl Format<ASTFormatContext> for FormatArg<'_> {
     fn fmt(&self, f: &mut Formatter<ASTFormatContext>) -> FormatResult<()> {
         let arg = self.item;
 
-        write!(f, [dynamic_text(&arg.arg, TextSize::default())])?;
+        write!(f, [dynamic_text(&arg.arg, None)])?;
         if let Some(annotation) = &arg.annotation {
             write!(f, [text(": ")])?;
             write!(f, [annotation.format()])?;

--- a/crates/ruff_python_formatter/src/format/builders.rs
+++ b/crates/ruff_python_formatter/src/format/builders.rs
@@ -1,6 +1,6 @@
 use ruff_formatter::prelude::*;
 use ruff_formatter::{write, Format};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::TextRange;
 
 use crate::context::ASTFormatContext;
 use crate::cst::{Body, Stmt};
@@ -98,7 +98,7 @@ impl<Context> Format<Context> for JoinNames<'_> {
     fn fmt(&self, f: &mut Formatter<Context>) -> FormatResult<()> {
         let mut join = f.join_with(text(", "));
         for name in self.names {
-            join.entry(&dynamic_text(name, TextSize::default()));
+            join.entry(&dynamic_text(name, None));
         }
         join.finish()
     }

--- a/crates/ruff_python_formatter/src/format/excepthandler.rs
+++ b/crates/ruff_python_formatter/src/format/excepthandler.rs
@@ -1,6 +1,5 @@
 use ruff_formatter::prelude::*;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::{Excepthandler, ExcepthandlerKind};
@@ -29,15 +28,7 @@ impl Format<ASTFormatContext> for FormatExcepthandler<'_> {
         if let Some(type_) = &type_ {
             write!(f, [space(), type_.format()])?;
             if let Some(name) = &name {
-                write!(
-                    f,
-                    [
-                        space(),
-                        text("as"),
-                        space(),
-                        dynamic_text(name, TextSize::default()),
-                    ]
-                )?;
+                write!(f, [space(), text("as"), space(), dynamic_text(name, None)])?;
             }
         }
         write!(f, [text(":")])?;

--- a/crates/ruff_python_formatter/src/format/expr.rs
+++ b/crates/ruff_python_formatter/src/format/expr.rs
@@ -4,7 +4,6 @@ use rustpython_parser::ast::{Constant, ConversionFlag};
 
 use ruff_formatter::prelude::*;
 use ruff_formatter::{format_args, write};
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::{
@@ -676,7 +675,7 @@ fn format_attribute(
 ) -> FormatResult<()> {
     write!(f, [value.format()])?;
     write!(f, [text(".")])?;
-    write!(f, [dynamic_text(attr, TextSize::default())])?;
+    write!(f, [dynamic_text(attr, None)])?;
     write!(f, [end_of_line_comments(expr)])?;
     Ok(())
 }

--- a/crates/ruff_python_formatter/src/format/keyword.rs
+++ b/crates/ruff_python_formatter/src/format/keyword.rs
@@ -1,6 +1,5 @@
 use ruff_formatter::prelude::*;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::Keyword;
@@ -25,7 +24,7 @@ impl Format<ASTFormatContext> for FormatKeyword<'_> {
 
         write!(f, [leading_comments(keyword)])?;
         if let Some(arg) = &keyword.arg {
-            write!(f, [dynamic_text(arg, TextSize::default())])?;
+            write!(f, [dynamic_text(arg, None)])?;
             write!(f, [text("=")])?;
             write!(f, [keyword.value.format()])?;
         } else {

--- a/crates/ruff_python_formatter/src/format/numbers.rs
+++ b/crates/ruff_python_formatter/src/format/numbers.rs
@@ -136,8 +136,8 @@ impl Format<ASTFormatContext> for IntLiteral {
                     write!(
                         f,
                         [
-                            dynamic_text(&prefix.to_lowercase(), TextSize::default()),
-                            dynamic_text(&suffix.to_uppercase(), TextSize::default())
+                            dynamic_text(&prefix.to_lowercase(), None),
+                            dynamic_text(&suffix.to_uppercase(), None)
                         ]
                     )?;
                 } else {

--- a/crates/ruff_python_formatter/src/format/pattern.rs
+++ b/crates/ruff_python_formatter/src/format/pattern.rs
@@ -2,7 +2,6 @@ use rustpython_parser::ast::Constant;
 
 use ruff_formatter::prelude::*;
 use ruff_formatter::write;
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::{Pattern, PatternKind};
@@ -79,7 +78,7 @@ impl Format<ASTFormatContext> for FormatPattern<'_> {
                             space(),
                             text("**"),
                             space(),
-                            dynamic_text(rest, TextSize::default())
+                            dynamic_text(rest, None)
                         ]
                     )?;
                 }
@@ -105,13 +104,10 @@ impl Format<ASTFormatContext> for FormatPattern<'_> {
                 if !kwd_attrs.is_empty() {
                     write!(f, [text("(")])?;
                     if let Some(attr) = kwd_attrs.first() {
-                        write!(f, [dynamic_text(attr, TextSize::default())])?;
+                        write!(f, [dynamic_text(attr, None)])?;
                     }
                     for attr in kwd_attrs.iter().skip(1) {
-                        write!(
-                            f,
-                            [text(","), space(), dynamic_text(attr, TextSize::default())]
-                        )?;
+                        write!(f, [text(","), space(), dynamic_text(attr, None)])?;
                     }
                     write!(f, [text(")")])?;
                 }
@@ -128,7 +124,7 @@ impl Format<ASTFormatContext> for FormatPattern<'_> {
             }
             PatternKind::MatchStar { name } => {
                 if let Some(name) = name {
-                    write!(f, [text("*"), dynamic_text(name, TextSize::default())])?;
+                    write!(f, [text("*"), dynamic_text(name, None)])?;
                 } else {
                     write!(f, [text("*_")])?;
                 }
@@ -141,7 +137,7 @@ impl Format<ASTFormatContext> for FormatPattern<'_> {
                     write!(f, [space()])?;
                 }
                 if let Some(name) = name {
-                    write!(f, [dynamic_text(name, TextSize::default())])?;
+                    write!(f, [dynamic_text(name, None)])?;
                 } else {
                     write!(f, [text("_")])?;
                 }

--- a/crates/ruff_python_formatter/src/format/stmt.rs
+++ b/crates/ruff_python_formatter/src/format/stmt.rs
@@ -2,7 +2,6 @@
 
 use ruff_formatter::prelude::*;
 use ruff_formatter::{format_args, write};
-use ruff_text_size::TextSize;
 
 use crate::context::ASTFormatContext;
 use crate::cst::{
@@ -110,14 +109,7 @@ fn format_class_def(
 
     write!(f, [leading_comments(body)])?;
 
-    write!(
-        f,
-        [
-            text("class"),
-            space(),
-            dynamic_text(name, TextSize::default())
-        ]
-    )?;
+    write!(f, [text("class"), space(), dynamic_text(name, None)])?;
 
     if !bases.is_empty() || !keywords.is_empty() {
         let format_bases = format_with(|f| {
@@ -180,7 +172,7 @@ fn format_func_def(
         [
             text("def"),
             space(),
-            dynamic_text(name, TextSize::default()),
+            dynamic_text(name, None),
             text("("),
             group(&soft_block_indent(&format_with(|f| {
                 if stmt.trivia.iter().any(|c| c.kind.is_magic_trailing_comma()) {
@@ -653,7 +645,7 @@ fn format_import_from(
         }
     }
     if let Some(module) = module {
-        write!(f, [dynamic_text(module, TextSize::default())])?;
+        write!(f, [dynamic_text(module, None)])?;
     }
     write!(f, [space()])?;
 

--- a/crates/ruff_python_formatter/src/format/strings.rs
+++ b/crates/ruff_python_formatter/src/format/strings.rs
@@ -3,7 +3,7 @@ use rustpython_parser::{Mode, Tok};
 use ruff_formatter::prelude::*;
 use ruff_formatter::{write, Format};
 use ruff_python_ast::str::{leading_quote, trailing_quote};
-use ruff_text_size::{TextRange, TextSize};
+use ruff_text_size::TextRange;
 
 use crate::context::ASTFormatContext;
 use crate::cst::Expr;
@@ -64,7 +64,6 @@ impl Format<ASTFormatContext> for StringLiteralPart {
                     } else {
                         double_escape(body).into()
                     },
-                    source_position: TextSize::default(),
                 })?;
                 f.write_element(FormatElement::StaticText { text: "\"" })?;
                 Ok(())
@@ -76,7 +75,6 @@ impl Format<ASTFormatContext> for StringLiteralPart {
                     } else {
                         single_escape(body).into()
                     },
-                    source_position: TextSize::default(),
                 })?;
                 f.write_element(FormatElement::StaticText { text: "'" })?;
                 Ok(())
@@ -90,7 +88,6 @@ impl Format<ASTFormatContext> for StringLiteralPart {
                 f.write_element(FormatElement::StaticText { text: "'''" })?;
                 f.write_element(FormatElement::DynamicText {
                     text: body.to_string().into_boxed_str(),
-                    source_position: TextSize::default(),
                 })?;
                 f.write_element(FormatElement::StaticText { text: "'''" })?;
                 Ok(())
@@ -98,7 +95,6 @@ impl Format<ASTFormatContext> for StringLiteralPart {
                 f.write_element(FormatElement::StaticText { text: "\"\"\"" })?;
                 f.write_element(FormatElement::DynamicText {
                     text: body.to_string().into_boxed_str(),
-                    source_position: TextSize::default(),
                 })?;
                 f.write_element(FormatElement::StaticText { text: "\"\"\"" })?;
                 Ok(())

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -67,7 +67,6 @@ mod tests {
     use insta::assert_snapshot;
 
     use ruff_testing_macros::fixture;
-    use ruff_text_size::TextSize;
     use similar::TextDiff;
 
     use crate::fmt;
@@ -208,7 +207,7 @@ mod tests {
                     while let Some(word) = words.next() {
                         let is_last = words.peek().is_none();
                         let format_word = format_with(|f| {
-                            write!(f, [dynamic_text(word, TextSize::default())])?;
+                            write!(f, [dynamic_text(word, None)])?;
 
                             if is_last {
                                 write!(f, [text("\"")])?;


### PR DESCRIPTION
## Summary

This PR removes the `source_position` from the `DynamicText` because it isn't always possible (at least in Ruff) to know the source position for dynamically formatted texts. We now used to pass `TextSize::default` which is incorrect because it will create source mappings from position `0` to the position in the output document, which is obviously incorrect and may drip over consumers of the source map. 

Providing source position information for `dynamic_text`s is still encouraged. That's why I leave the `source_position` on the `dynamic_text` builder as an `Optional` argument. The builder emits the new  `FormatElement::SourcePosition` element if the position is set. 

I decided to introduce the new `FormatElement::SourcePosition` in favor of changing the `position` field on `DynamicText` to `Option<TextSize>` because of:

* Having a dedicated IR element allows us to emit source positions at the start and end of every node even if we don't have a token.
* Changing the field to `Option<TextSize>` on `DynamicText` increases the field from 4 to 8 bytes so that `DynamicText` takes 24 bytes in total. This will prevent us from reducing our `FormatElement` back to 24 bytes again.

## Test Plan

I ran the formatter tests and added a new doctest for the new source position element