### PR TITLE
Abstract stylist to libcst style conversion

### DIFF
--- a/crates/ruff/src/autofix/codemods.rs
+++ b/crates/ruff/src/autofix/codemods.rs
@@ -13,11 +13,11 @@ use crate::cst::matchers::match_statement;
 
 /// Glue code to make libcst codegen work with ruff's Stylist
 pub(crate) trait CodegenStylist<'a>: Codegen<'a> {
-    fn codegen_stylist(&self, stylist: &'a Stylist<'a>) -> String;
+    fn codegen_stylist(&self, stylist: &'a Stylist) -> String;
 }
 
 impl<'a, T: Codegen<'a>> CodegenStylist<'a> for T {
-    fn codegen_stylist(&self, stylist: &'a Stylist<'a>) -> String {
+    fn codegen_stylist(&self, stylist: &'a Stylist) -> String {
         let mut state = CodegenState {
             default_newline: stylist.line_ending().as_str(),
             default_indent: stylist.indentation(),

--- a/crates/ruff/src/autofix/codemods.rs
+++ b/crates/ruff/src/autofix/codemods.rs
@@ -11,6 +11,23 @@ use ruff_python_ast::source_code::{Locator, Stylist};
 use crate::cst::helpers::compose_module_path;
 use crate::cst::matchers::match_statement;
 
+/// Glue code to make libcst codegen work with ruff's Stylist
+pub(crate) trait CodegenStylist<'a>: Codegen<'a> {
+    fn codegen_stylist(&self, stylist: &'a Stylist<'a>) -> String;
+}
+
+impl<'a, T: Codegen<'a>> CodegenStylist<'a> for T {
+    fn codegen_stylist(&self, stylist: &'a Stylist<'a>) -> String {
+        let mut state = CodegenState {
+            default_newline: stylist.line_ending().as_str(),
+            default_indent: stylist.indentation(),
+            ..Default::default()
+        };
+        self.codegen(&mut state);
+        state.to_string()
+    }
+}
+
 /// Given an import statement, remove any imports that are specified in the `imports` iterator.
 ///
 /// Returns `Ok(None)` if the statement is empty after removing the imports.
@@ -110,18 +127,7 @@ pub(crate) fn remove_imports<'a>(
         }
     }
 
-    if aliases.is_empty() {
-        return Ok(None);
-    }
-
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Some(state.to_string()))
+    Ok(Some(tree.codegen_stylist(&stylist)))
 }
 
 /// Given an import statement, remove any imports that are not specified in the `imports` slice.
@@ -200,11 +206,5 @@ pub(crate) fn retain_imports(
         }
     }
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-    Ok(state.to_string())
+    Ok(tree.codegen_stylist(stylist))
 }

--- a/crates/ruff/src/autofix/codemods.rs
+++ b/crates/ruff/src/autofix/codemods.rs
@@ -127,7 +127,11 @@ pub(crate) fn remove_imports<'a>(
         }
     }
 
-    Ok(Some(tree.codegen_stylist(&stylist)))
+    if aliases.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(tree.codegen_stylist(stylist)))
 }
 
 /// Given an import statement, remove any imports that are not specified in the `imports` slice.

