### PR TITLE
Fix COM819 auto-fix introducing E202

### DIFF
--- a/crates/ruff/src/rules/flake8_commas/rules/trailing_commas.rs
+++ b/crates/ruff/src/rules/flake8_commas/rules/trailing_commas.rs
@@ -323,11 +323,17 @@ pub(crate) fn trailing_commas(
             }
         };
         if comma_prohibited {
+            // SAFETY: The following token spans are always `Some` as they come from `tokens` which has
+            // been mapped with `Token::from_spanned`.
             let comma = prev.spanned.unwrap();
+            let closing_bracket = token.spanned.unwrap();
             let mut diagnostic = Diagnostic::new(ProhibitedTrailingComma, comma.1);
             if settings.rules.should_fix(Rule::ProhibitedTrailingComma) {
                 #[allow(deprecated)]
-                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(diagnostic.range())));
+                diagnostic.set_fix(Fix::unspecified(Edit::range_deletion(TextRange::new(
+                    comma.1.start(),
+                    closing_bracket.1.start(),
+                ))));
             }
             diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_commas/snapshots/ruff__rules__flake8_commas__tests__COM81.py.snap
+++ b/crates/ruff/src/rules/flake8_commas/snapshots/ruff__rules__flake8_commas__tests__COM81.py.snap
@@ -527,7 +527,7 @@ COM81.py:496:21: COM819 [*] Trailing comma prohibited
 494 494 | (0, 1,)
 495 495 | 
 496     |-foo = ['a', 'b', 'c', ]
-    496 |+foo = ['a', 'b', 'c' ]
+    496 |+foo = ['a', 'b', 'c']
 497 497 | 
 498 498 | bar = { a: b, }
 499 499 | 
@@ -548,7 +548,7 @@ COM81.py:498:13: COM819 [*] Trailing comma prohibited
 496 496 | foo = ['a', 'b', 'c', ]
 497 497 | 
 498     |-bar = { a: b, }
-    498 |+bar = { a: b }
+    498 |+bar = { a: b}
 499 499 | 
 500 500 | def bah(ham, spam, ):
 501 501 |     pass
@@ -568,7 +568,7 @@ COM81.py:500:18: COM819 [*] Trailing comma prohibited
 498 498 | bar = { a: b, }
 499 499 | 
 500     |-def bah(ham, spam, ):
-    500 |+def bah(ham, spam ):
+    500 |+def bah(ham, spam):
 501 501 |     pass
 502 502 | 
 503 503 | (0, )
@@ -589,7 +589,7 @@ COM81.py:505:6: COM819 [*] Trailing comma prohibited
 503 503 | (0, )
 504 504 | 
 505     |-(0, 1, )
-    505 |+(0, 1 )
+    505 |+(0, 1)
 506 506 | 
 507 507 | image[:, :, 0]
 508 508 | 
@@ -631,7 +631,7 @@ COM81.py:513:9: COM819 [*] Trailing comma prohibited
 511 511 | image[:,:,]
 512 512 | 
 513     |-lambda x, :
-    513 |+lambda x :
+    513 |+lambda x:
 514 514 | 
 515 515 | # ==> unpack.py <==
 516 516 | def function(


### PR DESCRIPTION
- Close #1975
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

COM819 now removes the spaces after the prohibited comma to avoid introducing `E202`.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

The fixture already contained examples with spaces after the prohibited comma.
So, the snapshot has been updated.

<!-- How was it tested? -->
