### PR TITLE
Fix PLW3301 false positive single argument nested min/max

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/nested_min_max.py
+++ b/crates/ruff/resources/test/fixtures/pylint/nested_min_max.py
@@ -25,3 +25,14 @@ min(1, min(a))
 min(1, min(i for i in range(10)))
 max(1, max(a))
 max(1, max(i for i in range(10)))
+
+tuples_list = [
+    (1, 2),
+    (2, 3),
+    (3, 4),
+    (4, 5),
+    (5, 6),
+]
+
+min(min(tuples_list))
+max(max(tuples_list))

--- a/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff/src/rules/pylint/rules/nested_min_max.rs
@@ -132,6 +132,12 @@ pub(crate) fn nested_min_max(
         return;
     };
 
+    if args.len() == 1
+        && matches!(&args[0], Expr::Call(ast::ExprCall { args, .. }) if args.len() == 1)
+    {
+        return;
+    }
+
     if args.iter().any(|arg| {
         let Expr::Call(ast::ExprCall { func, keywords, ..} )= arg else {
             return false;

--- a/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW3301_nested_min_max.py.snap
+++ b/crates/ruff/src/rules/pylint/snapshots/ruff__rules__pylint__tests__PLW3301_nested_min_max.py.snap
@@ -235,6 +235,7 @@ nested_min_max.py:25:1: PLW3301 [*] Nested `min` calls can be flattened
    25 |+min(1, *(i for i in range(10)))
 26 26 | max(1, max(a))
 27 27 | max(1, max(i for i in range(10)))
+28 28 | 
 
 nested_min_max.py:26:1: PLW3301 [*] Nested `max` calls can be flattened
    |
@@ -253,6 +254,8 @@ nested_min_max.py:26:1: PLW3301 [*] Nested `max` calls can be flattened
 26    |-max(1, max(a))
    26 |+max(1, *a)
 27 27 | max(1, max(i for i in range(10)))
+28 28 | 
+29 29 | tuples_list = [
 
 nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
    |
@@ -260,6 +263,8 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
 28 | max(1, max(a))
 29 | max(1, max(i for i in range(10)))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ PLW3301
+30 | 
+31 | tuples_list = [
    |
    = help: Flatten nested `max` calls
 
@@ -269,5 +274,8 @@ nested_min_max.py:27:1: PLW3301 [*] Nested `max` calls can be flattened
 26 26 | max(1, max(a))
 27    |-max(1, max(i for i in range(10)))
    27 |+max(1, *(i for i in range(10)))
+28 28 | 
+29 29 | tuples_list = [
+30 30 |     (1, 2),
 
 


### PR DESCRIPTION
- Close #4682
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Nested `min`/`max` with a single argument should not be flattened.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

Added a fixture.

<!-- How was it tested? -->