--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -4,12 +4,11 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ast::{self, Excepthandler, Expr, Keyword, Ranged, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use crate::autofix::codemods;
 use ruff_diagnostics::Edit;
 use ruff_newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
-
-use crate::autofix::codemods;
 
 /// Return the `Fix` to use when deleting a `Stmt`.
 ///

--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -4,11 +4,12 @@ use ruff_text_size::{TextLen, TextRange, TextSize};
 use rustpython_parser::ast::{self, Excepthandler, Expr, Keyword, Ranged, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use crate::autofix::codemods;
 use ruff_diagnostics::Edit;
 use ruff_newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
+
+use crate::autofix::codemods;
 
 /// Return the `Fix` to use when deleting a `Stmt`.
 ///

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -3,11 +3,12 @@
 use std::error::Error;
 
 use anyhow::Result;
-use libcst_native::{Codegen, CodegenState, ImportAlias, Name, NameOrAttribute};
+use libcst_native::{ImportAlias, Name, NameOrAttribute};
 use ruff_text_size::TextSize;
 use rustpython_parser::ast::{self, Ranged, Stmt, Suite};
 
 use crate::autofix;
+use crate::autofix::codemods::CodegenStylist;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::imports::{AnyImport, Import, ImportFrom};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -324,13 +325,10 @@ impl<'a> Importer<'a> {
             asname: None,
             comma: aliases.last().and_then(|alias| alias.comma.clone()),
         });
-        let mut state = CodegenState {
-            default_newline: &self.stylist.line_ending(),
-            default_indent: self.stylist.indentation(),
-            ..CodegenState::default()
-        };
-        statement.codegen(&mut state);
-        Ok(Edit::range_replacement(state.to_string(), stmt.range()))
+        Ok(Edit::range_replacement(
+            statement.codegen_stylist(self.stylist),
+            stmt.range(),
+        ))
     }
 
     /// Add a `TYPE_CHECKING` block to the given module.

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -1,14 +1,15 @@
 use anyhow::{bail, Result};
 use itertools::Itertools;
 use libcst_native::{
-    Arg, AssignEqual, AssignTargetExpression, Call, Codegen, CodegenState, Comment, CompFor, Dict,
-    DictComp, DictElement, Element, EmptyLine, Expression, GeneratorExp, LeftCurlyBrace, LeftParen,
-    LeftSquareBracket, List, ListComp, Name, ParenthesizableWhitespace, ParenthesizedWhitespace,
-    RightCurlyBrace, RightParen, RightSquareBracket, Set, SetComp, SimpleString, SimpleWhitespace,
+    Arg, AssignEqual, AssignTargetExpression, Call, Comment, CompFor, Dict, DictComp, DictElement,
+    Element, EmptyLine, Expression, GeneratorExp, LeftCurlyBrace, LeftParen, LeftSquareBracket,
+    List, ListComp, Name, ParenthesizableWhitespace, ParenthesizedWhitespace, RightCurlyBrace,
+    RightParen, RightSquareBracket, Set, SetComp, SimpleString, SimpleWhitespace,
     TrailingWhitespace, Tuple,
 };
 use rustpython_parser::ast::Ranged;
 
