### PR TITLE
Implement `IntoFormat` for `&T`

### DIFF
--- a/crates/ruff_formatter/shared_traits.rs
+++ b/crates/ruff_formatter/shared_traits.rs
@@ -44,6 +44,18 @@ where
     }
 }
 
+/// Implement [`IntoFormat`] for references to types that implement [`AsFormat`].
+impl<'a, T, C> IntoFormat<C> for &'a T
+where
+    T: AsFormat<C>,
+{
+    type Format = T::Format<'a>;
+
+    fn into_format(self) -> Self::Format {
+        AsFormat::format(self)
+    }
+}
+
 /// Formatting specific [`Iterator`] extensions
 pub trait FormattedIterExt {
     /// Converts every item to an object that knows how to format it.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

This implementation adds a generic implementation of `IntoFormat` for all references that implement `AsFormat`. This is what we'll most commonly use because we only work with references to AST nodes and not owned nodes. 

The case where I wanted to use it was formatting statements and `module.body.iter().formatted()` didn't work because it requires `IntoFormat`. 

## Test Plan

`cargo build`
