### PR TITLE
Add more Pyflakes docs

### DIFF
--- a/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
@@ -6,21 +6,22 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for assert tests that are non-empty tuples.
+/// Checks for `assert` statements that use non-empty tuples as test
+/// conditions.
 ///
 /// ## Why is this bad?
-/// Assert tests are boolean expressions. Non-empty tuples are always `True`.
-/// This means that the assert statement will always pass, which is likely a
+/// Non-empty tuples are always `True`, so an `assert` statement with a
+/// non-empty tuple as its test condition will always pass. This is likely a
 /// mistake.
 ///
 /// ## Example
 /// ```python
-/// assert (False,)  # always passes
+/// assert (some_condition,)
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// assert False  # always fails
+/// assert some_condition
 /// ```
 ///
 /// ## References

--- a/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/assert_tuple.rs
@@ -5,6 +5,26 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for assert tests that are non-empty tuples.
+///
+/// ## Why is this bad?
+/// Assert tests are boolean expressions. Non-empty tuples are always `True`.
+/// This means that the assert statement will always pass, which is likely a
+/// mistake.
+///
+/// ## Example
+/// ```python
+/// assert (False,)  # always passes
+/// ```
+///
+/// Use instead:
+/// ```python
+/// assert False  # always fails
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement)
 #[violation]
 pub struct AssertTuple;
 

--- a/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
@@ -5,6 +5,27 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for if tests that are non-empty tuples.
+///
+/// ## Why is this bad?
+/// If tests are boolean expressions. Non-empty tuples are always `True`. This
+/// means that the if statement will always run, which is likely a mistake.
+///
+/// ## Example
+/// ```python
+/// if (False,):
+///     print("This will always run")
+/// ```
+///
+/// Use instead:
+/// ```python
+/// if False:
+///     print("This will never run")
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/reference/compound_stmts.html#the-if-statement)
 #[violation]
 pub struct IfTuple;
 

--- a/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/if_tuple.rs
@@ -6,11 +6,11 @@ use ruff_macros::{derive_message_formats, violation};
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for if tests that are non-empty tuples.
+/// Checks for `if statements that use non-empty tuples as test conditions.
 ///
 /// ## Why is this bad?
-/// If tests are boolean expressions. Non-empty tuples are always `True`. This
-/// means that the if statement will always run, which is likely a mistake.
+/// Non-empty tuples are always `True`, so an `if` statement with a non-empty
+/// tuple as its test condition will always pass. This is likely a mistake.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -27,6 +27,36 @@ impl From<&Cmpop> for IsCmpop {
     }
 }
 
