### PR TITLE
Add devcontainer support (#4676)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,9 +19,11 @@
 		"vscode": {
 			"extensions": [
 				"ms-python.python",
-				"1YiB.rust-bundle",
+				"rust-lang.rust-analyzer",
+				"serayuzgur.crates",
 				"tamasfe.even-better-toml",
-				"Swellaby.vscode-rust-test-adapter"
+				"Swellaby.vscode-rust-test-adapter",
+				"charliermarsh.ruff"
 			],
 			"settings": {
 				"rust-analyzer.updates.askBeforeDownload": false

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+	"mounts": [
+		{
+			"source": "devcontainer-cargo-cache-${devcontainerId}",
+			"target": "/usr/local/cargo",
+			"type": "volume"
+		}
+	],
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				"CONTRIBUTING.md"
+			]
+		},
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"1YiB.rust-bundle",
+				"tamasfe.even-better-toml",
+				"Swellaby.vscode-rust-test-adapter"
+			],
+			"settings": {
+				"rust-analyzer.updates.askBeforeDownload": false
+			}
+		}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/devcontainers/features/python": {
+			"installTools": false
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	"postCreateCommand": ".devcontainer/post-create.sh"
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
-	"name": "Rust",
+	"name": "Ruff",
 	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
 	"mounts": [
 		{

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+rustup default < rust-toolchain
+rustup component add clippy rustfmt
+cargo install cargo-insta
+cargo fetch
+
+pip install maturin pre-commit
+
+pre-commit install

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -6,5 +6,3 @@ cargo install cargo-insta
 cargo fetch
 
 pip install maturin pre-commit
-
-pre-commit install


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Added devcontainers environment support.

Devcontainer environment contains:
* Main utilities needed to develop `Ruff`
* Configurated `pre-commit`
* Additional extensions for vscode

### Known problems:
Test Explorer doesn't work
```
[2023-05-27 11:51:25.922] [INFO] Test Explorer found
[2023-05-27 11:51:25.922] [INFO] Initializing Rust adapter
[2023-05-27 11:51:25.924] [INFO] Loading Rust Tests
[2023-05-27 11:51:26.244] [WARN] Unsupported target type: bench for linter
[2023-05-27 11:51:26.244] [WARN] Unsupported target type: bench for parser
[2023-05-27 11:58:23.366] [DEBUG] Unable to retrieve enumeration of tests. Details: Error: Command failed: cargo test -p ruff_testing_macros --lib -- --list
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on build directory
   Compiling syn v2.0.15
   Compiling ruff_testing_macros v0.0.0 (/workspaces/ruff/crates/ruff_testing_macros)
error[E0432]: unresolved imports `syn::FnArg`, `syn::ItemFn`, `syn::Pat`
  --> crates/ruff_testing_macros/src/lib.rs:13:61
   |
13 | use syn::{bracketed, parse_macro_input, parse_quote, Error, FnArg, ItemFn, LitStr, Pat, Token};
   |                                                             ^^^^^  ^^^^^^          ^^^
   |                                                             |      |               |
   |                                                             |      |               no `Pat` in the root
   |                                                             |      |               help: a similar name exists in the module: `Path`
   |                                                             |      no `ItemFn` in the root
   |                                                             no `FnArg` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `ruff_testing_macros` due to previous error
```

## Test Plan
<details> 
  <summary>Using vscode `devcontainer` extension</summary>

  1. Open the project in vscode
  2. Reopen in container
  ![image](https://github.com/charliermarsh/ruff/assets/1702003/8661a5fb-ed9e-4cd7-b790-12ac45977ab8)
  ![image](https://github.com/charliermarsh/ruff/assets/1702003/04caca66-892a-4596-9762-5d27ff94d0a4)
</details>


<details> 
  <summary>Using Codespace</summary>

  1. Click on `Code` 
  2. Go to the `Codespaces` tab 
  3. Click the big green :green_square: button
  ![image](https://github.com/charliermarsh/ruff/assets/1702003/cb011663-64a5-423a-84cc-0f79ab9e2379) 
</details>

