### PR TITLE
Change fixable_set to include RuleSelector::All/Nursery

### DIFF
--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -14,6 +14,8 @@ use crate::rule_redirects::get_redirect;
 pub enum RuleSelector {
     /// Select all rules.
     All,
+    /// Select all nursery rules.
+    Nursery,
     /// Legacy category to select both the `mccabe` and `flake8-comprehensions` linters
     /// via a single selector.
     C,
@@ -39,30 +41,30 @@ impl FromStr for RuleSelector {
     type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "ALL" {
-            Ok(Self::All)
-        } else if s == "C" {
-            Ok(Self::C)
-        } else if s == "T" {
-            Ok(Self::T)
-        } else {
-            let (s, redirected_from) = match get_redirect(s) {
-                Some((from, target)) => (target, Some(from)),
-                None => (s, None),
-            };
+        match s {
+            "ALL" => Ok(Self::All),
+            "NURSERY" => Ok(Self::Nursery),
+            "C" => Ok(Self::C),
+            "T" => Ok(Self::T),
+            _ => {
+                let (s, redirected_from) = match get_redirect(s) {
+                    Some((from, target)) => (target, Some(from)),
+                    None => (s, None),
+                };
 
-            let (linter, code) =
-                Linter::parse_code(s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
+                let (linter, code) =
+                    Linter::parse_code(s).ok_or_else(|| ParseError::Unknown(s.to_string()))?;
 
-            if code.is_empty() {
-                return Ok(Self::Linter(linter));
+                if code.is_empty() {
+                    return Ok(Self::Linter(linter));
+                }
+
+                Ok(Self::Prefix {
+                    prefix: RuleCodePrefix::parse(&linter, code)
+                        .map_err(|_| ParseError::Unknown(s.to_string()))?,
+                    redirected_from,
+                })
             }
-
-            Ok(Self::Prefix {
-                prefix: RuleCodePrefix::parse(&linter, code)
-                    .map_err(|_| ParseError::Unknown(s.to_string()))?,
-                redirected_from,
-            })
         }
     }
 }
@@ -79,6 +81,7 @@ impl RuleSelector {
     pub fn prefix_and_code(&self) -> (&'static str, &'static str) {
         match self {
             RuleSelector::All => ("", "ALL"),
+            RuleSelector::Nursery => ("", "NURSERY"),
             RuleSelector::C => ("", "C"),
             RuleSelector::T => ("", "T"),
             RuleSelector::Prefix { prefix, .. } => {
@@ -157,6 +160,9 @@ impl IntoIterator for &RuleSelector {
             RuleSelector::All => {
                 RuleSelectorIter::All(Rule::iter().filter(|rule| select_all(*rule)))
             }
+            RuleSelector::Nursery => {
+                RuleSelectorIter::Nursery(Rule::iter().filter(|rule| rule.is_nursery()))
+            }
             RuleSelector::C => RuleSelectorIter::Chain(
                 Linter::Flake8Comprehensions
                     .into_iter()
@@ -175,6 +181,7 @@ impl IntoIterator for &RuleSelector {
 
 pub enum RuleSelectorIter {
     All(std::iter::Filter<RuleIter, fn(&Rule) -> bool>),
+    Nursery(std::iter::Filter<RuleIter, fn(&Rule) -> bool>),
     Chain(std::iter::Chain<std::vec::IntoIter<Rule>, std::vec::IntoIter<Rule>>),
     Vec(std::vec::IntoIter<Rule>),
 }
@@ -185,6 +192,7 @@ impl Iterator for RuleSelectorIter {
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             RuleSelectorIter::All(iter) => iter.next(),
+            RuleSelectorIter::Nursery(iter) => iter.next(),
             RuleSelectorIter::Chain(iter) => iter.next(),
             RuleSelectorIter::Vec(iter) => iter.next(),
         }
@@ -262,6 +270,7 @@ impl RuleSelector {
     pub(crate) fn specificity(&self) -> Specificity {
         match self {
             RuleSelector::All => Specificity::All,
+            RuleSelector::Nursery => Specificity::All,
             RuleSelector::T => Specificity::LinterGroup,
             RuleSelector::C => Specificity::LinterGroup,
             RuleSelector::Linter(..) => Specificity::Linter,

--- a/crates/ruff/src/rule_selector.rs
+++ b/crates/ruff/src/rule_selector.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-use crate::codes::RuleCodePrefix;
 use crate::codes::RuleIter;
+use crate::codes::{self, RuleCodePrefix};
 use crate::registry::{Linter, Rule, RuleNamespace};
 use crate::rule_redirects::get_redirect;
 
@@ -161,7 +161,7 @@ impl IntoIterator for &RuleSelector {
                 RuleSelectorIter::All(Rule::iter().filter(|rule| select_all(*rule)))
             }
             RuleSelector::Nursery => {
-                RuleSelectorIter::Nursery(Rule::iter().filter(|rule| rule.is_nursery()))
+                RuleSelectorIter::Nursery(Rule::iter().filter(codes::Rule::is_nursery))
             }
             RuleSelector::C => RuleSelectorIter::Chain(
                 Linter::Flake8Comprehensions

--- a/crates/ruff/src/settings/mod.rs
+++ b/crates/ruff/src/settings/mod.rs
@@ -259,7 +259,10 @@ impl From<&Configuration> for RuleTable {
         // The select_set keeps track of which rules have been selected.
         let mut select_set: RuleSet = defaults::PREFIXES.iter().flatten().collect();
         // The fixable set keeps track of which rules are fixable.
-        let mut fixable_set: RuleSet = RuleSelector::All.into_iter().collect();
+        let mut fixable_set: RuleSet = RuleSelector::All
+            .into_iter()
+            .chain(RuleSelector::Nursery.into_iter())
+            .collect();
 
         // Ignores normally only subtract from the current set of selected
         // rules.  By that logic the ignore in `select = [], ignore = ["E501"]`


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Fixes #4761. 

This PR merges `RuleSelector::All` and `RuleSelector::Nursery` by default into `Configuration`'s `fixable_set`.

## Test Plan

`cargo run -p ruff_cli -- crates/ruff/resources/test/fixtures/pycodestyle/E20.py --no-cache --select E202,E203,E201 --fix`

On `main`, this command will detect 19 fixes, but won't fix any of them. On my branch, this command will fix all 19 errors.
