### PR TITLE
Add a formatter CLI for debugging

### DIFF
--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -1,11 +1,24 @@
 use std::path::PathBuf;
 
-use clap::{command, Parser};
+use clap::{command, Parser, ValueEnum};
+
+#[derive(ValueEnum, Clone, Debug)]
+pub enum Emit {
+    /// Write back to the original files
+    Files,
+    /// Write to stdout
+    Stdout,
+}
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    /// Python file to round-trip.
-    #[arg(required = true)]
-    pub file: PathBuf,
+    /// Python files to format. If there are none, stdin will be used. `-` as stdin is not supported
+    pub files: Vec<PathBuf>,
+    #[clap(long)]
+    pub emit: Option<Emit>,
+    /// Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 and prints
+    /// a diff if formatting is required.
+    #[clap(long)]
+    pub check: bool,
 }

--- a/crates/ruff_python_formatter/src/cli.rs
+++ b/crates/ruff_python_formatter/src/cli.rs
@@ -1,6 +1,16 @@
+#![allow(clippy::print_stdout)]
+
 use std::path::PathBuf;
 
+use anyhow::{bail, Context, Result};
 use clap::{command, Parser, ValueEnum};
+use rustpython_parser::lexer::lex;
+use rustpython_parser::{parse_tokens, Mode};
+
+use ruff_formatter::SourceCode;
+use ruff_python_ast::source_code::CommentRangesBuilder;
+
+use crate::format_node;
 
 #[derive(ValueEnum, Clone, Debug)]
 pub enum Emit {
@@ -21,4 +31,45 @@ pub struct Cli {
     /// a diff if formatting is required.
     #[clap(long)]
     pub check: bool,
+    #[clap(long)]
+    pub print_ir: bool,
+    #[clap(long)]
+    pub print_comments: bool,
+}
+
+pub fn format_and_debug_print(input: &str, cli: &Cli) -> Result<String> {
+    let mut tokens = Vec::new();
+    let mut comment_ranges = CommentRangesBuilder::default();
+
+    for result in lex(input, Mode::Module) {
+        let (token, range) = match result {
+            Ok((token, range)) => (token, range),
+            Err(err) => bail!("Source contains syntax errors {err:?}"),
+        };
+
+        comment_ranges.visit_token(&token, range);
+        tokens.push(Ok((token, range)));
+    }
+
+    let comment_ranges = comment_ranges.finish();
+
+    // Parse the AST.
+    let python_ast = parse_tokens(tokens, Mode::Module, "<filename>")
+        .with_context(|| "Syntax error in input")?;
+
+    let formatted = format_node(&python_ast, &comment_ranges, input)?;
+    if cli.print_ir {
+        println!("{}", formatted.document().display(SourceCode::new(input)));
+    }
+    if cli.print_comments {
+        println!(
+            "{:?}",
+            formatted.context().comments().debug(SourceCode::new(input))
+        );
+    }
+    Ok(formatted
+        .print()
+        .with_context(|| "Failed to print the formatter IR")?
+        .as_code()
+        .to_string())
 }

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -1,15 +1,55 @@
-use std::fs;
+use std::io::{stdout, Read, Write};
+use std::{fs, io};
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::Parser as ClapParser;
 
-use ruff_python_formatter::cli::Cli;
+use ruff_python_formatter::cli::{Cli, Emit};
 use ruff_python_formatter::format_module;
+
+/// Read a `String` from `stdin`.
+pub(crate) fn read_from_stdin() -> Result<String> {
+    let mut buffer = String::new();
+    io::stdin().lock().read_to_string(&mut buffer)?;
+    Ok(buffer)
+}
 
 #[allow(clippy::print_stdout)]
 fn main() -> Result<()> {
-    let cli = Cli::parse();
-    let contents = fs::read_to_string(cli.file)?;
-    println!("{}", format_module(&contents)?.as_code());
+    let cli: Cli = Cli::parse();
+
+    if cli.files.is_empty() {
+        if !matches!(cli.emit, None | Some(Emit::Stdout)) {
+            bail!(
+                "Can only write to stdout when formatting from stdin, but you asked for {:?}",
+                cli.emit
+            );
+        }
+        let input = read_from_stdin()?;
+        let formatted = format_module(&input)?;
+        if cli.check {
+            if formatted.as_code() == input {
+                return Ok(());
+            } else {
+                bail!("Content not correctly formatted")
+            }
+        }
+        stdout().lock().write_all(formatted.as_code().as_bytes())?;
+    } else {
+        for file in cli.files {
+            let unformatted = fs::read_to_string(&file)
+                .with_context(|| format!("Could not read {}: ", file.display()))?;
+            let formatted = format_module(&unformatted)?;
+            match cli.emit {
+                Some(Emit::Stdout) => stdout().lock().write_all(formatted.as_code().as_bytes())?,
+                None | Some(Emit::Files) => {
+                    fs::write(&file, formatted.as_code().as_bytes()).with_context(|| {
+                        format!("Could not write to {}, exiting", file.display())
+                    })?;
+                }
+            }
+        }
+    }
+
     Ok(())
 }

--- a/crates/ruff_python_formatter/src/main.rs
+++ b/crates/ruff_python_formatter/src/main.rs
@@ -30,9 +30,8 @@ fn main() -> Result<()> {
         if cli.check {
             if formatted.as_code() == input {
                 return Ok(());
-            } else {
-                bail!("Content not correctly formatted")
             }
+            bail!("Content not correctly formatted")
         }
         stdout().lock().write_all(formatted.as_code().as_bytes())?;
     } else {


### PR DESCRIPTION
## Summary

This add a `ruff_python_formatter` cli modeled after `rustfmt` that i use to test my changes.

## Test Plan

It's a debugging tool, as which it worked for me
