### PR TITLE
Track symbol deletions separately from bindings

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/nonlocal_without_binding.py
+++ b/crates/ruff/resources/test/fixtures/pylint/nonlocal_without_binding.py
@@ -17,3 +17,30 @@ def f():
 
     def f():
         nonlocal y
+
+
+def f():
+    x = 1
+
+    def g():
+        nonlocal x
+
+    del x
+
+
+def f():
+    def g():
+        nonlocal x
+
+    del x
+
+
+def f():
+    try:
+        pass
+    except Exception as x:
+        pass
+
+    def g():
+        nonlocal x
+        x = 2

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -316,6 +316,7 @@ where
                                 .scopes
                                 .ancestors(self.semantic_model.scope_id)
                                 .skip(1)
+                                .take_while(|scope| !scope.kind.is_module())
                                 .all(|scope| !scope.declares(name.as_str()))
                             {
                                 self.diagnostics.push(Diagnostic::new(

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_export.rs
@@ -51,7 +51,7 @@ impl Violation for UndefinedExport {
 pub(crate) fn undefined_export(name: &str, range: TextRange, scope: &Scope) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     if !scope.uses_star_imports() {
-        if !scope.defines(name) {
+        if !scope.has(name) {
             diagnostics.push(Diagnostic::new(
                 UndefinedExport {
                     name: (*name).to_string(),

--- a/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff/src/rules/pyflakes/rules/undefined_local.rs
@@ -47,7 +47,7 @@ impl Violation for UndefinedLocal {
 pub(crate) fn undefined_local(checker: &mut Checker, name: &str) {
     // If the name hasn't already been defined in the current scope...
     let current = checker.semantic_model().scope();
-    if !current.kind.is_any_function() || current.defines(name) {
+    if !current.kind.is_any_function() || current.has(name) {
         return;
     }
 


### PR DESCRIPTION
## Summary

#4746 revealed some subtle issues related to Python's handling of `nonlocal`. If you use `nonlocal`, and the non-local symbol isn't declared in the parent scope, Python raises a syntax error at parse time (!). However, I didn't realize that, for the purpose of declarations, Python will respect a `del` statement -- so this works fine:

```py
def f():
    def g():
        nonlocal x

    del x
```

Previously, to determine whether the symbol was declared in the parent scope, we checked if the symbol was _bound_ in the parent scope. But we don't create bindings for deletions, and in fact, we remove any existing bindings when we hit a deletion.

This PR thus modifies `Scope` to track all deleted symbols, so that we can ask the scope whether the symbol should be considered "declared" for the purpose of `nonlocal` analysis.

Closes #4746.
