### PR TITLE
Fix UP036 auto-fix error

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP036_5.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP036_5.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info < (3, 8):
+
+    def a():
+        if b:
+            print(1)
+        elif c:
+            print(2)
+        return None
+
+else:
+    pass

--- a/crates/ruff/resources/test/fixtures/pyupgrade/UP036_5.py
+++ b/crates/ruff/resources/test/fixtures/pyupgrade/UP036_5.py
@@ -11,3 +11,20 @@ if sys.version_info < (3, 8):
 
 else:
     pass
+
+
+import sys
+
+if sys.version_info < (3, 8):
+    pass
+
+else:
+
+    def a():
+        if b:
+            print(1)
+        elif c:
+            print(2)
+        else:
+            print(3)
+        return None

--- a/crates/ruff/src/rules/pyupgrade/mod.rs
+++ b/crates/ruff/src/rules/pyupgrade/mod.rs
@@ -71,6 +71,7 @@ mod tests {
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_2.py"); "UP036_2")]
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_3.py"); "UP036_3")]
     #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_4.py"); "UP036_4")]
+    #[test_case(Rule::OutdatedVersionBlock, Path::new("UP036_5.py"); "UP036_5")]
     #[test_case(Rule::QuotedAnnotation, Path::new("UP037.py"); "UP037")]
     #[test_case(Rule::NonPEP604Isinstance, Path::new("UP038.py"); "UP038")]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -52,36 +52,28 @@ impl BlockMetadata {
     }
 }
 
