### PR TITLE
Ignore error calls with `exc_info` in TRY400

### DIFF
--- a/crates/ruff/resources/test/fixtures/tryceratops/TRY400.py
+++ b/crates/ruff/resources/test/fixtures/tryceratops/TRY400.py
@@ -4,6 +4,7 @@ Use '.exception' over '.error' inside except blocks
 """
 
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -60,3 +61,17 @@ def good():
         a = 1
     except Exception:
         foo.exception("Context message here")
+
+
+def fine():
+    try:
+        a = 1
+    except Exception:
+        logger.error("Context message here", exc_info=True)
+
+
+def fine():
+    try:
+        a = 1
+    except Exception:
+        logger.error("Context message here", exc_info=sys.exc_info())

--- a/crates/ruff/src/rules/tryceratops/helpers.rs
+++ b/crates/ruff/src/rules/tryceratops/helpers.rs
@@ -7,14 +7,14 @@ use ruff_python_semantic::model::SemanticModel;
 
 /// Collect `logging`-like calls from an AST.
 pub(crate) struct LoggerCandidateVisitor<'a, 'b> {
-    context: &'a SemanticModel<'b>,
-    pub(crate) calls: Vec<(&'b Expr, &'b Expr)>,
+    semantic_model: &'a SemanticModel<'b>,
+    pub(crate) calls: Vec<&'b ast::ExprCall>,
 }
 
 impl<'a, 'b> LoggerCandidateVisitor<'a, 'b> {
-    pub(crate) fn new(context: &'a SemanticModel<'b>) -> Self {
+    pub(crate) fn new(semantic_model: &'a SemanticModel<'b>) -> Self {
         LoggerCandidateVisitor {
-            context,
+            semantic_model,
             calls: Vec::new(),
         }
     }
@@ -22,9 +22,9 @@ impl<'a, 'b> LoggerCandidateVisitor<'a, 'b> {
 
 impl<'a, 'b> Visitor<'b> for LoggerCandidateVisitor<'a, 'b> {
     fn visit_expr(&mut self, expr: &'b Expr) {
-        if let Expr::Call(ast::ExprCall { func, .. }) = expr {
-            if logging::is_logger_candidate(func, self.context) {
-                self.calls.push((expr, func));
+        if let Expr::Call(call) = expr {
+            if logging::is_logger_candidate(&call.func, self.semantic_model) {
+                self.calls.push(call);
             }
         }
         visitor::walk_expr(self, expr);

--- a/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
+++ b/crates/ruff/src/rules/tryceratops/rules/error_instead_of_exception.rs
@@ -3,6 +3,7 @@ use rustpython_parser::ast::{self, Excepthandler, Expr, Ranged};
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_ast::visitor::Visitor;
+use ruff_python_semantic::analyze::logging::exc_info;
 
 use crate::checkers::ast::Checker;
 use crate::rules::tryceratops::helpers::LoggerCandidateVisitor;
@@ -41,7 +42,7 @@ use crate::rules::tryceratops::helpers::LoggerCandidateVisitor;
 /// ```
 ///
 /// ## References
-/// - [Python documentation](https://docs.python.org/3/library/logging.html#logging.exception)
+/// - [Python documentation: `logging.exception`](https://docs.python.org/3/library/logging.html#logging.exception)
 #[violation]
 pub struct ErrorInsteadOfException;
 
@@ -61,12 +62,14 @@ pub(crate) fn error_instead_of_exception(checker: &mut Checker, handlers: &[Exce
             visitor.visit_body(body);
             visitor.calls
         };
-        for (expr, func) in calls {
-            if let Expr::Attribute(ast::ExprAttribute { attr, .. }) = func {
+        for expr in calls {
+            if let Expr::Attribute(ast::ExprAttribute { attr, .. }) = expr.func.as_ref() {
                 if attr == "error" {
-                    checker
-                        .diagnostics
-                        .push(Diagnostic::new(ErrorInsteadOfException, expr.range()));
+                    if exc_info(&expr.keywords, checker.semantic_model()).is_none() {
+                        checker
+                            .diagnostics
+                            .push(Diagnostic::new(ErrorInsteadOfException, expr.range()));
+                    }
                 }
             }
         }

--- a/crates/ruff/src/rules/tryceratops/snapshots/ruff__rules__tryceratops__tests__error-instead-of-exception_TRY400.py.snap
+++ b/crates/ruff/src/rules/tryceratops/snapshots/ruff__rules__tryceratops__tests__error-instead-of-exception_TRY400.py.snap
@@ -1,71 +1,71 @@
 ---
 source: crates/ruff/src/rules/tryceratops/mod.rs
 ---
-TRY400.py:15:9: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:16:9: TRY400 Use `logging.exception` instead of `logging.error`
    |
-15 |         a = 1
-16 |     except Exception:
-17 |         logging.error("Context message here")
+16 |         a = 1
+17 |     except Exception:
+18 |         logging.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-18 | 
-19 |         if True:
+19 | 
+20 |         if True:
    |
 
-TRY400.py:18:13: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:19:13: TRY400 Use `logging.exception` instead of `logging.error`
    |
-18 |         if True:
-19 |             logging.error("Context message here")
+19 |         if True:
+20 |             logging.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
 
-TRY400.py:25:9: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:26:9: TRY400 Use `logging.exception` instead of `logging.error`
    |
-25 |         a = 1
-26 |     except Exception:
-27 |         logger.error("Context message here")
+26 |         a = 1
+27 |     except Exception:
+28 |         logger.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-28 | 
-29 |         if True:
+29 | 
+30 |         if True:
    |
 
-TRY400.py:28:13: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:29:13: TRY400 Use `logging.exception` instead of `logging.error`
    |
-28 |         if True:
-29 |             logger.error("Context message here")
+29 |         if True:
+30 |             logger.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
 
-TRY400.py:35:9: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:36:9: TRY400 Use `logging.exception` instead of `logging.error`
    |
-35 |         a = 1
-36 |     except Exception:
-37 |         log.error("Context message here")
+36 |         a = 1
+37 |     except Exception:
+38 |         log.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-38 | 
-39 |         if True:
+39 | 
+40 |         if True:
    |
 
-TRY400.py:38:13: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:39:13: TRY400 Use `logging.exception` instead of `logging.error`
    |
-38 |         if True:
-39 |             log.error("Context message here")
+39 |         if True:
+40 |             log.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
 
-TRY400.py:45:9: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:46:9: TRY400 Use `logging.exception` instead of `logging.error`
    |
-45 |         a = 1
-46 |     except Exception:
-47 |         self.logger.error("Context message here")
+46 |         a = 1
+47 |     except Exception:
+48 |         self.logger.error("Context message here")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
-48 | 
-49 |         if True:
+49 | 
+50 |         if True:
    |
 
-TRY400.py:48:13: TRY400 Use `logging.exception` instead of `logging.error`
+TRY400.py:49:13: TRY400 Use `logging.exception` instead of `logging.error`
    |
-48 |         if True:
-49 |             self.logger.error("Context message here")
+49 |         if True:
+50 |             self.logger.error("Context message here")
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ TRY400
    |
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

TRY400 is focused on flagging `logging.error` calls that fail to capture a traceback. But adding `exc_info` manually does "solve" that problem. We have a separate rule (`G201`) to flag usages of `logging.error` with `exc_info` that can be rewritten as `logging.exception`, so refining TRY400 to allow `exc_info=True` helps avoid any overlapping responsibilities.

Closes #4603.
