### PR TITLE
Respect mixed variable assignment in RET504

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff/resources/test/fixtures/flake8_return/RET504.py
@@ -272,3 +272,34 @@ def str_to_bool(val):
     if isinstance(val, bool):
         return some_obj
     return val
+
+
+# Mixed assignments
+def function_assignment(x):
+    def f(): ...
+
+    return f
+
+
+def class_assignment(x):
+    class Foo: ...
+
+    return Foo
+
+
+def mixed_function_assignment(x):
+    if x:
+        def f(): ...
+    else:
+        f = 42
+
+    return f
+
+
+def mixed_class_assignment(x):
+    if x:
+        class Foo: ...
+    else:
+        Foo = 42
+
+    return Foo


### PR DESCRIPTION
## Summary

In RET504, we haven't been considering function and class assignments at all. This PR modifies the rule to track multiple declarations, but only flag for unused _assignments_.

Closes #4824.
