### PR TITLE
Remove globals table from `Scope`

### DIFF
--- a/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
+++ b/crates/ruff/src/rules/pylint/rules/load_before_global_declaration.rs
@@ -54,8 +54,7 @@ impl Violation for LoadBeforeGlobalDeclaration {
 }
 /// PLE0118
 pub(crate) fn load_before_global_declaration(checker: &mut Checker, name: &str, expr: &Expr) {
-    let scope = checker.semantic_model().scope();
-    if let Some(stmt) = scope.get_global(name) {
+    if let Some(stmt) = checker.semantic_model().global(name) {
         if expr.start() < stmt.start() {
             #[allow(deprecated)]
             let location = checker.locator.compute_source_location(stmt.start());

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -959,34 +959,6 @@ where
     }
 }
 
-#[derive(Default)]
-struct GlobalStatementVisitor<'a> {
-    globals: FxHashMap<&'a str, TextRange>,
-}
-
-impl<'a> StatementVisitor<'a> for GlobalStatementVisitor<'a> {
-    fn visit_stmt(&mut self, stmt: &'a Stmt) {
-        match stmt {
-            Stmt::Global(ast::StmtGlobal { names, range }) => {
-                for name in names {
-                    self.globals.insert(name.as_str(), *range);
-                }
-            }
-            Stmt::FunctionDef(_) | Stmt::AsyncFunctionDef(_) | Stmt::ClassDef(_) => {
-                // Don't recurse.
-            }
-            _ => walk_stmt(self, stmt),
-        }
-    }
-}
-
-/// Extract a map from global name to its last-defining [`Stmt`].
-pub fn extract_globals(body: &[Stmt]) -> FxHashMap<&str, TextRange> {
-    let mut visitor = GlobalStatementVisitor::default();
-    visitor.visit_body(body);
-    visitor.globals
-}
-
 /// Return `true` if a [`Ranged`] has leading content.
 pub fn has_leading_content<T>(located: &T, locator: &Locator) -> bool
 where

--- a/crates/ruff_python_semantic/src/globals.rs
+++ b/crates/ruff_python_semantic/src/globals.rs
@@ -1,0 +1,89 @@
+//! When building a semantic model, we often need to know which names in a given scope are declared
+//! as `global`. This module provides data structures for storing and querying the set of `global`
+//! names in a given scope.
+
+use std::ops::Index;
+
+use ruff_text_size::TextRange;
+use rustc_hash::FxHashMap;
+use rustpython_parser::ast;
+use rustpython_parser::ast::Stmt;
+
+use ruff_index::{newtype_index, IndexVec};
+use ruff_python_ast::statement_visitor::{walk_stmt, StatementVisitor};
+
+/// Id uniquely identifying the set of global names for a given scope.
+#[newtype_index]
+pub struct GlobalsId;
+
+#[derive(Debug, Default)]
+pub(crate) struct GlobalsArena<'a>(IndexVec<GlobalsId, Globals<'a>>);
+
+impl<'a> GlobalsArena<'a> {
+    /// Inserts a new set of global names into the global names arena and returns its unique id.
+    pub(crate) fn push(&mut self, globals: Globals<'a>) -> GlobalsId {
+        self.0.push(globals)
+    }
+}
+
+impl<'a> Index<GlobalsId> for GlobalsArena<'a> {
+    type Output = Globals<'a>;
+
+    #[inline]
+    fn index(&self, index: GlobalsId) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+/// The set of global names for a given scope, represented as a map from the name of the global to
+/// the range of the declaration in the source code.
+#[derive(Debug)]
+pub struct Globals<'a>(FxHashMap<&'a str, TextRange>);
+
+impl<'a> Globals<'a> {
+    /// Extracts the set of global names from a given scope, or return `None` if the scope does not
+    /// contain any `global` declarations.
+    pub fn from_body(body: &'a [Stmt]) -> Option<Self> {
+        let mut builder = GlobalsVisitor::new();
+        builder.visit_body(body);
+        builder.finish()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&TextRange> {
+        self.0.get(name)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&&'a str, &TextRange)> + '_ {
+        self.0.iter()
+    }
+}
+
+/// Extracts the set of global names from a given scope.
+#[derive(Debug)]
+struct GlobalsVisitor<'a>(FxHashMap<&'a str, TextRange>);
+
+impl<'a> GlobalsVisitor<'a> {
+    fn new() -> Self {
+        Self(FxHashMap::default())
+    }
+
+    fn finish(self) -> Option<Globals<'a>> {
+        (!self.0.is_empty()).then_some(Globals(self.0))
+    }
+}
+
+impl<'a> StatementVisitor<'a> for GlobalsVisitor<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::Global(ast::StmtGlobal { names, range }) => {
+                for name in names {
+                    self.0.insert(name.as_str(), *range);
+                }
+            }
+            Stmt::FunctionDef(_) | Stmt::AsyncFunctionDef(_) | Stmt::ClassDef(_) => {
+                // Don't recurse.
+            }
+            _ => walk_stmt(self, stmt),
+        }
+    }
+}

--- a/crates/ruff_python_semantic/src/lib.rs
+++ b/crates/ruff_python_semantic/src/lib.rs
@@ -2,6 +2,7 @@ pub mod analyze;
 pub mod binding;
 pub mod context;
 pub mod definition;
+pub mod globals;
 pub mod model;
 pub mod node;
 pub mod reference;


### PR DESCRIPTION
## Summary

This is a follow-up to #4648 to further reduce the size of `Scope`.

At present, on each `Scope`, we store an optional `globals` hash map, which enumerates all the symbols declared as "global" in the scope. (We need to store these persistently and prior to traversal, since as we encountered bindings through the scope body, we need to know if they're declared as global _later on_.) Most scopes don't have any globals, so storing a hash map per scope unnecessarily increases the size of a very common struct.

This PR instead uses an arena to store a vector of hash maps, and stores the `Option<GlobalsId>` on `Scope` instead, as suggested by @MichaReiser in the aforementioned PR. It should reduce the size by 40 bytes per allocation.
