### PR TITLE
Remove libafl while it remains unstable

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -629,16 +629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libafl_libfuzzer"
-version = "0.10.1"
-source = "git+https://github.com/AFLplusplus/LibAFL.git?branch=libfuzzer#ce0be4066016a40f92f1202621bbce93274655ce"
-dependencies = [
- "cc",
- "libfuzzer-sys",
- "rustversion",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,7 +1091,6 @@ name = "ruff-fuzz"
 version = "0.0.0"
 dependencies = [
  "arbitrary",
- "libafl_libfuzzer",
  "libfuzzer-sys",
  "ruff",
  "ruff_python_ast",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2021"
 [features]
 default = ["libfuzzer"]
 full-idempotency = []
-libafl = ["libafl_libfuzzer"]
-libafl_merge = ["libafl", "libafl_libfuzzer/merge"]
 libfuzzer = ["libfuzzer-sys/link_libfuzzer"]
 
 [package.metadata]
@@ -20,7 +18,6 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { version = "1.3.0", features = ["derive"] }
-libafl_libfuzzer = { git = "https://github.com/AFLplusplus/LibAFL.git", branch = "libfuzzer", optional = true }
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
 ruff = { path = "../crates/ruff" }
 ruff_python_ast = { path = "../crates/ruff_python_ast" }

--- a/fuzz/fuzz_targets/ruff_fix_validity.rs
+++ b/fuzz/fuzz_targets/ruff_fix_validity.rs
@@ -3,9 +3,6 @@
 
 #![no_main]
 
-#[cfg(feature = "libafl")]
-extern crate libafl_libfuzzer;
-
 use libfuzzer_sys::{fuzz_target, Corpus};
 use ruff::settings::Settings;
 use std::sync::OnceLock;

--- a/fuzz/fuzz_targets/ruff_parse_idempotency.rs
+++ b/fuzz/fuzz_targets/ruff_parse_idempotency.rs
@@ -3,9 +3,6 @@
 
 #![no_main]
 
-#[cfg(feature = "libafl")]
-extern crate libafl_libfuzzer;
-
 use libfuzzer_sys::{fuzz_target, Corpus};
 use ruff_python_ast::source_code::round_trip;
 use similar::TextDiff;

--- a/fuzz/fuzz_targets/ruff_parse_simple.rs
+++ b/fuzz/fuzz_targets/ruff_parse_simple.rs
@@ -3,9 +3,6 @@
 
 #![no_main]
 
-#[cfg(feature = "libafl")]
-extern crate libafl_libfuzzer;
-
 use libfuzzer_sys::{fuzz_target, Corpus};
 use ruff_python_ast::source_code::round_trip;
 


### PR DESCRIPTION
#4928 shows that this wasn't as stable as I thought. We can revisit this when it's stable, but for now it's probably best to omit these dependencies -- I'll just enable them locally.