### PR TITLE
Handle trailing body end-of-line comments

### DIFF
--- a/crates/ruff_python_formatter/src/comments/mod.rs
+++ b/crates/ruff_python_formatter/src/comments/mod.rs
@@ -858,4 +858,18 @@ a = (
 
         assert_debug_snapshot!(comments.debug(test_case.source_code));
     }
+
+    #[test]
+    fn while_trailing_end_of_line_comment() {
+        let source = r#"while True:
+    if something.changed:
+        do.stuff()  # trailing comment
+"#;
+
+        let test_case = CommentsTestCase::from_code(source);
+
+        let comments = test_case.to_comments();
+
+        assert_debug_snapshot!(comments.debug(test_case.source_code));
+    }
 }

--- a/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__while_trailing_end_of_line_comment.snap
+++ b/crates/ruff_python_formatter/src/comments/snapshots/ruff_python_formatter__comments__tests__while_trailing_end_of_line_comment.snap
@@ -1,0 +1,21 @@
+---
+source: crates/ruff_python_formatter/src/comments/mod.rs
+expression: comments.debug(test_case.source_code)
+---
+{
+    Node {
+        kind: StmtExpr,
+        range: 46..56,
+        source: `do.stuff()`,
+    }: {
+        "leading": [],
+        "dangling": [],
+        "trailing": [
+            SourceComment {
+                text: "# trailing comment",
+                position: EndOfLine,
+                formatted: false,
+            },
+        ],
+    },
+}

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments5_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments5_py.snap
@@ -89,12 +89,13 @@ if __name__ == "__main__":
 @@ -1,11 +1,6 @@
  while True:
      if something.changed:
-         do.stuff()  # trailing comment
+-        do.stuff()  # trailing comment
 -        # Comment belongs to the `if` block.
 -    # This one belongs to the `while` block.
 -
 -    # Should this one, too?  I guess so.
 -
++        do.stuff()
  # This one is properly standalone now.
  
  for i in range(100):
@@ -161,7 +162,7 @@ if __name__ == "__main__":
 ```py
 while True:
     if something.changed:
-        do.stuff()  # trailing comment
+        do.stuff()
 # This one is properly standalone now.
 
 for i in range(100):

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments6_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__comments6_py.snap
@@ -168,12 +168,14 @@ aaaaaaaaaaaaa, bbbbbbbbb = map(list, map(itertools.chain.from_iterable, zip(*ite
  def f(
      a,  # type: int
      b,  # type: int
-@@ -67,22 +57,16 @@
+@@ -66,23 +56,17 @@
+         + element
          + another_element
          + another_element_with_long_name
-     )  # type: int
+-    )  # type: int
 -
 -
++    )
  def f(
      x,  # not a type comment
      y,  # type: int
@@ -272,7 +274,7 @@ def f(
         + element
         + another_element
         + another_element_with_long_name
-    )  # type: int
+    )
 def f(
     x,  # not a type comment
     y,  # type: int

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtonoff_py.snap
@@ -369,7 +369,7 @@ d={'a':1,
 +        (1, 2, 3, 4),
 +        (5, 6, 7, 8),
 +        (9, 10, 11, 12)
-+    }  # yapf: disable
++    }
  cfg.rule(
 -    "Default",
 -    "address",
@@ -544,7 +544,7 @@ def single_literal_yapf_disable():
         (1, 2, 3, 4),
         (5, 6, 7, 8),
         (9, 10, 11, 12)
-    }  # yapf: disable
+    }
 cfg.rule(
     "Default", "address",
     xxxx_xxxx=["xxx-xxxxxx-xxxxxxxxxx"],

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtskip6_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__fmtskip6_py.snap
@@ -1,0 +1,49 @@
+---
+source: crates/ruff_python_formatter/src/lib.rs
+expression: snapshot
+input_file: crates/ruff_python_formatter/resources/test/fixtures/black/simple_cases/fmtskip6.py
+---
+## Input
+
+```py
+class A:
+    def f(self):
+        for line in range(10):
+            if True:
+                pass  # fmt: skip
+```
+
+## Black Differences
+
+```diff
+--- Black
++++ Ruff
+@@ -2,4 +2,4 @@
+     def f(self):
+         for line in range(10):
+             if True:
+-                pass  # fmt: skip
++                pass
+```
+
+## Ruff Output
+
+```py
+class A:
+    def f(self):
+        for line in range(10):
+            if True:
+                pass
+```
+
+## Black Output
+
+```py
+class A:
+    def f(self):
+        for line in range(10):
+            if True:
+                pass  # fmt: skip
+```
+
+

--- a/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__remove_await_parens_py.snap
+++ b/crates/ruff_python_formatter/src/snapshots/ruff_python_formatter__tests__black_test__remove_await_parens_py.snap
@@ -143,7 +143,7 @@ async def main():
 -
 +    await (
 +        asyncio.sleep(1)
-+    )  # Hello
++    )
  # Long lines
  async def main():
 -    await asyncio.gather(
@@ -251,7 +251,7 @@ async def main():
 async def main():
     await (
         asyncio.sleep(1)
-    )  # Hello
+    )
 # Long lines
 async def main():
     await asyncio.gather(asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1), asyncio.sleep(1))


### PR DESCRIPTION
### Summary

This PR adds custom logic to handle end-of-line comments of the last statement in a body. 

For example: 

```python
while True:
    if something.changed:
        do.stuff()  # trailing comment

b
```

The `# trailing comment` is a trailing comment of the `do.stuff()` expression statement. We incorrectly attached the comment as a trailing comment of the enclosing `while` statement  because the comment is between the end of the while statement (the `while` statement ends right after `do.stuff()`) and before the `b` statement. 


This PR fixes the placement to correctly attach these comments to the last statement in a body (recursively). 

## Test Plan

I reviewed the snapshots and they now look correct. This may appear odd because a lot comments have now disappeared. This is the expected result because we use `verbatim` formatting for the block statements (like `while`) and that means that it only formats the inner content of the block, but not any trailing comments. The comments were visible before, because they were associated with the block statement (e.g. `while`). 
