### PR TITLE
Make running ruff on ruff possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ exclude = [
   "crates/ruff/src/rules/*/snapshots/**/*"
 ]
 
+[tool.ruff]
+extend-exclude = [
+  "crates/ruff/resources/",
+  "crates/ruff_python_formatter/resources/"
+]
+
 [tool.black]
 force-exclude = '''
 /(


### PR DESCRIPTION
I was wondering why `pip install -U ruff && ruff .` in the ruff repo would result in only noise while the pre-commit ruff works. Turns out the pre-commit has an exclude for the resources directories.

## Summary

This adds the excludes from pre-commit to ruff's own pyproject.toml so `ruff .` works on ruff itself

## Test Plan

`pip install -U ruff && ruff .`
