### PR TITLE
Remove unused `getrandom` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,10 +775,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2063,7 +2061,6 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "getrandom",
  "js-sys",
  "log",
  "ruff",

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -13,16 +13,14 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
+ruff = { path = "../ruff" }
 ruff_diagnostics = { path = "../ruff_diagnostics" }
 ruff_python_ast = { path = "../ruff_python_ast" }
 ruff_rustpython = { path = "../ruff_rustpython" }
 
 console_error_panic_hook = { version = "0.1.7", optional = true }
-
 console_log = { version = "1.0.0" }
-getrandom = { version = "0.2.8", features = ["js"] }
 log = { workspace = true }
-ruff = { path = "../ruff" }
 rustpython-parser = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { version = "0.5.0" }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This is being flagged by the `udeps` job, though not sure why it's only now being marked as unused?
