### PR TITLE
Format `ExprName`

### DIFF
--- a/crates/ruff_python_formatter/src/expression/expr_name.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_name.rs
@@ -1,5 +1,6 @@
-use crate::{verbatim_text, FormatNodeRule, PyFormatter};
-use ruff_formatter::{write, Buffer, FormatResult};
+use crate::prelude::*;
+use crate::FormatNodeRule;
+use ruff_formatter::{write, FormatContext};
 use rustpython_parser::ast::ExprName;
 
 #[derive(Default)]
@@ -7,6 +8,44 @@ pub struct FormatExprName;
 
 impl FormatNodeRule<ExprName> for FormatExprName {
     fn fmt_fields(&self, item: &ExprName, f: &mut PyFormatter) -> FormatResult<()> {
-        write!(f, [verbatim_text(item.range)])
+        let ExprName { id, range, ctx: _ } = item;
+
+        debug_assert_eq!(
+            id.as_str(),
+            f.context()
+                .source_code()
+                .slice(*range)
+                .text(f.context().source_code())
+        );
+
+        write!(f, [source_text_slice(*range, ContainsNewlines::No)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_text_size::{TextRange, TextSize};
+    use rustpython_parser::ast::{ModModule, Ranged};
+    use rustpython_parser::Parse;
+
+    #[test]
+    fn name_range_with_comments() {
+        let source = ModModule::parse("a # comment", "file.py").unwrap();
+
+        let expression_statement = source
+            .body
+            .first()
+            .expect("Expected non-empty body")
+            .as_expr_stmt()
+            .unwrap();
+        let name = expression_statement
+            .value
+            .as_name_expr()
+            .expect("Expected name expression");
+
+        assert_eq!(
+            name.range(),
+            TextRange::at(TextSize::new(0), TextSize::new(1))
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Implements formatting of `ExprName`. 

We, unfortunately, don't have the `Identifier` range. Luckily, we get away by simply using the `Name` range because it only encloses the `Identifier`. 

```
    <location:@L> <name:Identifier> <end_location:@R> => ast::Expr::Name(
        ast::ExprName { id: name, ctx: ast::ExprContext::Load, range: (location..end_location).into() }
    ),
```

We may need to inspect the source code in other places to get the Identifier's range, or decide not to bother and use `dynamic_text` if the syntax element is rarely used (e.g. `nonlocal`). 

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

I added a new test asserting my assumption that the name and identifier ranges are identical. 

There are no snapshot changes because the new implementation slices the same text as the `verbatim_range` implementation.