### PR TITLE
Remove deprecated --universal2 flag

### DIFF
--- a/.github/workflows/flake8-to-ruff.yaml
+++ b/.github/workflows/flake8-to-ruff.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --universal2 --out dist -m ./${{ env.CRATE_NAME }}/Cargo.toml
+          args: --release --target universal2-apple-darwin --out dist -m ./${{ env.CRATE_NAME }}/Cargo.toml
       - name: "Install built wheel - universal2"
         run: |
           pip install dist/${{ env.CRATE_NAME }}-*universal2.whl --force-reinstall

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --universal2 --out dist
+          args: --release --target universal2-apple-darwin --out dist
       - name: "Test wheel - universal2"
         run: |
           pip install dist/${{ env.PACKAGE_NAME }}-*universal2.whl --force-reinstall


### PR DESCRIPTION
This was removed as part of the Maturin 1.0 release (https://github.com/PyO3/maturin/pull/1620).