### PR TITLE
Remove libcst from ruff_python_ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,6 @@ dependencies = [
  "insta",
  "is-macro",
  "itertools",
- "libcst",
  "log",
  "memchr",
  "num-bigint",

--- a/crates/ruff/src/autofix/edits.rs
+++ b/crates/ruff/src/autofix/edits.rs
@@ -11,6 +11,7 @@ use ruff_newlines::NewlineWithTrailingNewline;
 use ruff_python_ast::helpers;
 use ruff_python_ast::source_code::{Indexer, Locator, Stylist};
 
+use crate::autofix::stylist_to_codegen_state;
 use crate::cst::helpers::compose_module_path;
 use crate::cst::matchers::match_statement;
 
@@ -169,7 +170,7 @@ pub(crate) fn remove_unused_imports<'a>(
     if aliases.is_empty() {
         delete_stmt(stmt, parent, deleted, locator, indexer, stylist)
     } else {
-        let mut state = stylist.codegen_state();
+        let mut state = stylist_to_codegen_state(stylist);
         tree.codegen(&mut state);
 
         Ok(Edit::range_replacement(state.to_string(), stmt.range()))

--- a/crates/ruff/src/autofix/mod.rs
+++ b/crates/ruff/src/autofix/mod.rs
@@ -1,11 +1,12 @@
 use std::collections::BTreeSet;
 
 use itertools::Itertools;
+use libcst_native::CodegenState;
 use ruff_text_size::{TextRange, TextSize};
 use rustc_hash::FxHashMap;
 
 use ruff_diagnostics::{Diagnostic, Edit, Fix};
-use ruff_python_ast::source_code::Locator;
+use ruff_python_ast::source_code::{Locator, Stylist};
 
 use crate::linter::FixTable;
 use crate::registry::{AsRule, Rule};
@@ -102,6 +103,15 @@ fn cmp_fix(rule1: Rule, rule2: Rule, fix1: &Fix, fix2: &Fix) -> std::cmp::Orderi
             (Rule::NewLineAfterLastParagraph, Rule::EndsInPeriod) => std::cmp::Ordering::Greater,
             _ => std::cmp::Ordering::Equal,
         })
+}
+
+/// Convert a rust stylist style to a libcst style
+pub(crate) fn stylist_to_codegen_state<'a>(stylist: &'a Stylist<'a>) -> CodegenState<'a> {
+    CodegenState {
+        default_newline: stylist.line_ending().as_str(),
+        default_indent: stylist.indentation(),
+        ..Default::default()
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruff/src/importer/mod.rs
+++ b/crates/ruff/src/importer/mod.rs
@@ -8,6 +8,7 @@ use ruff_text_size::TextSize;
 use rustpython_parser::ast::{self, Ranged, Stmt, Suite};
 
 use crate::autofix;
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::imports::{AnyImport, Import, ImportFrom};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -324,7 +325,7 @@ impl<'a> Importer<'a> {
             asname: None,
             comma: aliases.last().and_then(|alias| alias.comma.clone()),
         });
-        let mut state = self.stylist.codegen_state();
+        let mut state = stylist_to_codegen_state(self.stylist);
         statement.codegen(&mut state);
         Ok(Edit::range_replacement(state.to_string(), stmt.range()))
     }

--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -9,6 +9,7 @@ use libcst_native::{
 };
 use rustpython_parser::ast::Ranged;
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -44,7 +45,7 @@ pub(crate) fn fix_unnecessary_generator_list(
         rpar: generator_exp.rpar.clone(),
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -78,7 +79,7 @@ pub(crate) fn fix_unnecessary_generator_set(
         rpar: generator_exp.rpar.clone(),
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     let mut content = state.to_string();
@@ -128,7 +129,7 @@ pub(crate) fn fix_unnecessary_generator_dict(
         whitespace_after_colon: ParenthesizableWhitespace::SimpleWhitespace(SimpleWhitespace(" ")),
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     let mut content = state.to_string();
@@ -170,7 +171,7 @@ pub(crate) fn fix_unnecessary_list_comprehension_set(
         rpar: list_comp.rpar.clone(),
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -213,7 +214,7 @@ pub(crate) fn fix_unnecessary_list_comprehension_dict(
         rpar: list_comp.rpar.clone(),
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -298,7 +299,7 @@ pub(crate) fn fix_unnecessary_literal_set(
         }));
     }
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -362,7 +363,7 @@ pub(crate) fn fix_unnecessary_literal_dict(
         rpar: vec![],
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -467,7 +468,7 @@ pub(crate) fn fix_unnecessary_collection_call(
         }
     };
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -517,7 +518,7 @@ pub(crate) fn fix_unnecessary_literal_within_tuple_call(
         }],
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -569,7 +570,7 @@ pub(crate) fn fix_unnecessary_literal_within_list_call(
         rpar: vec![],
     }));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -589,7 +590,7 @@ pub(crate) fn fix_unnecessary_list_call(
 
     tree = arg.value.clone();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -703,7 +704,7 @@ pub(crate) fn fix_unnecessary_call_around_sorted(
         }
     }
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -733,7 +734,7 @@ pub(crate) fn fix_unnecessary_double_cast_or_process(
         None => bail!("Expected at least one argument in outer function call"),
     };
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -820,7 +821,7 @@ pub(crate) fn fix_unnecessary_comprehension(
         }
     }
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -962,7 +963,7 @@ pub(crate) fn fix_unnecessary_map(
             }
         }
 
