### PR TITLE
Fix pre-commit typos action

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 fail_fast: true
+
+exclude: |
+  (?x)^(
+    crates/ruff/resources/.*|
+    crates/ruff_python_formatter/resources/.*|
+    crates/ruff_python_formatter/src/snapshots/.*
+  )$
+
 repos:
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.12.1
@@ -19,7 +27,7 @@ repos:
       - id: markdownlint-fix
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.14.8
+    rev: v1.14.12
     hooks:
       - id: typos
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,5 @@
 [files]
-extend-exclude = ["snapshots", "black"]
+extend-exclude = ["resources", "snapshots"]
 
 [default.extend-words]
 trivias = "trivias"


### PR DESCRIPTION
The typos pre-commit action would previously edit test fixtures and snapshots. Unfortunately the pre-commit action also doesn't respect _typos.toml and typos action doesn't allow for an exclude key, so i've added a top level exclude key. I have confirmed that this does stop typos from rewriting my fixtures and snapshots
