### PR TITLE
Skip class scopes when resolving nonlocal references

### DIFF
--- a/crates/ruff/resources/test/fixtures/pyflakes/F841_0.py
+++ b/crates/ruff/resources/test/fixtures/pyflakes/F841_0.py
@@ -126,3 +126,22 @@ def f(x: int):
 def f():
     if any((key := (value := x)) for x in ["ok"]):
         print(key)
+
+
+def f() -> None:
+    is_connected = False
+
+    class Foo:
+        @property
+        def is_connected(self):
+            nonlocal is_connected
+            return is_connected
+
+        def do_thing(self):
+            # This should resolve to the `is_connected` in the function scope.
+            nonlocal is_connected
+            print(is_connected)
+
+    obj = Foo()
+    obj.do_thing()
+

--- a/crates/ruff/src/checkers/ast/mod.rs
+++ b/crates/ruff/src/checkers/ast/mod.rs
@@ -291,14 +291,14 @@ where
                     }
 
                     // Mark the binding in the defining scopes as used too. (Skip the global scope
-                    // and the current scope.)
+                    // and the current scope, and, per standard resolution rules, any class scopes.)
                     for (name, range) in names.iter().zip(ranges.iter()) {
                         let binding_id = self
                             .semantic_model
                             .scopes
                             .ancestors(self.semantic_model.scope_id)
                             .skip(1)
-                            .take_while(|scope| !scope.kind.is_module())
+                            .filter(|scope| !(scope.kind.is_module() || scope.kind.is_class()))
                             .find_map(|scope| scope.get(name.as_str()));
 
                         if let Some(binding_id) = binding_id {


### PR DESCRIPTION
## Summary

When we visit a `nonlocal`, we add a usage to the resolved `nonlocal` in the parent scope. However, we're not properly skipping resolutions within class scopes (see the new snippet, below).

Closes #4940.
