### PR TITLE
Apply edits in sorted order

### DIFF
--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -65,7 +65,11 @@ fn apply_fixes<'a>(
             continue;
         }
 
-        for edit in fix.edits() {
+        for edit in fix
+            .edits()
+            .iter()
+            .sorted_unstable_by_key(|edit| edit.start())
+        {
             // Add all contents from `last_pos` to `fix.location`.
             let slice = locator.slice(TextRange::new(last_pos.unwrap_or_default(), edit.start()));
             output.push_str(slice);


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

We allow users to store edits in any order, but there's an assumption (in the fix application code) that they're stored in _sorted_ order. This PR modifies the fixer to sort the edits, thereby removing the responsibility from the user.

This is a revival of #4210, in response to a need that arose in https://github.com/charliermarsh/ruff/pull/4742#discussion_r1211233416.
