### PR TITLE
Include ImportError in non-fixable try-catch imports

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -1976,10 +1976,17 @@ where
                 let mut handled_exceptions = Exceptions::empty();
                 for type_ in extract_handled_exceptions(handlers) {
                     if let Some(call_path) = self.semantic_model.resolve_call_path(type_) {
-                        if call_path.as_slice() == ["", "NameError"] {
-                            handled_exceptions |= Exceptions::NAME_ERROR;
-                        } else if call_path.as_slice() == ["", "ModuleNotFoundError"] {
-                            handled_exceptions |= Exceptions::MODULE_NOT_FOUND_ERROR;
+                        match call_path.as_slice() {
+                            ["", "NameError"] => {
+                                handled_exceptions |= Exceptions::NAME_ERROR;
+                            }
+                            ["", "ModuleNotFoundError"] => {
+                                handled_exceptions |= Exceptions::MODULE_NOT_FOUND_ERROR;
+                            }
+                            ["", "ImportError"] => {
+                                handled_exceptions |= Exceptions::IMPORT_ERROR;
+                            }
+                            _ => {}
                         }
                     }
                 }

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_10.py.snap
@@ -12,7 +12,7 @@ F401_10.py:6:16: F401 `orjson` imported but unused; consider using `importlib.ut
    |
    = help: Remove unused import: `orjson`
 
-F401_10.py:15:16: F401 [*] `orjson` imported but unused
+F401_10.py:15:16: F401 `orjson` imported but unused; consider using `importlib.util.find_spec` to test for availability
    |
 15 | def import_error():
 16 |     try:
@@ -22,14 +22,5 @@ F401_10.py:15:16: F401 [*] `orjson` imported but unused
 19 |         return True
    |
    = help: Remove unused import: `orjson`
-
-ℹ Suggested fix
-12 12 | 
-13 13 | def import_error():
-14 14 |     try:
-15    |-        import orjson
-16 15 | 
-17 16 |         return True
-18 17 |     except ImportError:
 
 


### PR DESCRIPTION
I think this was just an oversight. The flag exists, but we never set it. Closes #4790.
