### PR TITLE
Testing Macros: Add `extra-traits` feature to syn

### DIFF
--- a/crates/ruff_testing_macros/Cargo.toml
+++ b/crates/ruff_testing_macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 glob = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true }
+syn = { workspace = true, features = ["extra-traits"] }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR adds the `extra-traits` feature dependency to `syn`. 
Including the feature fixes the compile error when only building the `ruff_python_formatter` that `ItemFn` does not implement `Debug`.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo build -p ruff_python_formatter`

<!-- How was it tested? -->
