### PR TITLE
Enable callers to specify import-style preferences in `Importer`

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/suppressible_exception.rs
@@ -8,6 +8,7 @@ use ruff_python_ast::helpers;
 use ruff_python_ast::helpers::has_comments;
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::registry::AsRule;
 
 #[violation]
@@ -87,8 +88,7 @@ pub(crate) fn suppressible_exception(
                 if !has_comments(stmt, checker.locator) {
                     diagnostic.try_set_fix(|| {
                         let (import_edit, binding) = checker.importer.get_or_import_symbol(
-                            "contextlib",
-                            "suppress",
+                            &ImportRequest::import("contextlib", "suppress"),
                             stmt.start(),
                             checker.semantic_model(),
                         )?;

--- a/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
+++ b/crates/ruff/src/rules/pylint/rules/sys_exit_alias.rs
@@ -4,6 +4,7 @@ use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::registry::AsRule;
 
 /// ## What it does
@@ -76,8 +77,7 @@ pub(crate) fn sys_exit_alias(checker: &mut Checker, func: &Expr) {
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {
                 let (import_edit, binding) = checker.importer.get_or_import_symbol(
-                    "sys",
-                    "exit",
+                    &ImportRequest::import("sys", "exit"),
                     func.start(),
                     checker.semantic_model(),
                 )?;

--- a/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -5,6 +5,7 @@ use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::registry::AsRule;
 
 #[violation]
@@ -65,8 +66,7 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &mut Checker, decorator_list:
                 if checker.patch(diagnostic.kind.rule()) {
                     diagnostic.try_set_fix(|| {
                         let (import_edit, binding) = checker.importer.get_or_import_symbol(
-                            "functools",
-                            "cache",
+                            &ImportRequest::import("functools", "cache"),
                             expr.start(),
                             checker.semantic_model(),
                         )?;

--- a/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/use_pep585_annotation.rs
@@ -6,6 +6,7 @@ use ruff_python_ast::call_path::compose_call_path;
 use ruff_python_semantic::analyze::typing::ModuleMember;
 
 use crate::checkers::ast::Checker;
+use crate::importer::ImportRequest;
 use crate::registry::AsRule;
 
 #[violation]
@@ -61,8 +62,7 @@ pub(crate) fn use_pep585_annotation(
                     // Imported type, like `collections.deque`.
                     diagnostic.try_set_fix(|| {
                         let (import_edit, binding) = checker.importer.get_or_import_symbol(
-                            module,
-                            member,
+                            &ImportRequest::import_from(module, member),
                             expr.start(),
                             checker.semantic_model(),
                         )?;

--- a/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006_0.py.snap
+++ b/crates/ruff/src/rules/pyupgrade/snapshots/ruff__rules__pyupgrade__tests__UP006_0.py.snap
@@ -243,7 +243,7 @@ UP006_0.py:61:10: UP006 [*] Use `collections.deque` instead of `typing.Deque` fo
 20 20 | 
 21 21 | 
 22 22 | from typing import List as IList
-   23 |+import collections
+   23 |+from collections import deque
 23 24 | 
 24 25 | 
 25 26 | def f(x: IList[str]) -> None:
@@ -252,7 +252,7 @@ UP006_0.py:61:10: UP006 [*] Use `collections.deque` instead of `typing.Deque` fo
 59 60 | 
 60 61 | 
 61    |-def f(x: typing.Deque[str]) -> None:
-   62 |+def f(x: collections.deque[str]) -> None:
+   62 |+def f(x: deque[str]) -> None:
 62 63 |     ...
 63 64 | 
 64 65 | 
@@ -269,7 +269,7 @@ UP006_0.py:65:10: UP006 [*] Use `collections.defaultdict` instead of `typing.Def
 20 20 | 
 21 21 | 
 22 22 | from typing import List as IList
-   23 |+import collections
+   23 |+from collections import defaultdict
 23 24 | 
 24 25 | 
 25 26 | def f(x: IList[str]) -> None:
@@ -278,7 +278,7 @@ UP006_0.py:65:10: UP006 [*] Use `collections.defaultdict` instead of `typing.Def
 63 64 | 
 64 65 | 
 65    |-def f(x: typing.DefaultDict[str, str]) -> None:
-   66 |+def f(x: collections.defaultdict[str, str]) -> None:
+   66 |+def f(x: defaultdict[str, str]) -> None:
 66 67 |     ...
 
 

--- a/crates/ruff_python_ast/src/imports.rs
+++ b/crates/ruff_python_ast/src/imports.rs
@@ -31,12 +31,27 @@ pub struct Alias<'a> {
 }
 
 impl<'a> Import<'a> {
+    /// Creates a new `Import` to import the specified module.
     pub fn module(name: &'a str) -> Self {
         Self {
             name: Alias {
                 name,
                 as_name: None,
             },
+        }
+    }
+}
+
+impl<'a> ImportFrom<'a> {
+    /// Creates a new `ImportFrom` to import a member from the specified module.
+    pub fn member(module: &'a str, name: &'a str) -> Self {
+        Self {
+            module: Some(module),
+            name: Alias {
+                name,
+                as_name: None,
+            },
+            level: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

When we go through the `Importer` flow, to get or import a symbol from an external module during an autofix, if the symbol isn't present in the scope, then we try to add an import to bring it into scope. At present, we always use an `import` statement for this, but sometimes, it might be more conventional to use an `import from`.

For example, when importing symbols from typing, it's more conventional to `from typing import List` than `import typing; typing.List`. This will be especially relevant when importing `TYPE_CHECKING` from `typing` for `flake8-type-checking` autofixes.