-        let mut state = stylist.codegen_state();
+        let mut state = stylist_to_codegen_state(stylist);
         tree.codegen(&mut state);
 
         let mut content = state.to_string();
@@ -994,7 +995,7 @@ pub(crate) fn fix_unnecessary_literal_within_dict_call(
 
     tree = arg.value.clone();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), expr.range()))
@@ -1167,7 +1168,7 @@ pub(crate) fn fix_unnecessary_comprehension_any_all(
         _ => whitespace_after_arg,
     };
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Fix::suggested(Edit::range_replacement(

--- a/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
+++ b/crates/ruff/src/rules/flake8_pytest_style/rules/assertion.rs
@@ -9,6 +9,7 @@ use libcst_native::{
 };
 use rustpython_parser::ast::{self, Boolop, Excepthandler, Expr, Keyword, Ranged, Stmt, Unaryop};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::helpers::{has_comments_in, Truthiness};
@@ -410,7 +411,7 @@ fn fix_composite_condition(stmt: &Stmt, locator: &Locator, stylist: &Stylist) ->
         }));
     }
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     // Reconstruct and reformat the code.

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_if.rs
@@ -7,6 +7,7 @@ use libcst_native::{
 };
 use rustpython_parser::ast::Ranged;
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::whitespace;
@@ -110,7 +111,7 @@ pub(crate) fn fix_nested_if_statements(
     }));
     outer_if.body = inner_if.body.clone();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     // Reconstruct and reformat the code.

--- a/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/fix_with.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use libcst_native::{Codegen, CompoundStatement, Statement, Suite, With};
 use rustpython_parser::ast::Ranged;
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::whitespace;
@@ -70,7 +71,7 @@ pub(crate) fn fix_multiple_with_statements(
     }
     outer_with.body = inner_with.body.clone();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     // Reconstruct and reformat the code.

--- a/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -4,6 +4,7 @@ use log::error;
 use ruff_text_size::TextRange;
 use rustpython_parser::ast::{self, Cmpop, Expr, Ranged};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
@@ -42,7 +43,7 @@ fn get_value_content_for_key_in_dict(
     let call = match_call_mut(&mut expression)?;
     let attribute = match_attribute(&mut call.func)?;
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     attribute.value.codegen(&mut state);
 
     Ok(state.to_string())

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use libcst_native::{Codegen, CompOp};
 use rustpython_parser::ast::{self, Cmpop, Expr, Ranged, Unaryop};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -117,7 +118,7 @@ fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Resu
         _ => panic!("Expected comparison operator"),
     };
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     expression.codegen(&mut state);
     Ok(state.to_string())
 }

--- a/crates/ruff/src/rules/pyflakes/fixes.rs
+++ b/crates/ruff/src/rules/pyflakes/fixes.rs
@@ -7,6 +7,7 @@ use rustpython_format::{
 use rustpython_parser::ast::{Excepthandler, Expr, Ranged};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 use ruff_python_ast::str::raw_contents;
@@ -33,7 +34,7 @@ pub(crate) fn remove_unused_format_arguments_from_dict(
         } if raw_contents(name.value).map_or(false, |name| unused_arguments.contains(&name)))
     });
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), stmt.range()))
@@ -53,7 +54,7 @@ pub(crate) fn remove_unused_keyword_arguments_from_format_call(
     call.args
         .retain(|e| !matches!(&e.keyword, Some(kw) if unused_arguments.contains(&kw.value)));
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), location))
@@ -153,7 +154,7 @@ pub(crate) fn remove_unused_positional_arguments_from_format_call(
         simple_string.value = new_format_string.as_str();
     }
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Ok(Edit::range_replacement(state.to_string(), location))

