### PR TITLE
Use class name as range for `B024`

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_bugbear/B027.py
+++ b/crates/ruff/resources/test/fixtures/flake8_bugbear/B027.py
@@ -120,3 +120,11 @@ class AbstractClass(ABC):
     @abstractmethod
     def empty_1(self, foo: Union[str, int, list, float]):
         ...
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Foo(ABC):  # noqa: B024
+    ...

--- a/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
+++ b/crates/ruff/src/rules/flake8_bugbear/rules/abstract_base_class.rs
@@ -2,6 +2,7 @@ use rustpython_parser::ast::{self, Constant, Expr, Keyword, Ranged, Stmt};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
+use ruff_python_ast::helpers::identifier_range;
 use ruff_python_semantic::analyze::visibility::{is_abstract, is_overload};
 use ruff_python_semantic::model::SemanticModel;
 
@@ -133,7 +134,7 @@ pub(crate) fn abstract_base_class(
                 AbstractBaseClassWithoutAbstractMethod {
                     name: name.to_string(),
                 },
-                stmt.range(),
+                identifier_range(stmt, checker.locator),
             ));
         }
     }

--- a/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B024_B024.py.snap
+++ b/crates/ruff/src/rules/flake8_bugbear/snapshots/ruff__rules__flake8_bugbear__tests__B024_B024.py.snap
@@ -1,52 +1,52 @@
 ---
 source: crates/ruff/src/rules/flake8_bugbear/mod.rs
 ---
-B024.py:18:1: B024 `Base_1` is an abstract base class, but it has no abstract methods
+B024.py:18:7: B024 `Base_1` is an abstract base class, but it has no abstract methods
    |
-18 | / class Base_1(ABC):  # error
-19 | |     def method(self):
-20 | |         foo()
-   | |_____________^ B024
-   |
-
-B024.py:71:1: B024 `MetaBase_1` is an abstract base class, but it has no abstract methods
-   |
-71 | / class MetaBase_1(metaclass=ABCMeta):  # error
-72 | |     def method(self):
-73 | |         foo()
-   | |_____________^ B024
+18 | class Base_1(ABC):  # error
+   |       ^^^^^^ B024
+19 |     def method(self):
+20 |         foo()
    |
 
-B024.py:82:1: B024 `abc_Base_1` is an abstract base class, but it has no abstract methods
+B024.py:71:7: B024 `MetaBase_1` is an abstract base class, but it has no abstract methods
    |
-82 | / class abc_Base_1(abc.ABC):  # error
-83 | |     def method(self):
-84 | |         foo()
-   | |_____________^ B024
-   |
-
-B024.py:87:1: B024 `abc_Base_2` is an abstract base class, but it has no abstract methods
-   |
-87 | / class abc_Base_2(metaclass=abc.ABCMeta):  # error
-88 | |     def method(self):
-89 | |         foo()
-   | |_____________^ B024
+71 | class MetaBase_1(metaclass=ABCMeta):  # error
+   |       ^^^^^^^^^^ B024
+72 |     def method(self):
+73 |         foo()
    |
 
-B024.py:92:1: B024 `notabc_Base_1` is an abstract base class, but it has no abstract methods
+B024.py:82:7: B024 `abc_Base_1` is an abstract base class, but it has no abstract methods
    |
-92 | / class notabc_Base_1(notabc.ABC):  # error
-93 | |     def method(self):
-94 | |         foo()
-   | |_____________^ B024
+82 | class abc_Base_1(abc.ABC):  # error
+   |       ^^^^^^^^^^ B024
+83 |     def method(self):
+84 |         foo()
    |
 
-B024.py:141:1: B024 `abc_set_class_variable_4` is an abstract base class, but it has no abstract methods
+B024.py:87:7: B024 `abc_Base_2` is an abstract base class, but it has no abstract methods
+   |
+87 | class abc_Base_2(metaclass=abc.ABCMeta):  # error
+   |       ^^^^^^^^^^ B024
+88 |     def method(self):
+89 |         foo()
+   |
+
+B024.py:92:7: B024 `notabc_Base_1` is an abstract base class, but it has no abstract methods
+   |
+92 | class notabc_Base_1(notabc.ABC):  # error
+   |       ^^^^^^^^^^^^^ B024
+93 |     def method(self):
+94 |         foo()
+   |
+
+B024.py:141:7: B024 `abc_set_class_variable_4` is an abstract base class, but it has no abstract methods
     |
-141 |   # this doesn't actually declare a class variable, it's just an expression
-142 | / class abc_set_class_variable_4(ABC):  # error
-143 | |     foo
-    | |_______^ B024
+141 | # this doesn't actually declare a class variable, it's just an expression
+142 | class abc_set_class_variable_4(ABC):  # error
+    |       ^^^^^^^^^^^^^^^^^^^^^^^^ B024
+143 |     foo
     |
 
 


### PR DESCRIPTION
## Summary

Previously, this used the whole class as the diagnostic range -- which, in addition to being inconsistent with other diagnostics, means that if a class includes a decorator, the `noqa` now needs to appear on the line of the first decorator, rather than the line on which the class is defined.

This PR tweaks the range to use the identifier range.

Closes #4646.
