### PR TITLE
Add ability to generate snapshot tests on code snippets 

### DIFF
--- a/crates/ruff/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff/src/rules/pandas_vet/mod.rs
@@ -8,103 +8,97 @@ mod tests {
     use std::path::Path;
 
     use anyhow::Result;
-    use rustpython_parser::lexer::LexResult;
     use test_case::test_case;
-    use textwrap::dedent;
 
-    use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+    use crate::registry::{Linter, Rule};
+    use crate::test::{test_path, test_snippet};
+    use crate::{assert_messages, settings};
 
-    use crate::linter::{check_path, LinterResult};
-    use crate::registry::{AsRule, Linter, Rule};
-    use crate::settings::flags;
-    use crate::test::test_path;
-    use crate::{assert_messages, directives, settings};
-
-    fn rule_code(contents: &str, expected: &[Rule]) {
-        let contents = dedent(contents);
-        let settings = settings::Settings::for_rules(&Linter::PandasVet);
-        let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&contents);
-        let locator = Locator::new(&contents);
-        let stylist = Stylist::from_tokens(&tokens, &locator);
-        let indexer = Indexer::from_tokens(&tokens, &locator);
-        let directives = directives::extract_directives(
-            &tokens,
-            directives::Flags::from_settings(&settings),
-            &locator,
-            &indexer,
-        );
-        let LinterResult {
-            data: (diagnostics, _imports),
-            ..
-        } = check_path(
-            Path::new("<filename>"),
-            None,
-            tokens,
-            &locator,
-            &stylist,
-            &indexer,
-            &directives,
-            &settings,
-            flags::Noqa::Enabled,
-        );
-        let actual: Vec<Rule> = diagnostics
-            .into_iter()
-            .map(|diagnostic| diagnostic.kind.rule())
-            .collect();
-        assert_eq!(actual, expected);
-    }
-
-    #[test_case(r#"
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        x.drop(['a'], axis=1, inplace=False)
-    "#, &[]; "PD002_pass")]
-    #[test_case(r#"
+        x.drop(["a"], axis=1, inplace=False)
+    "#,
+        "PD002_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        x.drop(['a'], axis=1, inplace=True)
-    "#, &[Rule::PandasUseOfInplaceArgument]; "PD002_fail")]
-    #[test_case(r#"
+        x.drop(["a"], axis=1, inplace=True)
+    "#,
+        "PD002_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         nas = pd.isna(val)
-    "#, &[]; "PD003_pass")]
-    #[test_case(r#"
+    "#,
+        "PD003_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         nulls = pd.isnull(val)
-    "#, &[Rule::PandasUseOfDotIsNull]; "PD003_fail")]
-    #[test_case(r#"
+    "#,
+        "PD003_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
-        print('bah humbug')
-    "#, &[]; "PD003_allows_other_calls")]
-    #[test_case(r#"
+        print("bah humbug")
+    "#,
+        "PD003_allows_other_calls"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         not_nas = pd.notna(val)
-    "#, &[]; "PD004_pass")]
-    #[test_case(r#"
+    "#,
+        "PD004_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         not_nulls = pd.notnull(val)
-    "#, &[Rule::PandasUseOfDotNotNull]; "PD004_fail")]
-    #[test_case(r#"
+    "#,
+        "PD004_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        new_x = x.loc['d':, 'A':'C']
-    "#, &[]; "PD007_pass_loc")]
-    #[test_case(r#"
+        new_x = x.loc["d":, "A":"C"]
+    "#,
+        "PD007_pass_loc"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         new_x = x.iloc[[1, 3, 5], [1, 3]]
-    "#, &[]; "PD007_pass_iloc")]
-    #[test_case(r#"
+    "#,
+        "PD007_pass_iloc"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        y = x.ix[[0, 2], 'A']
-    "#, &[Rule::PandasUseOfDotIx]; "PD007_fail")]
-    #[test_case(r#"
+        y = x.ix[[0, 2], "A"]
+    "#,
+        "PD007_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        index = x.loc[:, ['B', 'A']]
-    "#, &[]; "PD008_pass")]
-    #[test_case(r#"
+        index = x.loc[:, ["B", "A"]]
+    "#,
+        "PD008_pass"
+    )]
+    #[test_case(
+        r#"
         import io
         import zipfile
 
