### PR TITLE
Update option anchors to include group name

### DIFF
--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -104,7 +104,7 @@ fn process_documentation(documentation: &str, out: &mut String) {
                     "unknown option {option}"
                 );
 
-                let anchor = option.rsplit('.').next().unwrap();
+                let anchor = option.replace('.', "-");
                 out.push_str(&format!("- [`{option}`][{option}]\n"));
                 after.push_str(&format!("[{option}]: ../../settings#{anchor}"));
 

--- a/crates/ruff_dev/src/generate_docs.rs
+++ b/crates/ruff_dev/src/generate_docs.rs
@@ -152,7 +152,7 @@ Something [`else`][other].
 
 [other]: http://example.com.
 
-[mccabe.max-complexity]: ../../settings#max-complexity\n"
+[mccabe.max-complexity]: ../../settings#mccabe-max-complexity\n"
         );
     }
 }

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -5,7 +5,14 @@ use ruff::settings::options::Options;
 use ruff::settings::options_base::{OptionEntry, OptionField};
 
 fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: Option<&str>) {
-    output.push_str(&format!("#### [`{name}`](#{name})\n"));
+    // if there's a group name, we need to add it to the anchor
+    if let Some(group_name) = group_name {
+        output.push_str(&format!(
+            "#### [`{name}`](#{group_name}-{name}) {{: #{group_name}-{name} }}\n"
+        ));
+    } else {
+        output.push_str(&format!("#### [`{name}`](#{name})\n"));
+    }
     output.push('\n');
     output.push_str(field.doc);
     output.push_str("\n\n");

--- a/crates/ruff_dev/src/generate_options.rs
+++ b/crates/ruff_dev/src/generate_options.rs
@@ -7,6 +7,10 @@ use ruff::settings::options_base::{OptionEntry, OptionField};
 fn emit_field(output: &mut String, name: &str, field: &OptionField, group_name: Option<&str>) {
     // if there's a group name, we need to add it to the anchor
     if let Some(group_name) = group_name {
+        // the anchor used to just be the name, but now it's the group name
+        // for backwards compatibility, we need to keep the old anchor
+        output.push_str(&format!("<span id=\"{name}\"></span>\n"));
+
         output.push_str(&format!(
             "#### [`{name}`](#{group_name}-{name}) {{: #{group_name}-{name} }}\n"
         ));


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

closes https://github.com/charliermarsh/ruff/issues/4707

This PR updates the docs generation to include the group name (if it's there) in the anchor (the `#pep8-naming-ignore-names` in `/docs/settings/#pep8-naming-ignore-names`). Previously, there were issues when option names collided, as described in the linked issue.

## Test Plan

<!-- How was it tested? -->

n/a