### PR TITLE
Improve token handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -396,22 +396,24 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     environment:
       name: release
+    permissions:
+      # For pypi trusted publishing
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: wheels
-      - uses: actions/setup-python@v4
+          path: wheels
       - name: "Publish to PyPi"
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.RUFF_TOKEN }}
-        run: |
-          pip install --upgrade twine
-          twine upload --skip-existing *
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          packages-dir: .
+          verbose: true
       - uses: actions/download-artifact@v3
         with:
           name: binaries
-          path: binaries
+          path: wheels
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -408,12 +408,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
-          packages-dir: .
+          packages-dir: wheels
           verbose: true
       - uses: actions/download-artifact@v3
         with:
           name: binaries
-          path: wheels
+          path: binaries
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -394,6 +394,8 @@ jobs:
       - musllinux
       - musllinux-cross
     if: "startsWith(github.ref, 'refs/tags/')"
+    environment:
+      name: release
     steps:
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
## Summary

The first small change is that this puts the release job in an environment, which we can customize later e.g. for custom approvals.

@charliermarsh Could you please create an environment "release" under https://github.com/charliermarsh/ruff/settings/environments? Defaults should be fine.

The more important change is that this switches to pypi trusted publishing, e.g. removes token handling on our end altogether.

@charliermarsh if you agree with this, could you please follow https://docs.pypi.org/trusted-publishers/adding-a-publisher/ to allow trusted publishing on pypi?

## Test Plan

Cut a release (maybe a beta release) and see whether it works :no_mouth: 
