### PR TITLE
Make `C413` fix as suggested for `reversed` call

### DIFF
--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -66,7 +66,7 @@ pub(crate) fn unnecessary_call_around_sorted(
     let Some(arg) = args.first() else {
         return;
     };
-    let Expr::Call(ast::ExprCall { func, keywords, .. }) = arg else {
+    let Expr::Call(ast::ExprCall { func, .. }) = arg else {
         return;
     };
     let Some(inner) = helpers::expr_name(func) else {
@@ -76,16 +76,6 @@ pub(crate) fn unnecessary_call_around_sorted(
         return;
     }
     if !checker.semantic_model().is_builtin(inner) || !checker.semantic_model().is_builtin(outer) {
-        return;
-    }
-    // Avoid flagging when there's the `key` keyword argument present as it could
-    // lead to false positive (issue #4879).
-    if keywords.iter().any(|keyword| {
-        keyword
-            .arg
-            .as_ref()
-            .map_or(false, |id| id.as_str() == "key")
-    }) {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -1,6 +1,6 @@
 use rustpython_parser::ast::{self, Expr, Ranged};
 
-use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic};
+use ruff_diagnostics::{AlwaysAutofixableViolation, Diagnostic, Fix};
 use ruff_macros::{derive_message_formats, violation};
 
 use crate::checkers::ast::Checker;
@@ -85,9 +85,14 @@ pub(crate) fn unnecessary_call_around_sorted(
         expr.range(),
     );
     if checker.patch(diagnostic.kind.rule()) {
-        #[allow(deprecated)]
-        diagnostic.try_set_fix_from_edit(|| {
-            fixes::fix_unnecessary_call_around_sorted(checker.locator, checker.stylist, expr)
+        diagnostic.try_set_fix(|| {
+            let edit =
+                fixes::fix_unnecessary_call_around_sorted(checker.locator, checker.stylist, expr)?;
+            if outer == "reversed" {
+                Ok(Fix::suggested(edit))
+            } else {
+                Ok(Fix::automatic(edit))
+            }
         });
     }
     checker.diagnostics.push(diagnostic);

--- a/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
+++ b/crates/ruff/src/rules/flake8_comprehensions/rules/unnecessary_call_around_sorted.rs
@@ -66,7 +66,7 @@ pub(crate) fn unnecessary_call_around_sorted(
     let Some(arg) = args.first() else {
         return;
     };
-    let Expr::Call(ast::ExprCall { func, .. }) = arg else {
+    let Expr::Call(ast::ExprCall { func, keywords, .. }) = arg else {
         return;
     };
     let Some(inner) = helpers::expr_name(func) else {
@@ -76,6 +76,16 @@ pub(crate) fn unnecessary_call_around_sorted(
         return;
     }
     if !checker.semantic_model().is_builtin(inner) || !checker.semantic_model().is_builtin(outer) {
+        return;
+    }
+    // Avoid flagging when there's the `key` keyword argument present as it could
+    // lead to false positive (issue #4879).
+    if keywords.iter().any(|keyword| {
+        keyword
+            .arg
+            .as_ref()
+            .map_or(false, |id| id.as_str() == "key")
+    }) {
         return;
     }
     let mut diagnostic = Diagnostic::new(

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
@@ -42,27 +42,6 @@ C413.py:4:1: C413 [*] Unnecessary `reversed` call around `sorted()`
 6 6 | reversed(sorted(x, reverse=True))
 7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
 
-C413.py:5:1: C413 [*] Unnecessary `reversed` call around `sorted()`
-  |
-5 | list(sorted(x))
-6 | reversed(sorted(x))
-7 | reversed(sorted(x, key=lambda e: e))
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
-8 | reversed(sorted(x, reverse=True))
-9 | reversed(sorted(x, key=lambda e: e, reverse=True))
-  |
-  = help: Remove unnecessary `reversed` call
-
-ℹ Suggested fix
-2 2 | list(x)
-3 3 | list(sorted(x))
-4 4 | reversed(sorted(x))
-5   |-reversed(sorted(x, key=lambda e: e))
-  5 |+sorted(x, key=lambda e: e, reverse=True)
-6 6 | reversed(sorted(x, reverse=True))
-7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
-8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
-
 C413.py:6:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
  6 | reversed(sorted(x))
@@ -83,47 +62,6 @@ C413.py:6:1: C413 [*] Unnecessary `reversed` call around `sorted()`
 7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
 8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
 9 9 | reversed(sorted(x, reverse=False))
-
-C413.py:7:1: C413 [*] Unnecessary `reversed` call around `sorted()`
-   |
- 7 | reversed(sorted(x, key=lambda e: e))
- 8 | reversed(sorted(x, reverse=True))
- 9 | reversed(sorted(x, key=lambda e: e, reverse=True))
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
-10 | reversed(sorted(x, reverse=True, key=lambda e: e))
-11 | reversed(sorted(x, reverse=False))
-   |
-   = help: Remove unnecessary `reversed` call
-
-ℹ Suggested fix
-4 4 | reversed(sorted(x))
-5 5 | reversed(sorted(x, key=lambda e: e))
-6 6 | reversed(sorted(x, reverse=True))
-7   |-reversed(sorted(x, key=lambda e: e, reverse=True))
-  7 |+sorted(x, key=lambda e: e, reverse=False)
-8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
-9 9 | reversed(sorted(x, reverse=False))
-10 10 | 
-
-C413.py:8:1: C413 [*] Unnecessary `reversed` call around `sorted()`
-   |
- 8 | reversed(sorted(x, reverse=True))
- 9 | reversed(sorted(x, key=lambda e: e, reverse=True))
-10 | reversed(sorted(x, reverse=True, key=lambda e: e))
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
-11 | reversed(sorted(x, reverse=False))
-   |
-   = help: Remove unnecessary `reversed` call
-
-ℹ Suggested fix
-5 5 | reversed(sorted(x, key=lambda e: e))
-6 6 | reversed(sorted(x, reverse=True))
-7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
-8   |-reversed(sorted(x, reverse=True, key=lambda e: e))
-  8 |+sorted(x, reverse=False, key=lambda e: e)
-9 9 | reversed(sorted(x, reverse=False))
-10 10 | 
-11 11 | def reversed(*args, **kwargs):
 
 C413.py:9:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
@@ -42,6 +42,27 @@ C413.py:4:1: C413 [*] Unnecessary `reversed` call around `sorted()`
 6 6 | reversed(sorted(x, reverse=True))
 7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
 
+C413.py:5:1: C413 [*] Unnecessary `reversed` call around `sorted()`
+  |
+5 | list(sorted(x))
+6 | reversed(sorted(x))
+7 | reversed(sorted(x, key=lambda e: e))
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
+8 | reversed(sorted(x, reverse=True))
+9 | reversed(sorted(x, key=lambda e: e, reverse=True))
+  |
+  = help: Remove unnecessary `reversed` call
+
+ℹ Suggested fix
+2 2 | list(x)
+3 3 | list(sorted(x))
+4 4 | reversed(sorted(x))
+5   |-reversed(sorted(x, key=lambda e: e))
+  5 |+sorted(x, key=lambda e: e, reverse=True)
+6 6 | reversed(sorted(x, reverse=True))
+7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
+8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
+
 C413.py:6:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |
  6 | reversed(sorted(x))
@@ -62,6 +83,47 @@ C413.py:6:1: C413 [*] Unnecessary `reversed` call around `sorted()`
 7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
 8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
 9 9 | reversed(sorted(x, reverse=False))
+
+C413.py:7:1: C413 [*] Unnecessary `reversed` call around `sorted()`
+   |
+ 7 | reversed(sorted(x, key=lambda e: e))
+ 8 | reversed(sorted(x, reverse=True))
+ 9 | reversed(sorted(x, key=lambda e: e, reverse=True))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
+10 | reversed(sorted(x, reverse=True, key=lambda e: e))
+11 | reversed(sorted(x, reverse=False))
+   |
+   = help: Remove unnecessary `reversed` call
+
+ℹ Suggested fix
+4 4 | reversed(sorted(x))
+5 5 | reversed(sorted(x, key=lambda e: e))
+6 6 | reversed(sorted(x, reverse=True))
+7   |-reversed(sorted(x, key=lambda e: e, reverse=True))
+  7 |+sorted(x, key=lambda e: e, reverse=False)
+8 8 | reversed(sorted(x, reverse=True, key=lambda e: e))
+9 9 | reversed(sorted(x, reverse=False))
+10 10 | 
+
+C413.py:8:1: C413 [*] Unnecessary `reversed` call around `sorted()`
+   |
+ 8 | reversed(sorted(x, reverse=True))
+ 9 | reversed(sorted(x, key=lambda e: e, reverse=True))
+10 | reversed(sorted(x, reverse=True, key=lambda e: e))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C413
+11 | reversed(sorted(x, reverse=False))
+   |
+   = help: Remove unnecessary `reversed` call
+
+ℹ Suggested fix
+5 5 | reversed(sorted(x, key=lambda e: e))
+6 6 | reversed(sorted(x, reverse=True))
+7 7 | reversed(sorted(x, key=lambda e: e, reverse=True))
+8   |-reversed(sorted(x, reverse=True, key=lambda e: e))
+  8 |+sorted(x, reverse=False, key=lambda e: e)
+9 9 | reversed(sorted(x, reverse=False))
+10 10 | 
+11 11 | def reversed(*args, **kwargs):
 
 C413.py:9:1: C413 [*] Unnecessary `reversed` call around `sorted()`
    |

--- a/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
+++ b/crates/ruff/src/rules/flake8_comprehensions/snapshots/ruff__rules__flake8_comprehensions__tests__C413_C413.py.snap
@@ -12,7 +12,7 @@ C413.py:3:1: C413 [*] Unnecessary `list` call around `sorted()`
   |
   = help: Remove unnecessary `list` call
 
-ℹ Suggested fix
+ℹ Fix
 1 1 | x = [2, 3, 1]
 2 2 | list(x)
 3   |-list(sorted(x))


### PR DESCRIPTION
## Summary

~When the `key` keyword argument is present, the output for `sorted` and `reversed` will be different. This is especially true when the elements are itself a collection. The former will sort only as per the given key while the latter will sort using all the elements present in the collection. This could lead to different output for the suggested auto-fix.~

Look at the comments and the linked issue for description but the gist is that the fix for `reversed` call will be `Suggestion` while for others it'll be `Automatic`.

## Alternative

We could flag the auto-fix as `Suggested`, but I would rather not flag it as the diagnostic itself is incorrect.

## Test Plan

`cargo test`

fixes: #4879 
