### PR TITLE
Docs: mention `task-tags` option in two rules

### DIFF
--- a/crates/ruff/src/rules/eradicate/rules/commented_out_code.rs
+++ b/crates/ruff/src/rules/eradicate/rules/commented_out_code.rs
@@ -14,6 +14,9 @@ use super::super::detection::comment_contains_code;
 /// Commented-out code is dead code, and is often included inadvertently.
 /// It should be removed.
 ///
+/// ## Options
+/// - `task-tags`
+///
 /// ## Example
 /// ```python
 /// # print('foo')

--- a/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/line_too_long.rs
@@ -11,6 +11,9 @@ use crate::settings::Settings;
 /// ## Why is this bad?
 /// Overlong lines can hurt readability.
 ///
+/// ## Options
+/// - `task-tags`
+///
 /// ## Example
 /// ```python
 /// my_function(param1, param2, param3, param4, param5, param6, param7, param8, param9, param10)


### PR DESCRIPTION
## Summary

Mention `task-tags` option in two rules. Close #4618.
