### PR TITLE
Place comments of left and right binary expression operands

### DIFF
--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -802,4 +802,58 @@ def test(a=10,/, # trailing positional argument comment.
 
         assert_debug_snapshot!(comments.debug(test_case.source_code));
     }
+
+    #[test]
+    fn binary_expression_left_operand_comment() {
+        let source = r#"
+a = (
+    5
+    # trailing left comment
+    +
+    # leading right comment
+    3
+)
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn binary_expression_left_operand_trailing_end_of_line_comment() {
+        let source = r#"
+a = (
+    5 # trailing left comment
+    + # trailing operator comment
+    # leading right comment
+    3
+)
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
+
+    #[test]
+    fn nested_binary_expression() {
+        let source = r#"
+a = (
+    (5 # trailing left comment
+        *
+        2)
+    + # trailing operator comment
+    # leading right comment
+    3
+)
+"#;
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
 }

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__binary_expression_left_operand_comment.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__binary_expression_left_operand_comment.snap
@@ -1,0 +1,36 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: ExprConstant,
+        range: 11..12,
+        source: `5`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing left comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: ExprConstant,
+        range: 79..80,
+        source: `3`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading right comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__binary_expression_left_operand_trailing_end_of_line_comment.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__binary_expression_left_operand_trailing_end_of_line_comment.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: ExprConstant,
+        range: 11..12,
+        source: `5`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing left comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: ExprBinOp,
+        range: 11..104,
+        source: `5 # trailing left comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# trailing operator comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: ExprConstant,
+        range: 103..104,
+        source: `3`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading right comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__nested_binary_expression.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__nested_binary_expression.snap
@@ -1,0 +1,51 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: ExprBinOp,
+        range: 11..126,
+        source: `(5 # trailing left comment⏎`,
+    }: {
+        "leading": [],
+        "dangling": [
+            SourceComment {
+                text: "# trailing operator comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+        "trailing": [],
+    },
+    Node {
+        kind: ExprConstant,
+        range: 12..13,
+        source: `5`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing left comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+    Node {
+        kind: ExprConstant,
+        range: 125..126,
+        source: `3`,
+    }: {
+        "leading": [
+            SourceComment {
+                text: "# leading right comment",
+                position: OwnLine,
+                formatted: false,
+            },
+        ],
+        "dangling": [],
+        "trailing": [],
+    },
+}

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod other;
 pub(crate) mod pattern;
 mod prelude;
 pub(crate) mod statement;
+mod trivia;
 
 include!("../../ruff_formatter/shared_traits.rs");
 

--- a/crates/ruff_python_formatter/src/trivia.rs
+++ b/crates/ruff_python_formatter/src/trivia.rs
@@ -1,0 +1,41 @@
+use ruff_python_ast::whitespace::is_python_whitespace;
+use ruff_text_size::{TextLen, TextRange, TextSize};
+
+/// Searches for the first non-trivia character in `range`.
+///
+/// The search skips over any whitespace and comments.
+///
+/// Returns `Some` if the range contains any non-trivia character. The first item is the absolute offset
+/// of the character, the second item the non-trivia character.
+///
+/// Returns `None` if the range is empty or only contains trivia (whitespace or comments).
+pub(crate) fn find_first_non_trivia_character_in_range(
+    code: &str,
+    range: TextRange,
+) -> Option<(TextSize, char)> {
+    let rest = &code[range];
+    let mut char_iter = rest.chars();
+
+    while let Some(c) = char_iter.next() {
+        match c {
+            '#' => {
+                // We're now inside of a comment. Skip all content until the end of the line
+                for c in char_iter.by_ref() {
+                    if matches!(c, '\n' | '\r') {
+                        break;
+                    }
+                }
+            }
+            c => {
+                if !is_python_whitespace(c) {
+                    let index = range.start() + rest.text_len()
+                        - char_iter.as_str().text_len()
+                        - c.text_len();
+                    return Some((index, c));
+                }
+            }
+        }
+    }
+
+    None
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This PR implements the custom logic that associates comments between the left binary expression operand and the oprator as trailing comments to the `left` AND trailing end of line comments that are on the same line as the operator as dangling comments of the binary expression. 

```python
a = (
    5 # trailing left comment
    + # trailing operator comment
    # leading right comment
    3
)
```

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a few new snapshot tests
