### PR TITLE
Improve `Message` sorting performance

### DIFF
--- a/crates/ruff/src/message/mod.rs
+++ b/crates/ruff/src/message/mod.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
+use crate::jupyter::JupyterIndex;
 pub use azure::AzureEmitter;
 pub use github::GithubEmitter;
 pub use gitlab::GitlabEmitter;
@@ -16,9 +17,6 @@ pub use pylint::PylintEmitter;
 use ruff_diagnostics::{Diagnostic, DiagnosticKind, Fix};
 use ruff_python_ast::source_code::{SourceFile, SourceLocation};
 pub use text::TextEmitter;
-
-use crate::jupyter::JupyterIndex;
-use crate::registry::AsRule;
 
 mod azure;
 mod diff;
@@ -77,11 +75,7 @@ impl Message {
 
 impl Ord for Message {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.filename(), self.start(), self.kind.rule()).cmp(&(
-            other.filename(),
-            other.start(),
-            other.kind.rule(),
-        ))
+        (&self.file, self.start()).cmp(&(&other.file, other.start()))
     }
 }
 

--- a/crates/ruff_cli/src/commands/run.rs
+++ b/crates/ruff_cli/src/commands/run.rs
@@ -143,7 +143,8 @@ pub(crate) fn run(
             acc
         });
 
-    diagnostics.messages.sort_unstable();
+    diagnostics.messages.sort();
+
     let duration = start.elapsed();
     debug!("Checked {:?} files in: {:?}", paths.len(), duration);
 

--- a/crates/ruff_cli/src/lib.rs
+++ b/crates/ruff_cli/src/lib.rs
@@ -107,7 +107,7 @@ quoting the executed command, along with the relevant file contents and `pyproje
     #[cfg(windows)]
     assert!(colored::control::set_virtual_terminal(true).is_ok());
 
-    let log_level: LogLevel = (&log_level_args).into();
+    let log_level = LogLevel::from(&log_level_args);
     set_up_logging(&log_level)?;
 
     match command {

--- a/crates/ruff_python_ast/src/source_code/mod.rs
+++ b/crates/ruff_python_ast/src/source_code/mod.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -204,6 +205,23 @@ impl SourceFile {
     #[inline]
     pub fn source_text(&self) -> &str {
         &self.inner.code
+    }
+}
+
+impl PartialOrd for SourceFile {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SourceFile {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Short circuit if these are the same source files
+        if Arc::ptr_eq(&self.inner, &other.inner) {
+            Ordering::Equal
+        } else {
+            self.inner.name.cmp(&other.inner.name)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

I included the rule name in the `Message` `Ord` implementation to fix non-deterministic ordering of messages in the CLI output (which messed up my diffs when comparing the diagnostics before/after) in #3931. This regressed performance significantly for two reasons:

1. We need to compare the name
2. more importantly, we now call `AsRule::rule` which performs a lookup of the rule by name (involves plenty of string comparisons). 

This PR fixes the performance regression by:

1. Using `sort()` instead of `sort_unstable()` because we care about stable order. 
2. Remove `rule` from the comparison key because, in my view, a rule should never emit two diagnostics at the exact same location. We can include `kind.name` which is significantly cheaper, but using stable sorting and removing the rule name proved to be fastest
3. Compare the file and add a fast path to `SourceFile` that returns `Ordering::Equal` if the files point to the same address. I'm very surprised that Rust doesn't implement this optimisation by default for Arcs. They have such a fast path for the `PartialEq` implementation. 

Fixes #4606

## Test Plan

The performance is now roughly the same as before #3931, even though we've added new rules since. 

> *Note*: Measured with release builds that include debug information (for profiling). The release builds should be slightly faster. 


### Before #3931(using `sort_unstable`)

<pre><b>Benchmark 1</b>: ./target/release-debug/ruff --no-cache -e  --select=ALL ./crates/ruff/resources/test/cpython/
  Time (<span style="color:#26A269"><b>mean</b></span> ± <span style="color:#26A269">σ</span>):     <span style="color:#26A269"><b>712.1 ms</b></span> ± <span style="color:#26A269"> 19.9 ms</span>    [User: <span style="color:#12488B">7890.2 ms</span>, System: <span style="color:#12488B">222.2 ms</span>]
  Range (<span style="color:#2AA1B3">min</span> … <span style="color:#A347BA">max</span>):   <span style="color:#2AA1B3">688.7 ms</span> … <span style="color:#A347BA">749.0 ms</span>    10 runs
</pre>

### Before #3931 patched using `sort`

<pre><b>Benchmark 1</b>: ./target/release-debug/ruff --no-cache -e  --select=ALL ./crates/ruff/resources/test/cpython/
  Time (<span style="color:#26A269"><b>mean</b></span> ± <span style="color:#26A269">σ</span>):     <span style="color:#26A269"><b>725.6 ms</b></span> ± <span style="color:#26A269"> 17.8 ms</span>    [User: <span style="color:#12488B">7948.2 ms</span>, System: <span style="color:#12488B">227.7 ms</span>]
  Range (<span style="color:#2AA1B3">min</span> … <span style="color:#A347BA">max</span>):   <span style="color:#2AA1B3">708.6 ms</span> … <span style="color:#A347BA">760.5 ms</span>    10 runs
</pre>

### Main

<pre><b>Benchmark 1</b>: ./target/release-debug/ruff --no-cache -e  --select=ALL ./crates/ruff/resources/test/cpython/
  Time (<span style="color:#26A269"><b>mean</b></span> ± <span style="color:#26A269">σ</span>):     <span style="color:#26A269"><b> 1.638 s</b></span> ± <span style="color:#26A269"> 0.024 s</span>    [User: <span style="color:#12488B">8.997 s</span>, System: <span style="color:#12488B">0.238 s</span>]
  Range (<span style="color:#2AA1B3">min</span> … <span style="color:#A347BA">max</span>):   <span style="color:#2AA1B3"> 1.605 s</span> … <span style="color:#A347BA"> 1.676 s</span>    10 runs
</pre>

### Now

<pre><b>Benchmark 1</b>: ./target/release-debug/ruff --no-cache -e  --select=ALL ./crates/ruff/resources/test/cpython/
  Time (<span style="color:#26A269"><b>mean</b></span> ± <span style="color:#26A269">σ</span>):     <span style="color:#26A269"><b>734.9 ms</b></span> ± <span style="color:#26A269"> 10.0 ms</span>    [User: <span style="color:#12488B">8133.6 ms</span>, System: <span style="color:#12488B">211.3 ms</span>]
  Range (<span style="color:#2AA1B3">min</span> … <span style="color:#A347BA">max</span>):   <span style="color:#2AA1B3">720.9 ms</span> … <span style="color:#A347BA">752.5 ms</span>    10 runs
</pre>

## Alternatives
Ideally, we wouldn't even sort the `Message`s when passing `--silent`. I considered moving the logic into the `Printer,` but it only gets passed a read-only slice. We could consider changing the slice to be mutable, but that feels odd. 