@@ -114,7 +108,7 @@ mod tests {
                 super().__init__(*args, **kwargs)
 
             def close(self):
-                pass  # Don't allow closing the file, it would clear the buffer
+                pass  # Don"t allow closing the file, it would clear the buffer
 
 
         zip_buffer = MockBinaryFile()
@@ -122,165 +116,251 @@ mod tests {
         with zipfile.ZipFile(zip_buffer, "w") as zf:
             zf.writestr("dir/file.txt", "This is a test")
 
-        # Reset the BytesIO object's cursor to the start.
+        # Reset the BytesIO object"s cursor to the start.
         zip_buffer.seek(0)
 
         with zipfile.ZipFile(zip_buffer, "r") as zf:
             zpath = zipfile.Path(zf, "/")
 
         dir_name, file_name = zpath.at.split("/")
-    "#, &[]; "PD008_pass_on_attr")]
-    #[test_case(r#"
+    "#,
+        "PD008_pass_on_attr"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
-        index = x.at[:, ['B', 'A']]
-    "#, &[Rule::PandasUseOfDotAt]; "PD008_fail")]
-    #[test_case(r#"
+        index = x.at[:, ["B", "A"]]
+    "#,
+        "PD008_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         index = x.iloc[:, 1:3]
-    "#, &[]; "PD009_pass")]
-    #[test_case(r#"
+    "#,
+        "PD009_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         index = x.iat[:, 1:3]
-    "#, &[Rule::PandasUseOfDotIat]; "PD009_fail")]
-    #[test_case(r#"
+    "#,
+        "PD009_fail"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         table = x.pivot_table(
             x,
-            values='D',
-            index=['A', 'B'],
-            columns=['C'],
+            values="D",
+            index=["A", "B"],
+            columns=["C"],
             aggfunc=np.sum,
             fill_value=0
         )
-    "#, &[]; "PD010_pass")]
-    #[test_case(r#"
+    "#,
+        "PD010_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         table = pd.pivot(
             x,
-            index='foo',
-            columns='bar',
-            values='baz'
+            index="foo",
+            columns="bar",
+            values="baz"
         )
-    "#, &[Rule::PandasUseOfDotPivotOrUnstack]; "PD010_fail_pivot")]
-    #[test_case(r#"
+    "#,
+        "PD010_fail_pivot"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         result = x.to_array()
-    "#, &[]; "PD011_pass_to_array")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_to_array"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         result = x.array
-    "#, &[]; "PD011_pass_array")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_array"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         result = x.values
-    "#, &[Rule::PandasUseOfDotValues]; "PD011_fail_values")]
-    #[test_case(r#"
+    "#,
+        "PD011_fail_values"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         result = x.values()
-    "#, &[]; "PD011_pass_values_call")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_values_call"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         result = {}.values
-    "#, &[]; "PD011_pass_values_dict")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_values_dict"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         result = pd.values
-    "#, &[]; "PD011_pass_values_import")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_values_import"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         result = x.values
-    "#, &[]; "PD011_pass_values_unbound")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_values_unbound"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         result = values
-    "#, &[]; "PD011_pass_node_name")]
-    #[test_case(r#"
+    "#,
+        "PD011_pass_node_name"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         employees = pd.read_csv(input_file)
-    "#, &[]; "PD012_pass_read_csv")]
-    #[test_case(r#"
+    "#,
+        "PD012_pass_read_csv"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         employees = pd.read_table(input_file)
-    "#, &[Rule::PandasUseOfDotReadTable]; "PD012_fail_read_table")]
-    #[test_case(r#"
+    "#,
+        "PD012_fail_read_table"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         employees = read_table
-    "#, &[]; "PD012_node_Name_pass")]
-    #[test_case(r#"
+    "#,
+        "PD012_node_Name_pass"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         y = x.melt(
-            id_vars='airline',
-            value_vars=['ATL', 'DEN', 'DFW'],
-            value_name='airline delay'
+            id_vars="airline",
+            value_vars=["ATL", "DEN", "DFW"],
+            value_name="airline delay"
         )
-    "#, &[]; "PD013_pass")]
-    #[test_case(r#"
+    "#,
+        "PD013_pass"
+    )]
+    #[test_case(
+        r#"
         import numpy as np
         arrays = [np.random.randn(3, 4) for _ in range(10)]
         np.stack(arrays, axis=0).shape
