### PR TITLE
Use new formatter infrastructure in CLI and test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,7 @@ dependencies = [
  "ruff_cache",
  "ruff_diagnostics",
  "ruff_python_ast",
+ "ruff_python_formatter",
  "ruff_python_stdlib",
  "ruff_text_size",
  "ruff_textwrap",

--- a/crates/ruff_cli/Cargo.toml
+++ b/crates/ruff_cli/Cargo.toml
@@ -26,6 +26,7 @@ ruff = { path = "../ruff", features = ["clap"] }
 ruff_cache = { path = "../ruff_cache" }
 ruff_diagnostics = { path = "../ruff_diagnostics" }
 ruff_python_ast = { path = "../ruff_python_ast" }
+ruff_python_formatter = { path = "../ruff_python_formatter" }
 ruff_text_size = { workspace = true }
 ruff_textwrap = { path = "../ruff_textwrap" }
 

--- a/crates/ruff_python_formatter/generate.py
+++ b/crates/ruff_python_formatter/generate.py
@@ -78,19 +78,19 @@ for group, group_nodes in nodes_grouped.items():
     # src.joinpath(groups[group]).joinpath("mod.rs").write_text(rustfmt(mod_section))
     for node in group_nodes:
         code = f"""
-            use crate::{{FormatNodeRule, PyFormatter}};
-            use ruff_formatter::FormatResult;
+            use crate::{{verbatim_text, FormatNodeRule, PyFormatter}};
+            use ruff_formatter::{{write, Buffer, FormatResult}};
             use rustpython_parser::ast::{node};
 
             #[derive(Default)]
             pub struct Format{node};
 
             impl FormatNodeRule<{node}> for Format{node} {{
-                fn fmt_fields(&self, _item: &{node}, _f: &mut PyFormatter) -> FormatResult<()> {{
-                    Ok(())
+                fn fmt_fields(&self, item: &{node}, f: &mut PyFormatter) -> FormatResult<()> {{
+                    write!(f, [verbatim_text(item.range)])
                 }}
             }}
-        """.strip()  # noqa: E501
+            """.strip()  # noqa: E501
         src.joinpath(groups[group]).joinpath(f"{to_camel_case(node)}.rs").write_text(
             rustfmt(code)
         )

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprAttribute;
 
 #[derive(Default)]
 pub struct FormatExprAttribute;
 
 impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
-    fn fmt_fields(&self, _item: &ExprAttribute, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprAttribute, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_await.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_await.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprAwait;
 
 #[derive(Default)]
 pub struct FormatExprAwait;
 
 impl FormatNodeRule<ExprAwait> for FormatExprAwait {
-    fn fmt_fields(&self, _item: &ExprAwait, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprAwait, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bin_op.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprBinOp;
 
 #[derive(Default)]
 pub struct FormatExprBinOp;
 
 impl FormatNodeRule<ExprBinOp> for FormatExprBinOp {
-    fn fmt_fields(&self, _item: &ExprBinOp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprBinOp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_bool_op.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprBoolOp;
 
 #[derive(Default)]
 pub struct FormatExprBoolOp;
 
 impl FormatNodeRule<ExprBoolOp> for FormatExprBoolOp {
-    fn fmt_fields(&self, _item: &ExprBoolOp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprBoolOp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprCall;
 
 #[derive(Default)]
 pub struct FormatExprCall;
 
 impl FormatNodeRule<ExprCall> for FormatExprCall {
-    fn fmt_fields(&self, _item: &ExprCall, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprCall, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprCompare;
 
 #[derive(Default)]
 pub struct FormatExprCompare;
 
 impl FormatNodeRule<ExprCompare> for FormatExprCompare {
-    fn fmt_fields(&self, _item: &ExprCompare, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprCompare, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_constant.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_constant.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprConstant;
 
 #[derive(Default)]
 pub struct FormatExprConstant;
 
 impl FormatNodeRule<ExprConstant> for FormatExprConstant {
-    fn fmt_fields(&self, _item: &ExprConstant, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprConstant, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_dict.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprDict;
 
 #[derive(Default)]
 pub struct FormatExprDict;
 
 impl FormatNodeRule<ExprDict> for FormatExprDict {
-    fn fmt_fields(&self, _item: &ExprDict, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprDict, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_dict_comp.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprDictComp;
 
 #[derive(Default)]
 pub struct FormatExprDictComp;
 
 impl FormatNodeRule<ExprDictComp> for FormatExprDictComp {
-    fn fmt_fields(&self, _item: &ExprDictComp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprDictComp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_formatted_value.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprFormattedValue;
 
 #[derive(Default)]
 pub struct FormatExprFormattedValue;
 
 impl FormatNodeRule<ExprFormattedValue> for FormatExprFormattedValue {
-    fn fmt_fields(&self, _item: &ExprFormattedValue, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprFormattedValue, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_generator_exp.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprGeneratorExp;
 
 #[derive(Default)]
 pub struct FormatExprGeneratorExp;
 
 impl FormatNodeRule<ExprGeneratorExp> for FormatExprGeneratorExp {
-    fn fmt_fields(&self, _item: &ExprGeneratorExp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprGeneratorExp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_if_exp.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprIfExp;
 
 #[derive(Default)]
 pub struct FormatExprIfExp;
 
 impl FormatNodeRule<ExprIfExp> for FormatExprIfExp {
-    fn fmt_fields(&self, _item: &ExprIfExp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprIfExp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_joined_str.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprJoinedStr;
 
 #[derive(Default)]
 pub struct FormatExprJoinedStr;
 
 impl FormatNodeRule<ExprJoinedStr> for FormatExprJoinedStr {
-    fn fmt_fields(&self, _item: &ExprJoinedStr, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprJoinedStr, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_lambda.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_lambda.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprLambda;
 
 #[derive(Default)]
 pub struct FormatExprLambda;
 
 impl FormatNodeRule<ExprLambda> for FormatExprLambda {
-    fn fmt_fields(&self, _item: &ExprLambda, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprLambda, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_list.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprList;
 
 #[derive(Default)]
 pub struct FormatExprList;
 
 impl FormatNodeRule<ExprList> for FormatExprList {
-    fn fmt_fields(&self, _item: &ExprList, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprList, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_list_comp.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprListComp;
 
 #[derive(Default)]
 pub struct FormatExprListComp;
 
 impl FormatNodeRule<ExprListComp> for FormatExprListComp {
-    fn fmt_fields(&self, _item: &ExprListComp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprListComp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprName;
 
 #[derive(Default)]
 pub struct FormatExprName;
 
 impl FormatNodeRule<ExprName> for FormatExprName {
-    fn fmt_fields(&self, _item: &ExprName, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprName, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_named_expr.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprNamedExpr;
 
 #[derive(Default)]
 pub struct FormatExprNamedExpr;
 
 impl FormatNodeRule<ExprNamedExpr> for FormatExprNamedExpr {
-    fn fmt_fields(&self, _item: &ExprNamedExpr, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprNamedExpr, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_set.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprSet;
 
 #[derive(Default)]
 pub struct FormatExprSet;
 
 impl FormatNodeRule<ExprSet> for FormatExprSet {
-    fn fmt_fields(&self, _item: &ExprSet, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprSet, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_set_comp.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprSetComp;
 
 #[derive(Default)]
 pub struct FormatExprSetComp;
 
 impl FormatNodeRule<ExprSetComp> for FormatExprSetComp {
-    fn fmt_fields(&self, _item: &ExprSetComp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprSetComp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_slice.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_slice.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprSlice;
 
 #[derive(Default)]
 pub struct FormatExprSlice;
 
 impl FormatNodeRule<ExprSlice> for FormatExprSlice {
-    fn fmt_fields(&self, _item: &ExprSlice, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprSlice, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_starred.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_starred.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprStarred;
 
 #[derive(Default)]
 pub struct FormatExprStarred;
 
 impl FormatNodeRule<ExprStarred> for FormatExprStarred {
-    fn fmt_fields(&self, _item: &ExprStarred, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprStarred, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_subscript.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_subscript.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprSubscript;
 
 #[derive(Default)]
 pub struct FormatExprSubscript;
 
 impl FormatNodeRule<ExprSubscript> for FormatExprSubscript {
-    fn fmt_fields(&self, _item: &ExprSubscript, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprSubscript, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_tuple.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_tuple.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprTuple;
 
 #[derive(Default)]
 pub struct FormatExprTuple;
 
 impl FormatNodeRule<ExprTuple> for FormatExprTuple {
-    fn fmt_fields(&self, _item: &ExprTuple, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprTuple, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_unary_op.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprUnaryOp;
 
 #[derive(Default)]
 pub struct FormatExprUnaryOp;
 
 impl FormatNodeRule<ExprUnaryOp> for FormatExprUnaryOp {
-    fn fmt_fields(&self, _item: &ExprUnaryOp, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprUnaryOp, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_yield.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprYield;
 
 #[derive(Default)]
 pub struct FormatExprYield;
 
 impl FormatNodeRule<ExprYield> for FormatExprYield {
-    fn fmt_fields(&self, _item: &ExprYield, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprYield, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_yield_from.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExprYieldFrom;
 
 #[derive(Default)]
 pub struct FormatExprYieldFrom;
 
 impl FormatNodeRule<ExprYieldFrom> for FormatExprYieldFrom {
-    fn fmt_fields(&self, _item: &ExprYieldFrom, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ExprYieldFrom, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -16,7 +16,6 @@ use ruff_python_ast::source_code::{CommentRanges, CommentRangesBuilder, Locator}
 
 use crate::comments::Comments;
 use crate::context::PyFormatContext;
-use crate::module::FormatModule;
 
 pub mod cli;
 mod comments;
@@ -130,9 +129,9 @@ pub fn format_node<'a>(
                 line_width: 88.try_into().unwrap(),
             },
             locator.contents(),
-            comments
+            comments,
         ),
-        [FormatModule::new(root)]
+        [root.format()]
     )
 }
 
@@ -165,12 +164,32 @@ mod tests {
     use insta::assert_snapshot;
     use rustpython_parser::lexer::lex;
     use rustpython_parser::{parse_tokens, Mode};
+    use similar::TextDiff;
 
     use ruff_python_ast::source_code::CommentRangesBuilder;
     use ruff_testing_macros::fixture;
-    use similar::TextDiff;
 
     use crate::{format_module, format_node};
+
+    /// Very basic test intentionally kept very similar to the CLI
+    #[test]
+    fn basic() -> Result<()> {
+        let input = r#"
+# preceding
+if    True:
+    print( "hi" )
+# trailing
+"#;
+        let expected = r#"
+# preceding
+if    True:
+    print( "hi" )
+# trailing
+"#;
+        let actual = format_module(input)?.as_code().to_string();
+        assert_eq!(expected, actual);
+        Ok(())
+    }
 
     #[fixture(pattern = "resources/test/fixtures/black/**/*.py")]
     #[test]

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -6,12 +6,10 @@ use clap::Parser as ClapParser;
 use ruff_python_formatter::cli::Cli;
 use ruff_python_formatter::format_module;
 
+#[allow(clippy::print_stdout)]
 fn main() -> Result<()> {
     let cli = Cli::parse();
     let contents = fs::read_to_string(cli.file)?;
-    #[allow(clippy::print_stdout)]
-    {
-        println!("{}", format_module(&contents)?.as_code());
-    }
+    println!("{}", format_module(&contents)?.as_code());
     Ok(())
 }

--- a/crates/ruff_python_formatter/src/module/mod.rs
+++ b/crates/ruff_python_formatter/src/module/mod.rs
@@ -1,7 +1,6 @@
 use crate::context::PyFormatContext;
 use crate::{AsFormat, IntoFormat, PyFormatter};
-use ruff_formatter::Format;
-use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatRule};
+use ruff_formatter::{Format, FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatRule};
 use rustpython_parser::ast::Mod;
 
 pub(crate) mod mod_expression;
@@ -22,12 +21,14 @@ impl FormatRule<Mod, PyFormatContext<'_>> for FormatMod {
         }
     }
 }
+
 impl<'ast> AsFormat<PyFormatContext<'ast>> for Mod {
     type Format<'a> = FormatRefWithRule<'a, Mod, FormatMod, PyFormatContext<'ast>>;
     fn format(&self) -> Self::Format<'_> {
         FormatRefWithRule::new(self, FormatMod::default())
     }
 }
+
 impl<'ast> IntoFormat<PyFormatContext<'ast>> for Mod {
     type Format = FormatOwnedWithRule<Mod, FormatMod, PyFormatContext<'ast>>;
     fn into_format(self) -> Self::Format {

--- a/crates/ruff_python_formatter/src/module/mod.rs
+++ b/crates/ruff_python_formatter/src/module/mod.rs
@@ -1,38 +1,36 @@
+use crate::context::PyFormatContext;
+use crate::{AsFormat, IntoFormat, PyFormatter};
+use ruff_formatter::Format;
+use ruff_formatter::{FormatOwnedWithRule, FormatRefWithRule, FormatResult, FormatRule};
+use rustpython_parser::ast::Mod;
+
 pub(crate) mod mod_expression;
 pub(crate) mod mod_function_type;
 pub(crate) mod mod_interactive;
 pub(crate) mod mod_module;
 
-use crate::context::PyFormatContext;
-use ruff_formatter::format_element::tag::VerbatimKind;
-use ruff_formatter::prelude::*;
-use ruff_formatter::write;
-use rustpython_parser::ast::{Mod, Ranged};
+#[derive(Default)]
+pub struct FormatMod;
 
-pub(crate) struct FormatModule<'a> {
-    module: &'a Mod,
-}
-
-impl<'a> FormatModule<'a> {
-    pub(crate) fn new(module: &'a Mod) -> Self {
-        Self { module }
+impl FormatRule<Mod, PyFormatContext<'_>> for FormatMod {
+    fn fmt(&self, item: &Mod, f: &mut PyFormatter) -> FormatResult<()> {
+        match item {
+            Mod::Module(x) => x.format().fmt(f),
+            Mod::Interactive(x) => x.format().fmt(f),
+            Mod::Expression(x) => x.format().fmt(f),
+            Mod::FunctionType(x) => x.format().fmt(f),
+        }
     }
 }
-
-impl Format<PyFormatContext<'_>> for FormatModule<'_> {
-    fn fmt(&self, f: &mut Formatter<PyFormatContext<'_>>) -> FormatResult<()> {
-        let range = self.module.range();
-
-        write!(f, [source_position(range.start())])?;
-
-        f.write_element(FormatElement::Tag(Tag::StartVerbatim(
-            VerbatimKind::Verbatim {
-                length: range.len(),
-            },
-        )))?;
-        write!(f, [source_text_slice(range, ContainsNewlines::Detect)])?;
-        f.write_element(FormatElement::Tag(Tag::EndVerbatim))?;
-
-        write!(f, [source_position(range.end())])
+impl<'ast> AsFormat<PyFormatContext<'ast>> for Mod {
+    type Format<'a> = FormatRefWithRule<'a, Mod, FormatMod, PyFormatContext<'ast>>;
+    fn format(&self) -> Self::Format<'_> {
+        FormatRefWithRule::new(self, FormatMod::default())
+    }
+}
+impl<'ast> IntoFormat<PyFormatContext<'ast>> for Mod {
+    type Format = FormatOwnedWithRule<Mod, FormatMod, PyFormatContext<'ast>>;
+    fn into_format(self) -> Self::Format {
+        FormatOwnedWithRule::new(self, FormatMod::default())
     }
 }

--- a/crates/ruff_python_formatter/src/module/mod_expression.rs
+++ b/crates/ruff_python_formatter/src/module/mod_expression.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ModExpression;
 
 #[derive(Default)]
 pub struct FormatModExpression;
 
 impl FormatNodeRule<ModExpression> for FormatModExpression {
-    fn fmt_fields(&self, _item: &ModExpression, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ModExpression, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/module/mod_function_type.rs
+++ b/crates/ruff_python_formatter/src/module/mod_function_type.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ModFunctionType;
 
 #[derive(Default)]
 pub struct FormatModFunctionType;
 
 impl FormatNodeRule<ModFunctionType> for FormatModFunctionType {
-    fn fmt_fields(&self, _item: &ModFunctionType, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ModFunctionType, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/module/mod_interactive.rs
+++ b/crates/ruff_python_formatter/src/module/mod_interactive.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ModInteractive;
 
 #[derive(Default)]
 pub struct FormatModInteractive;
 
 impl FormatNodeRule<ModInteractive> for FormatModInteractive {
-    fn fmt_fields(&self, _item: &ModInteractive, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ModInteractive, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/module/mod_module.rs
+++ b/crates/ruff_python_formatter/src/module/mod_module.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ModModule;
 
 #[derive(Default)]
 pub struct FormatModModule;
 
 impl FormatNodeRule<ModModule> for FormatModModule {
-    fn fmt_fields(&self, _item: &ModModule, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &ModModule, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/alias.rs
+++ b/crates/ruff_python_formatter/src/other/alias.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Alias;
 
 #[derive(Default)]
 pub struct FormatAlias;
 
 impl FormatNodeRule<Alias> for FormatAlias {
-    fn fmt_fields(&self, _item: &Alias, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Alias, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/arg.rs
+++ b/crates/ruff_python_formatter/src/other/arg.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Arg;
 
 #[derive(Default)]
 pub struct FormatArg;
 
 impl FormatNodeRule<Arg> for FormatArg {
-    fn fmt_fields(&self, _item: &Arg, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Arg, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/arguments.rs
+++ b/crates/ruff_python_formatter/src/other/arguments.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Arguments;
 
 #[derive(Default)]
 pub struct FormatArguments;
 
 impl FormatNodeRule<Arguments> for FormatArguments {
-    fn fmt_fields(&self, _item: &Arguments, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Arguments, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/comprehension.rs
+++ b/crates/ruff_python_formatter/src/other/comprehension.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Comprehension;
 
 #[derive(Default)]
 pub struct FormatComprehension;
 
 impl FormatNodeRule<Comprehension> for FormatComprehension {
-    fn fmt_fields(&self, _item: &Comprehension, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Comprehension, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/excepthandler_except_handler.rs
+++ b/crates/ruff_python_formatter/src/other/excepthandler_except_handler.rs
@@ -1,5 +1,5 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::ExcepthandlerExceptHandler;
 
 #[derive(Default)]
@@ -8,9 +8,9 @@ pub struct FormatExcepthandlerExceptHandler;
 impl FormatNodeRule<ExcepthandlerExceptHandler> for FormatExcepthandlerExceptHandler {
     fn fmt_fields(
         &self,
-        _item: &ExcepthandlerExceptHandler,
-        _f: &mut PyFormatter,
+        item: &ExcepthandlerExceptHandler,
+        f: &mut PyFormatter,
     ) -> FormatResult<()> {
-        Ok(())
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/keyword.rs
+++ b/crates/ruff_python_formatter/src/other/keyword.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Keyword;
 
 #[derive(Default)]
 pub struct FormatKeyword;
 
 impl FormatNodeRule<Keyword> for FormatKeyword {
-    fn fmt_fields(&self, _item: &Keyword, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Keyword, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/match_case.rs
+++ b/crates/ruff_python_formatter/src/other/match_case.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::MatchCase;
 
 #[derive(Default)]
 pub struct FormatMatchCase;
 
 impl FormatNodeRule<MatchCase> for FormatMatchCase {
-    fn fmt_fields(&self, _item: &MatchCase, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &MatchCase, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/type_ignore_type_ignore.rs
+++ b/crates/ruff_python_formatter/src/other/type_ignore_type_ignore.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::TypeIgnoreTypeIgnore;
 
 #[derive(Default)]
 pub struct FormatTypeIgnoreTypeIgnore;
 
 impl FormatNodeRule<TypeIgnoreTypeIgnore> for FormatTypeIgnoreTypeIgnore {
-    fn fmt_fields(&self, _item: &TypeIgnoreTypeIgnore, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &TypeIgnoreTypeIgnore, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/other/withitem.rs
+++ b/crates/ruff_python_formatter/src/other/withitem.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::Withitem;
 
 #[derive(Default)]
 pub struct FormatWithitem;
 
 impl FormatNodeRule<Withitem> for FormatWithitem {
-    fn fmt_fields(&self, _item: &Withitem, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &Withitem, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_as.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchAs;
 
 #[derive(Default)]
 pub struct FormatPatternMatchAs;
 
 impl FormatNodeRule<PatternMatchAs> for FormatPatternMatchAs {
-    fn fmt_fields(&self, _item: &PatternMatchAs, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchAs, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_class.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchClass;
 
 #[derive(Default)]
 pub struct FormatPatternMatchClass;
 
 impl FormatNodeRule<PatternMatchClass> for FormatPatternMatchClass {
-    fn fmt_fields(&self, _item: &PatternMatchClass, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchClass, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_mapping.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchMapping;
 
 #[derive(Default)]
 pub struct FormatPatternMatchMapping;
 
 impl FormatNodeRule<PatternMatchMapping> for FormatPatternMatchMapping {
-    fn fmt_fields(&self, _item: &PatternMatchMapping, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchMapping, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_or.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_or.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchOr;
 
 #[derive(Default)]
 pub struct FormatPatternMatchOr;
 
 impl FormatNodeRule<PatternMatchOr> for FormatPatternMatchOr {
-    fn fmt_fields(&self, _item: &PatternMatchOr, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchOr, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_sequence.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchSequence;
 
 #[derive(Default)]
 pub struct FormatPatternMatchSequence;
 
 impl FormatNodeRule<PatternMatchSequence> for FormatPatternMatchSequence {
-    fn fmt_fields(&self, _item: &PatternMatchSequence, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchSequence, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_singleton.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchSingleton;
 
 #[derive(Default)]
 pub struct FormatPatternMatchSingleton;
 
 impl FormatNodeRule<PatternMatchSingleton> for FormatPatternMatchSingleton {
-    fn fmt_fields(&self, _item: &PatternMatchSingleton, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchSingleton, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_star.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchStar;
 
 #[derive(Default)]
 pub struct FormatPatternMatchStar;
 
 impl FormatNodeRule<PatternMatchStar> for FormatPatternMatchStar {
-    fn fmt_fields(&self, _item: &PatternMatchStar, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchStar, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
+++ b/crates/ruff_python_formatter/src/pattern/pattern_match_value.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::PatternMatchValue;
 
 #[derive(Default)]
 pub struct FormatPatternMatchValue;
 
 impl FormatNodeRule<PatternMatchValue> for FormatPatternMatchValue {
-    fn fmt_fields(&self, _item: &PatternMatchValue, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &PatternMatchValue, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_ann_assign.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAnnAssign;
 
 #[derive(Default)]
 pub struct FormatStmtAnnAssign;
 
 impl FormatNodeRule<StmtAnnAssign> for FormatStmtAnnAssign {
-    fn fmt_fields(&self, _item: &StmtAnnAssign, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAnnAssign, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_assert.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assert.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAssert;
 
 #[derive(Default)]
 pub struct FormatStmtAssert;
 
 impl FormatNodeRule<StmtAssert> for FormatStmtAssert {
-    fn fmt_fields(&self, _item: &StmtAssert, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAssert, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_assign.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAssign;
 
 #[derive(Default)]
 pub struct FormatStmtAssign;
 
 impl FormatNodeRule<StmtAssign> for FormatStmtAssign {
-    fn fmt_fields(&self, _item: &StmtAssign, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAssign, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_async_for.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_async_for.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAsyncFor;
 
 #[derive(Default)]
 pub struct FormatStmtAsyncFor;
 
 impl FormatNodeRule<StmtAsyncFor> for FormatStmtAsyncFor {
-    fn fmt_fields(&self, _item: &StmtAsyncFor, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAsyncFor, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_async_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_async_function_def.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAsyncFunctionDef;
 
 #[derive(Default)]
 pub struct FormatStmtAsyncFunctionDef;
 
 impl FormatNodeRule<StmtAsyncFunctionDef> for FormatStmtAsyncFunctionDef {
-    fn fmt_fields(&self, _item: &StmtAsyncFunctionDef, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAsyncFunctionDef, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_async_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_async_with.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAsyncWith;
 
 #[derive(Default)]
 pub struct FormatStmtAsyncWith;
 
 impl FormatNodeRule<StmtAsyncWith> for FormatStmtAsyncWith {
-    fn fmt_fields(&self, _item: &StmtAsyncWith, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAsyncWith, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_aug_assign.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_aug_assign.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtAugAssign;
 
 #[derive(Default)]
 pub struct FormatStmtAugAssign;
 
 impl FormatNodeRule<StmtAugAssign> for FormatStmtAugAssign {
-    fn fmt_fields(&self, _item: &StmtAugAssign, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtAugAssign, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_break.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_break.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtBreak;
 
 #[derive(Default)]
 pub struct FormatStmtBreak;
 
 impl FormatNodeRule<StmtBreak> for FormatStmtBreak {
-    fn fmt_fields(&self, _item: &StmtBreak, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtBreak, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_class_def.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtClassDef;
 
 #[derive(Default)]
 pub struct FormatStmtClassDef;
 
 impl FormatNodeRule<StmtClassDef> for FormatStmtClassDef {
-    fn fmt_fields(&self, _item: &StmtClassDef, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtClassDef, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_continue.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_continue.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtContinue;
 
 #[derive(Default)]
 pub struct FormatStmtContinue;
 
 impl FormatNodeRule<StmtContinue> for FormatStmtContinue {
-    fn fmt_fields(&self, _item: &StmtContinue, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtContinue, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_delete.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_delete.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtDelete;
 
 #[derive(Default)]
 pub struct FormatStmtDelete;
 
 impl FormatNodeRule<StmtDelete> for FormatStmtDelete {
-    fn fmt_fields(&self, _item: &StmtDelete, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtDelete, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_expr.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_expr.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtExpr;
 
 #[derive(Default)]
 pub struct FormatStmtExpr;
 
 impl FormatNodeRule<StmtExpr> for FormatStmtExpr {
-    fn fmt_fields(&self, _item: &StmtExpr, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtExpr, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_for.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_for.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtFor;
 
 #[derive(Default)]
 pub struct FormatStmtFor;
 
 impl FormatNodeRule<StmtFor> for FormatStmtFor {
-    fn fmt_fields(&self, _item: &StmtFor, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtFor, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_function_def.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtFunctionDef;
 
 #[derive(Default)]
 pub struct FormatStmtFunctionDef;
 
 impl FormatNodeRule<StmtFunctionDef> for FormatStmtFunctionDef {
-    fn fmt_fields(&self, _item: &StmtFunctionDef, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtFunctionDef, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_global.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_global.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtGlobal;
 
 #[derive(Default)]
 pub struct FormatStmtGlobal;
 
 impl FormatNodeRule<StmtGlobal> for FormatStmtGlobal {
-    fn fmt_fields(&self, _item: &StmtGlobal, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtGlobal, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_if.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_if.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtIf;
 
 #[derive(Default)]
 pub struct FormatStmtIf;
 
 impl FormatNodeRule<StmtIf> for FormatStmtIf {
-    fn fmt_fields(&self, _item: &StmtIf, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtIf, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_import.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtImport;
 
 #[derive(Default)]
 pub struct FormatStmtImport;
 
 impl FormatNodeRule<StmtImport> for FormatStmtImport {
-    fn fmt_fields(&self, _item: &StmtImport, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtImport, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_import_from.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtImportFrom;
 
 #[derive(Default)]
 pub struct FormatStmtImportFrom;
 
 impl FormatNodeRule<StmtImportFrom> for FormatStmtImportFrom {
-    fn fmt_fields(&self, _item: &StmtImportFrom, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtImportFrom, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtMatch;
 
 #[derive(Default)]
 pub struct FormatStmtMatch;
 
 impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
-    fn fmt_fields(&self, _item: &StmtMatch, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtMatch, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_nonlocal.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtNonlocal;
 
 #[derive(Default)]
 pub struct FormatStmtNonlocal;
 
 impl FormatNodeRule<StmtNonlocal> for FormatStmtNonlocal {
-    fn fmt_fields(&self, _item: &StmtNonlocal, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtNonlocal, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_pass.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_pass.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtPass;
 
 #[derive(Default)]
 pub struct FormatStmtPass;
 
 impl FormatNodeRule<StmtPass> for FormatStmtPass {
-    fn fmt_fields(&self, _item: &StmtPass, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtPass, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_raise.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_raise.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtRaise;
 
 #[derive(Default)]
 pub struct FormatStmtRaise;
 
 impl FormatNodeRule<StmtRaise> for FormatStmtRaise {
-    fn fmt_fields(&self, _item: &StmtRaise, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtRaise, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_return.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_return.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtReturn;
 
 #[derive(Default)]
 pub struct FormatStmtReturn;
 
 impl FormatNodeRule<StmtReturn> for FormatStmtReturn {
-    fn fmt_fields(&self, _item: &StmtReturn, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtReturn, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_try.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtTry;
 
 #[derive(Default)]
 pub struct FormatStmtTry;
 
 impl FormatNodeRule<StmtTry> for FormatStmtTry {
-    fn fmt_fields(&self, _item: &StmtTry, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtTry, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_try_star.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_try_star.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtTryStar;
 
 #[derive(Default)]
 pub struct FormatStmtTryStar;
 
 impl FormatNodeRule<StmtTryStar> for FormatStmtTryStar {
-    fn fmt_fields(&self, _item: &StmtTryStar, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtTryStar, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_while.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_while.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtWhile;
 
 #[derive(Default)]
 pub struct FormatStmtWhile;
 
 impl FormatNodeRule<StmtWhile> for FormatStmtWhile {
-    fn fmt_fields(&self, _item: &StmtWhile, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtWhile, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }

--- a/crates/ruff_python_formatter/src/statement/stmt_with.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_with.rs
@@ -1,12 +1,12 @@
-use crate::{FormatNodeRule, PyFormatter};
-use ruff_formatter::FormatResult;
+use crate::{verbatim_text, FormatNodeRule, PyFormatter};
+use ruff_formatter::{write, Buffer, FormatResult};
 use rustpython_parser::ast::StmtWith;
 
 #[derive(Default)]
 pub struct FormatStmtWith;
 
 impl FormatNodeRule<StmtWith> for FormatStmtWith {
-    fn fmt_fields(&self, _item: &StmtWith, _f: &mut PyFormatter) -> FormatResult<()> {
-        Ok(())
+    fn fmt_fields(&self, item: &StmtWith, f: &mut PyFormatter) -> FormatResult<()> {
+        write!(f, [verbatim_text(item.range)])
     }
 }


### PR DESCRIPTION
## Summary

This uses the new test infrastructure in the formatter cli, the ruff cli and the black tests.

## Test Plan

I've checked that the black tests run and added a basic none-black test to make developing easier for me. The formatter is a currently noop, so there is no visible effect. For proper testing we need to implement at least module at least in a bad way and update the snapshots. I have not tested the effect this has on the off-by-default LSP feature that uses this code.
