### PR TITLE
Respect noqa directives on `ImportFrom` parents for type-checking rules

### DIFF
--- a/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH002.py
+++ b/crates/ruff/resources/test/fixtures/flake8_type_checking/TCH002.py
@@ -150,3 +150,17 @@ def f():
 
 def f():
     import pandas as pd
+
+
+def f():
+    from pandas import DataFrame  # noqa: TCH002
+
+    x: DataFrame = 2
+
+
+def f():
+    from pandas import (  # noqa: TCH002
+        DataFrame,
+    )
+
+    x: DataFrame = 2

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -4410,13 +4410,8 @@ impl<'a> Checker<'a> {
                                 },
                                 binding.trimmed_range(&self.semantic_model, self.locator),
                             );
-                            if let Some(parent) = binding.source {
-                                let parent = self.semantic_model.stmts[parent];
-                                if parent.is_import_from_stmt()
-                                    && parent.range().contains_range(binding.range)
-                                {
-                                    diagnostic.set_parent(parent.start());
-                                }
+                            if let Some(range) = binding.parent_range(&self.semantic_model) {
+                                diagnostic.set_parent(range.start());
                             }
                             self.diagnostics.push(diagnostic);
                         }
@@ -5044,13 +5039,8 @@ impl<'a> Checker<'a> {
                             },
                             binding.trimmed_range(&self.semantic_model, self.locator),
                         );
-                        if let Some(parent) = binding
-                            .source
-                            .map(|source| &self.semantic_model.stmts[source])
-                        {
-                            if parent.is_import_from_stmt() {
-                                diagnostic.set_parent(parent.start());
-                            }
+                        if let Some(range) = binding.parent_range(&self.semantic_model) {
+                            diagnostic.set_parent(range.start());
                         }
                         diagnostics.push(diagnostic);
                     }

--- a/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
+++ b/crates/ruff/src/rules/flake8_type_checking/rules/runtime_import_in_type_checking_block.rs
@@ -86,8 +86,11 @@ pub(crate) fn runtime_import_in_type_checking_block(
             RuntimeImportInTypeCheckingBlock {
                 qualified_name: qualified_name.to_string(),
             },
-            binding.range,
+            binding.trimmed_range(checker.semantic_model(), checker.locator),
         );
+        if let Some(range) = binding.parent_range(checker.semantic_model()) {
+            diagnostic.set_parent(range.start());
+        }
 
         if checker.patch(diagnostic.kind.rule()) {
             diagnostic.try_set_fix(|| {

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use bitflags::bitflags;
 use ruff_text_size::TextRange;
+use rustpython_parser::ast::Ranged;
 
 use ruff_index::{newtype_index, IndexSlice, IndexVec};
 use ruff_python_ast::helpers;
@@ -142,6 +143,19 @@ impl<'a> Binding<'a> {
             }
             _ => self.range,
         }
+    }
+
+    /// Returns the range of the binding's parent.
+    pub fn parent_range(&self, semantic_model: &SemanticModel) -> Option<TextRange> {
+        self.source
+            .map(|node_id| semantic_model.stmts[node_id])
+            .and_then(|parent| {
+                if parent.is_import_from_stmt() {
+                    Some(parent.range())
+                } else {
+                    None
+                }
+            })
     }
 }
 


### PR DESCRIPTION
## Summary

Similar to unused imports, we need to respect `noqa` directives like:

```py
from pandas import (  # noqa: TCH002
    DataFrame,
)
```