### PR TITLE
Modify semantic model API to push bindings upon creation

### DIFF
--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -115,8 +115,8 @@ impl<'a> SemanticModel<'a> {
     }
 
     /// Create a new [`Binding`] for a builtin.
-    pub fn builtin_binding(&self) -> Binding<'static> {
-        Binding {
+    pub fn push_builtin(&mut self) -> BindingId {
+        self.bindings.push(Binding {
             range: TextRange::default(),
             kind: BindingKind::Builtin,
             references: Vec::new(),
@@ -124,17 +124,17 @@ impl<'a> SemanticModel<'a> {
             source: None,
             context: ExecutionContext::Runtime,
             exceptions: Exceptions::empty(),
-        }
+        })
     }
 
-    /// Create a new `Binding` for the given `name` and `range`.
-    pub fn declared_binding(
-        &self,
+    /// Create a new [`Binding`] for the given `name` and `range`.
+    pub fn push_binding(
+        &mut self,
         range: TextRange,
         kind: BindingKind<'a>,
         flags: BindingFlags,
-    ) -> Binding<'a> {
-        Binding {
+    ) -> BindingId {
+        self.bindings.push(Binding {
             range,
             kind,
             flags,
@@ -142,7 +142,7 @@ impl<'a> SemanticModel<'a> {
             source: self.stmt_id,
             context: self.execution_context(),
             exceptions: self.exceptions(),
-        }
+        })
     }
 
     /// Return the current `Binding` for a given `name`.


### PR DESCRIPTION
## Summary

Follow-up to some feedback in #4819.

My local benchmarks reported a meaningful performance improvement, but I'm not sure why that would be:

```
linter/default-rules/numpy/globals.py
                        time:   [77.086 µs 77.117 µs 77.159 µs]
                        thrpt:  [38.241 MiB/s 38.262 MiB/s 38.278 MiB/s]
                 change:
                        time:   [-0.0523% +0.1805% +0.3988%] (p = 0.12 > 0.05)
                        thrpt:  [-0.3972% -0.1801% +0.0523%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  4 (4.00%) high severe
linter/default-rules/pydantic/types.py
                        time:   [1.4842 ms 1.4845 ms 1.4848 ms]
                        thrpt:  [17.176 MiB/s 17.180 MiB/s 17.183 MiB/s]
                 change:
                        time:   [-0.2148% -0.1180% +0.0003%] (p = 0.02 < 0.05)
                        thrpt:  [-0.0003% +0.1181% +0.2152%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe
linter/default-rules/numpy/ctypeslib.py
                        time:   [693.03 µs 693.43 µs 693.87 µs]
                        thrpt:  [23.997 MiB/s 24.013 MiB/s 24.027 MiB/s]
                 change:
                        time:   [-0.4169% -0.2614% -0.1292%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1293% +0.2621% +0.4186%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
linter/default-rules/large/dataset.py
                        time:   [3.3584 ms 3.3612 ms 3.3638 ms]
                        thrpt:  [12.094 MiB/s 12.104 MiB/s 12.114 MiB/s]
                 change:
                        time:   [-0.1874% -0.1139% -0.0460%] (p = 0.00 < 0.05)
                        thrpt:  [+0.0460% +0.1141% +0.1878%]
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild

linter/all-rules/numpy/globals.py
                        time:   [148.26 µs 148.37 µs 148.47 µs]
                        thrpt:  [19.873 MiB/s 19.888 MiB/s 19.902 MiB/s]
                 change:
                        time:   [-2.0010% -1.5549% -1.0589%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0703% +1.5794% +2.0419%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
linter/all-rules/pydantic/types.py
                        time:   [2.9326 ms 2.9349 ms 2.9376 ms]
                        thrpt:  [8.6817 MiB/s 8.6896 MiB/s 8.6965 MiB/s]
                 change:
                        time:   [-1.1966% -1.0700% -0.9392%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9481% +1.0816% +1.2111%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
linter/all-rules/numpy/ctypeslib.py
                        time:   [1.6737 ms 1.6743 ms 1.6750 ms]
                        thrpt:  [9.9410 MiB/s 9.9450 MiB/s 9.9485 MiB/s]
                 change:
                        time:   [-1.4525% -1.2985% -1.1571%] (p = 0.00 < 0.05)
                        thrpt:  [+1.1707% +1.3156% +1.4739%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
linter/all-rules/large/dataset.py
                        time:   [6.9297 ms 6.9351 ms 6.9409 ms]
                        thrpt:  [5.8613 MiB/s 5.8663 MiB/s 5.8708 MiB/s]
                 change:
                        time:   [-1.4497% -1.3579% -1.2482%] (p = 0.00 < 0.05)
                        thrpt:  [+1.2640% +1.3766% +1.4711%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```