### PR TITLE
Add Checker::enabled shortcut

### DIFF
--- a/crates/ruff/src/rules/flake8_2020/rules.rs
+++ b/crates/ruff/src/rules/flake8_2020/rules.rs
@@ -135,15 +135,11 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                     ..
                 }) = upper.as_ref()
                 {
-                    if *i == BigInt::from(1)
-                        && checker.settings.rules.enabled(Rule::SysVersionSlice1)
-                    {
+                    if *i == BigInt::from(1) && checker.enabled(Rule::SysVersionSlice1) {
                         checker
                             .diagnostics
                             .push(Diagnostic::new(SysVersionSlice1, value.range()));
-                    } else if *i == BigInt::from(3)
-                        && checker.settings.rules.enabled(Rule::SysVersionSlice3)
-                    {
+                    } else if *i == BigInt::from(3) && checker.enabled(Rule::SysVersionSlice3) {
                         checker
                             .diagnostics
                             .push(Diagnostic::new(SysVersionSlice3, value.range()));
@@ -155,12 +151,11 @@ pub(crate) fn subscript(checker: &mut Checker, value: &Expr, slice: &Expr) {
                 value: Constant::Int(i),
                 ..
             }) => {
-                if *i == BigInt::from(2) && checker.settings.rules.enabled(Rule::SysVersion2) {
+                if *i == BigInt::from(2) && checker.enabled(Rule::SysVersion2) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersion2, value.range()));
-                } else if *i == BigInt::from(0) && checker.settings.rules.enabled(Rule::SysVersion0)
-                {
+                } else if *i == BigInt::from(0) && checker.enabled(Rule::SysVersion0) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersion0, value.range()));
@@ -192,9 +187,7 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], compara
                         })],
                     ) = (ops, comparators)
                     {
-                        if *n == BigInt::from(3)
-                            && checker.settings.rules.enabled(Rule::SysVersionInfo0Eq3)
-                        {
+                        if *n == BigInt::from(3) && checker.enabled(Rule::SysVersionInfo0Eq3) {
                             checker
                                 .diagnostics
                                 .push(Diagnostic::new(SysVersionInfo0Eq3, left.range()));
@@ -209,7 +202,7 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], compara
                         })],
                     ) = (ops, comparators)
                     {
-                        if checker.settings.rules.enabled(Rule::SysVersionInfo1CmpInt) {
+                        if checker.enabled(Rule::SysVersionInfo1CmpInt) {
                             checker
                                 .diagnostics
                                 .push(Diagnostic::new(SysVersionInfo1CmpInt, left.range()));
@@ -230,11 +223,7 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], compara
                 })],
             ) = (ops, comparators)
             {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::SysVersionInfoMinorCmpInt)
-                {
+                if checker.enabled(Rule::SysVersionInfoMinorCmpInt) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersionInfoMinorCmpInt, left.range()));
@@ -255,12 +244,12 @@ pub(crate) fn compare(checker: &mut Checker, left: &Expr, ops: &[Cmpop], compara
         ) = (ops, comparators)
         {
             if s.len() == 1 {
-                if checker.settings.rules.enabled(Rule::SysVersionCmpStr10) {
+                if checker.enabled(Rule::SysVersionCmpStr10) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(SysVersionCmpStr10, left.range()));
                 }
-            } else if checker.settings.rules.enabled(Rule::SysVersionCmpStr3) {
+            } else if checker.enabled(Rule::SysVersionCmpStr3) {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(SysVersionCmpStr3, left.range()));

