### PR TITLE
Ensure type_ignores for Module are empty

### DIFF
--- a/crates/ruff_python_formatter/src/module/mod_module.rs
+++ b/crates/ruff_python_formatter/src/module/mod_module.rs
@@ -9,10 +9,17 @@ pub struct FormatModModule;
 
 impl FormatNodeRule<ModModule> for FormatModModule {
     fn fmt_fields(&self, item: &ModModule, f: &mut PyFormatter) -> FormatResult<()> {
+        let ModModule {
+            range: _,
+            body,
+            type_ignores,
+        } = item;
+        // https://docs.python.org/3/library/ast.html#ast-helpers
+        debug_assert!(type_ignores.is_empty());
         write!(
             f,
             [
-                item.body.format().with_options(SuiteLevel::TopLevel),
+                body.format().with_options(SuiteLevel::TopLevel),
                 // Trailing newline at the end of the file
                 hard_line_break()
             ]


### PR DESCRIPTION
According to https://docs.python.org/3/library/ast.html#ast-helpers, we expect type_ignores to be always be empty, so this adds a debug assert.  

Test plan: I confirmed that the assertion holdes for the file below and for all the black tests which include a number of `type: ignore` comments.
```python
# type: ignore

if 1:
    print("1")  # type: ignore
    # elsebranch

# type: ignore

else:  # type: ignore
    print("2")  # type: ignore


while 1:
    print()

# type: ignore
```
