### PR TITLE
Use a separate fix-isolation group for every parent node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,6 @@ name = "ruff_diagnostics"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "is-macro",
  "log",
  "ruff_text_size",
  "serde",

--- a/crates/ruff/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
+++ b/crates/ruff/src/rules/flake8_pie/rules/duplicate_class_field_definition.rs
@@ -2,7 +2,7 @@ use rustc_hash::FxHashSet;
 use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
 use ruff_diagnostics::Diagnostic;
-use ruff_diagnostics::{AlwaysAutofixableViolation, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -95,7 +95,7 @@ pub(crate) fn duplicate_class_field_definition<'a, 'b>(
                     checker.indexer,
                     checker.stylist,
                 );
-                diagnostic.set_fix(Fix::suggested(edit).isolate(IsolationLevel::Isolated));
+                diagnostic.set_fix(Fix::suggested(edit).isolate(checker.isolation(Some(parent))));
             }
             checker.diagnostics.push(diagnostic);
         }

--- a/crates/ruff/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Expr, ExprConstant, Ranged, Stmt, StmtExpr};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, IsolationLevel, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -76,7 +76,7 @@ pub(crate) fn ellipsis_in_non_empty_class_body<'a>(
                 checker.indexer,
                 checker.stylist,
             );
-            diagnostic.set_fix(Fix::automatic(edit).isolate(IsolationLevel::Isolated));
+            diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(parent))));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
+++ b/crates/ruff/src/rules/flake8_pyi/rules/pass_in_class_body.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{Ranged, Stmt};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -46,7 +46,7 @@ pub(crate) fn pass_in_class_body<'a>(
                 checker.indexer,
                 checker.stylist,
             );
-            diagnostic.set_fix(Fix::automatic(edit).isolate(IsolationLevel::Isolated));
+            diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(parent))));
         }
         checker.diagnostics.push(diagnostic);
     }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/empty_type_checking_block.rs
@@ -1,7 +1,7 @@
 use rustpython_parser::ast;
 use rustpython_parser::ast::Ranged;
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -69,11 +69,7 @@ pub(crate) fn empty_type_checking_block(checker: &mut Checker, stmt: &ast::StmtI
             checker.indexer,
             checker.stylist,
         );
-        diagnostic.set_fix(Fix::automatic(edit).isolate(if parent.is_some() {
-            IsolationLevel::Isolated
-        } else {
-            IsolationLevel::NonOverlapping
-        }));
+        diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, IsolationLevel, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::binding::{
     Binding, BindingKind, FromImportation, Importation, SubmoduleImportation,
@@ -118,13 +118,8 @@ pub(crate) fn runtime_import_in_type_checking_block(
                 )?;
 
                 Ok(
-                    Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
-                        if parent.is_some() {
-                            IsolationLevel::Isolated
-                        } else {
-                            IsolationLevel::NonOverlapping
-                        },
-                    ),
+                    Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits())
+                        .isolate(checker.isolation(parent)),
                 )
             });
         }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -1,4 +1,4 @@
-use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, IsolationLevel, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::binding::{
     Binding, BindingKind, FromImportation, Importation, SubmoduleImportation,
@@ -391,13 +391,8 @@ pub(crate) fn typing_only_runtime_import(
                 )?;
 
                 Ok(
-                    Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits()).isolate(
-                        if parent.is_some() {
-                            IsolationLevel::Isolated
-                        } else {
-                            IsolationLevel::NonOverlapping
-                        },
-                    ),
+                    Fix::suggested_edits(remove_import_edit, add_import_edit.into_edits())
+                        .isolate(checker.isolation(parent)),
                 )
             });
         }

--- a/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_variable.rs
@@ -3,7 +3,7 @@ use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Ranged, Stmt};
 use rustpython_parser::{lexer, Mode, Tok};
 
-use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, IsolationLevel, Violation};
+use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::contains_effect;
 use ruff_python_ast::source_code::Locator;
@@ -215,11 +215,7 @@ fn remove_unused_variable(
                         checker.indexer,
                         checker.stylist,
                     );
-                    Some(Fix::suggested(edit).isolate(if parent.is_some() {
-                        IsolationLevel::Isolated
-                    } else {
-                        IsolationLevel::NonOverlapping
-                    }))
+                    Some(Fix::suggested(edit).isolate(checker.isolation(parent)))
                 };
             }
         }
@@ -250,11 +246,7 @@ fn remove_unused_variable(
                     checker.indexer,
                     checker.stylist,
                 );
-                Some(Fix::suggested(edit).isolate(if parent.is_some() {
-                    IsolationLevel::Isolated
-                } else {
-                    IsolationLevel::NonOverlapping
-                }))
+                Some(Fix::suggested(edit).isolate(checker.isolation(parent)))
             };
         }
     }

