### PR TITLE
Use saturating_sub in more token-walking methods

### DIFF
--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -104,7 +104,7 @@ pub(crate) fn remove_argument(
 
     if n_arguments == 1 {
         // Case 1: there is only one argument.
-        let mut count: usize = 0;
+        let mut count = 0u32;
         for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, call_at).flatten() {
             if matches!(tok, Tok::Lpar) {
                 if count == 0 {
@@ -114,11 +114,11 @@ pub(crate) fn remove_argument(
                         range.start() + TextSize::from(1)
                     });
                 }
-                count += 1;
+                count = count.saturating_add(1);
             }
 
             if matches!(tok, Tok::Rpar) {
-                count -= 1;
+                count = count.saturating_sub(1);
                 if count == 0 {
                     fix_end = Some(if remove_parentheses {
                         range.end()

--- a/crates/ruff/src/lex/docstring_detection.rs
+++ b/crates/ruff/src/lex/docstring_detection.rs
@@ -79,7 +79,7 @@ impl StateMachine {
             }
 
             Tok::Lpar | Tok::Lbrace | Tok::Lsqb => {
-                self.bracket_count += 1;
+                self.bracket_count = self.bracket_count.saturating_add(1);
                 if matches!(
                     self.state,
                     State::ExpectModuleDocstring
@@ -92,7 +92,7 @@ impl StateMachine {
             }
 
             Tok::Rpar | Tok::Rbrace | Tok::Rsqb => {
-                self.bracket_count -= 1;
+                self.bracket_count = self.bracket_count.saturating_sub(1);
                 if matches!(
                     self.state,
                     State::ExpectModuleDocstring

--- a/crates/ruff/src/rules/flake8_annotations/fixes.rs
+++ b/crates/ruff/src/rules/flake8_annotations/fixes.rs
@@ -16,7 +16,7 @@ pub(crate) fn add_return_annotation(
     // Find the colon (following the `def` keyword).
     let mut seen_lpar = false;
     let mut seen_rpar = false;
-    let mut count: usize = 0;
+    let mut count = 0u32;
     for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, stmt.start()).flatten() {
         if seen_lpar && seen_rpar {
             if matches!(tok, Tok::Colon) {
@@ -28,10 +28,10 @@ pub(crate) fn add_return_annotation(
             if count == 0 {
                 seen_lpar = true;
             }
-            count += 1;
+            count = count.saturating_add(1);
         }
         if matches!(tok, Tok::Rpar) {
-            count -= 1;
+            count = count.saturating_sub(1);
             if count == 0 {
                 seen_rpar = true;
             }

--- a/crates/ruff/src/rules/isort/helpers.rs
+++ b/crates/ruff/src/rules/isort/helpers.rs
@@ -10,14 +10,14 @@ use crate::rules::isort::types::TrailingComma;
 /// trailing comma.
 pub(crate) fn trailing_comma(stmt: &Stmt, locator: &Locator) -> TrailingComma {
     let contents = locator.slice(stmt.range());
-    let mut count: usize = 0;
+    let mut count = 0u32;
     let mut trailing_comma = TrailingComma::Absent;
     for (tok, _) in lexer::lex_starts_at(contents, Mode::Module, stmt.start()).flatten() {
         if matches!(tok, Tok::Lpar) {
-            count += 1;
+            count = count.saturating_add(1);
         }
         if matches!(tok, Tok::Rpar) {
-            count -= 1;
+            count = count.saturating_sub(1);
         }
         if count == 1 {
             if matches!(

--- a/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/compound_statements.rs
@@ -123,29 +123,29 @@ pub(crate) fn compound_statements(lxr: &[LexResult], settings: &Settings) -> Vec
     let mut allow_ellipsis = false;
 
     // Track the bracket depth.
-    let mut par_count = 0;
-    let mut sqb_count = 0;
-    let mut brace_count = 0;
+    let mut par_count = 0u32;
+    let mut sqb_count = 0u32;
+    let mut brace_count = 0u32;
 
     for &(ref tok, range) in lxr.iter().flatten() {
         match tok {
             Tok::Lpar => {
-                par_count += 1;
+                par_count = par_count.saturating_add(1);
             }
             Tok::Rpar => {
-                par_count -= 1;
+                par_count = par_count.saturating_sub(1);
             }
             Tok::Lsqb => {
-                sqb_count += 1;
+                sqb_count = sqb_count.saturating_add(1);
             }
             Tok::Rsqb => {
-                sqb_count -= 1;
+                sqb_count = sqb_count.saturating_sub(1);
             }
             Tok::Lbrace => {
-                brace_count += 1;
+                brace_count = brace_count.saturating_add(1);
             }
             Tok::Rbrace => {
-                brace_count -= 1;
+                brace_count = brace_count.saturating_sub(1);
             }
             _ => {}
         }

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/missing_whitespace.rs
@@ -53,11 +53,11 @@ pub(crate) fn missing_whitespace(
         let kind = token.kind();
         match kind {
             TokenKind::Lsqb => {
-                open_parentheses += 1;
+                open_parentheses = open_parentheses.saturating_add(1);
                 prev_lsqb = token.start();
             }
             TokenKind::Rsqb => {
-                open_parentheses -= 1;
+                open_parentheses = open_parentheses.saturating_sub(1);
             }
             TokenKind::Lbrace => {
                 prev_lbrace = token.start();

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/mod.rs
@@ -87,7 +87,7 @@ impl<'a> LogicalLines<'a> {
         assert!(u32::try_from(tokens.len()).is_ok());
 
         let mut builder = LogicalLinesBuilder::with_capacity(tokens.len());
-        let mut parens: u32 = 0;
+        let mut parens = 0u32;
 
         for (token, range) in tokens.iter().flatten() {
             let token_kind = TokenKind::from_token(token);
@@ -95,10 +95,10 @@ impl<'a> LogicalLines<'a> {
 
             match token_kind {
                 TokenKind::Lbrace | TokenKind::Lpar | TokenKind::Lsqb => {
-                    parens += 1;
+                    parens = parens.saturating_add(1);
                 }
                 TokenKind::Rbrace | TokenKind::Rpar | TokenKind::Rsqb => {
-                    parens -= 1;
+                    parens = parens.saturating_sub(1);
                 }
                 TokenKind::Newline | TokenKind::NonLogicalNewline if parens == 0 => {
                     builder.finish_line();

--- a/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
+++ b/crates/ruff/src/rules/pycodestyle/rules/logical_lines/whitespace_around_named_parameter_equals.rs
@@ -60,11 +60,10 @@ pub(crate) fn whitespace_around_named_parameter_equals(
 
         match kind {
             TokenKind::Lpar | TokenKind::Lsqb => {
-                parens += 1;
+                parens = parens.saturating_add(1);
             }
             TokenKind::Rpar | TokenKind::Rsqb => {
-                parens -= 1;
-
+                parens = parens.saturating_sub(1);
                 if parens == 0 {
                     annotated_func_arg = false;
                 }

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -73,9 +73,9 @@ where
     let contents = locator.after(located.start());
 
     // Track the bracket depth.
-    let mut par_count = 0;
-    let mut sqb_count = 0;
-    let mut brace_count = 0;
+    let mut par_count = 0u32;
+    let mut sqb_count = 0u32;
+    let mut brace_count = 0u32;
 
     for ((tok, _), (_, range)) in lexer::lex_starts_at(contents, Mode::Module, located.start())
         .flatten()
@@ -83,30 +83,30 @@ where
     {
         match tok {
             Tok::Lpar => {
-                par_count += 1;
+                par_count = par_count.saturating_add(1);
             }
             Tok::Lsqb => {
-                sqb_count += 1;
+                sqb_count = sqb_count.saturating_add(1);
             }
             Tok::Lbrace => {
-                brace_count += 1;
+                brace_count = brace_count.saturating_add(1);
             }
             Tok::Rpar => {
-                par_count -= 1;
+                par_count = par_count.saturating_sub(1);
                 // If this is a closing bracket, continue.
                 if par_count == 0 {
                     continue;
                 }
             }
             Tok::Rsqb => {
-                sqb_count -= 1;
+                sqb_count = sqb_count.saturating_sub(1);
                 // If this is a closing bracket, continue.
                 if sqb_count == 0 {
                     continue;
                 }
             }
             Tok::Rbrace => {
-                brace_count -= 1;
+                brace_count = brace_count.saturating_sub(1);
                 // If this is a closing bracket, continue.
                 if brace_count == 0 {
                     continue;

--- a/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/extraneous_parentheses.rs
@@ -51,7 +51,7 @@ fn match_extraneous_parentheses(tokens: &[LexResult], mut i: usize) -> Option<(u
     let start = i;
 
     // Verify that we're not in a tuple or coroutine.
-    let mut depth = 1;
+    let mut depth = 1u32;
     while depth > 0 {
         i += 1;
         if i >= tokens.len() {
@@ -65,9 +65,9 @@ fn match_extraneous_parentheses(tokens: &[LexResult], mut i: usize) -> Option<(u
         if depth == 1 && matches!(tok, Tok::Comma | Tok::Yield) {
             return None;
         } else if matches!(tok, Tok::Lpar | Tok::Lbrace | Tok::Lsqb) {
-            depth += 1;
+            depth = depth.saturating_add(1);
         } else if matches!(tok, Tok::Rpar | Tok::Rbrace | Tok::Rsqb) {
-            depth -= 1;
+            depth = depth.saturating_sub(1);
         }
     }
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1026,7 +1026,7 @@ pub fn match_parens(start: TextSize, locator: &Locator) -> Option<TextRange> {
 
     let mut fix_start = None;
     let mut fix_end = None;
-    let mut count: usize = 0;
+    let mut count = 0u32;
 
     for (tok, range) in lexer::lex_starts_at(contents, Mode::Module, start).flatten() {
         match tok {
@@ -1034,10 +1034,10 @@ pub fn match_parens(start: TextSize, locator: &Locator) -> Option<TextRange> {
                 if count == 0 {
                     fix_start = Some(range.start());
                 }
-                count += 1;
+                count = count.saturating_add(1);
             }
             Tok::Rpar => {
-                count -= 1;
+                count = count.saturating_sub(1);
                 if count == 0 {
                     fix_end = Some(range.end());
                     break;
@@ -1433,16 +1433,16 @@ impl LocatedCmpop {
 pub fn locate_cmpops(contents: &str) -> Vec<LocatedCmpop> {
     let mut tok_iter = lexer::lex(contents, Mode::Module).flatten().peekable();
     let mut ops: Vec<LocatedCmpop> = vec![];
-    let mut count: usize = 0;
+    let mut count = 0u32;
     loop {
         let Some((tok, range)) = tok_iter.next() else {
             break;
         };
         if matches!(tok, Tok::Lpar) {
-            count += 1;
+            count = count.saturating_add(1);
             continue;
         } else if matches!(tok, Tok::Rpar) {
-            count -= 1;
+            count = count.saturating_sub(1);
             continue;
         }
         if count == 0 {

--- a/crates/ruff_python_ast/src/source_code/generator.rs
+++ b/crates/ruff_python_ast/src/source_code/generator.rs
@@ -132,11 +132,11 @@ impl<'a> Generator<'a> {
     }
 
     fn body<U>(&mut self, stmts: &[Stmt<U>]) {
-        self.indent_depth += 1;
+        self.indent_depth = self.indent_depth.saturating_add(1);
         for stmt in stmts {
             self.unparse_stmt(stmt);
         }
-        self.indent_depth -= 1;
+        self.indent_depth = self.indent_depth.saturating_sub(1);
     }
 
     fn p(&mut self, s: &str) {
@@ -531,11 +531,11 @@ impl<'a> Generator<'a> {
                     self.p(":");
                 });
                 for case in cases {
-                    self.indent_depth += 1;
+                    self.indent_depth = self.indent_depth.saturating_add(1);
                     statement!({
                         self.unparse_match_case(case);
                     });
-                    self.indent_depth -= 1;
+                    self.indent_depth = self.indent_depth.saturating_sub(1);
                 }
             }
             Stmt::Raise(ast::StmtRaise {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I got this feedback in a separate PR from @MichaReiser, on some new code, and am wondering if we want to do this everywhere?
