### PR TITLE
Visit `TypeVar` and `NewType` name arguments

### DIFF
--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -3689,6 +3689,16 @@ mod tests {
         "#,
             &[],
         );
+        flakes(
+            r#"
+            from typing import NewType
+
+            def f():
+                name = "x"
+                NewType(name, int)
+        "#,
+            &[],
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Given `NewType(x, y)`, we weren't visiting `x` at all. I think this is because `x` is typically a string constant (the name of the `NewType`), and we wanted to avoid treating it as a forward reference -- but we have support for that kind of traversal anyway.

Closes #4623.