--- a/crates/ruff/src/rules/pyupgrade/fixes.rs
+++ b/crates/ruff/src/rules/pyupgrade/fixes.rs
@@ -4,6 +4,7 @@ use ruff_text_size::{TextRange, TextSize};
 use rustpython_parser::ast::{Expr, Ranged};
 use rustpython_parser::{lexer, Mode, Tok};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::Edit;
 use ruff_python_ast::source_code::{Locator, Stylist};
 
@@ -29,7 +30,7 @@ pub(crate) fn adjust_indentation(
     let indented_block = match_indented_block(&mut embedding.body)?;
     indented_block.indent = Some(indentation);
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     indented_block.codegen(&mut state);
 
     let module_text = state.to_string();
@@ -57,7 +58,7 @@ pub(crate) fn remove_super_arguments(
     body.whitespace_before_args = ParenthesizableWhitespace::default();
     body.whitespace_after_func = ParenthesizableWhitespace::default();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     tree.codegen(&mut state);
 
     Some(Edit::range_replacement(state.to_string(), range))

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -6,6 +6,7 @@ use libcst_native::{
 use log::error;
 use rustpython_parser::ast::{self, Expr, Ranged, Stmt};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::call_path::collect_call_path;
@@ -137,7 +138,7 @@ fn format_import(
     } else {
         import.names = clean_aliases;
 
-        let mut state = stylist.codegen_state();
+        let mut state = stylist_to_codegen_state(stylist);
         tree.codegen(&mut state);
 
         let mut content = state.to_string();
@@ -183,7 +184,7 @@ fn format_import_from(
             lpar: vec![],
             rpar: vec![],
         })));
-        let mut state = stylist.codegen_state();
+        let mut state = stylist_to_codegen_state(stylist);
         tree.codegen(&mut state);
         Ok(state.to_string())
     } else if let ImportFrom {
@@ -216,7 +217,7 @@ fn format_import_from(
                 rpar: vec![],
             })));
 
-            let mut state = stylist.codegen_state();
+            let mut state = stylist_to_codegen_state(stylist);
             tree.codegen(&mut state);
 
             let mut content = state.to_string();

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rustpython_parser::ast::{Expr, Ranged};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{AutofixKind, Diagnostic, Edit, Fix, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -99,13 +100,13 @@ fn generate_call(
     // Fix the string itself.
     let item = match_attribute(&mut call.func)?;
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     item.codegen(&mut state);
     let cleaned = remove_specifiers(&state.to_string());
 
     call.func = Box::new(match_expression(&cleaned)?);
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     expression.codegen(&mut state);
     if module_text == state.to_string() {
         // Ex) `'{' '0}'.format(1)`

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 use libcst_native::Codegen;
 use rustpython_parser::ast::{self, Expr, Ranged};
 
+use crate::autofix::stylist_to_codegen_state;
 use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Edit, Fix};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::source_code::{Locator, Stylist};
@@ -77,7 +78,7 @@ fn fix_explicit_f_string_type_conversion(
     }
     formatted_string_expression.expression = call.args[0].value.clone();
 
-    let mut state = stylist.codegen_state();
+    let mut state = stylist_to_codegen_state(stylist);
     expression.codegen(&mut state);
 
     Ok(Fix::automatic(Edit::range_replacement(

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -15,7 +15,6 @@ anyhow = { workspace = true }
 bitflags = { workspace = true }
 is-macro = { workspace = true }
 itertools = { workspace = true }
-libcst = { workspace = true }
 log = { workspace = true }
 memchr = { workspace = true }
 num-bigint = { workspace = true }

--- a/crates/ruff_python_ast/src/source_code/stylist.rs
+++ b/crates/ruff_python_ast/src/source_code/stylist.rs
@@ -1,6 +1,5 @@
 //! Detect code style from Python source code.
 
-use libcst_native::CodegenState;
 use std::fmt;
 use std::ops::Deref;
 
@@ -46,15 +45,6 @@ impl<'a> Stylist<'a> {
             indentation,
             quote: detect_quote(tokens, locator),
             line_ending: OnceCell::default(),
-        }
-    }
-
-    /// Convert this style to libcst style
-    pub fn codegen_state(&self) -> CodegenState {
-        CodegenState {
-            default_newline: self.line_ending().as_str(),
-            default_indent: self.indentation(),
-            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Follow-up/alternative to https://github.com/charliermarsh/ruff/pull/4749 we can either merge into it or discard.