-    "#, &[]; "PD013_pass_numpy")]
-    #[test_case(r#"
+    "#,
+        "PD013_pass_numpy"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         y = x.stack(level=-1, dropna=True)
-    "#, &[]; "PD013_pass_unbound")]
-    #[test_case(r#"
+    "#,
+        "PD013_pass_unbound"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         y = x.stack(level=-1, dropna=True)
-    "#, &[Rule::PandasUseOfDotStack]; "PD013_fail_stack")]
-    #[test_case(r#"
+    "#,
+        "PD013_fail_stack"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         pd.stack(
-    "#, &[]; "PD015_pass_merge_on_dataframe")]
-    #[test_case(r#"
+    "#,
+        "PD015_pass_merge_on_dataframe"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         y = pd.DataFrame()
-        x.merge(y, 'inner')
-    "#, &[]; "PD015_pass_merge_on_dataframe_with_multiple_args")]
-    #[test_case(r#"
+        x.merge(y, "inner")
+    "#,
+        "PD015_pass_merge_on_dataframe_with_multiple_args"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         x = pd.DataFrame()
         y = pd.DataFrame()
         pd.merge(x, y)
-    "#, &[Rule::PandasUseOfPdMerge]; "PD015_fail_merge_on_pandas_object")]
+    "#,
+        "PD015_fail_merge_on_pandas_object"
+    )]
     #[test_case(
-        "pd.to_datetime(timestamp * 10 ** 9).strftime('%Y-%m-%d %H:%M:%S.%f')",
-        &[];
+        r#"
+        pd.to_datetime(timestamp * 10 ** 9).strftime("%Y-%m-%d %H:%M:%S.%f")
+    "#,
         "PD015_pass_other_pd_function"
     )]
-    #[test_case(r#"
+    #[test_case(
+        r#"
         import pandas as pd
         employees = pd.DataFrame(employee_dict)
-    "#, &[]; "PD901_pass_non_df")]
-    #[test_case(r#"
+    "#,
+        "PD901_pass_non_df"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         employees_df = pd.DataFrame(employee_dict)
-    "#, &[]; "PD901_pass_part_df")]
-    #[test_case(r#"
+    "#,
+        "PD901_pass_part_df"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         my_function(df=data)
-    "#, &[]; "PD901_pass_df_param")]
-    #[test_case(r#"
+    "#,
+        "PD901_pass_df_param"
+    )]
+    #[test_case(
+        r#"
         import pandas as pd
         df = pd.DataFrame()
-    "#, &[Rule::PandasDfVariableName]; "PD901_fail_df_var")]
-    fn test_pandas_vet(code: &str, expected: &[Rule]) {
-        rule_code(code, expected);
+    "#,
+        "PD901_fail_df_var"
+    )]
+    fn contents(contents: &str, snapshot: &str) {
+        let diagnostics =
+            test_snippet(contents, &settings::Settings::for_rules(&Linter::PandasVet));
+        assert_messages!(snapshot, diagnostics);
     }
 
     #[test_case(Rule::PandasUseOfInplaceArgument, Path::new("PD002.py"))]
