### PR TITLE
Add `contents: write` permission to release step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -400,6 +400,8 @@ jobs:
     permissions:
       # For pypi trusted publishing
       id-token: write
+      # For GitHub release publishing
+      contents: write
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -415,7 +417,7 @@ jobs:
         with:
           name: binaries
           path: binaries
-      - name: Release
+      - name: "Publish to GitHub"
         uses: softprops/action-gh-release@v1
         with:
           files: binaries/*


### PR DESCRIPTION
## Summary

In the most recent release, the "add the binaries to the GitHub release" step [failed](https://github.com/charliermarsh/ruff/actions/runs/5194110770/jobs/9365856414), due to a missing permission. I think that when we introduced `id-token: write`, it effectively turned off all other permissions (see [docs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)). The `action-gh-release` docs state that they need [`contents: write`](https://github.com/softprops/action-gh-release#permissions), so this PR adds it.
