### PR TITLE
Remove `name` field from import binding kinds

### DIFF
--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -872,7 +872,6 @@ where
                             name,
                             Binding {
                                 kind: BindingKind::SubmoduleImportation(SubmoduleImportation {
-                                    name,
                                     full_name,
                                 }),
                                 range: alias.range(),
@@ -889,7 +888,7 @@ where
                         self.add_binding(
                             name,
                             Binding {
-                                kind: BindingKind::Importation(Importation { name, full_name }),
+                                kind: BindingKind::Importation(Importation { full_name }),
                                 range: alias.range(),
                                 references: Vec::new(),
                                 source: self.semantic_model.stmt_id,
@@ -1196,10 +1195,7 @@ where
                         self.add_binding(
                             name,
                             Binding {
-                                kind: BindingKind::FromImportation(FromImportation {
-                                    name,
-                                    full_name,
-                                }),
+                                kind: BindingKind::FromImportation(FromImportation { full_name }),
                                 range: alias.range(),
                                 references: Vec::new(),
                                 source: self.semantic_model.stmt_id,

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -67,9 +67,9 @@ pub(crate) fn runtime_import_in_type_checking_block(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let full_name = match &binding.kind {
-        BindingKind::Importation(Importation { full_name, .. }) => full_name,
-        BindingKind::FromImportation(FromImportation { full_name, .. }) => full_name.as_str(),
-        BindingKind::SubmoduleImportation(SubmoduleImportation { full_name, .. }) => full_name,
+        BindingKind::Importation(Importation { full_name }) => full_name,
+        BindingKind::FromImportation(FromImportation { full_name }) => full_name.as_str(),
+        BindingKind::SubmoduleImportation(SubmoduleImportation { full_name }) => full_name,
         _ => return,
     };
 

--- a/crates/ruff/src/rules/pandas_vet/helpers.rs
+++ b/crates/ruff/src/rules/pandas_vet/helpers.rs
@@ -40,9 +40,11 @@ pub(crate) fn test_expression(expr: &Expr, model: &SemanticModel) -> Resolution 
                         | BindingKind::LoopVar
                         | BindingKind::Global
                         | BindingKind::Nonlocal => Resolution::RelevantLocal,
-                        BindingKind::Importation(Importation {
-                            full_name: module, ..
-                        }) if module == "pandas" => Resolution::PandasModule,
+                        BindingKind::Importation(Importation { full_name: module })
+                            if module == "pandas" =>
+                        {
+                            Resolution::PandasModule
+                        }
                         _ => Resolution::IrrelevantBinding,
                     }
                 })

--- a/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
+++ b/crates/ruff/src/rules/pandas_vet/rules/inplace_argument.rs
@@ -71,8 +71,7 @@ pub(crate) fn inplace_argument(
                 matches!(
                     binding.kind,
                     BindingKind::Importation(Importation {
-                        full_name: "pandas",
-                        ..
+                        full_name: "pandas"
                     })
                 )
             });

--- a/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/unused_import.rs
@@ -118,9 +118,9 @@ pub(crate) fn unused_import(checker: &Checker, scope: &Scope, diagnostics: &mut 
         }
 
         let full_name = match &binding.kind {
-            BindingKind::Importation(Importation { full_name, .. }) => full_name,
-            BindingKind::FromImportation(FromImportation { full_name, .. }) => full_name.as_str(),
-            BindingKind::SubmoduleImportation(SubmoduleImportation { full_name, .. }) => full_name,
+            BindingKind::Importation(Importation { full_name }) => full_name,
+            BindingKind::FromImportation(FromImportation { full_name }) => full_name.as_str(),
+            BindingKind::SubmoduleImportation(SubmoduleImportation { full_name }) => full_name,
             _ => continue,
         };
 

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -48,39 +48,34 @@ impl<'a> Binding<'a> {
     /// Return `true` if this binding redefines the given binding.
     pub fn redefines(&self, existing: &'a Binding) -> bool {
         match &self.kind {
-            BindingKind::Importation(Importation { full_name, .. }) => {
+            BindingKind::Importation(Importation { full_name }) => {
                 if let BindingKind::SubmoduleImportation(SubmoduleImportation {
                     full_name: existing,
-                    ..
                 }) = &existing.kind
                 {
                     return full_name == existing;
                 }
             }
-            BindingKind::FromImportation(FromImportation { full_name, .. }) => {
+            BindingKind::FromImportation(FromImportation { full_name }) => {
                 if let BindingKind::SubmoduleImportation(SubmoduleImportation {
                     full_name: existing,
-                    ..
                 }) = &existing.kind
                 {
                     return full_name == existing;
                 }
             }
-            BindingKind::SubmoduleImportation(SubmoduleImportation { full_name, .. }) => {
+            BindingKind::SubmoduleImportation(SubmoduleImportation { full_name }) => {
                 match &existing.kind {
                     BindingKind::Importation(Importation {
                         full_name: existing,
-                        ..
                     })
                     | BindingKind::SubmoduleImportation(SubmoduleImportation {
                         full_name: existing,
-                        ..
                     }) => {
                         return full_name == existing;
                     }
                     BindingKind::FromImportation(FromImportation {
                         full_name: existing,
-                        ..
                     }) => {
                         return full_name == existing;
                     }
@@ -211,37 +206,34 @@ pub struct Export<'a> {
     pub names: Vec<&'a str>,
 }
 
+/// A binding for an `import`, keyed on the name to which the import is bound.
+/// Ex) `import foo` would be keyed on "foo".
+/// Ex) `import foo as bar` would be keyed on "bar".
 #[derive(Clone, Debug)]
 pub struct Importation<'a> {
-    /// The name to which the import is bound.
-    /// Given `import foo`, `name` would be "foo".
-    /// Given `import foo as bar`, `name` would be "bar".
-    pub name: &'a str,
     /// The full name of the module being imported.
-    /// Given `import foo`, `full_name` would be "foo".
-    /// Given `import foo as bar`, `full_name` would be "foo".
+    /// Ex) Given `import foo`, `full_name` would be "foo".
+    /// Ex) Given `import foo as bar`, `full_name` would be "foo".
     pub full_name: &'a str,
 }
 
+/// A binding for a member imported from a module, keyed on the name to which the member is bound.
+/// Ex) `from foo import bar` would be keyed on "bar".
+/// Ex) `from foo import bar as baz` would be keyed on "baz".
 #[derive(Clone, Debug)]
-pub struct FromImportation<'a> {
-    /// The name to which the import is bound.
-    /// Given `from foo import bar`, `name` would be "bar".
-    /// Given `from foo import bar as baz`, `name` would be "baz".
-    pub name: &'a str,
-    /// The full name of the module being imported.
-    /// Given `from foo import bar`, `full_name` would be "foo.bar".
-    /// Given `from foo import bar as baz`, `full_name` would be "foo.bar".
+pub struct FromImportation {
+    /// The full name of the member being imported.
+    /// Ex) Given `from foo import bar`, `full_name` would be "foo.bar".
+    /// Ex) Given `from foo import bar as baz`, `full_name` would be "foo.bar".
     pub full_name: String,
 }
 
+/// A binding for a submodule imported from a module, keyed on the name of the parent module.
+/// Ex) `import foo.bar` would be keyed on "foo".
 #[derive(Clone, Debug)]
 pub struct SubmoduleImportation<'a> {
-    /// The parent module imported by the submodule import.
-    /// Given `import foo.bar`, `module` would be "foo".
-    pub name: &'a str,
     /// The full name of the submodule being imported.
-    /// Given `import foo.bar`, `full_name` would be "foo.bar".
+    /// Ex) Given `import foo.bar`, `full_name` would be "foo.bar".
     pub full_name: &'a str,
 }
 
@@ -261,7 +253,7 @@ pub enum BindingKind<'a> {
     Export(Export<'a>),
     FutureImportation,
     Importation(Importation<'a>),
-    FromImportation(FromImportation<'a>),
+    FromImportation(FromImportation),
     SubmoduleImportation(SubmoduleImportation<'a>),
 }
 


### PR DESCRIPTION
## Summary

We already store the name as the key in the symbol table, so there's no need to store it as both a key _and_ a value. This reduces the size of `BindingKind` from 48 to 32 bytes.
