### PR TITLE
Avoid extra newline between diagnostics in grouped mode

### DIFF
--- a/crates/ruff/src/message/grouped.rs
+++ b/crates/ruff/src/message/grouped.rs
@@ -74,7 +74,12 @@ impl Emitter for GroupedEmitter {
                     }
                 )?;
             }
-            writeln!(writer)?;
+
+            // Print a blank line between files, unless we're showing the source, in which case
+            // we'll have already printed a blank line between messages.
+            if !self.show_source {
+                writeln!(writer)?;
+            }
         }
 
         Ok(())
@@ -136,10 +141,8 @@ impl Display for DisplayGroupedMessage<'_> {
         if self.show_source {
             use std::fmt::Write;
             let mut padded = PadAdapter::new(f);
-            write!(padded, "{}", MessageCodeFrame { message })?;
+            writeln!(padded, "{}", MessageCodeFrame { message })?;
         }
-
-        writeln!(f)?;
 
         Ok(())
     }
@@ -185,6 +188,14 @@ mod tests {
 
     #[test]
     fn default() {
+        let mut emitter = GroupedEmitter::default();
+        let content = capture_emitter_output(&mut emitter, &create_messages());
+
+        assert_snapshot!(content);
+    }
+
+    #[test]
+    fn show_source() {
         let mut emitter = GroupedEmitter::default().with_show_source(true);
         let content = capture_emitter_output(&mut emitter, &create_messages());
 

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__default.snap
@@ -4,30 +4,9 @@ expression: content
 ---
 fib.py:
   1:8 F401 `os` imported but unused
-    |
-  1 | import os
-    |        ^^ F401
-    |
-    = help: Remove unused import: `os`
-
   6:5 F841 Local variable `x` is assigned to but never used
-     |
-   6 | def fibonacci(n):
-   7 |     """Compute the nth number in the Fibonacci sequence."""
-   8 |     x = 1
-     |     ^ F841
-   9 |     if n == 0:
-  10 |         return 0
-     |
-     = help: Remove assignment to unused variable `x`
-
 
 undef.py:
   1:4 F821 Undefined name `a`
-    |
-  1 | if a == 1: pass
-    |    ^ F821
-    |
-
 
 

--- a/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__show_source.snap
+++ b/crates/ruff/src/message/snapshots/ruff__message__grouped__tests__show_source.snap
@@ -3,14 +3,14 @@ source: crates/ruff/src/message/grouped.rs
 expression: content
 ---
 fib.py:
-  1:8 F401 [*] `os` imported but unused
+  1:8 F401 `os` imported but unused
     |
   1 | import os
     |        ^^ F401
     |
     = help: Remove unused import: `os`
   
-  6:5 F841 [*] Local variable `x` is assigned to but never used
+  6:5 F841 Local variable `x` is assigned to but never used
      |
    6 | def fibonacci(n):
    7 |     """Compute the nth number in the Fibonacci sequence."""


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

I think our grouped-mode format contains an extra line between each diagnostic:

```console
crates/ruff/resources/test/cpython/Lib/urllib/request.py:
  91:8 F401 [*] `posixpath` imported but unused


crates/ruff/resources/test/cpython/Lib/xml/dom/__init__.py:
  140:21 F401 [*] `.domreg.getDOMImplementation` imported but unused

  140:43 F401 [*] `.domreg.registerDOMImplementation` imported but unused


crates/ruff/resources/test/cpython/Lib/xml/sax/__init__.py:
  23:22 F401 [*] `.handler.ContentHandler` imported but unused

  24:26 F401 [*] `._exceptions.SAXException` imported but unused

  24:40 F401 [*] `._exceptions.SAXNotRecognizedException` imported but unused

  25:25 F401 [*] `._exceptions.SAXParseException` imported but unused

  25:44 F401 [*] `._exceptions.SAXNotSupportedException` imported but unused

  58:12 F401 [*] `xml.sax.expatreader` imported but unused
```

Now, after this change:

```console
crates/ruff/resources/test/cpython/Lib/lib2to3/tests/data/py3_test_grammar.py:
   13:8  F401 [*] `sys` imported but unused
  508:22 F401 [*] `sys` imported but unused
  511:27 F401 [*] `time.time` imported but unused
  516:26 F401 [*] `sys.path` imported but unused
  516:32 F401 [*] `sys.argv` imported but unused

crates/ruff/resources/test/cpython/Lib/lib2to3/tests/pytree_idempotency.py:
  12:15 F401 [*] `.support` imported but unused

crates/ruff/resources/test/cpython/Lib/lib2to3/tests/test_all_fixers.py:
  10:8 F401 [*] `sys` imported but unused

crates/ruff/resources/test/cpython/Lib/lzma.py:
  28:19 F401 [*] `_lzma._encode_filter_properties` imported but unused
  28:46 F401 [*] `_lzma._decode_filter_properties` imported but unused

crates/ruff/resources/test/cpython/Lib/msilib/text.py:
  1:8 F401 [*] `msilib` imported but unused
```

We still include a newline after each diagnostic if we have `--show-source` enabled:

```console
crates/ruff/resources/test/cpython/Tools/c-analyzer/cpython/_analyzer.py:
   2:8 F401 [*] `re` imported but unused
    |
  2 | import os.path
  3 | import re
    |        ^^ F401
  4 |
  5 | from c_common.clsutil import classonly
    |
    = help: Remove unused import: `re`

   7:5 F401 [*] `c_parser.info.DeclID` imported but unused
     |
   7 | from c_parser.info import (
   8 |     KIND,
   9 |     DeclID,
     |     ^^^^^^ F401
  10 |     Declaration,
  11 |     TypeDeclaration,
     |
     = help: Remove unused import

  10:5 F401 [*] `c_parser.info.TypeDef` imported but unused
     |
  10 |     Declaration,
  11 |     TypeDeclaration,
  12 |     TypeDef,
     |     ^^^^^^^ F401
  13 |     Struct,
  14 |     Member,
     |
     = help: Remove unused import
```
