### PR TITLE
testing_macros: Add missing `full` feature to `syn` dependency

### DIFF
--- a/crates/ruff_testing_macros/Cargo.toml
+++ b/crates/ruff_testing_macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 glob = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["extra-traits"] }
+syn = { workspace = true, features = ["extra-traits", "full"] }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fix the standalone build of `ruff_testing_macros`.

Before:

```bash
error[E0432]: unresolved imports `syn::FnArg`, `syn::ItemFn`, `syn::Pat`
  --> crates/ruff_testing_macros/src/lib.rs:13:61
   |
13 | use syn::{bracketed, parse_macro_input, parse_quote, Error, FnArg, ItemFn, LitStr, Pat, Token};
   |                                                             ^^^^^  ^^^^^^          ^^^
   |                                                             |      |               |
   |                                                             |      |               no `Pat` in the root
   |                                                             |      |               help: a similar name exists in the module: `Path`
   |                                                             |      no `ItemFn` in the root
   |                                                             no `FnArg` in the root

For more information about this error, try `rustc --explain E0432`.
error: could not compile `ruff_testing_macros` due to previous error
```

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

```bash
❯ cargo build -p ruff_testing_macros
   Compiling proc-macro2 v1.0.56
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.27
   Compiling glob v0.3.1
   Compiling syn v2.0.15
   Compiling ruff_testing_macros v0.0.0 (/home/micha/astral/ruff/crates/ruff_testing_macros)
    Finished dev [unoptimized + debuginfo] target(s) in 2.54s
```