+use crate::autofix::codemods::CodegenStylist;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -44,14 +45,10 @@ pub(crate) fn fix_unnecessary_generator_list(
         rpar: generator_exp.rpar.clone(),
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C401) Convert `set(x for x in y)` to `{x for x in y}`.
@@ -82,14 +79,7 @@ pub(crate) fn fix_unnecessary_generator_set(
         rpar: generator_exp.rpar.clone(),
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    let mut content = state.to_string();
+    let mut content = tree.codegen_stylist(stylist);
 
     // If the expression is embedded in an f-string, surround it with spaces to avoid
     // syntax errors.
@@ -136,14 +126,7 @@ pub(crate) fn fix_unnecessary_generator_dict(
         whitespace_after_colon: ParenthesizableWhitespace::SimpleWhitespace(SimpleWhitespace(" ")),
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    let mut content = state.to_string();
+    let mut content = tree.codegen_stylist(stylist);
 
     // If the expression is embedded in an f-string, surround it with spaces to avoid
     // syntax errors.
@@ -182,14 +165,10 @@ pub(crate) fn fix_unnecessary_list_comprehension_set(
         rpar: list_comp.rpar.clone(),
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C404) Convert `dict([(i, i) for i in range(3)])` to `{i: i for i in
@@ -229,14 +208,10 @@ pub(crate) fn fix_unnecessary_list_comprehension_dict(
         rpar: list_comp.rpar.clone(),
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// Drop a trailing comma from a list of tuple elements.
@@ -318,14 +293,10 @@ pub(crate) fn fix_unnecessary_literal_set(
         }));
     }
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C406) Convert `dict([(1, 2)])` to `{1: 2}`.
@@ -386,14 +357,10 @@ pub(crate) fn fix_unnecessary_literal_dict(
         rpar: vec![],
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C408)
@@ -495,14 +462,10 @@ pub(crate) fn fix_unnecessary_collection_call(
         }
     };
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C409) Convert `tuple([1, 2])` to `tuple(1, 2)`
@@ -549,14 +512,10 @@ pub(crate) fn fix_unnecessary_literal_within_tuple_call(
         }],
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C410) Convert `list([1, 2])` to `[1, 2]`
@@ -605,14 +564,10 @@ pub(crate) fn fix_unnecessary_literal_within_list_call(
         rpar: vec![],
     }));
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C411) Convert `list([i * i for i in x])` to `[i * i for i in x]`.
@@ -629,14 +584,10 @@ pub(crate) fn fix_unnecessary_list_call(
 
     tree = arg.value.clone();
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C413) Convert `list(sorted([2, 3, 1]))` to `sorted([2, 3, 1])`.
@@ -747,14 +698,10 @@ pub(crate) fn fix_unnecessary_call_around_sorted(
         }
     }
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C414) Convert `sorted(list(foo))` to `sorted(foo)`
@@ -781,14 +728,10 @@ pub(crate) fn fix_unnecessary_double_cast_or_process(
         None => bail!("Expected at least one argument in outer function call"),
     };
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C416) Convert `[i for i in x]` to `list(x)`.
@@ -872,14 +815,10 @@ pub(crate) fn fix_unnecessary_comprehension(
         }
     }
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C417) Convert `map(lambda x: x * 2, bar)` to `(x * 2 for x in bar)`.
@@ -1018,14 +957,7 @@ pub(crate) fn fix_unnecessary_map(
             }
         }
 
-        let mut state = CodegenState {
-            default_newline: &stylist.line_ending(),
-            default_indent: stylist.indentation(),
-            ..CodegenState::default()
-        };
-        tree.codegen(&mut state);
-
-        let mut content = state.to_string();
+        let mut content = tree.codegen_stylist(stylist);
 
         // If the expression is embedded in an f-string, surround it with spaces to avoid
         // syntax errors.
@@ -1054,14 +986,10 @@ pub(crate) fn fix_unnecessary_literal_within_dict_call(
 
     tree = arg.value.clone();
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
-    Ok(Edit::range_replacement(state.to_string(), expr.range()))
+    Ok(Edit::range_replacement(
+        tree.codegen_stylist(stylist),
+        expr.range(),
+    ))
 }
 
 /// (C419) Convert `[i for i in a]` into `i for i in a`
@@ -1231,15 +1159,8 @@ pub(crate) fn fix_unnecessary_comprehension_any_all(
         _ => whitespace_after_arg,
     };
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    tree.codegen(&mut state);
-
     Ok(Fix::suggested(Edit::range_replacement(
-        state.to_string(),
+        tree.codegen_stylist(stylist),
         expr.range(),
     )))
 }

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -1,9 +1,10 @@
 use anyhow::Result;
-use libcst_native::{Codegen, CodegenState};
+
 use log::error;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Cmpop, Expr, Ranged};
 
+use crate::autofix::codemods::CodegenStylist;
 use ruff_diagnostics::Edit;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -42,14 +43,7 @@ fn get_value_content_for_key_in_dict(
     let call = match_call_mut(&mut expression)?;
     let attribute = match_attribute(&mut call.func)?;
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    attribute.value.codegen(&mut state);
-
-    Ok(state.to_string())
+    Ok(attribute.value.codegen_stylist(stylist))
 }
 
 /// SIM118

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use libcst_native::{Codegen, CodegenState, CompOp};
+use libcst_native::CompOp;
 use rustpython_parser::ast::{self, Cmpop, Expr, Ranged, Unaryop};
 
+use crate::autofix::codemods::CodegenStylist;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -117,13 +118,7 @@ fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Resu
         _ => panic!("Expected comparison operator"),
     };
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    expression.codegen(&mut state);
-    Ok(state.to_string())
+    Ok(expression.codegen_stylist(stylist))
 }
 
 /// SIM300

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
-use libcst_native::{Codegen, CodegenState};
 use rustpython_parser::ast::{self, Expr, Ranged};
 
+use crate::autofix::codemods::CodegenStylist;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -77,15 +77,8 @@ fn fix_explicit_f_string_type_conversion(
     }
     formatted_string_expression.expression = call.args[0].value.clone();
 
-    let mut state = CodegenState {
-        default_newline: &stylist.line_ending(),
-        default_indent: stylist.indentation(),
-        ..CodegenState::default()
-    };
-    expression.codegen(&mut state);
-
     Ok(Fix::automatic(Edit::range_replacement(
-        state.to_string(),
+        expression.codegen_stylist(stylist),
         range,
     )))
 }


### PR DESCRIPTION
Replace all duplicate invocations of

```rust
let mut state = CodegenState {
    default_newline: &stylist.line_ending(),
    default_indent: stylist.indentation(),
    ..CodegenState::default()
}
tree.codegen(&mut state);
state.to_string()
```

with

```rust
tree.codegen_stylist(&stylist)
```

No functional changes.