### PR TITLE
Introduce `lines_before` helper

### DIFF
--- a/crates/ruff_python_formatter/src/prelude.rs
+++ b/crates/ruff_python_formatter/src/prelude.rs
@@ -1,4 +1,4 @@
 #[allow(unused_imports)]
-pub(crate) use crate::{AsFormat, FormattedIterExt as _, IntoFormat, PyFormatContext};
+pub(crate) use crate::{AsFormat, FormattedIterExt as _, IntoFormat, PyFormatContext, PyFormatter};
 #[allow(unused_imports)]
 pub(crate) use ruff_formatter::prelude::*;


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This creates a new helper to count the lines before a position in the source code. We'll need this for formatting statements and comments

## Test Plan

I added new unit tests