--- a/crates/ruff/src/rules/flake8_annotations/rules.rs
+++ b/crates/ruff/src/rules/flake8_annotations/rules.rs
@@ -502,7 +502,7 @@ pub(crate) fn definition(
         // ANN401 for dynamically typed arguments
         if let Some(annotation) = &arg.annotation {
             has_any_typed_arg = true;
-            if checker.settings.rules.enabled(Rule::AnyType) {
+            if checker.enabled(Rule::AnyType) {
                 check_dynamically_typed(
                     checker.semantic_model(),
                     annotation,
@@ -515,11 +515,7 @@ pub(crate) fn definition(
             if !(checker.settings.flake8_annotations.suppress_dummy_args
                 && checker.settings.dummy_variable_rgx.is_match(&arg.arg))
             {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::MissingTypeFunctionArgument)
-                {
+                if checker.enabled(Rule::MissingTypeFunctionArgument) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeFunctionArgument {
                             name: arg.arg.to_string(),
@@ -536,7 +532,7 @@ pub(crate) fn definition(
         if let Some(expr) = &arg.annotation {
             has_any_typed_arg = true;
             if !checker.settings.flake8_annotations.allow_star_arg_any {
-                if checker.settings.rules.enabled(Rule::AnyType) {
+                if checker.enabled(Rule::AnyType) {
                     let name = &arg.arg;
                     check_dynamically_typed(
                         checker.semantic_model(),
@@ -551,7 +547,7 @@ pub(crate) fn definition(
             if !(checker.settings.flake8_annotations.suppress_dummy_args
                 && checker.settings.dummy_variable_rgx.is_match(&arg.arg))
             {
-                if checker.settings.rules.enabled(Rule::MissingTypeArgs) {
+                if checker.enabled(Rule::MissingTypeArgs) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeArgs {
                             name: arg.arg.to_string(),
@@ -568,7 +564,7 @@ pub(crate) fn definition(
         if let Some(expr) = &arg.annotation {
             has_any_typed_arg = true;
             if !checker.settings.flake8_annotations.allow_star_arg_any {
-                if checker.settings.rules.enabled(Rule::AnyType) {
+                if checker.enabled(Rule::AnyType) {
                     let name = &arg.arg;
                     check_dynamically_typed(
                         checker.semantic_model(),
@@ -583,7 +579,7 @@ pub(crate) fn definition(
             if !(checker.settings.flake8_annotations.suppress_dummy_args
                 && checker.settings.dummy_variable_rgx.is_match(&arg.arg))
             {
-                if checker.settings.rules.enabled(Rule::MissingTypeKwargs) {
+                if checker.enabled(Rule::MissingTypeKwargs) {
                     diagnostics.push(Diagnostic::new(
                         MissingTypeKwargs {
                             name: arg.arg.to_string(),
@@ -603,7 +599,7 @@ pub(crate) fn definition(
             if arg.annotation.is_none() {
                 if visibility::is_classmethod(checker.semantic_model(), cast::decorator_list(stmt))
                 {
-                    if checker.settings.rules.enabled(Rule::MissingTypeCls) {
+                    if checker.enabled(Rule::MissingTypeCls) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeCls {
                                 name: arg.arg.to_string(),
@@ -612,7 +608,7 @@ pub(crate) fn definition(
                         ));
                     }
                 } else {
-                    if checker.settings.rules.enabled(Rule::MissingTypeSelf) {
+                    if checker.enabled(Rule::MissingTypeSelf) {
                         diagnostics.push(Diagnostic::new(
                             MissingTypeSelf {
                                 name: arg.arg.to_string(),
@@ -630,7 +626,7 @@ pub(crate) fn definition(
     // ANN201, ANN202, ANN401
     if let Some(expr) = &returns {
         has_typed_return = true;
-        if checker.settings.rules.enabled(Rule::AnyType) {
+        if checker.enabled(Rule::AnyType) {
             check_dynamically_typed(
                 checker.semantic_model(),
                 expr,
@@ -647,11 +643,7 @@ pub(crate) fn definition(
         if is_method
             && visibility::is_classmethod(checker.semantic_model(), cast::decorator_list(stmt))
         {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeClassMethod)
-            {
+            if checker.enabled(Rule::MissingReturnTypeClassMethod) {
                 diagnostics.push(Diagnostic::new(
                     MissingReturnTypeClassMethod {
                         name: name.to_string(),
@@ -662,11 +654,7 @@ pub(crate) fn definition(
         } else if is_method
             && visibility::is_staticmethod(checker.semantic_model(), cast::decorator_list(stmt))
         {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeStaticMethod)
-            {
+            if checker.enabled(Rule::MissingReturnTypeStaticMethod) {
                 diagnostics.push(Diagnostic::new(
                     MissingReturnTypeStaticMethod {
                         name: name.to_string(),
@@ -677,11 +665,7 @@ pub(crate) fn definition(
         } else if is_method && visibility::is_init(name) {
             // Allow omission of return annotation in `__init__` functions, as long as at
             // least one argument is typed.
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeSpecialMethod)
-            {
+            if checker.enabled(Rule::MissingReturnTypeSpecialMethod) {
                 if !(checker.settings.flake8_annotations.mypy_init_return && has_any_typed_arg) {
                     let mut diagnostic = Diagnostic::new(
                         MissingReturnTypeSpecialMethod {
@@ -699,11 +683,7 @@ pub(crate) fn definition(
                 }
             }
         } else if is_method && visibility::is_magic(name) {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::MissingReturnTypeSpecialMethod)
-            {
+            if checker.enabled(Rule::MissingReturnTypeSpecialMethod) {
                 let mut diagnostic = Diagnostic::new(
                     MissingReturnTypeSpecialMethod {
                         name: name.to_string(),
@@ -724,11 +704,7 @@ pub(crate) fn definition(
         } else {
             match visibility {
                 Visibility::Public => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::MissingReturnTypeUndocumentedPublicFunction)
-                    {
+                    if checker.enabled(Rule::MissingReturnTypeUndocumentedPublicFunction) {
                         diagnostics.push(Diagnostic::new(
                             MissingReturnTypeUndocumentedPublicFunction {
                                 name: name.to_string(),
@@ -738,11 +714,7 @@ pub(crate) fn definition(
                     }
                 }
                 Visibility::Private => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::MissingReturnTypePrivateFunction)
-                    {
+                    if checker.enabled(Rule::MissingReturnTypePrivateFunction) {
                         diagnostics.push(Diagnostic::new(
                             MissingReturnTypePrivateFunction {
                                 name: name.to_string(),

--- a/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/shell_injection.rs
@@ -194,11 +194,7 @@ pub(crate) fn shell_injection(
                     truthiness: Truthiness::Truthy,
                     keyword,
                 }) => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::SubprocessPopenWithShellEqualsTrue)
-                    {
+                    if checker.enabled(Rule::SubprocessPopenWithShellEqualsTrue) {
                         checker.diagnostics.push(Diagnostic::new(
                             SubprocessPopenWithShellEqualsTrue {
                                 seems_safe: shell_call_seems_safe(arg),
@@ -212,11 +208,7 @@ pub(crate) fn shell_injection(
                     truthiness: Truthiness::Falsey | Truthiness::Unknown,
                     keyword,
                 }) => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::SubprocessWithoutShellEqualsTrue)
-                    {
+                    if checker.enabled(Rule::SubprocessWithoutShellEqualsTrue) {
                         checker.diagnostics.push(Diagnostic::new(
                             SubprocessWithoutShellEqualsTrue,
                             keyword.range(),
@@ -225,11 +217,7 @@ pub(crate) fn shell_injection(
                 }
                 // S603
                 None => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::SubprocessWithoutShellEqualsTrue)
-                    {
+                    if checker.enabled(Rule::SubprocessWithoutShellEqualsTrue) {
                         checker.diagnostics.push(Diagnostic::new(
                             SubprocessWithoutShellEqualsTrue,
                             arg.range(),
@@ -244,11 +232,7 @@ pub(crate) fn shell_injection(
     }) = find_shell_keyword(checker.semantic_model(), keywords)
     {
         // S604
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::CallWithShellEqualsTrue)
-        {
+        if checker.enabled(Rule::CallWithShellEqualsTrue) {
             checker
                 .diagnostics
                 .push(Diagnostic::new(CallWithShellEqualsTrue, keyword.range()));
@@ -258,7 +242,7 @@ pub(crate) fn shell_injection(
     // S605
     if matches!(call_kind, Some(CallKind::Shell)) {
         if let Some(arg) = args.first() {
-            if checker.settings.rules.enabled(Rule::StartProcessWithAShell) {
+            if checker.enabled(Rule::StartProcessWithAShell) {
                 checker.diagnostics.push(Diagnostic::new(
                     StartProcessWithAShell {
                         seems_safe: shell_call_seems_safe(arg),
@@ -271,11 +255,7 @@ pub(crate) fn shell_injection(
 
     // S606
     if matches!(call_kind, Some(CallKind::NoShell)) {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::StartProcessWithNoShell)
-        {
+        if checker.enabled(Rule::StartProcessWithNoShell) {
             checker
                 .diagnostics
                 .push(Diagnostic::new(StartProcessWithNoShell, func.range()));
@@ -285,11 +265,7 @@ pub(crate) fn shell_injection(
     // S607
     if call_kind.is_some() {
         if let Some(arg) = args.first() {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::StartProcessWithPartialPath)
-            {
+            if checker.enabled(Rule::StartProcessWithPartialPath) {
                 if let Some(value) = try_string_literal(arg) {
                     if FULL_PATH_REGEX.find(value).is_none() {
                         checker

--- a/crates/ruff/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -512,7 +512,7 @@ pub(crate) fn suspicious_function_call(checker: &mut Checker, expr: &Expr) {
         Reason::FTPLib => SuspiciousFTPLibUsage.into(),
     };
     let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, expr.range());
-    if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+    if checker.enabled(diagnostic.kind.rule()) {
         checker.diagnostics.push(diagnostic);
     }
 }

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -111,11 +111,7 @@ pub(crate) fn abstract_base_class(
         let has_abstract_decorator = is_abstract(checker.semantic_model(), decorator_list);
         has_abstract_method |= has_abstract_decorator;
 
-        if !checker
-            .settings
-            .rules
-            .enabled(Rule::EmptyMethodWithoutAbstractDecorator)
-        {
+        if !checker.enabled(Rule::EmptyMethodWithoutAbstractDecorator) {
             continue;
         }
 
@@ -131,11 +127,7 @@ pub(crate) fn abstract_base_class(
             ));
         }
     }
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::AbstractBaseClassWithoutAbstractMethod)
-    {
+    if checker.enabled(Rule::AbstractBaseClassWithoutAbstractMethod) {
         if !has_abstract_method {
             checker.diagnostics.push(Diagnostic::new(
                 AbstractBaseClassWithoutAbstractMethod {

--- a/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/duplicate_exceptions.rs
@@ -75,11 +75,7 @@ fn duplicate_handler_exceptions<'a>(
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::DuplicateHandlerException)
-    {
+    if checker.enabled(Rule::DuplicateHandlerException) {
         // TODO(charlie): Handle "BaseException" and redundant exception aliases.
         if !duplicates.is_empty() {
             let mut diagnostic = Diagnostic::new(
@@ -140,11 +136,7 @@ pub(crate) fn duplicate_exceptions(checker: &mut Checker, handlers: &[Excepthand
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::DuplicateTryBlockException)
-    {
+    if checker.enabled(Rule::DuplicateTryBlockException) {
         for (name, exprs) in duplicates {
             for expr in exprs {
                 checker.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_errmsg/rules.rs
+++ b/crates/ruff/src/rules/flake8_errmsg/rules.rs
@@ -229,7 +229,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                     value: Constant::Str(string),
                     ..
                 }) => {
-                    if checker.settings.rules.enabled(Rule::RawStringInException) {
+                    if checker.enabled(Rule::RawStringInException) {
                         if string.len() > checker.settings.flake8_errmsg.max_string_length {
                             let indentation = whitespace::indentation(checker.locator, stmt)
                                 .and_then(|indentation| {
@@ -258,7 +258,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                 }
                 // Check for f-strings.
                 Expr::JoinedStr(_) => {
-                    if checker.settings.rules.enabled(Rule::FStringInException) {
+                    if checker.enabled(Rule::FStringInException) {
                         let indentation = whitespace::indentation(checker.locator, stmt).and_then(
                             |indentation| {
                                 if checker.semantic_model().find_binding("msg").is_none() {
@@ -285,7 +285,7 @@ pub(crate) fn string_in_exception(checker: &mut Checker, stmt: &Stmt, exc: &Expr
                 }
                 // Check for .format() calls.
                 Expr::Call(ast::ExprCall { func, .. }) => {
-                    if checker.settings.rules.enabled(Rule::DotFormatInException) {
+                    if checker.enabled(Rule::DotFormatInException) {
                         if let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) =
                             func.as_ref()
                         {

--- a/crates/ruff/src/rules/flake8_logging_format/rules.rs
+++ b/crates/ruff/src/rules/flake8_logging_format/rules.rs
@@ -44,14 +44,14 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         // Check for string concatenation and percent format.
         Expr::BinOp(ast::ExprBinOp { op, .. }) => match op {
             Operator::Add => {
-                if checker.settings.rules.enabled(Rule::LoggingStringConcat) {
+                if checker.enabled(Rule::LoggingStringConcat) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(LoggingStringConcat, msg.range()));
                 }
             }
             Operator::Mod => {
-                if checker.settings.rules.enabled(Rule::LoggingPercentFormat) {
+                if checker.enabled(Rule::LoggingPercentFormat) {
                     checker
                         .diagnostics
                         .push(Diagnostic::new(LoggingPercentFormat, msg.range()));
@@ -61,7 +61,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         },
         // Check for f-strings.
         Expr::JoinedStr(_) => {
-            if checker.settings.rules.enabled(Rule::LoggingFString) {
+            if checker.enabled(Rule::LoggingFString) {
                 checker
                     .diagnostics
                     .push(Diagnostic::new(LoggingFString, msg.range()));
@@ -69,7 +69,7 @@ fn check_msg(checker: &mut Checker, msg: &Expr) {
         }
         // Check for .format() calls.
         Expr::Call(ast::ExprCall { func, .. }) => {
-            if checker.settings.rules.enabled(Rule::LoggingStringFormat) {
+            if checker.enabled(Rule::LoggingStringFormat) {
                 if let Expr::Attribute(ast::ExprAttribute { value, attr, .. }) = func.as_ref() {
                     if attr == "format" && value.is_constant_expr() {
                         checker
@@ -167,7 +167,7 @@ pub(crate) fn logging_call(
             }
 
             // G010
-            if checker.settings.rules.enabled(Rule::LoggingWarn)
+            if checker.enabled(Rule::LoggingWarn)
                 && matches!(
                     logging_call_type,
                     LoggingCallType::LevelCall(LoggingLevel::Warn)
@@ -185,18 +185,15 @@ pub(crate) fn logging_call(
             }
 
             // G101
-            if checker.settings.rules.enabled(Rule::LoggingExtraAttrClash) {
+            if checker.enabled(Rule::LoggingExtraAttrClash) {
                 if let Some(extra) = find_keyword(keywords, "extra") {
                     check_log_record_attr_clash(checker, extra);
                 }
             }
 
             // G201, G202
-            if checker.settings.rules.enabled(Rule::LoggingExcInfo)
-                || checker
-                    .settings
-                    .rules
-                    .enabled(Rule::LoggingRedundantExcInfo)
+            if checker.enabled(Rule::LoggingExcInfo)
+                || checker.enabled(Rule::LoggingRedundantExcInfo)
             {
                 if !checker.semantic_model().in_exception_handler() {
                     return;
@@ -226,18 +223,14 @@ pub(crate) fn logging_call(
                     if let LoggingCallType::LevelCall(logging_level) = logging_call_type {
                         match logging_level {
                             LoggingLevel::Error => {
-                                if checker.settings.rules.enabled(Rule::LoggingExcInfo) {
+                                if checker.enabled(Rule::LoggingExcInfo) {
                                     checker
                                         .diagnostics
                                         .push(Diagnostic::new(LoggingExcInfo, level_call_range));
                                 }
                             }
                             LoggingLevel::Exception => {
-                                if checker
-                                    .settings
-                                    .rules
-                                    .enabled(Rule::LoggingRedundantExcInfo)
-                                {
+                                if checker.enabled(Rule::LoggingRedundantExcInfo) {
                                     checker.diagnostics.push(Diagnostic::new(
                                         LoggingRedundantExcInfo,
                                         exc_info.range(),

--- a/crates/ruff/src/rules/flake8_print/rules/print_call.rs
+++ b/crates/ruff/src/rules/flake8_print/rules/print_call.rs
@@ -112,7 +112,7 @@ pub(crate) fn print_call(checker: &mut Checker, func: &Expr, keywords: &[Keyword
         }
     };
 
-    if !checker.settings.rules.enabled(diagnostic.kind.rule()) {
+    if !checker.enabled(diagnostic.kind.rule()) {
         return;
     }
 

--- a/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -113,12 +113,7 @@ pub(crate) fn unrecognized_platform(
     }
 
     // "in" might also make sense but we don't currently have one.
-    if !matches!(op, Cmpop::Eq | Cmpop::NotEq)
-        && checker
-            .settings
-            .rules
-            .enabled(Rule::UnrecognizedPlatformCheck)
-    {
+    if !matches!(op, Cmpop::Eq | Cmpop::NotEq) && checker.enabled(Rule::UnrecognizedPlatformCheck) {
         checker
             .diagnostics
             .push(diagnostic_unrecognized_platform_check);
@@ -133,10 +128,7 @@ pub(crate) fn unrecognized_platform(
             // Other values are possible but we don't need them right now.
             // This protects against typos.
             if !["linux", "win32", "cygwin", "darwin"].contains(&value.as_str())
-                && checker
-                    .settings
-                    .rules
-                    .enabled(Rule::UnrecognizedPlatformName)
+                && checker.enabled(Rule::UnrecognizedPlatformName)
             {
                 checker.diagnostics.push(Diagnostic::new(
                     UnrecognizedPlatformName {
@@ -147,11 +139,7 @@ pub(crate) fn unrecognized_platform(
             }
         }
         _ => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::UnrecognizedPlatformCheck)
-            {
+            if checker.enabled(Rule::UnrecognizedPlatformCheck) {
                 checker
                     .diagnostics
                     .push(diagnostic_unrecognized_platform_check);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -285,10 +285,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             keywords,
             range: _,
         }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
+            if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
                 && !checker.settings.flake8_pytest_style.fixture_parentheses
                 && args.is_empty()
                 && keywords.is_empty()
@@ -304,12 +301,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 );
             }
 
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::PytestFixturePositionalArgs)
-                && !args.is_empty()
-            {
+            if checker.enabled(Rule::PytestFixturePositionalArgs) && !args.is_empty() {
                 checker.diagnostics.push(Diagnostic::new(
                     PytestFixturePositionalArgs {
                         function: func_name.to_string(),
@@ -318,11 +310,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
                 ));
             }
 
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::PytestExtraneousScopeFunction)
-            {
+            if checker.enabled(Rule::PytestExtraneousScopeFunction) {
                 let scope_keyword = keywords
                     .iter()
                     .find(|kw| kw.arg.as_ref().map_or(false, |arg| arg == "scope"));
@@ -350,10 +338,7 @@ fn check_fixture_decorator(checker: &mut Checker, func_name: &str, decorator: &E
             }
         }
         _ => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
+            if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
                 && checker.settings.flake8_pytest_style.fixture_parentheses
             {
                 #[allow(deprecated)]
@@ -381,10 +366,7 @@ fn check_fixture_returns(checker: &mut Checker, stmt: &Stmt, name: &str, body: &
         visitor.visit_stmt(stmt);
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::PytestIncorrectFixtureNameUnderscore)
+    if checker.enabled(Rule::PytestIncorrectFixtureNameUnderscore)
         && visitor.has_return_with_value
         && name.starts_with('_')
     {
@@ -394,10 +376,7 @@ fn check_fixture_returns(checker: &mut Checker, stmt: &Stmt, name: &str, body: &
             },
             helpers::identifier_range(stmt, checker.locator),
         ));
-    } else if checker
-        .settings
-        .rules
-        .enabled(Rule::PytestMissingFixtureNameUnderscore)
+    } else if checker.enabled(Rule::PytestMissingFixtureNameUnderscore)
         && !visitor.has_return_with_value
         && !visitor.has_yield_from
         && !name.starts_with('_')
@@ -410,11 +389,7 @@ fn check_fixture_returns(checker: &mut Checker, stmt: &Stmt, name: &str, body: &
         ));
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::PytestUselessYieldFixture)
-    {
+    if checker.enabled(Rule::PytestUselessYieldFixture) {
         if let Some(stmt) = body.last() {
             if let Stmt::Expr(ast::StmtExpr { value, range: _ }) = stmt {
                 if value.is_yield_expr() {
@@ -489,11 +464,7 @@ fn check_fixture_addfinalizer(checker: &mut Checker, args: &Arguments, body: &[S
 fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
     for (expr, call_path) in get_mark_decorators(decorators) {
         let name = call_path.last().expect("Expected a mark name");
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture)
-        {
+        if checker.enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture) {
             if *name == "asyncio" {
                 let mut diagnostic =
                     Diagnostic::new(PytestUnnecessaryAsyncioMarkOnFixture, expr.range());
@@ -506,11 +477,7 @@ fn check_fixture_marks(checker: &mut Checker, decorators: &[Expr]) {
             }
         }
 
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestErroneousUseFixturesOnFixture)
-        {
+        if checker.enabled(Rule::PytestErroneousUseFixturesOnFixture) {
             if *name == "usefixtures" {
                 let mut diagnostic =
                     Diagnostic::new(PytestErroneousUseFixturesOnFixture, expr.range());
@@ -535,75 +502,39 @@ pub(crate) fn fixture(
 ) {
     let decorator = get_fixture_decorator(checker.semantic_model(), decorators);
     if let Some(decorator) = decorator {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
-            || checker
-                .settings
-                .rules
-                .enabled(Rule::PytestFixturePositionalArgs)
-            || checker
-                .settings
-                .rules
-                .enabled(Rule::PytestExtraneousScopeFunction)
+        if checker.enabled(Rule::PytestFixtureIncorrectParenthesesStyle)
+            || checker.enabled(Rule::PytestFixturePositionalArgs)
+            || checker.enabled(Rule::PytestExtraneousScopeFunction)
         {
             check_fixture_decorator(checker, name, decorator);
         }
 
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestDeprecatedYieldFixture)
+        if checker.enabled(Rule::PytestDeprecatedYieldFixture)
             && checker.settings.flake8_pytest_style.fixture_parentheses
         {
             check_fixture_decorator_name(checker, decorator);
         }
 
-        if (checker
-            .settings
-            .rules
-            .enabled(Rule::PytestMissingFixtureNameUnderscore)
-            || checker
-                .settings
-                .rules
-                .enabled(Rule::PytestIncorrectFixtureNameUnderscore)
-            || checker
-                .settings
-                .rules
-                .enabled(Rule::PytestUselessYieldFixture))
+        if (checker.enabled(Rule::PytestMissingFixtureNameUnderscore)
+            || checker.enabled(Rule::PytestIncorrectFixtureNameUnderscore)
+            || checker.enabled(Rule::PytestUselessYieldFixture))
             && !is_abstract(checker.semantic_model(), decorators)
         {
             check_fixture_returns(checker, stmt, name, body);
         }
 
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestFixtureFinalizerCallback)
-        {
+        if checker.enabled(Rule::PytestFixtureFinalizerCallback) {
             check_fixture_addfinalizer(checker, args, body);
         }
 
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture)
-            || checker
-                .settings
-                .rules
-                .enabled(Rule::PytestErroneousUseFixturesOnFixture)
+        if checker.enabled(Rule::PytestUnnecessaryAsyncioMarkOnFixture)
+            || checker.enabled(Rule::PytestErroneousUseFixturesOnFixture)
         {
             check_fixture_marks(checker, decorators);
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::PytestFixtureParamWithoutValue)
-        && name.starts_with("test_")
-    {
+    if checker.enabled(Rule::PytestFixtureParamWithoutValue) && name.starts_with("test_") {
         check_test_function_args(checker, args);
     }
 }

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/marks.rs
@@ -125,14 +125,8 @@ fn check_useless_usefixtures(checker: &mut Checker, decorator: &Expr, call_path:
 }
 
 pub(crate) fn marks(checker: &mut Checker, decorators: &[Expr]) {
-    let enforce_parentheses = checker
-        .settings
-        .rules
-        .enabled(Rule::PytestIncorrectMarkParenthesesStyle);
-    let enforce_useless_usefixtures = checker
-        .settings
-        .rules
-        .enabled(Rule::PytestUseFixturesWithoutParameters);
+    let enforce_parentheses = checker.enabled(Rule::PytestIncorrectMarkParenthesesStyle);
+    let enforce_useless_usefixtures = checker.enabled(Rule::PytestUseFixturesWithoutParameters);
 
     for (expr, call_path) in get_mark_decorators(decorators) {
         if enforce_parentheses {

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -421,20 +421,12 @@ pub(crate) fn parametrize(checker: &mut Checker, decorators: &[Expr]) {
     for decorator in decorators {
         if is_pytest_parametrize(checker.semantic_model(), decorator) {
             if let Expr::Call(ast::ExprCall { args, .. }) = decorator {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestParametrizeNamesWrongType)
-                {
+                if checker.enabled(Rule::PytestParametrizeNamesWrongType) {
                     if let Some(names) = args.get(0) {
                         check_names(checker, decorator, names);
                     }
                 }
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::PytestParametrizeValuesWrongType)
-                {
+                if checker.enabled(Rule::PytestParametrizeValuesWrongType) {
                     if let Some(names) = args.get(0) {
                         if let Some(values) = args.get(1) {
                             check_values(checker, names, values);

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/raises.rs
@@ -65,11 +65,7 @@ const fn is_non_trivial_with_body(body: &[Stmt]) -> bool {
 
 pub(crate) fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], keywords: &[Keyword]) {
     if is_pytest_raises(func, checker.semantic_model()) {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::PytestRaisesWithoutException)
-        {
+        if checker.enabled(Rule::PytestRaisesWithoutException) {
             if args.is_empty() && keywords.is_empty() {
                 checker
                     .diagnostics
@@ -77,7 +73,7 @@ pub(crate) fn raises_call(checker: &mut Checker, func: &Expr, args: &[Expr], key
             }
         }
 
-        if checker.settings.rules.enabled(Rule::PytestRaisesTooBroad) {
+        if checker.enabled(Rule::PytestRaisesTooBroad) {
             let match_keyword = keywords
                 .iter()
                 .find(|kw| kw.arg == Some(Identifier::new("match")));

--- a/crates/ruff/src/rules/flake8_return/rules.rs
+++ b/crates/ruff/src/rules/flake8_return/rules.rs
@@ -633,7 +633,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
                 SuperfluousElseReturn { branch },
                 elif_else_range(stmt, checker.locator).unwrap_or_else(|| stmt.range()),
             );
-            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+            if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
             }
             return true;
@@ -642,7 +642,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
                 SuperfluousElseBreak { branch },
                 elif_else_range(stmt, checker.locator).unwrap_or_else(|| stmt.range()),
             );
-            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+            if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
             }
             return true;
@@ -651,7 +651,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
                 SuperfluousElseRaise { branch },
                 elif_else_range(stmt, checker.locator).unwrap_or_else(|| stmt.range()),
             );
-            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+            if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
             }
             return true;
@@ -660,7 +660,7 @@ fn superfluous_else_node(checker: &mut Checker, stmt: &Stmt, branch: Branch) -> 
                 SuperfluousElseContinue { branch },
                 elif_else_range(stmt, checker.locator).unwrap_or_else(|| stmt.range()),
             );
-            if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+            if checker.enabled(diagnostic.kind.rule()) {
                 checker.diagnostics.push(diagnostic);
             }
             return true;
@@ -727,14 +727,14 @@ pub(crate) fn function(checker: &mut Checker, body: &[Stmt], returns: Option<&Ex
 
     // If we have at least one non-`None` return...
     if result_exists(&stack.returns) {
-        if checker.settings.rules.enabled(Rule::ImplicitReturnValue) {
+        if checker.enabled(Rule::ImplicitReturnValue) {
             implicit_return_value(checker, &stack);
         }
-        if checker.settings.rules.enabled(Rule::ImplicitReturn) {
+        if checker.enabled(Rule::ImplicitReturn) {
             implicit_return(checker, last_stmt);
         }
 
-        if checker.settings.rules.enabled(Rule::UnnecessaryAssign) {
+        if checker.enabled(Rule::UnnecessaryAssign) {
             for (_, expr) in &stack.returns {
                 if let Some(expr) = expr {
                     unnecessary_assign(checker, &stack, expr);
@@ -742,7 +742,7 @@ pub(crate) fn function(checker: &mut Checker, body: &[Stmt], returns: Option<&Ex
             }
         }
     } else {
-        if checker.settings.rules.enabled(Rule::UnnecessaryReturnNone) {
+        if checker.enabled(Rule::UnnecessaryReturnNone) {
             // Skip functions that have a return annotation that is not `None`.
             if returns.map_or(true, is_const_none) {
                 unnecessary_return_none(checker, &stack);

--- a/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -213,7 +213,7 @@ pub(crate) fn convert_for_loop_to_any_all(
         .or_else(|| sibling.and_then(|sibling| return_values_for_siblings(stmt, sibling)))
     {
         if loop_info.return_value && !loop_info.next_return_value {
-            if checker.settings.rules.enabled(Rule::ReimplementedBuiltin) {
+            if checker.enabled(Rule::ReimplementedBuiltin) {
                 let contents = return_stmt(
                     "any",
                     loop_info.test,
@@ -253,7 +253,7 @@ pub(crate) fn convert_for_loop_to_any_all(
         }
 
         if !loop_info.return_value && loop_info.next_return_value {
-            if checker.settings.rules.enabled(Rule::ReimplementedBuiltin) {
+            if checker.enabled(Rule::ReimplementedBuiltin) {
                 // Invert the condition.
                 let test = {
                     if let Expr::UnaryOp(ast::ExprUnaryOp {

--- a/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
+++ b/crates/ruff/src/rules/flake8_unused_arguments/rules.rs
@@ -300,10 +300,7 @@ pub(crate) fn unused_arguments(
                 &checker.settings.pep8_naming.staticmethod_decorators,
             ) {
                 FunctionType::Function => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Argumentable::Function.rule_code())
+                    if checker.enabled(Argumentable::Function.rule_code())
                         && !visibility::is_overload(checker.semantic_model(), decorator_list)
                     {
                         function(
@@ -322,10 +319,7 @@ pub(crate) fn unused_arguments(
                     }
                 }
                 FunctionType::Method => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Argumentable::Method.rule_code())
+                    if checker.enabled(Argumentable::Method.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)
                             || visibility::is_init(name)
@@ -351,10 +345,7 @@ pub(crate) fn unused_arguments(
                     }
                 }
                 FunctionType::ClassMethod => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Argumentable::ClassMethod.rule_code())
+                    if checker.enabled(Argumentable::ClassMethod.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)
                             || visibility::is_init(name)
@@ -380,10 +371,7 @@ pub(crate) fn unused_arguments(
                     }
                 }
                 FunctionType::StaticMethod => {
-                    if checker
-                        .settings
-                        .rules
-                        .enabled(Argumentable::StaticMethod.rule_code())
+                    if checker.enabled(Argumentable::StaticMethod.rule_code())
                         && !helpers::is_empty(body)
                         && (!visibility::is_magic(name)
                             || visibility::is_init(name)
@@ -411,11 +399,7 @@ pub(crate) fn unused_arguments(
             }
         }
         ScopeKind::Lambda(Lambda { args, .. }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Argumentable::Lambda.rule_code())
-            {
+            if checker.enabled(Argumentable::Lambda.rule_code()) {
                 function(
                     Argumentable::Lambda,
                     args,

--- a/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
+++ b/crates/ruff/src/rules/flake8_use_pathlib/helpers.rs
@@ -52,7 +52,7 @@ pub(crate) fn replaceable_by_pathlib(checker: &mut Checker, expr: &Expr) {
     {
         let diagnostic = Diagnostic::new::<DiagnosticKind>(diagnostic_kind, expr.range());
 
-        if checker.settings.rules.enabled(diagnostic.kind.rule()) {
+        if checker.enabled(diagnostic.kind.rule()) {
             checker.diagnostics.push(diagnostic);
         }
     }

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_class.rs
@@ -68,11 +68,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
         return;
     };
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::OneBlankLineBeforeClass)
-        || checker.settings.rules.enabled(Rule::BlankLineBeforeClass)
+    if checker.enabled(Rule::OneBlankLineBeforeClass) || checker.enabled(Rule::BlankLineBeforeClass)
     {
         let before = checker
             .locator
@@ -91,7 +87,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
             }
         }
 
-        if checker.settings.rules.enabled(Rule::BlankLineBeforeClass) {
+        if checker.enabled(Rule::BlankLineBeforeClass) {
             if blank_lines_before != 0 {
                 let mut diagnostic = Diagnostic::new(
                     BlankLineBeforeClass {
@@ -110,11 +106,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
                 checker.diagnostics.push(diagnostic);
             }
         }
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::OneBlankLineBeforeClass)
-        {
+        if checker.enabled(Rule::OneBlankLineBeforeClass) {
             if blank_lines_before != 1 {
                 let mut diagnostic = Diagnostic::new(
                     OneBlankLineBeforeClass {
@@ -136,7 +128,7 @@ pub(crate) fn blank_before_after_class(checker: &mut Checker, docstring: &Docstr
         }
     }
 
-    if checker.settings.rules.enabled(Rule::OneBlankLineAfterClass) {
+    if checker.enabled(Rule::OneBlankLineAfterClass) {
         let after = checker
             .locator
             .slice(TextRange::new(docstring.end(), stmt.end()));

--- a/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/blank_before_after_function.rs
@@ -59,11 +59,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
         return;
     };
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::NoBlankLineBeforeFunction)
-    {
+    if checker.enabled(Rule::NoBlankLineBeforeFunction) {
         let before = checker
             .locator
             .slice(TextRange::new(stmt.start(), docstring.start()));
@@ -100,11 +96,7 @@ pub(crate) fn blank_before_after_function(checker: &mut Checker, docstring: &Doc
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::NoBlankLineAfterFunction)
-    {
+    if checker.enabled(Rule::NoBlankLineAfterFunction) {
         let after = checker
             .locator
             .slice(TextRange::new(docstring.end(), stmt.end()));

--- a/crates/ruff/src/rules/pydocstyle/rules/indent.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/indent.rs
@@ -82,7 +82,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
         // yet.
         has_seen_tab = has_seen_tab || line_indent.contains('\t');
 
-        if checker.settings.rules.enabled(Rule::UnderIndentation) {
+        if checker.enabled(Rule::UnderIndentation) {
             // We report under-indentation on every line. This isn't great, but enables
             // autofix.
             if (i == lines.len() - 1 || !is_blank)
@@ -116,7 +116,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
         }
     }
 
-    if checker.settings.rules.enabled(Rule::IndentWithSpaces) {
+    if checker.enabled(Rule::IndentWithSpaces) {
         if has_seen_tab {
             checker
                 .diagnostics
@@ -124,7 +124,7 @@ pub(crate) fn indent(checker: &mut Checker, docstring: &Docstring) {
         }
     }
 
-    if checker.settings.rules.enabled(Rule::OverIndentation) {
+    if checker.enabled(Rule::OverIndentation) {
         // If every line (except the last) is over-indented...
         if is_over_indented {
             for over_indented in over_indented_lines {

--- a/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/multi_line_summary_start.rs
@@ -60,11 +60,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
     };
 
     if is_triple_quote(&first_line) {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::MultiLineSummaryFirstLine)
-        {
+        if checker.enabled(Rule::MultiLineSummaryFirstLine) {
             let mut diagnostic = Diagnostic::new(MultiLineSummaryFirstLine, docstring.range());
             if checker.patch(diagnostic.kind.rule()) {
                 // Delete until first non-whitespace char.
@@ -82,11 +78,7 @@ pub(crate) fn multi_line_summary_start(checker: &mut Checker, docstring: &Docstr
             checker.diagnostics.push(diagnostic);
         }
     } else {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::MultiLineSummarySecondLine)
-        {
+        if checker.enabled(Rule::MultiLineSummarySecondLine) {
             let mut diagnostic = Diagnostic::new(MultiLineSummarySecondLine, docstring.range());
             if checker.patch(diagnostic.kind.rule()) {
                 let mut indentation = String::from(docstring.indentation);

--- a/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_empty.rs
@@ -21,7 +21,7 @@ pub(crate) fn not_empty(checker: &mut Checker, docstring: &Docstring) -> bool {
         return true;
     }
 
-    if checker.settings.rules.enabled(Rule::EmptyDocstring) {
+    if checker.enabled(Rule::EmptyDocstring) {
         checker
             .diagnostics
             .push(Diagnostic::new(EmptyDocstring, docstring.range()));

--- a/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/not_missing.rs
@@ -107,11 +107,7 @@ pub(crate) fn not_missing(
             kind: ModuleKind::Module,
             ..
         }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicModule)
-            {
+            if checker.enabled(Rule::UndocumentedPublicModule) {
                 checker.diagnostics.push(Diagnostic::new(
                     UndocumentedPublicModule,
                     TextRange::default(),
@@ -123,11 +119,7 @@ pub(crate) fn not_missing(
             kind: ModuleKind::Package,
             ..
         }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicPackage)
-            {
+            if checker.enabled(Rule::UndocumentedPublicPackage) {
                 checker.diagnostics.push(Diagnostic::new(
                     UndocumentedPublicPackage,
                     TextRange::default(),
@@ -140,11 +132,7 @@ pub(crate) fn not_missing(
             stmt,
             ..
         }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicClass)
-            {
+            if checker.enabled(Rule::UndocumentedPublicClass) {
                 checker.diagnostics.push(Diagnostic::new(
                     UndocumentedPublicClass,
                     identifier_range(stmt, checker.locator),
@@ -157,11 +145,7 @@ pub(crate) fn not_missing(
             stmt,
             ..
         }) => {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::UndocumentedPublicNestedClass)
-            {
+            if checker.enabled(Rule::UndocumentedPublicNestedClass) {
                 checker.diagnostics.push(Diagnostic::new(
                     UndocumentedPublicNestedClass,
                     identifier_range(stmt, checker.locator),
@@ -177,11 +161,7 @@ pub(crate) fn not_missing(
             if is_overload(checker.semantic_model(), cast::decorator_list(stmt)) {
                 true
             } else {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::UndocumentedPublicFunction)
-                {
+                if checker.enabled(Rule::UndocumentedPublicFunction) {
                     checker.diagnostics.push(Diagnostic::new(
                         UndocumentedPublicFunction,
                         identifier_range(stmt, checker.locator),
@@ -200,7 +180,7 @@ pub(crate) fn not_missing(
             {
                 true
             } else if is_init(cast::name(stmt)) {
-                if checker.settings.rules.enabled(Rule::UndocumentedPublicInit) {
+                if checker.enabled(Rule::UndocumentedPublicInit) {
                     checker.diagnostics.push(Diagnostic::new(
                         UndocumentedPublicInit,
                         identifier_range(stmt, checker.locator),
@@ -208,11 +188,7 @@ pub(crate) fn not_missing(
                 }
                 true
             } else if is_new(cast::name(stmt)) || is_call(cast::name(stmt)) {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::UndocumentedPublicMethod)
-                {
+                if checker.enabled(Rule::UndocumentedPublicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         UndocumentedPublicMethod,
                         identifier_range(stmt, checker.locator),
@@ -220,11 +196,7 @@ pub(crate) fn not_missing(
                 }
                 true
             } else if is_magic(cast::name(stmt)) {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::UndocumentedMagicMethod)
-                {
+                if checker.enabled(Rule::UndocumentedMagicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         UndocumentedMagicMethod,
                         identifier_range(stmt, checker.locator),
@@ -232,11 +204,7 @@ pub(crate) fn not_missing(
                 }
                 true
             } else {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::UndocumentedPublicMethod)
-                {
+                if checker.enabled(Rule::UndocumentedPublicMethod) {
                     checker.diagnostics.push(Diagnostic::new(
                         UndocumentedPublicMethod,
                         identifier_range(stmt, checker.locator),

--- a/crates/ruff/src/rules/pydocstyle/rules/sections.rs
+++ b/crates/ruff/src/rules/pydocstyle/rules/sections.rs
@@ -363,11 +363,7 @@ fn blanks_and_section_underline(
 
         if dash_line_found {
             if blank_lines_after_header > 0 {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::SectionUnderlineAfterName)
-                {
+                if checker.enabled(Rule::SectionUnderlineAfterName) {
                     let mut diagnostic = Diagnostic::new(
                         SectionUnderlineAfterName {
                             name: context.section_name().to_string(),
@@ -392,11 +388,7 @@ fn blanks_and_section_underline(
                 .count()
                 != context.section_name().len()
             {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::SectionUnderlineMatchesSectionLength)
-                {
+                if checker.enabled(Rule::SectionUnderlineMatchesSectionLength) {
                     let mut diagnostic = Diagnostic::new(
                         SectionUnderlineMatchesSectionLength {
                             name: context.section_name().to_string(),
@@ -422,11 +414,7 @@ fn blanks_and_section_underline(
                 }
             }
 
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::SectionUnderlineNotOverIndented)
-            {
+            if checker.enabled(Rule::SectionUnderlineNotOverIndented) {
                 let leading_space = whitespace::leading_space(&non_blank_line);
                 if leading_space.len() > docstring.indentation.len() {
                     let mut diagnostic = Diagnostic::new(
@@ -465,7 +453,7 @@ fn blanks_and_section_underline(
                     }
 
                     if following_lines.peek().is_none() {
-                        if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
+                        if checker.enabled(Rule::EmptyDocstringSection) {
                             checker.diagnostics.push(Diagnostic::new(
                                 EmptyDocstringSection {
                                     name: context.section_name().to_string(),
@@ -473,11 +461,7 @@ fn blanks_and_section_underline(
                                 docstring.range(),
                             ));
                         }
-                    } else if checker
-                        .settings
-                        .rules
-                        .enabled(Rule::BlankLinesBetweenHeaderAndContent)
-                    {
+                    } else if checker.enabled(Rule::BlankLinesBetweenHeaderAndContent) {
                         let mut diagnostic = Diagnostic::new(
                             BlankLinesBetweenHeaderAndContent {
                                 name: context.section_name().to_string(),
@@ -496,7 +480,7 @@ fn blanks_and_section_underline(
                     }
                 }
             } else {
-                if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
+                if checker.enabled(Rule::EmptyDocstringSection) {
                     checker.diagnostics.push(Diagnostic::new(
                         EmptyDocstringSection {
                             name: context.section_name().to_string(),
@@ -506,11 +490,7 @@ fn blanks_and_section_underline(
                 }
             }
         } else {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::DashedUnderlineAfterSection)
-            {
+            if checker.enabled(Rule::DashedUnderlineAfterSection) {
                 let mut diagnostic = Diagnostic::new(
                     DashedUnderlineAfterSection {
                         name: context.section_name().to_string(),
@@ -534,11 +514,7 @@ fn blanks_and_section_underline(
                 checker.diagnostics.push(diagnostic);
             }
             if blank_lines_after_header > 0 {
-                if checker
-                    .settings
-                    .rules
-                    .enabled(Rule::BlankLinesBetweenHeaderAndContent)
-                {
+                if checker.enabled(Rule::BlankLinesBetweenHeaderAndContent) {
                     let mut diagnostic = Diagnostic::new(
                         BlankLinesBetweenHeaderAndContent {
                             name: context.section_name().to_string(),
@@ -559,11 +535,7 @@ fn blanks_and_section_underline(
     }
     // Nothing but blank lines after the section header.
     else {
-        if checker
-            .settings
-            .rules
-            .enabled(Rule::DashedUnderlineAfterSection)
-        {
+        if checker.enabled(Rule::DashedUnderlineAfterSection) {
             let mut diagnostic = Diagnostic::new(
                 DashedUnderlineAfterSection {
                     name: context.section_name().to_string(),
@@ -587,7 +559,7 @@ fn blanks_and_section_underline(
             }
             checker.diagnostics.push(diagnostic);
         }
-        if checker.settings.rules.enabled(Rule::EmptyDocstringSection) {
+        if checker.enabled(Rule::EmptyDocstringSection) {
             checker.diagnostics.push(Diagnostic::new(
                 EmptyDocstringSection {
                     name: context.section_name().to_string(),
@@ -604,7 +576,7 @@ fn common_section(
     context: &SectionContext,
     next: Option<&SectionContext>,
 ) {
-    if checker.settings.rules.enabled(Rule::CapitalizeSectionName) {
+    if checker.enabled(Rule::CapitalizeSectionName) {
         let capitalized_section_name = context.kind().as_str();
         if context.section_name() != capitalized_section_name {
             let mut diagnostic = Diagnostic::new(
@@ -627,7 +599,7 @@ fn common_section(
         }
     }
 
-    if checker.settings.rules.enabled(Rule::SectionNotOverIndented) {
+    if checker.enabled(Rule::SectionNotOverIndented) {
         let leading_space = whitespace::leading_space(context.summary_line());
         if leading_space.len() > docstring.indentation.len() {
             let mut diagnostic = Diagnostic::new(
@@ -656,11 +628,7 @@ fn common_section(
     let last_line = context.following_lines().last();
     if last_line.map_or(true, |line| !line.trim().is_empty()) {
         if let Some(next) = next {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::NoBlankLineAfterSection)
-            {
+            if checker.enabled(Rule::NoBlankLineAfterSection) {
                 let mut diagnostic = Diagnostic::new(
                     NoBlankLineAfterSection {
                         name: context.section_name().to_string(),
@@ -678,11 +646,7 @@ fn common_section(
                 checker.diagnostics.push(diagnostic);
             }
         } else {
-            if checker
-                .settings
-                .rules
-                .enabled(Rule::BlankLineAfterLastSection)
-            {
+            if checker.enabled(Rule::BlankLineAfterLastSection) {
                 let mut diagnostic = Diagnostic::new(
                     BlankLineAfterLastSection {
                         name: context.section_name().to_string(),
@@ -702,11 +666,7 @@ fn common_section(
         }
     }
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::NoBlankLineBeforeSection)
-    {
+    if checker.enabled(Rule::NoBlankLineBeforeSection) {
         if !context.previous_line().map_or(false, str::is_empty) {
             let mut diagnostic = Diagnostic::new(
                 NoBlankLineBeforeSection {
@@ -904,11 +864,7 @@ fn numpy_section(
 ) {
     common_section(checker, docstring, context, next);
 
-    if checker
-        .settings
-        .rules
-        .enabled(Rule::NewLineAfterSectionName)
-    {
+    if checker.enabled(Rule::NewLineAfterSectionName) {
         let suffix = context.summary_after_section_name();
 
         if !suffix.is_empty() {
@@ -931,7 +887,7 @@ fn numpy_section(
         }
     }
 
-    if checker.settings.rules.enabled(Rule::UndocumentedParam) {
+    if checker.enabled(Rule::UndocumentedParam) {
         if matches!(context.kind(), SectionKind::Parameters) {
             parameters_section(checker, docstring, context);
         }
@@ -946,7 +902,7 @@ fn google_section(
 ) {
     common_section(checker, docstring, context, next);
 
-    if checker.settings.rules.enabled(Rule::SectionNameEndsInColon) {
+    if checker.enabled(Rule::SectionNameEndsInColon) {
         let suffix = context.summary_after_section_name();
         if suffix != ":" {
             let mut diagnostic = Diagnostic::new(
@@ -990,7 +946,7 @@ fn parse_google_sections(
         google_section(checker, docstring, &context, iterator.peek());
     }
 
-    if checker.settings.rules.enabled(Rule::UndocumentedParam) {
+    if checker.enabled(Rule::UndocumentedParam) {
         let mut has_args = false;
         let mut documented_args: FxHashSet<String> = FxHashSet::default();
         for section_context in section_contexts {

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -96,11 +96,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
             if let Some(seen_values) = seen.get_mut(&dict_key) {
                 match dict_key {
                     DictionaryKey::Constant(..) => {
-                        if checker
-                            .settings
-                            .rules
-                            .enabled(Rule::MultiValueRepeatedKeyLiteral)
-                        {
+                        if checker.enabled(Rule::MultiValueRepeatedKeyLiteral) {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);
                             let mut diagnostic = Diagnostic::new(
@@ -125,11 +121,7 @@ pub(crate) fn repeated_keys(checker: &mut Checker, keys: &[Option<Expr>], values
                         }
                     }
                     DictionaryKey::Variable(dict_key) => {
-                        if checker
-                            .settings
-                            .rules
-                            .enabled(Rule::MultiValueRepeatedKeyVariable)
-                        {
+                        if checker.enabled(Rule::MultiValueRepeatedKeyVariable) {
                             let comparable_value: ComparableExpr = (&values[i]).into();
                             let is_duplicate_value = seen_values.contains(&comparable_value);
                             let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/pylint/rules/logging.rs
+++ b/crates/ruff/src/rules/pylint/rules/logging.rs
@@ -124,7 +124,7 @@ pub(crate) fn logging_call(
 
                     let message_args = call_args.args.len() - 1;
 
-                    if checker.settings.rules.enabled(Rule::LoggingTooManyArgs) {
+                    if checker.enabled(Rule::LoggingTooManyArgs) {
                         if summary.num_positional < message_args {
                             checker
                                 .diagnostics
@@ -132,7 +132,7 @@ pub(crate) fn logging_call(
                         }
                     }
 
-                    if checker.settings.rules.enabled(Rule::LoggingTooFewArgs) {
+                    if checker.enabled(Rule::LoggingTooFewArgs) {
                         if message_args > 0
                             && call_args.kwargs.is_empty()
                             && summary.num_positional > message_args


### PR DESCRIPTION
## Summary

This is a refactoring that shortens a bunch of code by replacing `checker.settings.rules.enabled` with `checker.enabled`. github says +566/-1,273. 

## Test Plan

`cargo clippy` (no functional changes)
