### PR TITLE
Use taiki-e/install-action to install cargo fuzz

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,8 +96,9 @@ jobs:
         run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: "Install cargo-binstall"
-        uses: taiki-e/install-action@cargo-binstall
-      - run: cargo binstall cargo-fuzz -y
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz@0.11
       - run: cargo fuzz build -s none
 
   cargo-test-wasm:


### PR DESCRIPTION
The cargo fuzz ci run seems to sometimes fail for unclear reasons (https://github.com/charliermarsh/ruff/actions/runs/5200348677/jobs/9379742606?pr=4900). I hope that this might fix it. I'll push more commits to this PR to check the caching behaviour.