### PR TITLE
Remove enumerated plugins in rules page

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ stylistic rules made obsolete by the use of an autoformatter, like
 If you're just getting started with Ruff, **the default rule set is a great place to start**: it
 catches a wide variety of common errors (like unused imports) with zero configuration.
 
+<!-- End section: Rules -->
+
 Beyond the defaults, Ruff re-implements some of the most popular Flake8 plugins and related code
 quality tools, including:
 
@@ -297,8 +299,6 @@ quality tools, including:
 - [pyupgrade](https://pypi.org/project/pyupgrade/)
 - [tryceratops](https://pypi.org/project/tryceratops/)
 - [yesqa](https://pypi.org/project/yesqa/)
-
-<!-- End section: Rules -->
 
 For a complete enumeration of the supported rules, see [_Rules_](https://beta.ruff.rs/docs/rules/).
 


### PR DESCRIPTION
- Close #4709
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Remove the manually generated list of plugins on the rules page as they are already present on the table of content on the left.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

n/a
<!-- How was it tested? -->
