### PR TITLE
Remove collapsing `space` behaviour from `Printer` 

### DIFF
--- a/crates/ruff_formatter/src/format_element/document.rs
+++ b/crates/ruff_formatter/src/format_element/document.rs
@@ -144,6 +144,12 @@ impl std::fmt::Display for DisplayDocument<'_> {
     }
 }
 
+impl std::fmt::Debug for DisplayDocument<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
 #[derive(Clone, Debug)]
 struct IrFormatContext<'a> {
     /// The interned elements that have been printed to this point


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

The `Printer` has a custom behaviour for spaces that:

* Omits spaces at the end of a line
* Collapse a sequence of spaces into a single space

This PR removes this custom behaviour because:

* I need to print two spaces between the end of the line and a comment
* I experienced in Rome that this behaviour tolerates unnecessary emitted space elements (e.g. because they're always at the end of a line).

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

`cargo test`

<!-- How was it tested? -->
