### PR TITLE
Avoid early-exit in explicit-f-string-type-conversion

### DIFF
--- a/crates/ruff/resources/test/fixtures/ruff/RUF010.py
+++ b/crates/ruff/resources/test/fixtures/ruff/RUF010.py
@@ -12,6 +12,8 @@ f"{str(d['a'])}, {repr(d['b'])}, {ascii(d['c'])}"  # RUF010
 
 f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
 
+f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+
 f"{foo(bla)}"  # OK
 
 f"{str(bla, 'ascii')}, {str(bla, encoding='cp1255')}"  # OK

--- a/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
+++ b/crates/ruff/src/rules/ruff/rules/explicit_f_string_type_conversion.rs
@@ -97,9 +97,10 @@ pub(crate) fn explicit_f_string_type_conversion(
         }) = &formatted_value else {
             continue;
         };
+
         // Skip if there's already a conversion flag.
         if !conversion.is_none() {
-            return;
+            continue;
         }
 
         let Expr::Call(ast::ExprCall {
@@ -108,24 +109,24 @@ pub(crate) fn explicit_f_string_type_conversion(
             keywords,
             ..
         }) = value.as_ref() else {
-            return;
+            continue;
         };
 
         // Can't be a conversion otherwise.
         if args.len() != 1 || !keywords.is_empty() {
-            return;
+            continue;
         }
 
         let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() else {
-            return;
+            continue;
         };
 
         if !matches!(id.as_str(), "str" | "repr" | "ascii") {
-            return;
+            continue;
         };
 
         if !checker.semantic_model().is_builtin(id) {
-            return;
+            continue;
         }
 
         let mut diagnostic = Diagnostic::new(ExplicitFStringTypeConversion, value.range());

--- a/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF010_RUF010.py.snap
+++ b/crates/ruff/src/rules/ruff/snapshots/ruff__rules__ruff__tests__RUF010_RUF010.py.snap
@@ -128,7 +128,7 @@ RUF010.py:13:5: RUF010 [*] Use conversion in f-string
 15 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |     ^^^^^^^^ RUF010
 16 | 
-17 | f"{foo(bla)}"  # OK
+17 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |
    = help: Replace f-string function call with conversion
 
@@ -139,7 +139,7 @@ RUF010.py:13:5: RUF010 [*] Use conversion in f-string
 13    |-f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    13 |+f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
 14 14 | 
-15 15 | f"{foo(bla)}"  # OK
+15 15 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
 16 16 | 
 
 RUF010.py:13:19: RUF010 [*] Use conversion in f-string
@@ -149,7 +149,7 @@ RUF010.py:13:19: RUF010 [*] Use conversion in f-string
 15 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |                   ^^^^^^^^^ RUF010
 16 | 
-17 | f"{foo(bla)}"  # OK
+17 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |
    = help: Replace f-string function call with conversion
 
@@ -160,7 +160,7 @@ RUF010.py:13:19: RUF010 [*] Use conversion in f-string
 13    |-f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    13 |+f"{(str(bla))}, {bla!r}, {(ascii(bla))}"  # RUF010
 14 14 | 
-15 15 | f"{foo(bla)}"  # OK
+15 15 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
 16 16 | 
 
 RUF010.py:13:34: RUF010 [*] Use conversion in f-string
@@ -170,7 +170,7 @@ RUF010.py:13:34: RUF010 [*] Use conversion in f-string
 15 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |                                  ^^^^^^^^^^ RUF010
 16 | 
-17 | f"{foo(bla)}"  # OK
+17 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    |
    = help: Replace f-string function call with conversion
 
@@ -181,7 +181,49 @@ RUF010.py:13:34: RUF010 [*] Use conversion in f-string
 13    |-f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
    13 |+f"{(str(bla))}, {(repr(bla))}, {bla!a}"  # RUF010
 14 14 | 
-15 15 | f"{foo(bla)}"  # OK
+15 15 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
 16 16 | 
+
+RUF010.py:15:14: RUF010 [*] Use conversion in f-string
+   |
+15 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+16 | 
+17 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+   |              ^^^^^^^^^ RUF010
+18 | 
+19 | f"{foo(bla)}"  # OK
+   |
+   = help: Replace f-string function call with conversion
+
+ℹ Fix
+12 12 | 
+13 13 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+14 14 | 
+15    |-f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+   15 |+f"{bla!s}, {bla!r}, {(ascii(bla))}"  # RUF010
+16 16 | 
+17 17 | f"{foo(bla)}"  # OK
+18 18 | 
+
+RUF010.py:15:29: RUF010 [*] Use conversion in f-string
+   |
+15 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+16 | 
+17 | f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+   |                             ^^^^^^^^^^ RUF010
+18 | 
+19 | f"{foo(bla)}"  # OK
+   |
+   = help: Replace f-string function call with conversion
+
+ℹ Fix
+12 12 | 
+13 13 | f"{(str(bla))}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+14 14 | 
+15    |-f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"  # RUF010
+   15 |+f"{bla!s}, {(repr(bla))}, {bla!a}"  # RUF010
+16 16 | 
+17 17 | f"{foo(bla)}"  # OK
+18 18 | 
 
 


### PR DESCRIPTION
## Summary

All these `return` statements should've been `continue` statements. Using `return` meant that if a string contained multiple expression, like `f"{bla!s}, {(repr(bla))}, {(ascii(bla))}"`, and one of them was already modified to an explicit conversion (like the first), we'd skip fixing the remaining.

Closes #4567.