-    fn rules(rule_code: Rule, path: &Path) -> Result<()> {
+    fn paths(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(
             Path::new("pandas_vet").join(path).as_path(),

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_fail.snap
@@ -1,0 +1,20 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:23: PD002 [*] `inplace=True` should be avoided; it has inconsistent behavior
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | x.drop(["a"], axis=1, inplace=True)
+  |                       ^^^^^^^^^^^^ PD002
+  |
+  = help: Assign to variable; remove `inplace` arg
+
+ℹ Suggested fix
+1 1 | 
+2 2 | import pandas as pd
+3 3 | x = pd.DataFrame()
+4   |-x.drop(["a"], axis=1, inplace=True)
+  4 |+x = x.drop(["a"], axis=1)
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD002_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_allows_other_calls.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_allows_other_calls.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_fail.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:3:9: PD003 `.isna` is preferred to `.isnull`; functionality is equivalent
+  |
+3 | import pandas as pd
+4 | nulls = pd.isnull(val)
+  |         ^^^^^^^^^ PD003
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD003_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD004_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD004_fail.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:3:13: PD004 `.notna` is preferred to `.notnull`; functionality is equivalent
+  |
+3 | import pandas as pd
+4 | not_nulls = pd.notnull(val)
+  |             ^^^^^^^^^^ PD004
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD004_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD004_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:5: PD007 `.ix` is deprecated; use more explicit `.loc` or `.iloc`
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | y = x.ix[[0, 2], "A"]
+  |     ^^^^^^^^^^^^^^^^^ PD007
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_pass_iloc.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_pass_iloc.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_pass_loc.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD007_pass_loc.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:9: PD008 Use `.loc` instead of `.at`. If speed is important, use NumPy.
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | index = x.at[:, ["B", "A"]]
+  |         ^^^^^^^^^^^^^^^^^^^ PD008
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_pass_on_attr.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD008_pass_on_attr.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD009_fail.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD009_fail.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:9: PD009 Use `.iloc` instead of `.iat`. If speed is important, use NumPy.
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | index = x.iat[:, 1:3]
+  |         ^^^^^^^^^^^^^ PD009
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD009_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD009_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD010_fail_pivot.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD010_fail_pivot.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:9: PD010 `.pivot_table` is preferred to `.pivot` or `.unstack`; provides same functionality
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | table = pd.pivot(
+  |         ^^^^^^^^ PD010
+7 |     x,
+8 |     index="foo",
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD010_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD010_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_fail_values.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_fail_values.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:10: PD011 Use `.to_numpy()` instead of `.values`
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | result = x.values
+  |          ^^^^^^^^ PD011
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_array.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_array.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_node_name.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_node_name.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_to_array.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_to_array.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_call.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_call.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_dict.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_dict.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_import.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_import.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_unbound.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD011_pass_values_unbound.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_fail_read_table.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_fail_read_table.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:3:13: PD012 `.read_csv` is preferred to `.read_table`; provides same functionality
+  |
+3 | import pandas as pd
+4 | employees = pd.read_table(input_file)
+  |             ^^^^^^^^^^^^^ PD012
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_node_Name_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_node_Name_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_pass_read_csv.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD012_pass_read_csv.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_fail_stack.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_fail_stack.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:4:5: PD013 `.melt` is preferred to `.stack`; provides same functionality
+  |
+4 | import pandas as pd
+5 | x = pd.DataFrame()
+6 | y = x.stack(level=-1, dropna=True)
+  |     ^^^^^^^ PD013
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass_numpy.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass_numpy.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass_unbound.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD013_pass_unbound.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_fail_merge_on_pandas_object.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_fail_merge_on_pandas_object.snap
@@ -1,0 +1,12 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:5:1: PD015 Use `.merge` method instead of `pd.merge` function. They have equivalent functionality.
+  |
+5 | x = pd.DataFrame()
+6 | y = pd.DataFrame()
+7 | pd.merge(x, y)
+  | ^^^^^^^^ PD015
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_merge_on_dataframe.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_merge_on_dataframe.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_merge_on_dataframe_with_multiple_args.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_merge_on_dataframe_with_multiple_args.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_other_pd_function.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD015_pass_other_pd_function.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_fail_df_var.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_fail_df_var.snap
@@ -1,0 +1,11 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+<filename>:3:1: PD901 `df` is a bad variable name. Be kinder to your future self.
+  |
+3 | import pandas as pd
+4 | df = pd.DataFrame()
+  | ^^ PD901
+  |
+
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_df_param.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_df_param.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_non_df.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_non_df.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_part_df.snap
+++ b/crates/ruff/src/rules/pandas_vet/snapshots/ruff__rules__pandas_vet__tests__PD901_pass_part_df.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pandas_vet/mod.rs
+---
+

--- a/crates/ruff/src/test.rs
+++ b/crates/ruff/src/test.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use itertools::Itertools;
 use rustc_hash::FxHashMap;
 use rustpython_parser::lexer::LexResult;
+use textwrap::dedent;
 
 use ruff_diagnostics::{AutofixKind, Diagnostic};
 use ruff_python_ast::source_code::{Indexer, Locator, SourceFileBuilder, Stylist};
@@ -24,15 +25,27 @@ pub(crate) fn test_resource_path(path: impl AsRef<Path>) -> std::path::PathBuf {
     Path::new("./resources/test/").join(path)
 }
 
-/// A convenient wrapper around [`check_path`], that additionally
-/// asserts that autofixes converge after 10 iterations.
+/// Run [`check_path`] on a file in the `resources/test/fixtures` directory.
 pub(crate) fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<Vec<Message>> {
-    static MAX_ITERATIONS: usize = 10;
-
     let path = test_resource_path("fixtures").join(path);
     let contents = std::fs::read_to_string(&path)?;
-    let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&contents);
-    let locator = Locator::new(&contents);
+    Ok(test_contents(&contents, &path, settings))
+}
+
+/// Run [`check_path`] on a snippet of Python code.
+pub(crate) fn test_snippet(contents: &str, settings: &Settings) -> Vec<Message> {
+    let path = Path::new("<filename>");
+    let contents = dedent(contents);
+    test_contents(&contents, path, settings)
+}
+
+/// A convenient wrapper around [`check_path`], that additionally
+/// asserts that autofixes converge after 10 iterations.
+fn test_contents(contents: &str, path: &Path, settings: &Settings) -> Vec<Message> {
+    static MAX_ITERATIONS: usize = 10;
+
+    let tokens: Vec<LexResult> = ruff_rustpython::tokenize(contents);
+    let locator = Locator::new(contents);
     let stylist = Stylist::from_tokens(&tokens, &locator);
     let indexer = Indexer::from_tokens(&tokens, &locator);
     let directives = directives::extract_directives(
@@ -45,7 +58,7 @@ pub(crate) fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<V
         data: (diagnostics, _imports),
         error,
     } = check_path(
-        &path,
+        path,
         path.parent()
             .and_then(|parent| detect_package_root(parent, &settings.namespace_packages)),
         tokens,
@@ -67,18 +80,18 @@ pub(crate) fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<V
         .any(|diagnostic| diagnostic.fix.is_some())
     {
         let mut diagnostics = diagnostics.clone();
-        let mut contents = contents.clone();
+        let mut contents = contents.to_string();
 
         while let Some((fixed_contents, _)) = fix_file(&diagnostics, &Locator::new(&contents)) {
             if iterations < MAX_ITERATIONS {
                 iterations += 1;
             } else {
-                let output = print_diagnostics(diagnostics, &path, &contents);
+                let output = print_diagnostics(diagnostics, path, &contents);
 
                 panic!(
-                        "Failed to converge after {MAX_ITERATIONS} iterations. This likely \
-                         indicates a bug in the implementation of the fix. Last diagnostics:\n{output}"
-                    );
+                    "Failed to converge after {MAX_ITERATIONS} iterations. This likely \
+                     indicates a bug in the implementation of the fix. Last diagnostics:\n{output}"
+                );
             }
 
             let tokens: Vec<LexResult> = ruff_rustpython::tokenize(&fixed_contents);
@@ -96,7 +109,7 @@ pub(crate) fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<V
                 data: (fixed_diagnostics, _),
                 error: fixed_error,
             } = check_path(
-                &path,
+                path,
                 None,
                 tokens,
                 &locator,
@@ -110,12 +123,12 @@ pub(crate) fn test_path(path: impl AsRef<Path>, settings: &Settings) -> Result<V
             if let Some(fixed_error) = fixed_error {
                 if !source_has_errors {
                     // Previous fix introduced a syntax error, abort
-                    let fixes = print_diagnostics(diagnostics, &path, &contents);
+                    let fixes = print_diagnostics(diagnostics, path, &contents);
 
                     let mut syntax_diagnostics = Vec::new();
                     syntax_error(&mut syntax_diagnostics, &fixed_error, &locator);
                     let syntax_errors =
-                        print_diagnostics(syntax_diagnostics, &path, &fixed_contents);
+                        print_diagnostics(syntax_diagnostics, path, &fixed_contents);
 
                     panic!(
                         r#"Fixed source has a syntax error where the source document does not. This is a bug in one of the generated fixes:
@@ -139,7 +152,7 @@ Source with applied fixes:
     )
     .finish();
 
-    Ok(diagnostics
+    diagnostics
         .into_iter()
         .map(|diagnostic| {
             let rule = diagnostic.kind.rule();
@@ -166,7 +179,7 @@ Source with applied fixes:
             Message::from_diagnostic(diagnostic, source_code.clone(), noqa)
         })
         .sorted()
-        .collect())
+        .collect()
 }
 
 fn print_diagnostics(diagnostics: Vec<Diagnostic>, file_path: &Path, source: &str) -> String {


### PR DESCRIPTION
## Summary

This PR formalizes the ability to test inline code snippets with our snapshot testing infrastructure. We already used this pattern in `pandas_vet`, but it was one-off, and didn't benefit from all the infra we'd put in place to support snapshot testing of committed Python files.

## Test Plan

`cargo test`
