### PR TITLE
Remove unused mutable variables

### DIFF
--- a/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/fixes.rs
@@ -291,7 +291,7 @@ pub(crate) fn fix_unnecessary_literal_set(
     // Expr(Call(List|Tuple)))) -> Expr(Set)))
     let module_text = locator.slice(expr.range());
     let mut tree = match_expression(module_text)?;
-    let mut call = match_call_mut(&mut tree)?;
+    let call = match_call_mut(&mut tree)?;
     let arg = match_arg(call)?;
 
     let (elements, whitespace_after, whitespace_before) = match &arg.value {
@@ -765,7 +765,7 @@ pub(crate) fn fix_unnecessary_double_cast_or_process(
 ) -> Result<Edit> {
     let module_text = locator.slice(expr.range());
     let mut tree = match_expression(module_text)?;
-    let mut outer_call = match_call_mut(&mut tree)?;
+    let outer_call = match_call_mut(&mut tree)?;
 
     outer_call.args = match outer_call.args.split_first() {
         Some((first, rest)) => {

--- a/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -59,7 +59,7 @@ fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Resu
     let contents = locator.slice(range);
 
     let mut expression = match_expression(contents)?;
-    let mut comparison = match_comparison(&mut expression)?;
+    let comparison = match_comparison(&mut expression)?;
 
     let left = (*comparison.left).clone();
 

--- a/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/deprecated_mock_import.rs
@@ -127,7 +127,7 @@ fn format_import(
 ) -> Result<String> {
     let module_text = locator.slice(stmt.range());
     let mut tree = match_statement(module_text)?;
-    let mut import = match_import(&mut tree)?;
+    let import = match_import(&mut tree)?;
 
     let Import { names, .. } = import.clone();
     let (clean_aliases, mock_aliases) = clean_import_aliases(names);
@@ -161,7 +161,7 @@ fn format_import_from(
 ) -> Result<String> {
     let module_text = locator.slice(stmt.range());
     let mut tree = match_statement(module_text).unwrap();
-    let mut import = match_import_from(&mut tree)?;
+    let import = match_import_from(&mut tree)?;
 
     if let ImportFrom {
         names: ImportNames::Star(..),

--- a/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
+++ b/crates/ruff/src/rules/pyupgrade/rules/format_literals.rs
@@ -89,7 +89,7 @@ fn generate_call(
 ) -> Result<String> {
     let module_text = locator.slice(expr.range());
     let mut expression = match_expression(module_text)?;
-    let mut call = match_call_mut(&mut expression)?;
+    let call = match_call_mut(&mut expression)?;
 
     // Fix the call arguments.
     if !is_sequential(correct_order) {

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -59,7 +59,7 @@ fn fix_explicit_f_string_type_conversion(
     let formatted_string = match_formatted_string(&mut expression)?;
 
     // Replace the formatted call expression at `index` with a conversion flag.
-    let mut formatted_string_expression =
+    let formatted_string_expression =
         match_formatted_string_expression(&mut formatted_string.parts[index])?;
     let call = match_call_mut(&mut formatted_string_expression.expression)?;
     let name = match_name(&call.func)?;


### PR DESCRIPTION
The nightly rust compiler warns on these `mut` variables that are not mutated.

Fixed with `cargo +nightly fix --lib -p ruff`.
