### PR TITLE
Only run the playground release job on release

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,9 @@
 name: mkdocs
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+  release:
+    types: [ published ]
 
 jobs:
   mkdocs:

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -2,8 +2,8 @@ name: "[Playground] Release"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  release:
+    types: [ published ]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

It feels like a poor use of worker capacity to be building the WASM release build on every commit. Let's just run the playground release on _actual_ release.