-fn metadata<T>(locator: &Locator, located: &T) -> Option<BlockMetadata>
+fn metadata<T>(locator: &Locator, located: &T, body: &[Stmt]) -> Option<BlockMetadata>
 where
     T: Ranged,
 {
     indentation(locator, located)?;
 
-    let line_start = locator.line_start(located.start());
-    // Start the selection at the start-of-line. This ensures consistent indentation
-    // in the token stream, in the event that the entire block is indented.
-    let text = locator.slice(TextRange::new(line_start, located.end()));
+    let located_start = located.start();
+    let text = locator.slice(TextRange::new(located_start, located.end()));
+    let body_end = body.last().map(Ranged::end).unwrap();
 
-    let mut starter: Option<Tok> = None;
+    let mut starter = None;
     let mut elif = None;
     let mut else_ = None;
 
-    for (tok, range) in lexer::lex_starts_at(text, Mode::Module, line_start)
+    for (tok, range) in lexer::lex_starts_at(text, Mode::Module, located_start)
         .flatten()
-        .filter(|(tok, _)| {
-            !matches!(
-                tok,
-                Tok::Indent
-                    | Tok::Dedent
-                    | Tok::NonLogicalNewline
-                    | Tok::Newline
-                    | Tok::Comment(..)
-            )
-        })
+        .filter(|(tok, _)| matches!(tok, Tok::If | Tok::Elif | Tok::Else))
     {
         if starter.is_none() {
             starter = Some(tok.clone());
+        } else if range.start() < body_end {
+            continue;
         } else {
             if matches!(tok, Tok::Elif) && elif.is_none() {
                 elif = Some(range.start());
@@ -343,7 +335,7 @@ pub(crate) fn outdated_version_block(
                     if compare_version(&version, target, op == &Cmpop::LtE) {
                         let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, stmt.range());
                         if checker.patch(diagnostic.kind.rule()) {
-                            if let Some(block) = metadata(checker.locator, stmt) {
+                            if let Some(block) = metadata(checker.locator, stmt, body) {
                                 if let Some(fix) =
                                     fix_py2_block(checker, stmt, body, orelse, &block)
                                 {
@@ -357,7 +349,7 @@ pub(crate) fn outdated_version_block(
                     if compare_version(&version, target, op == &Cmpop::GtE) {
                         let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, stmt.range());
                         if checker.patch(diagnostic.kind.rule()) {
-                            if let Some(block) = metadata(checker.locator, stmt) {
+                            if let Some(block) = metadata(checker.locator, stmt, body) {
                                 if let Some(fix) = fix_py3_block(checker, stmt, test, body, &block)
                                 {
                                     diagnostic.set_fix(fix);
@@ -376,7 +368,7 @@ pub(crate) fn outdated_version_block(
                 if version_number == 2 && op == &Cmpop::Eq {
                     let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, stmt.range());
                     if checker.patch(diagnostic.kind.rule()) {
-                        if let Some(block) = metadata(checker.locator, stmt) {
+                        if let Some(block) = metadata(checker.locator, stmt, body) {
                             if let Some(fix) = fix_py2_block(checker, stmt, body, orelse, &block) {
                                 diagnostic.set_fix(fix);
                             }
@@ -386,7 +378,7 @@ pub(crate) fn outdated_version_block(
                 } else if version_number == 3 && op == &Cmpop::Eq {
                     let mut diagnostic = Diagnostic::new(OutdatedVersionBlock, stmt.range());
                     if checker.patch(diagnostic.kind.rule()) {
-                        if let Some(block) = metadata(checker.locator, stmt) {
+                        if let Some(block) = metadata(checker.locator, stmt, body) {
                             if let Some(fix) = fix_py3_block(checker, stmt, test, body, &block) {
                                 diagnostic.set_fix(fix);
                             }

--- a/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -77,15 +77,12 @@ where
             // Continue until the end of the `if` body, thus ensuring that we don't
             // accidentally pick up an `else` or `elif` in the nested block.
             continue;
-        } else {
-            if matches!(tok, Tok::Elif) && elif.is_none() {
-                elif = Some(range.start());
-            }
-            if matches!(tok, Tok::Else) && else_.is_none() {
-                else_ = Some(range.start());
-            }
-        }
-        if starter.is_some() && elif.is_some() && else_.is_some() {
+        // We only care about the first `elif` or `else` following the `if`.
+        } else if matches!(tok, Tok::Elif) {
+            elif = Some(range.start());
+            break;
+        } else if matches!(tok, Tok::Else) {
+            else_ = Some(range.start());
             break;
         }
     }

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_5.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_5.py.snap
@@ -21,19 +21,69 @@ UP036_5.py:3:1: UP036 [*] Version block is outdated for minimum Python version
    = help: Remove outdated version block
 
 ℹ Suggested fix
-1 1 | import sys
-2 2 | 
-3   |-if sys.version_info < (3, 8):
-4   |-
-5   |-    def a():
-6   |-        if b:
-7   |-            print(1)
-8   |-        elif c:
-9   |-            print(2)
-10   |-        return None
-11   |-
-12   |-else:
-13   |-    pass
-  3 |+pass
+1  1  | import sys
+2  2  | 
+3     |-if sys.version_info < (3, 8):
+4     |-
+5     |-    def a():
+6     |-        if b:
+7     |-            print(1)
+8     |-        elif c:
+9     |-            print(2)
+10    |-        return None
+11    |-
+12    |-else:
+13    |-    pass
+   3  |+pass
+14 4  | 
+15 5  | 
+16 6  | import sys
+
+UP036_5.py:18:1: UP036 [*] Version block is outdated for minimum Python version
+   |
+18 |   import sys
+19 |   
+20 | / if sys.version_info < (3, 8):
+21 | |     pass
+22 | | 
+23 | | else:
+24 | | 
+25 | |     def a():
+26 | |         if b:
+27 | |             print(1)
+28 | |         elif c:
+29 | |             print(2)
+30 | |         else:
+31 | |             print(3)
+32 | |         return None
+   | |___________________^ UP036
+   |
+   = help: Remove outdated version block
+
+ℹ Suggested fix
+15 15 | 
+16 16 | import sys
+17 17 | 
+18    |-if sys.version_info < (3, 8):
+19    |-    pass
+20    |-
+21    |-else:
+22    |-
+23    |-    def a():
+24    |-        if b:
+25    |-            print(1)
+26    |-        elif c:
+27    |-            print(2)
+28    |-        else:
+29    |-            print(3)
+30    |-        return None
+   18 |+def a():
+   19 |+    if b:
+   20 |+        print(1)
+   21 |+    elif c:
+   22 |+        print(2)
+   23 |+    else:
+   24 |+        print(3)
+   25 |+    return None
 
 

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_5.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP036_5.py.snap
@@ -1,0 +1,39 @@
+---
+source: crates/ruff/src/rules/pyupgrade/mod.rs
+---
+UP036_5.py:3:1: UP036 [*] Version block is outdated for minimum Python version
+   |
+ 3 |   import sys
+ 4 |   
+ 5 | / if sys.version_info < (3, 8):
+ 6 | | 
+ 7 | |     def a():
+ 8 | |         if b:
+ 9 | |             print(1)
+10 | |         elif c:
+11 | |             print(2)
+12 | |         return None
+13 | | 
+14 | | else:
+15 | |     pass
+   | |________^ UP036
+   |
+   = help: Remove outdated version block
+
+ℹ Suggested fix
+1 1 | import sys
+2 2 | 
+3   |-if sys.version_info < (3, 8):
+4   |-
+5   |-    def a():
+6   |-        if b:
+7   |-            print(1)
+8   |-        elif c:
+9   |-            print(2)
+10   |-        return None
+11   |-
+12   |-else:
+13   |-    pass
+  3 |+pass
+
+


### PR DESCRIPTION
- Close #4522
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `BlockMetadata` was incorrect. It was picking up `else` and `elif` tokens inside the `if` body.
Now, it will skip all tokens inside the `if` body.
<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

A fixture with the failing auto-fix has been added.
<!-- How was it tested? -->
