### PR TITLE
Remove subscript expressions from python_ast contains_effect helper

### DIFF
--- a/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
+++ b/crates/ruff/src/rules/flake8_simplify/snapshots/ruff__rules__flake8_simplify__tests__SIM401_SIM401.py.snap
@@ -131,4 +131,30 @@ SIM401.py:36:1: SIM401 [*] Use `vars[idx] = a_dict.get(key, "defaultß9💣2ℝ6
 41 38 | ###
 42 39 | # Negative cases
 
+SIM401.py:96:1: SIM401 [*] Use `var = a_dict.get(key, a_dict["fallback"])` instead of an `if` block
+    |
+ 96 |   # OK (complex default value)
+ 97 | / if key in a_dict:
+ 98 | |     var = a_dict[key]
+ 99 | | else:
+100 | |     var = a_dict["fallback"]
+    | |____________________________^ SIM401
+101 |   
+102 |   # OK (false negative for elif)
+    |
+    = help: Replace with `var = a_dict.get(key, a_dict["fallback"])`
+
+ℹ Suggested fix
+93  93  |     var = foo()
+94  94  | 
+95  95  | # OK (complex default value)
+96      |-if key in a_dict:
+97      |-    var = a_dict[key]
+98      |-else:
+99      |-    var = a_dict["fallback"]
+    96  |+var = a_dict.get(key, a_dict["fallback"])
+100 97  | 
+101 98  | # OK (false negative for elif)
+102 99  | if foo():
+
 

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -94,7 +94,6 @@ where
                 | Expr::GeneratorExp(_)
                 | Expr::ListComp(_)
                 | Expr::SetComp(_)
-                | Expr::Subscript(_)
                 | Expr::Yield(_)
                 | Expr::YieldFrom(_)
         )


### PR DESCRIPTION
## Summary

Hello!
This PR fixes a few rules where a fix was not possible because of the presence of square brackets in an expression. Previously, the `Subscript` expression was incorrectly considered to have runtime effects. However, I was unable to reproduce any scenarios where square brackets actually had any impact.

Here's an example for rule F841:
```py
foo = {"hello": "world"}

def hello():
    bar = foo["hello"] # Unused variable, ruff won't fix because of [...] 

hello()
```

With this PR, the rules using ruff_python_ast.helpers.contains_effect will be able to fix errors containing subscript expressions.

## Test Plan

`cargo test`
