### PR TITLE
Avoid attributing runtime references to module-level imports

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F401_17.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F401_17.py
@@ -1,0 +1,32 @@
+"""Test that runtime typing references are properly attributed to scoped imports."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from threading import Thread
+
+
+def fn(thread: Thread):
+    from threading import Thread
+
+    # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+    # top level.
+    x: Thread
+
+
+def fn(thread: Thread):
+    from threading import Thread
+
+    # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+    # top level.
+    cast("Thread", thread)
+
+
+def fn(thread: Thread):
+    from threading import Thread
+
+    # The `Thread` on the right-hand side should resolve to the`Thread` imported within
+    # `fn`.
+    cast(Thread, thread)

--- a/crates/ruff/src/rules/pyflakes/mod.rs
+++ b/crates/ruff/src/rules/pyflakes/mod.rs
@@ -42,6 +42,7 @@ mod tests {
     #[test_case(Rule::UnusedImport, Path::new("F401_14.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_15.py"))]
     #[test_case(Rule::UnusedImport, Path::new("F401_16.py"))]
+    #[test_case(Rule::UnusedImport, Path::new("F401_17.py"))]
     #[test_case(Rule::ImportShadowedByLoopVar, Path::new("F402.py"))]
     #[test_case(Rule::UndefinedLocalWithImportStar, Path::new("F403.py"))]
     #[test_case(Rule::LateFutureImport, Path::new("F404.py"))]

--- a/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_17.py.snap
+++ b/crates/ruff/src/rules/pyflakes/snapshots/ruff__rules__pyflakes__tests__F401_F401_17.py.snap
@@ -1,0 +1,42 @@
+---
+source: crates/ruff/src/rules/pyflakes/mod.rs
+---
+F401_17.py:12:27: F401 [*] `threading.Thread` imported but unused
+   |
+12 | def fn(thread: Thread):
+13 |     from threading import Thread
+   |                           ^^^^^^ F401
+14 | 
+15 |     # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+   |
+   = help: Remove unused import: `threading.Thread`
+
+ℹ Fix
+9  9  | 
+10 10 | 
+11 11 | def fn(thread: Thread):
+12    |-    from threading import Thread
+13 12 | 
+14 13 |     # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+15 14 |     # top level.
+
+F401_17.py:20:27: F401 [*] `threading.Thread` imported but unused
+   |
+20 | def fn(thread: Thread):
+21 |     from threading import Thread
+   |                           ^^^^^^ F401
+22 | 
+23 |     # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+   |
+   = help: Remove unused import: `threading.Thread`
+
+ℹ Fix
+17 17 | 
+18 18 | 
+19 19 | def fn(thread: Thread):
+20    |-    from threading import Thread
+21 20 | 
+22 21 |     # The `Thread` on the left-hand side should resolve to the `Thread` imported at the
+23 22 |     # top level.
+
+


### PR DESCRIPTION
## Summary

This PR fixes a subtle case in import-use attribution, illustrated here:

```py
from __future__ import annotations

from typing import TYPE_CHECKING, cast

if TYPE_CHECKING:
    from threading import Thread


def fn(thread: Thread):
    from threading import Thread  # Flagged as F401

    casted_thread: Thread = cast(Thread, thread)
    return casted_thread

print(fn(1))
```

When we do `cast(Thread, thread)`, we need `Thread` to be attributed to the import within `fn`. This is subtle, because similar to Pyright and other type checkers, the `Thread` on the _left-hand_ side of the assignment (`casted_thread: Thread`) is resolved to the _global_ import.

Closes #4939.