### PR TITLE
Change `iteration-over-set` to flag set literals only

### DIFF
--- a/crates/ruff/resources/test/fixtures/pylint/iteration_over_set.py
+++ b/crates/ruff/resources/test/fixtures/pylint/iteration_over_set.py
@@ -3,12 +3,6 @@
 for item in {"apples", "lemons", "water"}:  # flags in-line set literals
     print(f"I like {item}.")
 
-for item in set(("apples", "lemons", "water")):  # flags set() calls
-    print(f"I like {item}.")
-
-for number in {i for i in range(10)}:  # flags set comprehensions
-    print(number)
-
 numbers_list = [i for i in {1, 2, 3}]  # flags sets in list comprehensions
 
 numbers_set = {i for i in {1, 2, 3}}  # flags sets in set comprehensions
@@ -36,3 +30,9 @@ numbers_set = {i for i in (1, 2, 3)}  # tuples in comprehensions are fine
 numbers_dict = {str(i): i for i in [1, 2, 3]}  # lists in dict comprehensions are fine
 
 numbers_gen = (i for i in (1, 2, 3))  # tuples in generator expressions are fine
+
+for item in set(("apples", "lemons", "water")):  # set constructor is fine
+    print(f"I like {item}.")
+
+for number in {i for i in range(10)}:  # set comprehensions are fine
+    print(number)

--- a/crates/ruff/src/rules/pylint/rules/iteration_over_set.rs
+++ b/crates/ruff/src/rules/pylint/rules/iteration_over_set.rs
@@ -1,4 +1,4 @@
-use rustpython_parser::ast::{Expr, ExprName, Ranged};
+use rustpython_parser::ast::{Expr, Ranged};
 
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
@@ -38,23 +38,7 @@ impl Violation for IterationOverSet {
 
 /// PLC0208
 pub(crate) fn iteration_over_set(checker: &mut Checker, expr: &Expr) {
-    let is_set = match expr {
-        // Ex) `for i in {1, 2, 3}`
-        Expr::Set(_) => true,
-        // Ex)` for i in {n for n in range(1, 4)}`
-        Expr::SetComp(_) => true,
-        // Ex) `for i in set(1, 2, 3)`
-        Expr::Call(call) => {
-            if let Expr::Name(ExprName { id, .. }) = call.func.as_ref() {
-                id.as_str() == "set" && checker.semantic_model().is_builtin("set")
-            } else {
-                false
-            }
-        }
-        _ => false,
-    };
-
-    if is_set {
+    if let Expr::Set(_) = expr {
         checker
             .diagnostics
             .push(Diagnostic::new(IterationOverSet, expr.range()));


### PR DESCRIPTION
## Summary

Changes the logic of the `iteration-over-set` rule to match Pylint and only flag iterations over set literals.

Addresses comment by @andersk in https://github.com/charliermarsh/ruff/issues/4706#issuecomment-1579386665.

## Test Plan

`cargo test`