--- a/crates/ruff/src/rules/pylint/rules/useless_return.rs
+++ b/crates/ruff/src/rules/pylint/rules/useless_return.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{self, Constant, Expr, Ranged, Stmt};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{is_const_none, ReturnStatementVisitor};
 use ruff_python_ast::statement_visitor::StatementVisitor;
@@ -110,7 +110,7 @@ pub(crate) fn useless_return<'a>(
             checker.indexer,
             checker.stylist,
         );
-        diagnostic.set_fix(Fix::automatic(edit).isolate(IsolationLevel::Isolated));
+        diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(Some(stmt))));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, Ranged, Stmt};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -119,11 +119,7 @@ pub(crate) fn unnecessary_builtin_import(
                 checker.indexer,
                 checker.stylist,
             )?;
-            Ok(Fix::suggested(edit).isolate(if parent.is_some() {
-                IsolationLevel::Isolated
-            } else {
-                IsolationLevel::NonOverlapping
-            }))
+            Ok(Fix::suggested(edit).isolate(checker.isolation(parent)))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/unnecessary_future_import.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rustpython_parser::ast::{Alias, Ranged, Stmt};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -98,11 +98,7 @@ pub(crate) fn unnecessary_future_import(checker: &mut Checker, stmt: &Stmt, name
                 checker.indexer,
                 checker.stylist,
             )?;
-            Ok(Fix::suggested(edit).isolate(if parent.is_some() {
-                IsolationLevel::Isolated
-            } else {
-                IsolationLevel::NonOverlapping
-            }))
+            Ok(Fix::suggested(edit).isolate(checker.isolation(parent)))
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/useless_metaclass_type.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix, IsolationLevel};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::autofix;
@@ -55,7 +55,7 @@ pub(crate) fn useless_metaclass_type(
             checker.indexer,
             checker.stylist,
         );
-        diagnostic.set_fix(Fix::automatic(edit).isolate(IsolationLevel::Isolated));
+        diagnostic.set_fix(Fix::automatic(edit).isolate(checker.isolation(parent)));
     }
     checker.diagnostics.push(diagnostic);
 }

--- a/crates/ruff_diagnostics/Cargo.toml
+++ b/crates/ruff_diagnostics/Cargo.toml
@@ -11,6 +11,5 @@ rust-version = { workspace = true }
 ruff_text_size = { workspace = true }
 
 anyhow = { workspace = true }
-is-macro = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true, features = [] }

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -28,11 +28,11 @@ pub enum Applicability {
 }
 
 /// Indicates the level of isolation required to apply a fix.
-#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, is_macro::Is)]
+#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum IsolationLevel {
-    /// The fix should be applied in isolation.
-    Isolated(u32),
+    /// The fix should be applied as long as no other fixes in the same group have been applied.
+    Group(u32),
     /// The fix should be applied as long as it does not overlap with any other fixes.
     #[default]
     NonOverlapping,

--- a/crates/ruff_diagnostics/src/fix.rs
+++ b/crates/ruff_diagnostics/src/fix.rs
@@ -32,7 +32,7 @@ pub enum Applicability {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum IsolationLevel {
     /// The fix should be applied in isolation.
-    Isolated,
+    Isolated(u32),
     /// The fix should be applied as long as it does not overlap with any other fixes.
     #[default]
     NonOverlapping,


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This is a follow-up to #4766 aimed at improving performance of deletions. In #4766, we removed our stateful deletion-tracking code, and replaced it with a "fix isolation" concept, whereby we only apply one "isolated" fix per Ruff execution.

We can actually do quite a bit better by modifying this concept a bit: instead of using one isolation group per file, we can create an isolation group for every parent. This allows us to fix both of these unused imports in the same pass:

```py
if True:
  import os

if True:
  import sys
```

## Test Plan

We can benchmark the fix time on CPython via:

```shell
cargo build --release && hyperfine --ignore-failure --warmup 10 --runs 50 "./target/release/ruff ./crates/ruff/resources/test/cpython/ --select F --no-cache --silent --fix" --prepare "cd ./crates/ruff/resources/test/cpython/ && git reset --hard HEAD"
```

(We can either use `--select F` or `--select F401` -- by far the most impacted rule here is unused import removal.)

On `main`, `--select F` takes about 409ms, while `--select F401` takes about 266ms.

On this branch, `--select F` takes about 420ms, while `--select F401` takes about 270ms.

So there is a performance regression, but I think it's closer to the realm of reasonableness, especially for a behavior that only affects codebases with large numbers of nested diagnostics. (On #4766, `--select F` was more like ~600ms.)