+/// ## What it does
+/// Checks for `is` and `is not` comparisons with constant literals.
+///
+/// ## Why is this bad?
+/// `is` and `is not` are identity comparisons. They check if two objects are
+/// the same object. If the objects are not the same object, the comparison
+/// will always be false. This is likely a mistake.
+///
+/// Instead, use `==` and `!=` to compare constant literals. These comparisons
+/// check for equality, not identity. This means that `"foo" == "foo"` will be
+/// true, even if the two strings are not the same object.
+///
+/// ## Example
+/// ```python
+/// name = input("What is your name? ")
+/// if name is "Maria":
+///     print("Hello, Maria!")  # This will never print
+/// ```
+///
+/// Use instead:
+/// ```python
+/// name = input("What is your name? ")
+/// if name == "Maria":
+///     print("Hello, Maria!")  # This will print if the user inputs "Maria"
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/reference/expressions.html#is-not)
+/// - [Python documentation](https://docs.python.org/3/reference/expressions.html#value-comparisons)
+/// - [_Why does Python log a SyntaxWarning for ‘is’ with literals?_ by Adam Johnson](https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/)
 #[violation]
 pub struct IsLiteral {
     cmpop: IsCmpop,

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -28,29 +28,34 @@ impl From<&Cmpop> for IsCmpop {
 }
 
 /// ## What it does
-/// Checks for `is` and `is not` comparisons with constant literals.
+/// Checks for `is` and `is not` comparisons against constant literals, like
+/// integers and strings.
 ///
 /// ## Why is this bad?
-/// `is` and `is not` are identity comparisons. They check if two objects are
-/// the same object. If the objects are not the same object, the comparison
-/// will always be false. This is likely a mistake.
+/// The `is` and `is not` comparators operate on identity, in that they check
+/// whether two objects are the same object. If the objects are not the same
+/// object, the comparison will always be `False`. Using `is` and `is not` with
+/// constant literals often works "by accident", but are not guaranteed to produce
+/// the expected result.
 ///
-/// Instead, use `==` and `!=` to compare constant literals. These comparisons
-/// check for equality, not identity. This means that `"foo" == "foo"` will be
-/// true, even if the two strings are not the same object.
+/// As of Python 3.8, using `is` and `is not` with constant literals will produce
+/// a `SyntaxWarning`.
+///
+/// Instead, use `==` and `!=` to compare constant literals, which will compare
+/// the values of the objects instead of their identities.
 ///
 /// ## Example
 /// ```python
-/// name = input("What is your name? ")
-/// if name is "Maria":
-///     print("Hello, Maria!")  # This will never print
+/// x = 200
+/// if x is 200:
+///     print("It's 200!")
 /// ```
 ///
 /// Use instead:
 /// ```python
-/// name = input("What is your name? ")
-/// if name == "Maria":
-///     print("Hello, Maria!")  # This will print if the user inputs "Maria"
+/// x = 200
+/// if x == 200:
+///     print("It's 200!")
 /// ```
 ///
 /// ## References

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -5,6 +5,44 @@ use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
 
+/// ## What it does
+/// Checks for `print` statements that use the `>>` syntax.
+///
+/// ## Why is this bad?
+/// The `print >> sys.stderr` syntax is deprecated in Python 3.
+///
+/// Instead, use the `file` keyword argument to the `print` function, use the
+/// `sys.stderr.write` function, or use the `logging` module.
+///
+/// ## Example
+/// ```python
+/// from __future__ import print_function
+/// import sys
+///
+/// print >> sys.stderr, "Hello, world!"
+/// ```
+///
+/// Use instead:
+/// ```python
+/// print("Hello, world!", file=sys.stderr)
+/// ```
+///
+/// Or:
+/// ```python
+/// import sys
+///
+/// sys.stderr.write("Hello, world!\n")  # does not add a newline by default
+/// ```
+///
+/// Or:
+/// ```python
+/// import logging
+///
+/// logging.error("Hello, world!")
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/library/functions.html#print)
 #[violation]
 pub struct InvalidPrintSyntax;
 

--- a/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/invalid_print_syntax.rs
@@ -9,10 +9,12 @@ use crate::checkers::ast::Checker;
 /// Checks for `print` statements that use the `>>` syntax.
 ///
 /// ## Why is this bad?
-/// The `print >> sys.stderr` syntax is deprecated in Python 3.
+/// In Python 2, the `print` statement can be used with the `>>` syntax to
+/// print to a file-like object. This `print >> sys.stderr` syntax is
+/// deprecated in Python 3.
 ///
-/// Instead, use the `file` keyword argument to the `print` function, use the
-/// `sys.stderr.write` function, or use the `logging` module.
+/// Instead, use the `file` keyword argument to the `print` function, the
+/// `sys.stderr.write` function, or the `logging` module.
 ///
 /// ## Example
 /// ```python
@@ -31,7 +33,7 @@ use crate::checkers::ast::Checker;
 /// ```python
 /// import sys
 ///
-/// sys.stderr.write("Hello, world!\n")  # does not add a newline by default
+/// sys.stderr.write("Hello, world!\n")
 /// ```
 ///
 /// Or:

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -10,6 +10,35 @@ use ruff_python_ast::comparable::{ComparableConstant, ComparableExpr};
 use crate::checkers::ast::Checker;
 use crate::registry::{AsRule, Rule};
 
+/// ## What it does
+/// Checks for dictionary key literals that are repeated with different values.
+///
+/// ## Why is this bad?
+/// Dictionary keys should be unique. If a key is repeated with a different
+/// value, the first values will be overwritten and the key will correspond to
+/// the last value. This is likely a mistake.
+///
+/// ## Example
+/// ```python
+/// foo = {
+///     "bar": 1,
+///     "baz": 2,
+///     "baz": 3,
+/// }
+/// foo["baz"]  # 3
+/// ```
+///
+/// Use instead:
+/// ```python
+/// foo = {
+///     "bar": 1,
+///     "baz": 2,
+/// }
+/// foo["baz"]  # 2
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
 #[violation]
 pub struct MultiValueRepeatedKeyLiteral {
     name: String,
@@ -37,6 +66,36 @@ impl Violation for MultiValueRepeatedKeyLiteral {
         }
     }
 }
