### PR TITLE
Respect shadowed exports in `__all__` 

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F401_16.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F401_16.py
@@ -1,0 +1,15 @@
+"""Test that `__all__` exports are respected even with multiple declarations."""
+
+import random
+
+
+def some_dependency_check():
+    return random.uniform(0.0, 1.0) > 0.49999
+
+
+if some_dependency_check():
+    import math
+
+    __all__ = ["math"]
+else:
+    __all__ = []

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -40,6 +40,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_13.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_14.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_15.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_16.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404.py"))]

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -48,18 +48,16 @@ impl Violation for UndefinedExport {
 }
 
 /// F822
-pub(crate) fn undefined_export(names: &[&str], range: TextRange, scope: &Scope) -> Vec<Diagnostic> {
+pub(crate) fn undefined_export(name: &str, range: TextRange, scope: &Scope) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     if !scope.uses_star_imports() {
-        for name in names {
-            if !scope.defines(name) {
-                diagnostics.push(Diagnostic::new(
-                    UndefinedExport {
-                        name: (*name).to_string(),
-                    },
-                    range,
-                ));
-            }
+        if !scope.defines(name) {
+            diagnostics.push(Diagnostic::new(
+                UndefinedExport {
+                    name: (*name).to_string(),
+                },
+                range,
+            ));
         }
     }
     diagnostics

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_16.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_16.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+---
+


### PR DESCRIPTION
## Summary

This PR modifies our export tracking to iterate over all assignments to `__all__`, as opposed to just the most recent. This ensures that if `__all__` is defined conditionally (which isn't necessarily recommended, but is possible), we're conservative in how we flag unused imports and enforce other related rules.

Closes #4521.
