### PR TITLE
Handle dotted alias imports to check for implicit imports

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
@@ -96,8 +96,7 @@ def f():
 
 
 def f():
-    # Even in strict mode, this shouldn't rase an error, since `pkg.baz` is used at
-    # runtime, and implicitly imports `pkg.bar`.
+    # In un-strict mode, this shouldn't raise an error, since `pkg.bar` is used at runtime.
     import pkg.bar as B
     import pkg.foo as F
 

--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
@@ -93,3 +93,13 @@ def f():
 
     def test(value: pkg.A):
         return B()
+
+
+def f():
+    # Even in strict mode, this shouldn't rase an error, since `pkg.baz` is used at
+    # runtime, and implicitly imports `pkg.bar`.
+    import pkg.bar as B
+    import pkg.foo as F
+
+    def test(value: F.Foo):
+        return B.Bar()

--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/strict.py
@@ -55,3 +55,41 @@ def f():
 
     def test(value: A):
         return pkg.B()
+
+
+def f():
+    # In un-strict mode, this shouldn't rase an error, since `pkg.bar` is used at runtime.
+    import pkg
+    import pkg.bar as B
+
+    def test(value: pkg.A):
+        return B()
+
+
+def f():
+    # In un-strict mode, this shouldn't rase an error, since `pkg.foo.bar` is used at runtime.
+    import pkg.foo as F
+    import pkg.foo.bar as B
+
+    def test(value: F.Foo):
+        return B()
+
+
+def f():
+    # In un-strict mode, this shouldn't rase an error, since `pkg.foo.bar` is used at runtime.
+    import pkg
+    import pkg.foo.bar as B
+
+    def test(value: pkg.A):
+        return B()
+
+
+def f():
+    # In un-strict mode, this _should_ rase an error, since `pkgfoo.bar` is used at runtime.
+    # Note that `pkg` is a prefix of `pkgfoo` which are both different modules. This is
+    # testing the implementation.
+    import pkg
+    import pkgfoo.bar as B
+
+    def test(value: pkg.A):
+        return B()

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -181,9 +181,20 @@ fn is_implicit_import(this: &Binding, that: &Binding) -> bool {
             }
             BindingKind::Importation(Importation {
                 full_name: that_name,
-                ..
-            })
-            | BindingKind::SubmoduleImportation(SubmoduleImportation {
+                name: that_alias,
+            }) => {
+                if that_name == that_alias {
+                    // Ex) `pkg` vs. `pkg`
+                    this_name == that_name
+                } else {
+                    // Submodule importation with an alias: `import pkg.A as B`
+                    this_name
+                        .split('.')
+                        .zip(that_name.split('.'))
+                        .all(|(this_part, that_part)| this_part == that_part)
+                }
+            }
+            BindingKind::SubmoduleImportation(SubmoduleImportation {
                 name: that_name, ..
             }) => {
                 // Ex) `pkg.A` vs. `pkg.B`

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
@@ -31,4 +31,40 @@ strict.py:54:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking
 58 |     def test(value: A):
    |
 
+strict.py:62:12: TCH002 Move third-party import `pkg` into a type-checking block
+   |
+62 | def f():
+63 |     # In un-strict mode, this shouldn't rase an error, since `pkg.bar` is used at runtime.
+64 |     import pkg
+   |            ^^^ TCH002
+65 |     import pkg.bar as B
+   |
+
+strict.py:71:12: TCH002 Move third-party import `pkg.foo` into a type-checking block
+   |
+71 | def f():
+72 |     # In un-strict mode, this shouldn't rase an error, since `pkg.foo.bar` is used at runtime.
+73 |     import pkg.foo as F
+   |            ^^^^^^^^^^^^ TCH002
+74 |     import pkg.foo.bar as B
+   |
+
+strict.py:80:12: TCH002 Move third-party import `pkg` into a type-checking block
+   |
+80 | def f():
+81 |     # In un-strict mode, this shouldn't rase an error, since `pkg.foo.bar` is used at runtime.
+82 |     import pkg
+   |            ^^^ TCH002
+83 |     import pkg.foo.bar as B
+   |
+
+strict.py:91:12: TCH002 Move third-party import `pkg` into a type-checking block
+   |
+91 |     # Note that `pkg` is a prefix of `pkgfoo` which are both different modules. This is
+92 |     # testing the implementation.
+93 |     import pkg
+   |            ^^^ TCH002
+94 |     import pkgfoo.bar as B
+   |
+
 

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
@@ -67,14 +67,14 @@ strict.py:91:12: TCH002 Move third-party import `pkg` into a type-checking block
 94 |     import pkgfoo.bar as B
    |
 
-strict.py:102:12: TCH002 Move third-party import `pkg.foo` into a type-checking block
+strict.py:101:12: TCH002 Move third-party import `pkg.foo` into a type-checking block
     |
-102 |     # runtime, and implicitly imports `pkg.bar`.
-103 |     import pkg.bar as B
-104 |     import pkg.foo as F
+101 |     # In un-strict mode, this shouldn't raise an error, since `pkg.bar` is used at runtime.
+102 |     import pkg.bar as B
+103 |     import pkg.foo as F
     |            ^^^^^^^^^^^^ TCH002
-105 | 
-106 |     def test(value: F.Foo):
+104 | 
+105 |     def test(value: F.Foo):
     |
 
 

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__strict.snap
@@ -67,4 +67,14 @@ strict.py:91:12: TCH002 Move third-party import `pkg` into a type-checking block
 94 |     import pkgfoo.bar as B
    |
 
+strict.py:102:12: TCH002 Move third-party import `pkg.foo` into a type-checking block
+    |
+102 |     # runtime, and implicitly imports `pkg.bar`.
+103 |     import pkg.bar as B
+104 |     import pkg.foo as F
+    |            ^^^^^^^^^^^^ TCH002
+105 | 
+106 |     def test(value: F.Foo):
+    |
+
 

--- a/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
+++ b/crates/ruff/src/rules/flake8_type_checking/snapshots/ruff__rules__flake8_type_checking__tests__typing-only-third-party-import_strict.py.snap
@@ -11,4 +11,13 @@ strict.py:54:25: TCH002 Move third-party import `pkg.bar.A` into a type-checking
 58 |     def test(value: A):
    |
 
+strict.py:91:12: TCH002 Move third-party import `pkg` into a type-checking block
+   |
+91 |     # Note that `pkg` is a prefix of `pkgfoo` which are both different modules. This is
+92 |     # testing the implementation.
+93 |     import pkg
+   |            ^^^ TCH002
+94 |     import pkgfoo.bar as B
+   |
+
 


### PR DESCRIPTION
## Summary

Dotted alias import such as `import foo.bar as f` are presented as `Importation` instead of `SubmoduleImportation`. Thus, they were compared like `foo == foo.bar` which would conclude that it's not an implicit import (which is incorrect).

The implemented solution differentiates between a dotted alias import and a plain import, takes care of the former by zipping over every module part. The `starts_with` method cannot be used as it could yield false positive (`foo` vs `foobar`, substrings aren't the same).

### Alternative

We could implement a new binding kind for this `SubmoduleAliasImportation`:

```rust
pub struct SubmoduleAliasImportation<'a> {
	pub name: &'a str,
	pub full_name: &'a str,
	pub alias: &'a str,
}
```

Taking the below import as an example, the `name`, `full_name` and `alias` fields would be `foo`, `foo.bar` and `b` respectively.

```python
import foo.bar as b
```

## Analysis

So, the problem here is that a dotted alias import is represented using `Binding::Importation`:

```python
import libcst.matchers as m
#      |-------------|    |
#        full_name       name
```

This means that the comparison is done with `libcst` and `libcst.matchers` which are not the same, thus the former is not considered to be an implicit import of the latter even though it is.

The problem arises with multiple dotted alias import as well:

```python
import libcst.matchers as m  # this
import libcst.matches._visitors as v  # that
```

Here, the same thing happens where `this` is not considered an implicit import of `that`.

Another case:
```python
import libcst
import libcst.matches._visitors as v
```

## Test Plan

Test cases as provided in the Python files.

fixes: #4667
