### PR TITLE
Handle positional-only-arguments separator comments

### DIFF
--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -716,4 +716,90 @@ def test(
 
         assert_debug_snapshot!(comments.debug(test_case.source_code));
     }
+
+    #[test]
+    fn positional_argument_only_comment() {
+        let source = r#"
+def test(
+    a, # trailing positional comment
+    # Positional arguments only after here
+    /, # trailing positional argument comment.
+    # leading b comment
+    b,
+): pass
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn positional_argument_only_leading_comma_comment() {
+        let source = r#"
+def test(
+    a # trailing positional comment
+    # Positional arguments only after here
+    ,/, # trailing positional argument comment.
+    # leading b comment
+    b,
+): pass
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn positional_argument_only_comment_without_following_node() {
+        let source = r#"
+def test(
+    a, # trailing positional comment
+    # Positional arguments only after here
+    /, # trailing positional argument comment.
+    # Trailing on new line
+): pass
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn non_positional_arguments_with_defaults() {
+        let source = r#"
+def test(
+    a=10 # trailing positional comment
+    # Positional arguments only after here
+    ,/, # trailing positional argument comment.
+    # leading comment for b
+    b=20
+): pass
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn non_positional_arguments_slash_on_same_line() {
+        let source = r#"
+def test(a=10,/, # trailing positional argument comment.
+    # leading comment for b
+    b=20
+): pass
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
 }

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__non_positional_arguments_slash_on_same_line.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__non_positional_arguments_slash_on_same_line.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: Arguments,
+        range: 10..94,
+        source: `a=10,/, # trailing position...t comment.⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# trailing positional argument comment.",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: Arg,
+        range: 90..91,
+        source: `b`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading comment for b",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__non_positional_arguments_with_defaults.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__non_positional_arguments_with_defaults.snap
@@ -1,0 +1,56 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: Arguments,
+        range: 15..177,
+        source: `a=10 # trailing positional comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# Positional arguments only after here",
+                position: OwnLine,
+                formatted: false,
+            },
+            SourceComment {
+                text: "# trailing positional argument comment.",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: ExprConstant,
+        range: 17..19,
+        source: `10`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing positional comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: Arg,
+        range: 173..174,
+        source: `b`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading comment for b",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_comment.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_comment.snap
@@ -1,0 +1,56 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: Arg,
+        range: 15..16,
+        source: `a`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing positional comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: Arguments,
+        range: 15..168,
+        source: `a, # trailing positional comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# Positional arguments only after here",
+                position: OwnLine,
+                formatted: false,
+            },
+            SourceComment {
+                text: "# trailing positional argument comment.",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: Arg,
+        range: 166..167,
+        source: `b`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading b comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_comment_without_following_node.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_comment_without_following_node.snap
@@ -1,0 +1,57 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: Arg,
+        range: 15..16,
+        source: `a`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing positional comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: Arguments,
+        range: 15..97,
+        source: `a, # trailing positional comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# Positional arguments only after here",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [
+            SourceComment {
+                text: "# trailing positional argument comment.",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: StmtPass,
+        range: 168..172,
+        source: `pass`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# Trailing on new line",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_leading_comma_comment.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__positional_argument_only_leading_comma_comment.snap
@@ -1,0 +1,56 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: Arg,
+        range: 15..16,
+        source: `a`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing positional comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: Arguments,
+        range: 15..168,
+        source: `a # trailing positional comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# Positional arguments only after here",
+                position: OwnLine,
+                formatted: false,
+            },
+            SourceComment {
+                text: "# trailing positional argument comment.",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: Arg,
+        range: 166..167,
+        source: `b`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading b comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements the logic for handling leading and trailing comments of the positional-only arguments separator '/'. 

```python
def test(
    a,
    # Positional arguments only after here
    /, # trailing positional argument comment.
    b,
): pass
```

The implementation attaches these comments as trailing comments to the `Arguments` node because RustPython has no `positional-only` argument separator node to which we could attach the comments.
The `Arguments` formatting has to correctly format its dangling comments (except if there are no comments) as leading/trailing comments of the separator.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a few new unit tests.
<!-- How was it tested? -->