+
+/// ## What it does
+/// Checks for dictionary keys that are repeated with different values.
+///
+/// ## Why is this bad?
+/// Dictionary keys should be unique. If a key is repeated with a different
+/// value, the first values will be overwritten and the key will correspond to
+/// the last value. This is likely a mistake.
+///
+/// ## Example
+/// ```python
+/// foo = {
+///     bar: 1,
+///     baz: 2,
+///     baz: 3,
+/// }
+/// foo[baz]  # 3
+/// ```
+///
+/// Use instead:
+/// ```python
+/// foo = {
+///     bar: 1,
+///     baz: 2,
+/// }
+/// foo[baz]  # 2
+/// ```
+///
+/// ## References
+/// - [Python documentation](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
 #[violation]
 pub struct MultiValueRepeatedKeyVariable {
     name: String,

--- a/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/repeated_keys.rs
@@ -11,12 +11,13 @@ use crate::checkers::ast::Checker;
 use crate::registry::{AsRule, Rule};
 
 /// ## What it does
-/// Checks for dictionary key literals that are repeated with different values.
+/// Checks for dictionary literals that associate multiple values with the
+/// same key.
 ///
 /// ## Why is this bad?
-/// Dictionary keys should be unique. If a key is repeated with a different
-/// value, the first values will be overwritten and the key will correspond to
-/// the last value. This is likely a mistake.
+/// Dictionary keys should be unique. If a key is associated with multiple values,
+/// the earlier values will be overwritten. Including multiple values for the
+/// same key in a dictionary literal is likely a mistake.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
@@ -14,6 +14,26 @@ impl Violation for ExpressionsInStarAssignment {
     }
 }
 
+/// ## What it does
+/// Checks for more than one starred expression in an assignment.
+///
+/// ## Why is this bad?
+/// Starred expressions in assignments are used to unpack iterables. If there
+/// are more than one starred expressions, it is unclear how the iterable is
+/// unpacked and will raise a `SyntaxError` at runtime.
+///
+/// ## Example
+/// ```python
+/// *foo, *bar, baz = (1, 2, 3)
+/// ```
+///
+/// Use instead:
+/// ```python
+/// *foo, bar, baz = (1, 2, 3)
+/// ```
+///
+/// ## References
+/// - [PEP 3132](https://peps.python.org/pep-3132/)
 #[violation]
 pub struct MultipleStarredExpressions;
 

--- a/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/starred_expressions.rs
@@ -4,6 +4,15 @@ use rustpython_parser::ast::Expr;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
+/// ## What it does
+/// Checks for the use of too many expressions in starred assignment statements.
+///
+/// ## Why is this bad?
+/// In assignment statements, starred expressions can be used to unpack iterables.
+///
+/// In Python 3, no more than 1 << 8 assignments are allowed before a starred
+/// expression, and no more than 1 << 24 expressions are allowed after a starred
+/// expression.
 #[violation]
 pub struct ExpressionsInStarAssignment;
 
@@ -15,21 +24,17 @@ impl Violation for ExpressionsInStarAssignment {
 }
 
 /// ## What it does
-/// Checks for more than one starred expression in an assignment.
+/// Checks for the use of multiple starred expressions in assignment statements.
 ///
 /// ## Why is this bad?
-/// Starred expressions in assignments are used to unpack iterables. If there
-/// are more than one starred expressions, it is unclear how the iterable is
-/// unpacked and will raise a `SyntaxError` at runtime.
+/// In assignment statements, starred expressions can be used to unpack iterables.
+/// Including more than one starred expression on the left-hand-side of an
+/// assignment will cause a `SyntaxError`, as it is unclear which expression
+/// should receive the remaining values.
 ///
 /// ## Example
 /// ```python
 /// *foo, *bar, baz = (1, 2, 3)
-/// ```
-///
-/// Use instead:
-/// ```python
-/// *foo, bar, baz = (1, 2, 3)
 /// ```
 ///
 /// ## References


### PR DESCRIPTION
## Summary

Add docs for Pyflakes string rules (F6) apart from `F621` which I don't think I can do justice at the moment.

Related to #2646.

## Test Plan

Ran `scripts/check_docs_formatted.py` on local machine.
